### PR TITLE
feat(app): "Report an issue" card on per-package help screen

### DIFF
--- a/app/a/[orgSlug]/help/[pkg]/index.tsx
+++ b/app/a/[orgSlug]/help/[pkg]/index.tsx
@@ -1,4 +1,5 @@
 import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
+import { ReportIssueRow } from '@tinycld/core/components/help/ReportIssueRow'
 import { useHelpGroupForPackage } from '@tinycld/core/lib/help/use-help-topics'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
@@ -56,6 +57,9 @@ export default function PackageHelpIndex() {
                             <ChevronRight size={18} color={mutedColor} />
                         </Pressable>
                     ))}
+                </View>
+                <View className="mt-4 rounded-xl border overflow-hidden bg-surface-secondary border-border">
+                    <ReportIssueRow pkgSlug={group.pkgSlug} />
                 </View>
             </View>
         </ScrollView>

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -29,6 +29,7 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
             ...(manifest.nav ? { nav: manifest.nav } : {}),
             ...(manifest.routes ? { routes: manifest.routes } : {}),
             ...(manifest.publicRoutes ? { publicRoutes: manifest.publicRoutes } : {}),
+            ...(manifest.repository ? { repository: manifest.repository } : {}),
             ...(manifest.dependencies ? { dependencies: manifest.dependencies } : {}),
         },
     }

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -21,6 +21,7 @@ export interface PackageManifest {
     build?: { script: string }
     server?: { package: string; module: string }
     help?: { directory: string }
+    repository?: { url: string; issueTemplate?: string }
     dependencies?: string[]
 }
 


### PR DESCRIPTION
## Summary

- Plumb manifest's new \`repository?: { url; issueTemplate? }\` field through \`load-manifest.ts\` + \`describe-packages.ts\` so it lands in \`tinycld.config.ts\` and reaches the runtime registry.
- Add a second card under the topics card on the per-package help screen (\`/a/[orgSlug]/help/[pkg]\`) containing core's new \`ReportIssueRow\`. Renders nothing when the package's manifest has no \`repository.url\` (graceful for third-party packages and core).

Depends on tinycld/core#18 (the schema field, helper, and row component).

## Test plan

- [x] \`npm run packages:generate\` regenerates \`tinycld.config.ts\` cleanly
- [x] \`npm run checks\` (lint + typecheck) green
- [ ] Manual: after the first feature package adopts the field (calc PR next), navigate to \`/a/<org>/help/calc\` and confirm the "Report an issue" card appears under the topics card