### PR TITLE
chore(app): decouple from feature packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # app (this repo) is the triggering checkout. bootstrap GENERATES the
-      # workspace root into ws/ and clones the other members around ws/app.
+      # workspace root into ws/ and clones core as the only sibling app
+      # genuinely depends on — no `--with <feature>` flags. App PRs only
+      # check app's own code; cross-package integration drift surfaces on
+      # the downstream feature PR's CI.
       - uses: actions/checkout@v5
         with:
           path: ws/app
@@ -28,19 +31,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: ws/app/.node-version
-      # bootstrap clones every feature so `npm install` can resolve app's
-      # `@tinycld/contacts` workspace dep. The check below is scoped to app
-      # only — feature siblings run their own CI against their own changes,
-      # so app PRs shouldn't be gated on cross-package type drift or
-      # cross-package lint debt. This matches the discipline: each repo's
-      # PRs check that repo's code; integration drift surfaces at merge
-      # time via per-repo CI on the downstream PR.
-      - name: Assemble workspace (generate root + all members)
+      - name: Assemble workspace (app + core)
         working-directory: ws
-        run: >
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
-          --with contacts --with mail --with calendar --with drive
-          --with calc --with text --with google-takeout-import
+        run: TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
       # Go toolchain after assembly: .go-version is bootstrap-generated into ws/.
       - uses: actions/setup-go@v6
         with:
@@ -48,13 +41,6 @@ jobs:
       - name: Install (workspace root)
         working-directory: ws
         run: npm install
-      # tinycld-pkg check runs lint + typecheck + unit, scoped to the app
-      # member. Replaces the previous separate `npm run lint` (ecosystem-wide
-      # biome sweep) + `tinycld-pkg check` pair. The ecosystem sweep was
-      # accidentally making every app PR depend on every sibling's lint
-      # cleanliness — a single feature repo's biome regression would block
-      # unrelated app PRs. With this change, app PRs check app's own code
-      # and each feature repo catches its own lint issues on its own PRs.
       - name: Check (lint + typecheck + unit)
         working-directory: ws/app
         run: npx tinycld-pkg check
@@ -63,23 +49,21 @@ jobs:
     name: Go build & test
     runs-on: ubuntu-latest
     steps:
-      # app (this repo) is the triggering checkout; bootstrap generates the root
-      # and clones the rest around ws/app.
+      # Same minimal assembly as the checks job — app+core only. The
+      # generator emits a package_extensions.go and go.work that import
+      # only the features present in the workspace, so without `--with
+      # <feature>` flags, app's Go build embeds zero feature servers and
+      # builds cleanly. Feature PRs verify their own Go modules on their
+      # own CI; integration is tested at release time.
       - uses: actions/checkout@v5
         with:
           path: ws/app
       - uses: actions/setup-node@v5
         with:
           node-version-file: ws/app/.node-version
-      # All feature server packages must be present so go.work + the Go build
-      # see every tinycld.org/packages/* module.
-      - name: Assemble workspace (generate root + all members)
+      - name: Assemble workspace (app + core)
         working-directory: ws
-        run: >
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
-          --with contacts --with mail --with calendar --with drive
-          --with calc --with text --with google-takeout-import
-      # Go toolchain after assembly: .go-version is bootstrap-generated into ws/.
+        run: TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
       - uses: actions/setup-go@v6
         with:
           go-version-file: ws/.go-version
@@ -92,3 +76,52 @@ jobs:
       - name: Go test
         working-directory: ws/app/server
         run: go test -tags no_ui ./...
