### PR TITLE
feat(package-scripts): add lint to tinycld-pkg check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,16 @@ jobs:
         with:
           node-version-file: ws/app/.node-version
       # bootstrap clones every feature so `npm install` can resolve app's
-      # `@tinycld/contacts` workspace dep (and the lint sweep below covers
-      # every member's tree). The TS typecheck below is scoped to app only —
-      # feature siblings run their own typecheck CI against their own changes,
-      # so app PRs shouldn't be gated on cross-package type drift.
+      # `@tinycld/contacts` workspace dep. The check below is scoped to app
+      # only — feature siblings run their own CI against their own changes,
+      # so app PRs shouldn't be gated on cross-package type drift or
+      # cross-package lint debt. This matches the discipline: each repo's
+      # PRs check that repo's code; integration drift surfaces at merge
+      # time via per-repo CI on the downstream PR.
       - name: Assemble workspace (generate root + all members)
         working-directory: ws
         run: >
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --tooling
+          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
           --with contacts --with mail --with calendar --with drive
           --with calc --with text --with google-takeout-import
       # Go toolchain after assembly: .go-version is bootstrap-generated into ws/.
@@ -46,10 +48,14 @@ jobs:
       - name: Install (workspace root)
         working-directory: ws
         run: npm install
-      - name: Lint
-        working-directory: ws/app
-        run: npm run lint
-      - name: Typecheck + unit (app)
+      # tinycld-pkg check runs lint + typecheck + unit, scoped to the app
+      # member. Replaces the previous separate `npm run lint` (ecosystem-wide
+      # biome sweep) + `tinycld-pkg check` pair. The ecosystem sweep was
+      # accidentally making every app PR depend on every sibling's lint
+      # cleanliness — a single feature repo's biome regression would block
+      # unrelated app PRs. With this change, app PRs check app's own code
+      # and each feature repo catches its own lint issues on its own PRs.
+      - name: Check (lint + typecheck + unit)
         working-directory: ws/app
         run: npx tinycld-pkg check
 
@@ -70,7 +76,7 @@ jobs:
       - name: Assemble workspace (generate root + all members)
         working-directory: ws
         run: >
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --tooling
+          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
           --with contacts --with mail --with calendar --with drive
           --with calc --with text --with google-takeout-import
       # Go toolchain after assembly: .go-version is bootstrap-generated into ws/.

--- a/package-scripts/src/runners.ts
+++ b/package-scripts/src/runners.ts
@@ -29,6 +29,31 @@ export function buildTypecheckCommand(
     return { bin: 'tsc', args: ['--noEmit', '-p', tsconfigFor(pkg), ...passthrough], cwd: pkg.dir }
 }
 
+// Lint scoped to a single package's tree, using the app shell's biome
+// config. We always run from the app dir (where biome.json lives) and
+// target the package's dir as the argument — running biome from
+// pkg.dir would miss app/biome.json and fall back to biome's defaults
+// (which flag a much wider set of files and produce different output).
+//
+// Why this lives in `check` (and gates every package's per-PR CI):
+// before this, biome only ran via `npm run lint` (the workspace-wide
+// sweep) on app's CI. That meant feature packages could merge code
+// with lint regressions, and the issue would only surface later on
+// the next app PR — by which time the offending change had landed in
+// multiple member repos. Scoping a lint pass into `tinycld-pkg check`
+// catches each package's lint regressions on its OWN PR before merge.
+export function buildLintCommand(
+    pkg: CurrentPackage,
+    appDir: string,
+    passthrough: string[] = []
+): Command {
+    return {
+        bin: 'biome',
+        args: ['check', pkg.dir, ...passthrough],
+        cwd: appDir,
+    }
+}
+
 export function buildTestCommand(
     pkg: CurrentPackage,
     _appDir: string,
@@ -53,9 +78,15 @@ export function buildE2eCommand(
     }
 }
 
-// check runs typecheck + unit; passthrough only makes sense for one runner at a
-// time, so it is intentionally NOT forwarded here (a combined run has no single
-// target for a filter). Use `test` or `typecheck` directly to pass args.
+// check runs lint + typecheck + unit; passthrough only makes sense for one
+// runner at a time, so it is intentionally NOT forwarded here (a combined
+// run has no single target for a filter). Use `test` or `typecheck`
+// directly to pass args. Order: lint first because it's the cheapest and
+// catches issues that often surface as compile/test failures downstream.
 export function buildCheckCommands(pkg: CurrentPackage, appDir: string): Command[] {
-    return [buildTypecheckCommand(pkg, appDir), buildTestCommand(pkg, appDir)]
+    return [
+        buildLintCommand(pkg, appDir),
+        buildTypecheckCommand(pkg, appDir),
+        buildTestCommand(pkg, appDir),
+    ]
 }

