### PR TITLE
style(app): fix biome formatting in OrgTitle

### DIFF
--- a/app/a/[orgSlug]/_layout.tsx
+++ b/app/a/[orgSlug]/_layout.tsx
@@ -60,7 +60,7 @@ function OrgLayoutInner() {
 
 function OrgTitle() {
     const { org } = useOrgInfo()
-    const title = org ? `TinyCld – ${org.name}` : "TinyCld";
+    const title = org ? `TinyCld – ${org.name}` : 'TinyCld'
     return (
         <Head>
             <title>{title}</title>


### PR DESCRIPTION
## Summary
- Single-quote + drop trailing semicolon on `OrgTitle`'s `title` string. Matches `biome.json` (single quotes, no superfluous semicolons).

## Why
CI's lint job has been failing on origin/main since PR#5 merged — this line is the only formatting violation. Blocking every downstream PR (#13, all feature PRs that rebase). One-liner unblocks the queue.

## Test plan
- [x] `npx biome check app/a/[orgSlug]/_layout.tsx` clean locally
- [ ] CI green