### PR TITLE
feat(app): add LeaveOrgSection to personal settings

### DIFF
--- a/app/a/[orgSlug]/settings/personal.tsx
+++ b/app/a/[orgSlug]/settings/personal.tsx
@@ -2,6 +2,7 @@ import { DragHandle } from '@tinycld/core/components/DragHandle'
 import { AboutSection } from '@tinycld/core/components/settings/AboutSection'
 import { DeleteAccountSection } from '@tinycld/core/components/settings/DeleteAccountSection'
 import { DisconnectServerSection } from '@tinycld/core/components/settings/DisconnectServerSection'
+import { LeaveOrgSection } from '@tinycld/core/components/settings/leave-org/LeaveOrgSection'
 import { getIcon } from '@tinycld/core/components/workspace/package-icon-map'
 import { useAuth } from '@tinycld/core/lib/auth'
 import { COLOR_THEMES, type ColorThemeSlug } from '@tinycld/core/lib/color-themes'
@@ -70,6 +71,7 @@ export default function PersonalSettings() {
                     <NavigationSection />
                     <DisconnectServerSection />
                     <AboutSection />
+                    <LeaveOrgSection />
                     <DeleteAccountSection />
                 </View>
             </ScrollView>


### PR DESCRIPTION
## Summary

Wires the self-leave entry point into **Settings → Personal**, below About and above Delete Account. Uses the \`LeaveOrgFlow\` modal from tinycld/core#2.

Two-line change in \`personal.tsx\`.

## Depends on

- tinycld/core#2 — defines \`LeaveOrgSection\`. Merge core first.

## Test plan

- [x] \`npm run pkg:check\` ecosystem-wide — green
- [ ] Manual smoke: open Settings → Personal, click "Leave organization", confirm the modal renders correctly in all three cases (multi-member, sole-owner, sole-member).