### PR TITLE
fix(ci): use bootstrap v2 --assemble-only flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Assemble workspace (generate root + all members)
         working-directory: ws
         run: >
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --tooling
+          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
           --with contacts --with mail --with calendar --with drive
           --with calc --with text --with google-takeout-import
       # Go toolchain after assembly: .go-version is bootstrap-generated into ws/.
@@ -67,7 +67,7 @@ jobs:
       - name: Assemble workspace (generate root + all members)
         working-directory: ws
         run: >
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --tooling
+          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
           --with contacts --with mail --with calendar --with drive
           --with calc --with text --with google-takeout-import
       # Go toolchain after assembly: .go-version is bootstrap-generated into ws/.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ name: Build and publish Docker image
 #   - app (this repo) is checked out at the triggering tag into ws/app,
 #   - the release's manifest.json + package-lock.json assets are downloaded,
 #   - each sibling listed in the manifest is cloned at its pinned SHA,
-#   - bootstrap --tooling writes the workspace-root scaffolding (members
+#   - bootstrap --assemble-only writes the workspace-root scaffolding (members
 #     are already present, so it doesn't re-clone them),
 #   - the pinned package-lock.json is dropped into ws/ for npm ci.
 #
@@ -111,7 +111,7 @@ jobs:
           done
           # bootstrap sees every member already cloned and just writes the
           # workspace-root scaffolding (package.json + .npmrc + tinycld.packages.ts).
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --tooling \
+          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only \
             --with contacts --with mail --with calendar --with drive \
             --with calc --with text --with google-takeout-import
           # Drop the pinned lockfile into the workspace root so npm ci uses it.


### PR DESCRIPTION
## Summary

@tinycld/bootstrap v2 was published 2026-05-30 21:52 UTC and dropped the \`--tooling\` flag in favor of \`--assemble-only\`. CI on this repo started failing as soon as v2 propagated to \`latest\` — every PR opened after the v2 publish hits:

\`\`\`
Bad arguments:
  --tooling: \`--tooling\` was removed in v2. Use \`--assemble-only\` instead.
##[error]Process completed with exit code 2.
\`\`\`

This patches the two workflows in this repo (\`.github/workflows/ci.yml\` and the comment + invocation in \`.github/workflows/docker-publish.yml\`).

## Scope

**Only tinycld/app.** Five other repos still need the same one-line fix in their own \`.github/workflows/ci.yml\`:

- tinycld/mail
- tinycld/calc
- tinycld/calendar
- tinycld/contacts
- tinycld/google-takeout-import

core, drive, and text were already migrated alongside the bootstrap v2 release.

## Test plan

- [ ] CI run on this PR succeeds (the two workflows that run on PR open)

## Related

This unblocks tinycld/app#8 (export-types pipeline), which can't get a green check until this lands.