### PR TITLE
test: default navigateToPackage to wait for sidebar mount

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -40,14 +40,28 @@ export async function login(page: Page) {
 // chunk downloads cleanly without contention, and the page never tears
 // down + remounts.
 //
-// Returns after the URL change is observed. Callers that need to wait
-// for a specific page element (e.g. a sidebar entry, an inbox row, a
-// button) MUST assert on it explicitly — this helper deliberately
-// doesn't wait on package-internal UI so it works for any package,
-// including ones with no sidebar.
+// `waitFor` gates the helper on a package-specific UI element that
+// proves the screen has rendered.
+//
+// Default (omitted): wait for the sidebar to mount via the
+// `package-sidebar-mounted` testID emitted by PackageSidebar.tsx
+// inside its Suspense boundary. This is the common case — most
+// packages contribute a sidebar (mail, contacts, calendar, drive),
+// and waiting for the lazy chunk to actually unsuspend is what tests
+// usually need.
+//
+// Packages WITHOUT a sidebar (text, calc, the shortcut-stub fixture)
+// must pass an explicit `waitFor: '<text>'` since the testID will
+// never appear. The same override is useful when the test needs to
+// gate on a specific screen element rather than just the sidebar
+// shell (e.g. `waitFor: 'Compose'` for mail).
 //
 // `pkg` is the lowercase slug (mail, calendar, drive, ...).
-export async function navigateToPackage(page: Page, pkg: string) {
+export async function navigateToPackage(
+    page: Page,
+    pkg: string,
+    options?: { waitFor?: string }
+) {
     // Match by URL prefix rather than exact href: some packages (calc,
     // text, …) rewrite their rail link to deep-link the user's last
     // visited file (e.g. /a/<org>/calc/<id>), so the rail anchor no
@@ -58,6 +72,14 @@ export async function navigateToPackage(page: Page, pkg: string) {
     await railLink.waitFor({ state: 'visible' })
     await railLink.click()
     await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/${pkg}(/|$|\\?)`))
+    if (options?.waitFor) {
+        await page
+            .getByText(options.waitFor, { exact: true })
+            .first()
+            .waitFor({ state: 'visible' })
+    } else {
+        await page.getByTestId('package-sidebar-mounted').waitFor({ state: 'visible' })
+    }
 }
 
 export async function clickSidebarItem(page: Page, label: string) {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 export const ORG_SLUG = 'test-org'
 export const TEST_USER_EMAIL = process.env.TEST_USER_LOGIN || 'user@tinycld.org'
@@ -40,24 +40,31 @@ export async function login(page: Page) {
 // chunk downloads cleanly without contention, and the page never tears
 // down + remounts.
 //
-// `waitFor` gates the helper on a package-specific UI element that
-// proves the screen has rendered.
+// `waitFor` gates the helper on a Locator that proves the package's
+// screen has rendered before returning.
 //
-// Default (omitted): wait for the sidebar to mount via the
-// `package-sidebar-mounted` testID emitted by PackageSidebar.tsx
-// inside its Suspense boundary. This is the common case — most
-// packages contribute a sidebar (mail, contacts, calendar, drive),
-// and waiting for the lazy chunk to actually unsuspend is what tests
-// usually need.
+// Default (omitted): waits for the sidebar to mount via the
+// `package-sidebar-mounted` testID PackageSidebar.tsx emits inside
+// its Suspense boundary. This is the common case — most packages
+// contribute a sidebar (mail, contacts, calendar, drive), and the
+// lazy sidebar chunk unsuspending is what tests need to wait on.
 //
 // Packages WITHOUT a sidebar (text, calc, the shortcut-stub fixture)
-// must pass an explicit `waitFor: '<text>'` since the testID will
-// never appear. The same override is useful when the test needs to
-// gate on a specific screen element rather than just the sidebar
-// shell (e.g. `waitFor: 'Compose'` for mail).
+// must pass an explicit Locator since the default testID will never
+// appear. Same applies when the test needs to gate on a specific
+// screen element instead of just the sidebar shell:
+//
+//     await navigateToPackage(page, 'mail', {
+//         waitFor: page.getByRole('button', { name: 'Compose' }),
+//     })
+//
+// Accepts any Playwright `Locator` (`page.getByRole(...)`,
+// `page.getByTestId(...)`, `page.getByText(...).first()`, …) and
+// forwards to the same `locator.waitFor({ state: 'visible' })`
+// callers would write by hand.
 //
 // `pkg` is the lowercase slug (mail, calendar, drive, ...).
-export async function navigateToPackage(page: Page, pkg: string, options?: { waitFor?: string }) {
+export async function navigateToPackage(page: Page, pkg: string, options?: { waitFor?: Locator }) {
     // Match by URL prefix rather than exact href: some packages (calc,
     // text, …) rewrite their rail link to deep-link the user's last
     // visited file (e.g. /a/<org>/calc/<id>), so the rail anchor no
@@ -68,11 +75,8 @@ export async function navigateToPackage(page: Page, pkg: string, options?: { wai
     await railLink.waitFor({ state: 'visible' })
     await railLink.click()
     await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/${pkg}(/|$|\\?)`))
-    if (options?.waitFor) {
-        await page.getByText(options.waitFor, { exact: true }).first().waitFor({ state: 'visible' })
-    } else {
-        await page.getByTestId('package-sidebar-mounted').waitFor({ state: 'visible' })
-    }
+    const target = options?.waitFor ?? page.getByTestId('package-sidebar-mounted')
+    await target.waitFor({ state: 'visible' })
 }
 
 export async function clickSidebarItem(page: Page, label: string) {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -57,11 +57,7 @@ export async function login(page: Page) {
 // shell (e.g. `waitFor: 'Compose'` for mail).
 //
 // `pkg` is the lowercase slug (mail, calendar, drive, ...).
-export async function navigateToPackage(
-    page: Page,
-    pkg: string,
-    options?: { waitFor?: string }
-) {
+export async function navigateToPackage(page: Page, pkg: string, options?: { waitFor?: string }) {
     // Match by URL prefix rather than exact href: some packages (calc,
     // text, …) rewrite their rail link to deep-link the user's last
     // visited file (e.g. /a/<org>/calc/<id>), so the rail anchor no
@@ -73,10 +69,7 @@ export async function navigateToPackage(
     await railLink.click()
     await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/${pkg}(/|$|\\?)`))
     if (options?.waitFor) {
-        await page
-            .getByText(options.waitFor, { exact: true })
-            .first()
-            .waitFor({ state: 'visible' })
+        await page.getByText(options.waitFor, { exact: true }).first().waitFor({ state: 'visible' })
     } else {
         await page.getByTestId('package-sidebar-mounted').waitFor({ state: 'visible' })
     }

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -25,7 +25,9 @@ test.describe('Keyboard shortcuts', () => {
         // helper's default sidebar gate would hang. Waiting on the
         // landing text also confirms the stub's lazy chunk has
         // mounted before we start typing shortcuts.
-        await navigateToPackage(page, STUB_SLUG, { waitFor: 'Shortcut stub landing' })
+        await navigateToPackage(page, STUB_SLUG, {
+            waitFor: page.getByText('Shortcut stub landing', { exact: true }),
+        })
         await expect(page.getByRole('link', { name: STUB_NAV_LABEL, exact: true })).toBeVisible({
             timeout: 10_000,
         })

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -21,10 +21,11 @@ const STUB_SHORTCUT = 'k'
 test.describe('Keyboard shortcuts', () => {
     test.beforeEach(async ({ page }) => {
         await login(page)
-        await navigateToPackage(page, STUB_SLUG)
-        // Wait for the rail's stub entry to render so the shortcut
-        // provider has mounted and tinykeys has bound its listeners
-        // before we start typing.
+        // The stub has no sidebar, so pass an explicit waitFor — the
+        // helper's default sidebar gate would hang. Waiting on the
+        // landing text also confirms the stub's lazy chunk has
+        // mounted before we start typing shortcuts.
+        await navigateToPackage(page, STUB_SLUG, { waitFor: 'Shortcut stub landing' })
         await expect(page.getByRole('link', { name: STUB_NAV_LABEL, exact: true })).toBeVisible({
             timeout: 10_000,
         })

--- a/tests/e2e/offline-overlay.spec.ts
+++ b/tests/e2e/offline-overlay.spec.ts
@@ -13,13 +13,14 @@ test.describe('Offline overlay', () => {
         // both CI (where only the stub is installed) and local dev (where
         // it lands alongside real packages). The stub is provisioned by
         // app/tests/scripts/scaffold-shortcut-stub.ts.
-        // (2) waitFor: 'Shortcut stub landing' makes the helper wait
-        // until the stub's screen has rendered, guaranteeing no chunk
-        // fetches are in flight when we toggle offline below —
-        // otherwise React.lazy's mid-flight fetch fails when the network
-        // drops, surfacing a "Failed to fetch" dev overlay that covers
-        // the actual offline-overlay.
-        await navigateToPackage(page, 'shortcut-stub', { waitFor: 'Shortcut stub landing' })
+        // (2) the explicit waitFor on the landing text guarantees the
+        // stub's lazy chunk has settled before we toggle offline below
+        // — otherwise React.lazy's mid-flight fetch fails when the
+        // network drops, surfacing a "Failed to fetch" dev overlay
+        // that covers the actual offline-overlay.
+        await navigateToPackage(page, 'shortcut-stub', {
+            waitFor: page.getByText('Shortcut stub landing', { exact: true }),
+        })
 
         await expect(page.getByTestId('offline-overlay')).toBeHidden()
 

--- a/tests/e2e/offline-overlay.spec.ts
+++ b/tests/e2e/offline-overlay.spec.ts
@@ -13,12 +13,13 @@ test.describe('Offline overlay', () => {
         // both CI (where only the stub is installed) and local dev (where
         // it lands alongside real packages). The stub is provisioned by
         // app/tests/scripts/scaffold-shortcut-stub.ts.
-        // (2) the chunk + screen render are guaranteed to settle before
-        // we toggle offline below — otherwise React.lazy's mid-flight
-        // fetch fails when the network drops, surfacing a "Failed to
-        // fetch" dev overlay that covers the actual offline-overlay.
-        await navigateToPackage(page, 'shortcut-stub')
-        await expect(page.getByText('Shortcut stub landing')).toBeVisible()
+        // (2) waitFor: 'Shortcut stub landing' makes the helper wait
+        // until the stub's screen has rendered, guaranteeing no chunk
+        // fetches are in flight when we toggle offline below —
+        // otherwise React.lazy's mid-flight fetch fails when the network
+        // drops, surfacing a "Failed to fetch" dev overlay that covers
+        // the actual offline-overlay.
+        await navigateToPackage(page, 'shortcut-stub', { waitFor: 'Shortcut stub landing' })
 
         await expect(page.getByTestId('offline-overlay')).toBeHidden()
 


### PR DESCRIPTION
## Summary
- Default `navigateToPackage` to wait for the lazy sidebar chunk to unsuspend (via the `package-sidebar-mounted` testID PackageSidebar.tsx already emits inside its Suspense boundary).
- Sidebar-less packages (text, calc, the shortcut-stub fixture) opt out by passing an explicit `waitFor: '<text>'`.
- Convert offline-overlay's stub navigation to the new override; it now reads `navigateToPackage(page, 'shortcut-stub', { waitFor: 'Shortcut stub landing' })`.

## Why
After app#12, the helper deliberately did NOT wait on any package-internal UI so it would work with sidebar-less packages. But most callers DO have a sidebar and need it mounted before interacting — they were each having to add their own settle wait, and forgetting to caused flakes (mail#3 is the live example). Flipping the default puts the common case in the helper and keeps the override for the minority case.

## Test plan
- [x] biome check on the two changed files
- [ ] CI green on this PR (app's e2e job covers the offline-overlay test)
- [ ] Once merged, mail#3 should turn green without further test changes (mail tests stop needing per-test sidebar waits)