--- a/package-scripts/tests/runners.test.ts
+++ b/package-scripts/tests/runners.test.ts
@@ -1,6 +1,11 @@
 import * as path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { buildCheckCommands, buildTestCommand, buildTypecheckCommand } from '../src/runners'
+import {
+    buildCheckCommands,
+    buildLintCommand,
+    buildTestCommand,
+    buildTypecheckCommand,
+} from '../src/runners'
 
 const appDir = '/ws/app'
 const featurePkg = { dir: '/ws/contacts', name: '@tinycld/contacts', kind: 'feature' as const }
@@ -27,9 +32,21 @@ describe('buildTestCommand', () => {
     })
 })
 
+describe('buildLintCommand', () => {
+    it('runs biome from the app dir, scoped to the package dir', () => {
+        // biome MUST run from app/ so it picks up app/biome.json — the
+        // single ecosystem config. Running from pkg.dir falls back to
+        // biome's defaults and produces different (stricter) output.
+        const cmd = buildLintCommand(featurePkg, appDir)
+        expect(cmd.bin).toBe('biome')
+        expect(cmd.args).toEqual(['check', '/ws/contacts'])
+        expect(cmd.cwd).toBe(appDir)
+    })
+})
+
 describe('buildCheckCommands', () => {
-    it('is typecheck then test (NOT e2e)', () => {
+    it('is lint then typecheck then test (NOT e2e)', () => {
         const cmds = buildCheckCommands(featurePkg, appDir)
-        expect(cmds.map(c => c.bin)).toEqual(['tsc', 'vitest'])
+        expect(cmds.map(c => c.bin)).toEqual(['biome', 'tsc', 'vitest'])
     })
 })


### PR DESCRIPTION
## Summary

Two coupled changes that together fix the systemic lint-coverage gap and the chicken-and-egg it created.

### 1. `tinycld-pkg check` now runs lint + typecheck + unit

Before this change, `tinycld-pkg check` ran typecheck + unit only. Every feature repo (mail, calc, calendar, contacts, drive, text, google-takeout-import) uses `tinycld-pkg check` as its per-PR CI gate, so before this change none of those repos linted their own code — biome only ran on app PRs via the ecosystem-wide `npm run lint` sweep.

That created a perverse asymmetry: feature packages could merge code with lint regressions, and the issue would only surface later on the next app PR — by which time the offending change had landed in multiple member repos.

- `buildLintCommand`: invokes biome from `app/` (where `biome.json` lives) with the package's dir as the target. Running from a feature package's dir would miss the config and fall back to biome's defaults.
- `buildCheckCommands`: now returns `[lint, typecheck, test]`. Lint runs first.
- Test coverage updated to match.

### 2. app's CI replaces ecosystem-wide lint with `tinycld-pkg check`

With (1) in place, every per-feature-repo CI catches its own biome regressions. app's CI no longer needs to ecosystem-sweep — that step was becoming a coupling point where one sibling's lint debt blocked unrelated app PRs (e.g., drive's biome regressions were blocking app#9 and app#10 from merging).

- Drops the separate `npm run lint` (ecosystem sweep) step from `.github/workflows/ci.yml`.
- The remaining `tinycld-pkg check` step now also lints, app-scoped.
- Drive-by: also fixes `--tooling` → `--assemble-only` in this file's two bootstrap invocations.

## Validation

- Local `cd contacts && npx tinycld-pkg check` → green
- Local `cd core && npx tinycld-pkg check` → green (211 tests + lint clean)
- Local `cd app && npx tinycld-pkg check` → green (3 tests + lint clean)
- Local `cd drive && npx tinycld-pkg check` → fails on lint (the 2 known biome errors drive#8 fixes), bails before typecheck — proves the lint gate works

## Cascading effects on existing open PRs

Once this merges and other PRs rebase:
- tinycld/drive#8 — its biome fix is exactly what this catches. CI will prove the fix works.
- tinycld/app#9 + #10 — no longer fail lint because of drive's debt (they were on `npm run lint` ecosystem sweep)
- Feature repos with accumulated biome debt may surface failures on their next PR. Acceptable: those failures are real and should have been caught at the time the change merged.