### PR TITLE
fix(vitest): stub expo-router/head so packages importing DocumentTitle build

### DIFF
--- a/tests/expo-router-head-stub.ts
+++ b/tests/expo-router-head-stub.ts
@@ -1,0 +1,9 @@
+// Test-only stub for expo-router/head. The real module re-exports
+// react-helmet-async whose CJS entry contains JSX that Vite's SSR node
+// environment cannot parse. Unit tests don't observe document.title
+// effects; this stub renders nothing and exposes the `default export`
+// shape (the Head component) that callers consume.
+
+const Head = (_props: { children?: unknown }) => null
+
+export default Head

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,6 +46,13 @@ export default defineConfig({
                 find: /^expo-router$/,
                 replacement: path.join(APP_DIR, 'tests', 'expo-router-stub.ts'),
             },
+            // expo-router/head re-exports react-helmet-async whose CJS entry
+            // contains JSX that Vite cannot parse. Unit tests don't observe
+            // document.title side-effects; stub Head to a no-op renderer.
+            {
+                find: /^expo-router\/head$/,
+                replacement: path.join(APP_DIR, 'tests', 'expo-router-head-stub.ts'),
+            },
             // lucide-react-native v1.16+ individual icon .mjs files contain
             // Flow-style `typeof` syntax that Vite cannot parse. Stub the whole
             // package so unit tests that transitively import icons don't crash.


### PR DESCRIPTION
## Summary

After [tinycld/core#15](https://github.com/tinycld/core/pull/15) landed the `DocumentTitle` component, any package that imports it and reaches the import from a unit-test code path crashes during vitest module loading:

\`\`\`
Failed to parse source for import analysis because the content contains invalid JS syntax.
File: node_modules/expo-router/build/head/ExpoHead.js
      return <lib_1.Helmet>{children}</lib_1.Helmet>;
\`\`\`

\`expo-router/head\`'s web build re-exports react-helmet-async with raw JSX in the CJS entry. Vite's node environment can't parse it. Same class of issue as \`expo-router\` itself (already stubbed) and the other RN-only modules in \`vitest.config\` aliases.

Adds an \`expo-router-head-stub.ts\` that renders nothing and exposes the default-export \`Head\` component shape callers consume; aliases \`expo-router/head\` to it.

Unblocks the per-package \`DocumentTitle\` wiring PRs (text, calc, drive, calendar, mail, contacts).

## Test plan

- [x] \`npx tinycld-pkg check\` in app passes locally (3/3 unit tests)
- [ ] After merge, per-package PRs that import \`DocumentTitle\` from \`@tinycld/core/components/DocumentTitle\` build cleanly in vitest