### PR TITLE
ci: add configure-test-env composite action (installs watchman)

### DIFF
--- a/.github/actions/configure-test-env/action.yml
+++ b/.github/actions/configure-test-env/action.yml
@@ -1,0 +1,37 @@
+name: 'Configure tinycld test environment'
+description: >-
+  System-level setup that every tinycld e2e job needs before booting
+  the dev server. Today: installs watchman so Metro's file watcher
+  doesn't fall back to polling. Extensible — append steps here when
+  another OS-level prerequisite emerges (fontconfig caches, kernel
+  inotify limits, additional binaries, etc.). Filesystem and env-var
+  setup that depends on the assembled workspace lives in playwright's
+  globalSetup, not here.
+
+runs:
+  using: 'composite'
+  steps:
+    # Metro warns "Watchman was not found in PATH" without this and
+    # falls back to fs.watch polling. Under Playwright multi-worker
+    # e2e load that's been correlated with Metro going silent for
+    # 70+s on `page.reload()`-triggered bundle re-fetches, surfacing
+    # as a blank-page-after-reload flake. See drive#13 for the trace
+    # evidence (post-reload entry.bundle request status=-1 after 70s
+    # of WebServer silence).
+    #
+    # Watchman ships only as rpm or Linux zip via GitHub releases.
+    # Pin to a known-working tag rather than `latest` so a future
+    # release that drops or restructures the zip can't silently
+    # break CI. The zip bundles libgflags/libglog/libsnappy, so the
+    # binary resolves at runtime via ldconfig.
+    - name: Install watchman
+      shell: bash
+      run: |
+        curl -fsSL -o /tmp/watchman.zip https://github.com/facebook/watchman/releases/download/v2026.05.11.00/watchman-v2026.05.11.00-linux.zip
+        unzip -q /tmp/watchman.zip -d /tmp/watchman
+        sudo mv /tmp/watchman/watchman-v2026.05.11.00-linux/bin/* /usr/local/bin/
+        sudo mv /tmp/watchman/watchman-v2026.05.11.00-linux/lib/* /usr/local/lib/
+        sudo ldconfig
+        sudo mkdir -p /usr/local/var/run/watchman
+        sudo chmod 2777 /usr/local/var/run/watchman
+        watchman --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,13 @@ jobs:
       - name: Go mod download
         working-directory: ws/app/server
         run: go mod download
+      # Composite action: installs watchman so Metro doesn't fall back to
+      # the fs.watch polling that has correlated with a blank-page-after-
+      # reload flake under Playwright multi-worker load. Lives in this
+      # repo and is also consumed by sibling repos via
+      # `tinycld/app/.github/actions/configure-test-env@main`.
+      - name: Configure test env
+        uses: ./ws/app/.github/actions/configure-test-env
       - name: Scaffold shortcut-stub package
         working-directory: ws
         run: npx tsx app/tests/scripts/scaffold-shortcut-stub.ts


### PR DESCRIPTION
## Summary
Lifts the inline watchman-install step from tinycld/drive#13 into a reusable composite action so the other six repos that run Metro e2e (mail, calendar, contacts, calc, text, plus drive follow-up + bootstrap template) don't each carry the same nine lines.

Wires app's own e2e job to consume it locally. Follow-up PRs in each sibling repo will reference it as `tinycld/app/.github/actions/configure-test-env@main` once this merges.

## Why
Trace evidence from tinycld/drive#13 showed Metro going silent for 70+s after `page.reload()`-triggered bundle re-fetches; the root cause was Metro falling back to `fs.watch` polling because watchman wasn't in PATH. Drive#13 fixed its own CI inline; this PR makes the fix shareable.

The action is named `configure-test-env` (not `install-watchman`) so future system-level CI prerequisites — fontconfig caches, kernel inotify limits, additional binaries — become new steps in the same action rather than new actions to discover and wire in.

## What changed
- `.github/actions/configure-test-env/action.yml` — composite action; today installs watchman v2026.05.11.00 from the Linux zip release, runs `ldconfig` for bundled libs.
- `.github/workflows/ci.yml` — e2e job gains a `Configure test env` step before Playwright install.

## Test plan
- [ ] CI green on this PR (validates the action works in the same-repo `./ws/app/...` path form).
- [ ] After merge: open follow-up PRs in bootstrap, mail, calendar, contacts, calc, text, drive that reference `tinycld/app/.github/actions/configure-test-env@main`.

Follow-up to tinycld/drive#13 / tinycld/core#10.