### PR TITLE
feat(app): wire per-screen web tab titles via DocumentTitle

### DIFF
--- a/app/a/[orgSlug]/_layout.tsx
+++ b/app/a/[orgSlug]/_layout.tsx
@@ -1,5 +1,6 @@
 import { DemoFollowUpModal } from '@tinycld/core/components/DemoFollowUpModal'
 import { DemoIntroModal } from '@tinycld/core/components/DemoIntroModal'
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { HelpDrawer } from '@tinycld/core/components/help/HelpDrawer'
 import { HelpSearchPalette } from '@tinycld/core/components/help/HelpSearchPalette'
 import { NotifyContextSync } from '@tinycld/core/components/NotifyContextSync'
@@ -13,7 +14,6 @@ import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useOrgInfo } from '@tinycld/core/lib/use-org-info'
 import { OrgSlugProvider } from '@tinycld/core/lib/use-org-slug'
 import { useGlobalSearchParams, usePathname } from 'expo-router'
-import Head from 'expo-router/head'
 import { useEffect } from 'react'
 
 export default function OrgLayout() {
@@ -29,6 +29,7 @@ export default function OrgLayout() {
 function OrgLayoutInner() {
     const auth = useAuth({ throwIfAnon: false })
     const isReady = !auth.isInitializing && auth.isLoggedIn
+    const { org } = useOrgInfo()
     // Bind ⌘/ globally so the help palette is reachable from any
     // org-scoped screen — not just package detail screens. The hook
     // is a no-op on native.
@@ -45,7 +46,7 @@ function OrgLayoutInner() {
 
     return (
         <>
-            <OrgTitle />
+            <DocumentTitle title={org?.name} includeOrg={false} />
             <ActivePkgSync />
             <ImportNotifier />
             <NotifyContextSync />
@@ -55,16 +56,6 @@ function OrgLayoutInner() {
             <HelpDrawer />
             <HelpSearchPalette />
         </>
-    )
-}
-
-function OrgTitle() {
-    const { org } = useOrgInfo()
-    const title = org ? `TinyCld – ${org.name}` : 'TinyCld'
-    return (
-        <Head>
-            <title>{title}</title>
-        </Head>
     )
 }
 

--- a/app/a/[orgSlug]/help/[pkg]/[topic].tsx
+++ b/app/a/[orgSlug]/help/[pkg]/[topic].tsx
@@ -1,3 +1,4 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { HelpTopicView } from '@tinycld/core/components/help/HelpTopicView'
 import type { HelpTopicId } from '@tinycld/core/lib/help/types'
 import { useHelpTopic } from '@tinycld/core/lib/help/use-help-topics'
@@ -12,6 +13,7 @@ export default function HelpTopicPermalink() {
     if (!helpTopic) {
         return (
             <View className="flex-1 bg-background p-5">
+                <DocumentTitle pkg="Help" />
                 <Text className="text-foreground text-2xl font-bold mb-2">Topic not found</Text>
                 <Text className="text-muted-foreground text-sm">
                     The help topic "{id}" is not installed.
@@ -22,6 +24,7 @@ export default function HelpTopicPermalink() {
 
     return (
         <ScrollView className="flex-1 bg-background" contentContainerStyle={{ flexGrow: 1 }}>
+            <DocumentTitle pkg="Help" title={helpTopic.title} />
             <View className="p-5 max-w-[720px] w-full">
                 <HelpTopicView topic={helpTopic} />
             </View>

--- a/app/a/[orgSlug]/help/[pkg]/index.tsx
+++ b/app/a/[orgSlug]/help/[pkg]/index.tsx
@@ -1,3 +1,4 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { useHelpGroupForPackage } from '@tinycld/core/lib/help/use-help-topics'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
@@ -15,6 +16,7 @@ export default function PackageHelpIndex() {
     if (!group) {
         return (
             <View className="flex-1 bg-background p-5">
+                <DocumentTitle pkg="Help" />
                 <Text className="text-foreground text-2xl font-bold mb-2">Help not available</Text>
                 <Text className="text-muted-foreground text-sm">
                     No help topics are installed for "{pkg}".
@@ -25,6 +27,7 @@ export default function PackageHelpIndex() {
 
     return (
         <ScrollView className="flex-1 bg-background" contentContainerStyle={{ flexGrow: 1 }}>
+            <DocumentTitle pkg="Help" title={group.packageName} />
             <View className="p-5 max-w-[720px] w-full">
                 <Text className="mb-4 text-foreground text-[28px] font-bold">
                     {group.packageName} help

--- a/app/a/[orgSlug]/help/index.tsx
+++ b/app/a/[orgSlug]/help/index.tsx
@@ -1,3 +1,4 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { searchHelpTopics } from '@tinycld/core/lib/help/search'
 import type { HelpTopicId } from '@tinycld/core/lib/help/types'
 import { useHelpGroups, useHelpTopics } from '@tinycld/core/lib/help/use-help-topics'
@@ -35,6 +36,7 @@ export default function HelpHub() {
 
     return (
         <ScrollView className="flex-1 bg-background" contentContainerStyle={{ flexGrow: 1 }}>
+            <DocumentTitle pkg="Help" />
             <View className="p-5 max-w-[720px] w-full">
                 <Text className="mb-4 text-foreground text-[28px] font-bold">Help</Text>
 

--- a/app/a/[orgSlug]/settings/_layout.tsx
+++ b/app/a/[orgSlug]/settings/_layout.tsx
@@ -1,5 +1,11 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { Slot } from 'expo-router'
 
 export default function SettingsLayout() {
-    return <Slot />
+    return (
+        <>
+            <DocumentTitle pkg="Settings" />
+            <Slot />
+        </>
+    )
 }

--- a/app/a/[orgSlug]/settings/audit-log.tsx
+++ b/app/a/[orgSlug]/settings/audit-log.tsx
@@ -1,4 +1,5 @@
 import { and, eq } from '@tanstack/db'
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import { useStore } from '@tinycld/core/lib/pocketbase'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
@@ -49,6 +50,7 @@ export default function AuditLogSettings() {
     if (!isAdmin) {
         return (
             <View className="flex-1 p-5 items-center justify-center bg-background">
+                <DocumentTitle pkg="Settings" title="Audit log" />
                 <Text className="text-muted-foreground text-base">
                     Only admins can view audit logs.
                 </Text>
@@ -58,6 +60,7 @@ export default function AuditLogSettings() {
 
     return (
         <ScrollView contentContainerStyle={{ flexGrow: 1 }} className="bg-background">
+            <DocumentTitle pkg="Settings" title="Audit log" />
             <View className="flex-1 p-5 max-w-[700px]">
                 <View className="flex-row gap-3 items-center mb-5">
                     <Pressable onPress={navigateBack}>

--- a/app/a/[orgSlug]/settings/labels.tsx
+++ b/app/a/[orgSlug]/settings/labels.tsx
@@ -1,3 +1,4 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { LabelManagerPanel } from '@tinycld/core/components/LabelManagerDialog'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
@@ -12,6 +13,7 @@ export default function LabelsSettings() {
 
     return (
         <View className="flex-1 bg-background">
+            <DocumentTitle pkg="Settings" title="Labels" />
             <View className="flex-row gap-3 items-center p-5 pb-0">
                 <Pressable onPress={navigateBack}>
                     <ArrowLeft size={24} color={fgColor} />

--- a/app/a/[orgSlug]/settings/members.tsx
+++ b/app/a/[orgSlug]/settings/members.tsx
@@ -1,4 +1,5 @@
 import { eq } from '@tanstack/db'
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { MemberAvatar } from '@tinycld/core/components/settings/members/MemberAvatar'
 import {
     PendingBadge,
@@ -122,6 +123,7 @@ export default function MembersSettings() {
     if (!isAdmin) {
         return (
             <View className="flex-1 items-center justify-center p-5 bg-background">
+                <DocumentTitle pkg="Settings" title="Members" />
                 <View
                     className="items-center gap-3 rounded-xl bg-surface-secondary border border-border"
                     style={{
@@ -155,6 +157,7 @@ export default function MembersSettings() {
 
     return (
         <>
+            <DocumentTitle pkg="Settings" title="Members" />
             <ScrollView contentContainerStyle={{ flexGrow: 1 }} className="bg-background">
                 <View className="flex-1 gap-6 p-5" style={{ maxWidth: 820 }}>
                     <View className="flex-row items-center gap-3">

--- a/app/a/[orgSlug]/settings/organization.tsx
+++ b/app/a/[orgSlug]/settings/organization.tsx
@@ -1,5 +1,6 @@
 import { eq } from '@tanstack/db'
 import { useQuery, useQueryClient, useMutation as useRawMutation } from '@tanstack/react-query'
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { OrgLogo } from '@tinycld/core/components/OrgLogo'
 import { handleMutationErrorsWithForm } from '@tinycld/core/lib/errors'
 import { formatBytes } from '@tinycld/core/lib/format-utils'
@@ -106,6 +107,7 @@ export default function OrganizationSettings() {
     if (!isAdmin) {
         return (
             <View className="flex-1 p-5 items-center justify-center bg-background">
+                <DocumentTitle pkg="Settings" title="Organization" />
                 <Text className="text-muted-foreground" style={{ fontSize: 16 }}>
                     Only admins can manage organization settings.
                 </Text>
@@ -115,6 +117,7 @@ export default function OrganizationSettings() {
 
     return (
         <ScrollView contentContainerStyle={{ flexGrow: 1 }} className="bg-background">
+            <DocumentTitle pkg="Settings" title="Organization" />
             <View className="flex-1 p-5 max-w-[600px]">
                 <View className="flex-row justify-between items-center mb-5">
                     <View className="flex-row gap-3 items-center">

--- a/app/a/[orgSlug]/settings/packages.tsx
+++ b/app/a/[orgSlug]/settings/packages.tsx
@@ -1,5 +1,6 @@
 import { eq } from '@tanstack/db'
 import { useLiveQuery } from '@tanstack/react-db'
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { getIcon } from '@tinycld/core/components/workspace/package-icon-map'
 import { captureException } from '@tinycld/core/lib/errors'
 import { mutation, useMutation } from '@tinycld/core/lib/mutations'
@@ -18,6 +19,7 @@ export default function OrgPackageSettings() {
     if (!isAdmin) {
         return (
             <View className="flex-1 p-5 items-center justify-center bg-background">
+                <DocumentTitle pkg="Settings" title="Packages" />
                 <Text className="text-muted-foreground text-base">
                     Only admins can manage packages.
                 </Text>
@@ -27,6 +29,7 @@ export default function OrgPackageSettings() {
 
     return (
         <ScrollView className="flex-1 bg-background" contentContainerStyle={{ flexGrow: 1 }}>
+            <DocumentTitle pkg="Settings" title="Packages" />
             <View className="p-5 max-w-[600px] w-full gap-4">
                 <Text className="text-foreground text-[22px] font-bold">Packages</Text>
                 <Text className="text-muted-foreground text-sm">

--- a/app/a/[orgSlug]/settings/personal.tsx
+++ b/app/a/[orgSlug]/settings/personal.tsx
@@ -1,3 +1,4 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { DragHandle } from '@tinycld/core/components/DragHandle'
 import { AboutSection } from '@tinycld/core/components/settings/AboutSection'
 import { DeleteAccountSection } from '@tinycld/core/components/settings/DeleteAccountSection'
@@ -54,6 +55,7 @@ export default function PersonalSettings() {
 
     return (
         <GestureHandlerRootView className="flex-1">
+            <DocumentTitle pkg="Settings" title="Personal" />
             <ScrollView className="flex-1 bg-background" contentContainerStyle={{ flexGrow: 1 }}>
                 <View className="p-5 max-w-[600px] gap-6">
                     <View className="flex-row gap-3 items-center">

--- a/app/accept-invite/[token].tsx
+++ b/app/accept-invite/[token].tsx
@@ -1,3 +1,4 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { PB_SERVER_ADDR } from '@tinycld/core/lib/config'
 import { captureException } from '@tinycld/core/lib/errors'
 import { pb } from '@tinycld/core/lib/pocketbase'
@@ -72,6 +73,7 @@ export default function AcceptInvite() {
 
     return (
         <View className="flex-1 items-center justify-center p-5 bg-background">
+            <DocumentTitle title="Accept invite" includeOrg={false} />
             {loadState.status === 'loading' && <LoadingCard />}
             {loadState.status === 'invalid' && <InvalidCard message={loadState.message} />}
             {loadState.status === 'ready' && <AcceptForm token={token} info={loadState.info} />}

--- a/app/connect.tsx
+++ b/app/connect.tsx
@@ -1,4 +1,5 @@
 import { ConnectIllustration } from '@tinycld/core/components/connect/ConnectIllustration'
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
 import {
     normalizeAddress,
@@ -97,6 +98,7 @@ export default function Connect() {
 
     return (
         <SafeAreaView className="flex-1 bg-background" edges={['top', 'bottom']}>
+            <DocumentTitle title="Connect" includeOrg={false} />
             <ScrollView
                 contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 28, paddingBottom: 32 }}
                 showsVerticalScrollIndicator={false}

--- a/app/connect.web.tsx
+++ b/app/connect.web.tsx
@@ -1,4 +1,5 @@
 import { ConnectIllustration } from '@tinycld/core/components/connect/ConnectIllustration'
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
 import {
     normalizeAddress,
@@ -86,6 +87,7 @@ export default function ConnectWeb() {
                 padding: 32,
             }}
         >
+            <DocumentTitle title="Connect" includeOrg={false} />
             <View
                 className="w-full rounded-[20px] bg-surface border border-border overflow-hidden flex-row flex-wrap"
                 style={{ maxWidth: 880 }}

--- a/app/setup.tsx
+++ b/app/setup.tsx
@@ -1,7 +1,13 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { SetupPage } from '@tinycld/core/components/setup/SetupPage'
 import { useLocalSearchParams } from 'expo-router'
 
 export default function Setup() {
     const { token } = useLocalSearchParams<{ token?: string }>()
-    return <SetupPage token={token} />
+    return (
+        <>
+            <DocumentTitle title="Setup" includeOrg={false} />
+            <SetupPage token={token} />
+        </>
+    )
 }

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -1,10 +1,15 @@
 import type { CoreConfig } from '@tinycld/core'
+import Constants from 'expo-constants'
 
 // Minimal app config for the ./new dev app. Web resolves the PB address from
 // the page origin (the dev proxy / app server routes /api to PocketBase
 // same-origin). Sentry/review-mode/demo are intentionally omitted for the spike.
+//
+// brandName flows from app.json's expo.name so a fork rebrands by editing
+// app.json alone. The fallback covers the rare case Constants.expoConfig is
+// unavailable (e.g. some unit-test environments).
 export const appConfig: CoreConfig = {
-    brandName: 'TinyCld',
+    brandName: Constants.expoConfig?.name ?? 'TinyCld',
     serverShortcuts: {},
     webShortcut: () => (typeof window !== 'undefined' ? window.location.origin : null),
     defaultServer: 'http://localhost:7100',

--- a/tests/e2e/document-title.spec.ts
+++ b/tests/e2e/document-title.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+import { login, ORG_SLUG } from './helpers'
+
+// Covers the DocumentTitle component's compositional behavior:
+//   - pre-auth screens compose brand + leaf, suppressing the org segment
+//   - the org layout's title shows through to package screens that
+//     haven't mounted their own DocumentTitle yet
+//   - the settings layout fallback fires when no settings child is mounted
+//   - a settings child wins over the layout fallback (react-helmet-async
+//     last-mount-wins ordering)
+//   - pkg-only mounts compose brand + org + pkg with no leaf
+test.describe('Document title', () => {
+    test('pre-auth /connect shows brand + leaf only, no org segment', async ({ page }) => {
+        await page.goto('/connect')
+        await expect(page).toHaveTitle('TinyCld: Connect')
+    })
+
+    test('settings layout fallback wins on bare /settings', async ({ page }) => {
+        await login(page)
+        await page.goto(`/a/${ORG_SLUG}/settings`)
+        // The settings index.tsx doesn't mount its own DocumentTitle, so
+        // only the layout's <DocumentTitle pkg="Settings" /> is active.
+        await expect(page).toHaveTitle('TinyCld: Test Organization — Settings')
+    })
+
+    test('settings child overrides the layout fallback', async ({ page }) => {
+        await login(page)
+        await page.goto(`/a/${ORG_SLUG}/settings/personal`)
+        // Both the layout (pkg="Settings") and the child
+        // (pkg="Settings" title="Personal") mount; child wins per
+        // react-helmet-async ordering, producing the more-specific title.
+        await expect(page).toHaveTitle('TinyCld: Test Organization — Settings — Personal')
+    })
+
+    test('help hub uses pkg without a leaf', async ({ page }) => {
+        await login(page)
+        await page.goto(`/a/${ORG_SLUG}/help`)
+        await expect(page).toHaveTitle('TinyCld: Test Organization — Help')
+    })
+})


### PR DESCRIPTION
## Summary

Extends [#5](https://github.com/tinycld/app/pull/5) to **every screen** in the app and unifies the title mechanism behind a single composable component.

PR #5 set the org-layout tab title via `<Head>` (rendering `TinyCld – {org.name}`). This PR finishes the job by:

- Replacing the inline `<OrgTitle>`/`<Head>` from #5 with the new `DocumentTitle` component (from [tinycld/core#15](https://github.com/tinycld/core/pull/15)). The component composes the tab from three optional segments: `TinyCld: <org> — <pkg> — <title>`, with empty segments dropped.
- Wiring `<DocumentTitle>` into the 14 shell + pre-auth screens that #5 didn't touch — connect, connect.web, setup, accept-invite, settings/{audit-log, labels, members, organization, packages, personal} + the `_layout` fallback, help/{index, [pkg]/index, [pkg]/[topic]}.
- Adding `tests/e2e/document-title.spec.ts` (4 tests) to lock in the composition rules.

### Why segments instead of a single string

A single string prop (`title="Mail — Inbox"`) works in isolation but loses the org name on every per-screen mount (last-mount-wins in `react-helmet-async`). With segmented composition, a user with multiple orgs in multiple tabs can disambiguate them — `TinyCld: Acme — Mail` vs `TinyCld: Globex — Mail` — instead of two identical `TinyCld: Mail` tabs.

### Tab titles after this PR

| Route | Tab title |
|---|---|
| `/connect` | `TinyCld: Connect` (no org segment — pre-auth) |
| `/setup` | `TinyCld: Setup` |
| `/accept-invite/<token>` | `TinyCld: Accept invite` |
| `/a/<org>` (no child) | `TinyCld: Acme` (the org name IS the leaf) |
| `/a/<org>/settings` | `TinyCld: Acme — Settings` |
| `/a/<org>/settings/personal` | `TinyCld: Acme — Settings — Personal` |
| `/a/<org>/help` | `TinyCld: Acme — Help` |
| `/a/<org>/help/mail` | `TinyCld: Acme — Help — Mail` |
| `/a/<org>/help/mail/keyboard-shortcuts` | `TinyCld: Acme — Help — Keyboard shortcuts` |

### Brand prefix from app.json

`app/lib/app-config.ts` previously hardcoded `brandName: 'TinyCld'`. Now it reads `Constants.expoConfig?.name ?? 'TinyCld'`, so the brand-name source-of-truth is `app.json`'s `expo.name`. A fork rebrands by editing `app.json` alone. The `'TinyCld'` fallback is a guard for test environments where `Constants` isn't wired.

### Known interaction with feature packages

Some feature-package screens (mail, contacts, text) currently use the older `useDocumentTitle` hook to set their own titles. On web, the hook and `<DocumentTitle>` both write to `document.title`, so when a user navigates to e.g. `/a/<org>/mail/<id>`, mail's hook wins — the tab reads `TinyCld: Mail — Re: subject` (no org segment) instead of `TinyCld: Acme — Mail — Re: subject`. This will be resolved in follow-up per-package PRs that migrate those screens to `<DocumentTitle pkg="Mail" title={subject} />`. The org-layout title from this PR is still set; it's just overridden on the package screen by the package's own hook call. Nothing breaks; the tab just doesn't gain the org segment until the package migrates.

## Depends on

- [tinycld/core#15](https://github.com/tinycld/core/pull/15) — the `DocumentTitle` component this PR imports. Must land + publish first.

## Test plan

- [x] `npx tinycld-pkg check` passes locally (96 files lint-clean, typecheck clean, 3/3 unit tests pass)
- [x] `npx tinycld-pkg test:e2e document-title.spec.ts` passes locally (4/4)
- [x] Full e2e suite `npx tinycld-pkg test:e2e` passes locally (15/15)
- [ ] Walk every covered screen on web in a dev build; confirm tab titles match the table above
- [ ] On iOS device, navigate between screens; confirm no crash from `<Head>` mount/unmount
- [ ] On Android device, same; `<Head>` is a no-op so nothing visible should change