+
+  e2e:
+    name: E2E (app shell)
+    runs-on: ubuntu-latest
+    steps:
+      # app+core assembled by bootstrap as usual, then we scaffold a tiny
+      # shortcut-stub package locally so the keyboard-shortcut tests have
+      # a real package contributing nav.shortcut + a routable URL. The
+      # stub keeps app's e2e fully self-contained (no dependency on any
+      # real feature package) — the same pattern drive/ uses for its
+      # share-stub scaffolder. See tests/scripts/scaffold-shortcut-stub.ts
+      # for what the stub provides.
+      - uses: actions/checkout@v5
+        with:
+          path: ws/app
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: ws/app/.node-version
+      - name: Assemble workspace (app + core)
+        working-directory: ws
+        run: TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ws/.go-version
+      - name: Install (workspace root)
+        working-directory: ws
+        run: npm install
+      - name: Scaffold shortcut-stub package
+        working-directory: ws
+        run: npx tsx app/tests/scripts/scaffold-shortcut-stub.ts
+      - name: Install Playwright browsers
+        working-directory: ws/app
+        run: npx playwright install --with-deps chromium
+      - name: E2E
+        working-directory: ws/app
+        run: npx tinycld-pkg test:e2e
+      # Capture Playwright's per-failure artifacts (trace, screenshot,
+      # video, error-context.md) so a CI failure can be diagnosed
+      # without a re-run. `if: failure()` skips the upload on green
+      # runs to save bandwidth + retention.
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            ws/app/test-results/
+            ws/app/playwright-report/
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
       - name: Install (workspace root)
         working-directory: ws
         run: npm install
+      # go mod download populates go.sum entries the committed go.sum is
+      # missing — specifically the `/go.mod h1:` hashes for transitive
+      # deps resolved through go.work's `use ../../core/server`. Without
+      # this, go build errors on "missing go.sum entry for go.mod file"
+      # the first time a sibling module is reached.
+      - name: Go mod download
+        working-directory: ws/app/server
+        run: go mod download
       - name: Go build
         working-directory: ws/app/server
         run: go build -o tinycld .
@@ -103,6 +111,14 @@ jobs:
       - name: Install (workspace root)
         working-directory: ws
         run: npm install
+      # go mod download before E2E so the webServer (which builds PB
+      # via npm run expo:test → reset-dev-db) doesn't fail on a missing
+      # go.sum entry. Same fix as the Go job above; both need it
+      # because the committed go.sum lacks the `/go.mod h1:` hashes for
+      # transitive deps resolved through go.work's `use ../../core/server`.
+      - name: Go mod download
+        working-directory: ws/app/server
+        run: go mod download
       - name: Scaffold shortcut-stub package
         working-directory: ws
         run: npx tsx app/tests/scripts/scaffold-shortcut-stub.ts

--- a/package.json
+++ b/package.json
@@ -152,8 +152,7 @@
         "yjs": "^13.6.30",
         "zod": "^4.3.6",
         "zustand": "^5.0.12",
-        "@tinycld/core": "*",
-        "@tinycld/contacts": "*"
+        "@tinycld/core": "*"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.4.10",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,13 @@ const PORT = Number(process.env.E2E_PORT ?? 7200)
 const EMAIL_LOG_PATH = path.join(import.meta.dirname, 'tmp', 'emails.log')
 
 export default defineConfig({
+    // Scoped to tests/e2e/ specifically. The tests/install/ tree has
+    // its own playwright.config.ts and is invoked separately by the
+    // docker smoke-test workflow — leaving testDir at the playwright
+    // default (this file's dir) would pull both into the same run, and
+    // the install spec's EXPECTED_BUNDLED assertions would trip when
+    // run against the regular expo:test webServer.
+    testDir: path.join(import.meta.dirname, 'tests', 'e2e'),
     testMatch: '**/*.spec.ts',
     // Per-failure artifacts: trace, screenshot, video. retain-on-failure
     // skips writing for passing tests (saves disk + upload size on green

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -28,9 +28,36 @@ export async function login(page: Page) {
     await page.waitForURL(/\/a\//, { timeout: 15_000 })
 }
 
+// Navigate to a package's org-scoped route via the rail link in the app
+// shell. We click the rail link rather than calling page.goto() because
+// goto is a hard browser navigation that cancels every in-flight fetch,
+// including any lazy chunk the previous route had already started
+// loading. On CI that cancellation triggers a 5+ second retry/recompile
+// cycle inside Metro, and the package's screen chunk (lazy() in
+// tinycld.config.ts) doesn't settle until after the test's first
+// assertion has already timed out. Clicking does SPA navigation through
+// expo-router: previously-loaded chunks stay loaded, the new package's
+// chunk downloads cleanly without contention, and the page never tears
+// down + remounts.
+//
+// Returns after the URL change is observed. Callers that need to wait
+// for a specific page element (e.g. a sidebar entry, an inbox row, a
+// button) MUST assert on it explicitly — this helper deliberately
+// doesn't wait on package-internal UI so it works for any package,
+// including ones with no sidebar.
+//
+// `pkg` is the lowercase slug (mail, calendar, drive, ...).
 export async function navigateToPackage(page: Page, pkg: string) {
-    await page.goto(`/a/${ORG_SLUG}/${pkg}`)
-    await page.waitForLoadState('domcontentloaded')
+    // Match by URL prefix rather than exact href: some packages (calc,
+    // text, …) rewrite their rail link to deep-link the user's last
+    // visited file (e.g. /a/<org>/calc/<id>), so the rail anchor no
+    // longer matches the bare /a/<org>/<pkg> URL. Prefix match keeps
+    // this working regardless of whether the rail item is bare or
+    // deep-linked.
+    const railLink = page.locator(`a[href^="/a/${ORG_SLUG}/${pkg}"]`).first()
+    await railLink.waitFor({ state: 'visible' })
+    await railLink.click()
+    await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/${pkg}(/|$|\\?)`))
 }
 
 export async function clickSidebarItem(page: Page, label: string) {

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -25,9 +25,9 @@ test.describe('Keyboard shortcuts', () => {
         // Wait for the rail's stub entry to render so the shortcut
         // provider has mounted and tinykeys has bound its listeners
         // before we start typing.
-        await expect(
-            page.getByRole('link', { name: STUB_NAV_LABEL, exact: true })
-        ).toBeVisible({ timeout: 10_000 })
+        await expect(page.getByRole('link', { name: STUB_NAV_LABEL, exact: true })).toBeVisible({
+            timeout: 10_000,
+        })
 
         // Ensure focus is on body, not an input that would suppress
         // shortcuts.

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -1,36 +1,50 @@
 import { expect, test } from '@playwright/test'
-import { isPackageLinked, login, navigateToPackage, ORG_SLUG } from './helpers'
+import { login, navigateToPackage, ORG_SLUG } from './helpers'
 
-// These tests navigate through package-contributed routes (mail, contacts)
-// and assert on package-owned UI like email rows. When core runs standalone
-// (e.g. its own CI) those routes don't exist, so skip rather than fail.
-const mailLinked = isPackageLinked('mail')
-const contactsLinked = isPackageLinked('contacts')
+// These tests verify app-shell keyboard-shortcut behavior using a
+// stub package scaffolded by app/tests/scripts/scaffold-shortcut-stub.ts.
+// The stub registers a minimal nav entry with shortcut 'k' and a
+// landing route, which is everything the chord/help tests need to
+// exercise the app's OWN contract — no coupling to mail, contacts, or
+// any real feature package.
+//
+// To run locally, scaffold the stub first:
+//     npx tsx tests/scripts/scaffold-shortcut-stub.ts
+//     cd app && npx tinycld-pkg test:e2e -- --grep "Keyboard shortcuts"
+//
+// CI runs the scaffold step as part of the e2e job.
+
+const STUB_NAV_LABEL = 'Shortcut Stub'
+const STUB_SLUG = 'shortcut-stub'
+const STUB_SHORTCUT = 'k'
 
 test.describe('Keyboard shortcuts', () => {
     test.beforeEach(async ({ page }) => {
         await login(page)
-    })
+        await navigateToPackage(page, STUB_SLUG)
+        // Wait for the rail's stub entry to render so the shortcut
+        // provider has mounted and tinykeys has bound its listeners
+        // before we start typing.
+        await expect(
+            page.getByRole('link', { name: STUB_NAV_LABEL, exact: true })
+        ).toBeVisible({ timeout: 10_000 })
 
-    test('? opens the help dialog and Escape closes it', async ({ page }) => {
-        test.skip(!mailLinked, 'mail package not linked')
-        await navigateToPackage(page, 'mail')
-        // Wait for the rail to render so the shortcut provider has mounted
-        // and tinykeys has bound its listeners before we start typing.
-        await expect(page.getByRole('link', { name: 'Mail', exact: true })).toBeVisible({
-            timeout: 10_000,
-        })
-
-        // Ensure focus is on body, not an input that would suppress shortcuts.
+        // Ensure focus is on body, not an input that would suppress
+        // shortcuts.
         await page.evaluate(() => {
             ;(document.activeElement as HTMLElement | null)?.blur?.()
         })
+    })
 
-        // The help shortcut binds to `Shift+?` because on real keyboards producing
-        // a `?` always holds Shift. Playwright's press('?') fires the event with
-        // shiftKey=false, so use the explicit combo to match what a human types.
+    test('? opens the help dialog and Escape closes it', async ({ page }) => {
+        // The help shortcut binds to `Shift+?` because on real keyboards
+        // producing a `?` always holds Shift. Playwright's press('?')
+        // fires the event with shiftKey=false, so use the explicit combo
+        // to match what a human types.
         await page.keyboard.press('Shift+?')
-        await expect(page.getByText('Keyboard shortcuts').first()).toBeVisible({ timeout: 5_000 })
+        await expect(page.getByText('Keyboard shortcuts').first()).toBeVisible({
+            timeout: 5_000,
+        })
 
         await page.keyboard.press('Escape')
         await expect(page.getByText('Keyboard shortcuts').first()).not.toBeVisible({
@@ -38,37 +52,12 @@ test.describe('Keyboard shortcuts', () => {
         })
     })
 
-    test('t o jumps to contacts', async ({ page }) => {
-        test.skip(!mailLinked || !contactsLinked, 'mail + contacts packages not linked')
-        await navigateToPackage(page, 'mail')
-        // Wait for the rail link to render so the shortcut provider has mounted
-        // and tinykeys has bound its listeners before we start typing.
-        await expect(page.getByRole('link', { name: 'Mail', exact: true })).toBeVisible({
-            timeout: 10_000,
-        })
-
-        // Ensure focus is on body, not an input that would suppress shortcuts.
-        await page.evaluate(() => {
-            ;(document.activeElement as HTMLElement | null)?.blur?.()
-        })
-
-        // Small delay between keys helps the sequence matcher — the two presses
-        // must arrive within its 1s window but fast enough that neither is lost.
+    test(`t ${STUB_SHORTCUT} jumps to the stub package`, async ({ page }) => {
+        // Small delay between keys helps the sequence matcher — the two
+        // presses must arrive within its 1s window but fast enough that
+        // neither is lost.
         await page.keyboard.press('t', { delay: 50 })
-        await page.keyboard.press('o', { delay: 50 })
-        await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/contacts`), { timeout: 10_000 })
-    })
-
-    test('j/k move focus and Enter opens the focused mail row', async ({ page }) => {
-        test.skip(!mailLinked, 'mail package not linked')
-        await navigateToPackage(page, 'mail')
-        await page.mouse.click(10, 10)
-        await page.waitForSelector('[data-testid="email-row"]', { timeout: 10_000 })
-
-        await page.keyboard.press('j')
-        await page.keyboard.press('j')
-        await page.keyboard.press('Enter')
-
-        await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/mail/[^/?]+`), { timeout: 5_000 })
+        await page.keyboard.press(STUB_SHORTCUT, { delay: 50 })
+        await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/${STUB_SLUG}`), { timeout: 10_000 })
     })
 })

--- a/tests/e2e/offline-overlay.spec.ts
+++ b/tests/e2e/offline-overlay.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { login } from './helpers'
+import { login, navigateToPackage } from './helpers'
 
 test.describe('Offline overlay', () => {
     test('appears when the browser goes offline and dismisses on recovery', async ({
@@ -8,15 +8,17 @@ test.describe('Offline overlay', () => {
     }) => {
         await login(page)
 
-        // After login the org-index route redirects to the first installed
-        // package's page, which lazy-loads its sidebar + screen chunks. If
-        // we go offline while those are still in flight, React.lazy
-        // surfaces a "Failed to fetch" error overlay (in dev mode) that
-        // covers our actual offline-overlay. Wait for the package's
-        // Suspense boundary to unsuspend (signalled by core's
-        // package-sidebar-mounted testID) so no chunk fetches are racing
-        // the offline toggle.
-        await page.getByTestId('package-sidebar-mounted').waitFor({ state: 'attached' })
+        // Navigate explicitly to the shortcut-stub package. Two purposes:
+        // (1) we get a stable, package-independent target that exists in
+        // both CI (where only the stub is installed) and local dev (where
+        // it lands alongside real packages). The stub is provisioned by
+        // app/tests/scripts/scaffold-shortcut-stub.ts.
+        // (2) the chunk + screen render are guaranteed to settle before
+        // we toggle offline below — otherwise React.lazy's mid-flight
+        // fetch fails when the network drops, surfacing a "Failed to
+        // fetch" dev overlay that covers the actual offline-overlay.
+        await navigateToPackage(page, 'shortcut-stub')
+        await expect(page.getByText('Shortcut stub landing')).toBeVisible()
 
         await expect(page.getByTestId('offline-overlay')).toBeHidden()
 

--- a/tests/e2e/offline-overlay.spec.ts
+++ b/tests/e2e/offline-overlay.spec.ts
@@ -8,6 +8,16 @@ test.describe('Offline overlay', () => {
     }) => {
         await login(page)
 
+        // After login the org-index route redirects to the first installed
+        // package's page, which lazy-loads its sidebar + screen chunks. If
+        // we go offline while those are still in flight, React.lazy
+        // surfaces a "Failed to fetch" error overlay (in dev mode) that
+        // covers our actual offline-overlay. Wait for the package's
+        // Suspense boundary to unsuspend (signalled by core's
+        // package-sidebar-mounted testID) so no chunk fetches are racing
+        // the offline toggle.
+        await page.getByTestId('package-sidebar-mounted').waitFor({ state: 'attached' })
+
         await expect(page.getByTestId('offline-overlay')).toBeHidden()
 
         await context.setOffline(true)

--- a/tests/scripts/scaffold-shortcut-stub.ts
+++ b/tests/scripts/scaffold-shortcut-stub.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env tsx
+/**
+ * scaffold-shortcut-stub.ts — provisions the @tinycld/shortcut-stub
+ * package into the workspace that's hosting app.
+ *
+ * Why a stub: app's keyboard-shortcut tests (open help, navigate via
+ * `t <letter>` chord) need a package installed that contributes a nav
+ * entry with a shortcut, plus a routable URL to land on. Pointing them
+ * at real packages (mail, contacts) couples app's CI to those packages'
+ * presence — when a feature's branch breaks, app's CI goes red over a
+ * bug that doesn't live in app. The stub registers a minimal package
+ * with `nav.shortcut: 'o'` and a single placeholder screen, giving the
+ * shortcut tests exactly what they need to verify app's OWN contract:
+ * "shortcut chord navigates to the package whose manifest registered it."
+ *
+ * The script is idempotent. If shortcut-stub already lives in the
+ * workspace (e.g. a developer ran tests once locally), we skip the
+ * bootstrap call and just re-emit the stub source files so iterating on
+ * them doesn't require a clean checkout.
+ *
+ * Invocation:
+ *   - CI: workflow runs `tsx app/tests/scripts/scaffold-shortcut-stub.ts`
+ *     from the workspace root after `npm install`.
+ *   - Local: developers run it once before `tinycld-pkg test:e2e`.
+ *
+ * Layout invariant: the workspace root is the parent of app/, and the
+ * script always operates on that root, NOT on cwd. Running from inside
+ * app/ or the root behaves the same.
+ *
+ * Pattern source: drive/tests/scripts/scaffold-share-stub.ts. Both
+ * scripts use bootstrap's --new --preset settings-only flow then patch
+ * the scaffolded manifest + package.json to expose exactly the surface
+ * each repo's tests need.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Slug, nav shortcut, and screen path are stable identifiers the
+// keyboard-shortcuts spec asserts on. Changing any of these requires
+// updating both this script AND tests/e2e/keyboard-shortcuts.spec.ts.
+export const STUB_SLUG = 'shortcut-stub'
+export const STUB_NAV_SHORTCUT = 'k'
+export const STUB_NAV_LABEL = 'Shortcut Stub'
+const BOOTSTRAP_VERSION = '@tinycld/bootstrap@2.0.1'
+
+function workspaceRoot(): string {
+    // app/tests/scripts/scaffold-shortcut-stub.ts → app/ → workspace root
+    return resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..')
+}
+
+function ensureBootstrapped(wsRoot: string): void {
+    const stubDir = join(wsRoot, STUB_SLUG)
+    if (existsSync(stubDir)) {
+        console.log(`[scaffold-shortcut-stub] ${STUB_SLUG}/ exists — skipping bootstrap`)
+        return
+    }
+    console.log(`[scaffold-shortcut-stub] running bootstrap to scaffold ${STUB_SLUG}/`)
+    // --no-link: bootstrap would otherwise try to assemble app+core (already
+    // present) and run npm install. The caller is responsible for the
+    // install step, so we skip both.
+    execFileSync(
+        'npx',
+        [
+            '--yes',
+            BOOTSTRAP_VERSION,
+            '--new',
+            STUB_SLUG,
+            '--yes',
+            '--preset',
+            'settings-only',
+            '--name',
+            STUB_NAV_LABEL,
+            '--description',
+            'app E2E keyboard-shortcut stub',
+            '--no-link',
+            '--target',
+            stubDir,
+        ],
+        { stdio: 'inherit', cwd: wsRoot }
+    )
+}
+
+function patchManifest(stubDir: string): void {
+    const path = join(stubDir, 'manifest.ts')
+    // Wholesale replace. The settings-only preset ships a `settings:
+    // [...]` array we don't need. We want only routes + nav with a
+    // shortcut, the minimum surface the keyboard-shortcuts spec
+    // exercises. Keeping the file shape minimal makes the test fixture
+    // legible — anyone reading app's e2e suite can see exactly what
+    // the stub contributes.
+    const contents = `const manifest = {
+    name: '${STUB_NAV_LABEL}',
+    slug: '${STUB_SLUG}',
+    version: '0.1.0',
+    description: 'app E2E keyboard-shortcut stub',
+    routes: { directory: 'screens' },
+    nav: {
+        label: '${STUB_NAV_LABEL}',
+        // Any lucide icon name in core's package-icon-map.ts works;
+        // 'users' is a safe pick that doesn't collide with the
+        // shortcut letter and ships in every workspace.
+        icon: 'users',
+        // High order so the stub sorts below real features in the rail
+        // — keeps the visible rail layout stable when both run together.
+        order: 999,
+        // 'k' is the chord letter the keyboard-shortcuts spec types
+        // (\`t k\` jumps here). Picked because no real first-party
+        // package claims 'k' as a shortcut, so locally running with
+        // contacts/mail/etc. installed alongside the stub doesn't
+        // cause a chord-binding collision. MUST stay in sync with
+        // STUB_NAV_SHORTCUT in this file AND the assertion in
+        // tests/e2e/keyboard-shortcuts.spec.ts.
+        shortcut: '${STUB_NAV_SHORTCUT}',
+    },
+}
+
+export default manifest
+`
+    writeFileSync(path, contents)
+}
+
+function patchPackageJson(stubDir: string): void {
+    const path = join(stubDir, 'package.json')
+    const pkg = JSON.parse(readFileSync(path, 'utf8'))
+    // The settings-only template's exports map doesn't include
+    // screens/* — we need it because we add a routes directory above.
+    pkg.exports = {
+        ...(pkg.exports ?? {}),
+        './screens/*': `./tinycld/${STUB_SLUG}/screens/*.tsx`,
+    }
+    writeFileSync(path, `${JSON.stringify(pkg, null, 4)}\n`)
+}
+
+function writeScreens(stubDir: string): void {
+    const dir = join(stubDir, 'tinycld', STUB_SLUG, 'screens')
+    mkdirSync(dir, { recursive: true })
+    // _layout: Expo Router requires a layout file for nested routes.
+    // Just a Slot — no chrome of our own; the app shell provides the
+    // surrounding navigation.
+    writeFileSync(
+        join(dir, '_layout.tsx'),
+        `import { Slot } from 'expo-router'
+
+export default function StubLayout() {
+    return <Slot />
+}
+`
+    )
+    // index: the landing page when the shortcut chord lands. Renders
+    // one identifiable text node the spec can assert on if needed; in
+    // practice the spec just waits for the URL change.
+    writeFileSync(
+        join(dir, 'index.tsx'),
+        `import { Text, View } from 'react-native'
+
+export default function StubIndex() {
+    return (
+        <View className="flex-1 p-4 bg-background">
+            <Text className="text-foreground" data-test-id="shortcut-stub-landing">
+                Shortcut stub landing
+            </Text>
+        </View>
+    )
+}
+`
+    )
+}
+
+function ensureMember(wsRoot: string): void {
+    const path = join(wsRoot, 'package.json')
+    const pkg = JSON.parse(readFileSync(path, 'utf8'))
+    const workspaces: string[] = Array.isArray(pkg.workspaces) ? pkg.workspaces : []
+    if (workspaces.includes(STUB_SLUG)) return
+    pkg.workspaces = [...workspaces, STUB_SLUG]
+    writeFileSync(path, `${JSON.stringify(pkg, null, 4)}\n`)
+    // npm install relinks workspaces. We piggy-back on the caller's
+    // install (CI runs npm install before invoking this script) by
+    // requiring this script to run AFTER install — but only when adding
+    // a brand-new member. The first-time scaffold path needs a second
+    // install to wire the symlink; subsequent runs are no-ops.
+    const r = spawnSync('npm', ['install'], { cwd: wsRoot, stdio: 'inherit' })
+    if (r.status !== 0) {
+        throw new Error(
+            'npm install (post-member-add) failed; the shortcut-stub symlink under node_modules may be missing'
+        )
+    }
+}
+
+function regenerateConfig(wsRoot: string): void {
+    // The generator emits app/tinycld.config.ts from getPackages() output.
+    // After adding shortcut-stub to the workspace tree we have to re-run
+    // it, otherwise the rail won't render the stub's nav entry and the
+    // shortcut binding won't be registered.
+    const r = spawnSync('npm', ['run', 'packages:generate'], {
+        cwd: join(wsRoot, 'app'),
+        stdio: 'inherit',
+    })
+    if (r.status !== 0) {
+        throw new Error('packages:generate failed; shortcut-stub will not be loaded by the app')
+    }
+}
+
+function main(): void {
+    const wsRoot = workspaceRoot()
+    console.log(`[scaffold-shortcut-stub] workspace root: ${wsRoot}`)
+
+    ensureBootstrapped(wsRoot)
+
+    const stubDir = join(wsRoot, STUB_SLUG)
+    patchManifest(stubDir)
+    patchPackageJson(stubDir)
+    writeScreens(stubDir)
+
+    ensureMember(wsRoot)
+    regenerateConfig(wsRoot)
+
+    console.log(`[scaffold-shortcut-stub] done — ${STUB_SLUG}/ ready at ${stubDir}`)
+}
+
+main()


### PR DESCRIPTION
## Summary

App was implicitly depending on every feature sibling — CI cloned all 7 features, app/package.json pinned @tinycld/contacts despite no app code importing it, and the ecosystem `npm run lint` sweep made every app PR gated on every sibling's lint cleanliness.

Five coordinated changes that together let app's CI assemble + verify ONLY app+core.

## What's in the PR

### Drop vestigial coupling

1. **`package.json`**: drop `"@tinycld/contacts": "*"` from dependencies. App's TS code never imports contacts; the pin was vestigial. Generator emits no contacts-specific routes/wiring when contacts isn't installed.

2. **`.github/workflows/ci.yml`**: drop `--with <feature>` flags from both `checks` and `go` jobs. `bootstrap --assemble-only` always clones app+core; the extras were 6 unnecessary feature clones per run. Without features installed, generator emits a minimal `package_extensions.go` / `go.work` so `go build` succeeds embedding only what's actually present.

### Add CI coverage for app's own e2e

3. **`.github/workflows/ci.yml`**: add new `e2e` job. Until now app's e2e tests (offline-overlay, signup-flow, demo-lead, help, invite-flow, keyboard-shortcuts) had **zero CI coverage** — they could only be exercised locally. The job assembles app+core, scaffolds a shortcut-stub, runs `tinycld-pkg test:e2e`, uploads playwright artifacts on failure.

### Stub package for keyboard tests

4. **`tests/scripts/scaffold-shortcut-stub.ts`** (new, ~220 lines): mirrors drive's `scaffold-share-stub` pattern. Provisions a minimal `@tinycld/shortcut-stub` package via `bootstrap --new --preset settings-only` then patches the manifest to add `nav.shortcut: 'k'` and a placeholder screen. Lets the keyboard-shortcut tests exercise the shortcut system without coupling to any real feature package.

5. **`tests/e2e/keyboard-shortcuts.spec.ts`**: rewritten to use the stub. `t k jumps to the stub package` replaces the old `t o jumps to contacts`. The `?` help-dialog test now navigates to the stub instead of mail. The j/k mail-row test moves to mail's repo (where it belongs — it's testing mail's inbox keyboard nav, not the app-shell shortcut system) — see tinycld/mail companion PR.

### Bug fixes surfaced by adding e2e to CI

6. **`tests/e2e/offline-overlay.spec.ts`**: wait for the package sidebar to mount before toggling offline. Was failing reliably because the post-login redirect lazy-loads chunks; if the network drops mid-load, React surfaces a "Failed to fetch" error overlay that covers the offline-overlay. Waiting for `package-sidebar-mounted` ensures no chunks are in flight when the offline toggle fires.

7. **`playwright.config.ts`**: set `testDir` to `tests/e2e/` specifically. Previously testDir defaulted to `app/`, which pulled in `tests/install/setup-and-packages.spec.ts` (the docker smoke test) — that spec has its OWN playwright config and asserts on `EXPECTED_BUNDLED` which would fail against the regular `expo:test` webServer.

## Validation

- **Local**: 11/11 app e2e tests pass with the scaffold step, including previously-failing offline-overlay
- `cd contacts && npx tinycld-pkg check` → green
- `cd core && npx tinycld-pkg check` → green
- The stub layout was verified by scaffolding manually and watching the generator pick it up

## Cross-repo coordination

Companion PR on **tinycld/mail** moves the `j/k focus + Enter opens row` test from app's keyboard-shortcuts.spec.ts to mail's mail-navigation.spec.ts — the test exercises mail's inbox-row keyboard nav, not the app-shell shortcut system.