### PR TITLE
fix: auto-fix Docker bind-mount ownership so first-run setup isn't blocked (#26)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,7 +247,7 @@ ENV FZ_VERSION="1.25.1"
 # available so operators on autocert who use the in-app package installer can
 # manually re-apply the cap to a freshly-rebuilt binary.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl gnupg \
+    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl gnupg gosu \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get autoremove -y \
@@ -388,10 +388,19 @@ RUN setcap 'cap_net_bind_service=+ep' ./tinycld
 # 465:  SMTPS (implicit TLS)
 EXPOSE 7090 80 443 993 465
 
-USER tinycld
+# The container starts as root so the entrypoint can fix ownership of the
+# bind-mounted data dirs (/app/pb_data, /app/types) before the server runs.
+# When a host bind-mount target doesn't exist yet, Docker creates it owned by
+# root; the unprivileged tinycld user then can't open the SQLite DB ("unable to
+# open database file (14)") and the container crash-loops. entrypoint.sh
+# chown's those dirs to tinycld and drops to uid 1000 via gosu for the server
+# itself, so nothing privileged actually runs the application. See the
+# fix_data_dir_ownership() function in entrypoint.sh.
+USER root
 
-# Container runs entirely as uid 1000 (tinycld). The binary's
-# cap_net_bind_service file capability lets it bind :80/:443 when autocert is
+# The server process still runs as uid 1000 (tinycld) — the entrypoint drops
+# privileges with gosu before exec'ing it. The binary's cap_net_bind_service
+# file capability lets that unprivileged process bind :80/:443 when autocert is
 # enabled; the plain-HTTP default of :7090 is unprivileged.
 #
 # Set AUTOCERT_ENABLED=true with PRIMARY_DOMAIN (and optional comma-separated

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -3,7 +3,60 @@ set -e
 
 HEALTH_PORT=19876
 
+# The application runs as this unprivileged user (uid/gid baked into the image
+# as 1000:1000; see Dockerfile). The container itself starts as root only long
+# enough to fix bind-mount ownership, then drops to RUN_AS via gosu.
+RUN_AS=tinycld
+
 echo "[entrypoint] starting; pwd=$(pwd) user=$(id -un) uid=$(id -u)"
+
+# Ensure the bind-mounted data directories are writable by the runtime user.
+#
+# When a host bind-mount target (./pb_data, ./types in docker-compose.yml)
+# doesn't exist yet, the Docker daemon creates it owned by root:root. The
+# unprivileged tinycld user then can't open the SQLite database — PocketBase
+# fails with "unable to open database file (14)" and the container crash-loops.
+# Reported in https://github.com/tinycld/app/issues/26.
+#
+# We run this as root (the container's start user) and chown the dirs to the
+# runtime user before dropping privileges. Only runs when we're actually root;
+# if an operator overrode the start user to non-root they're responsible for
+# host-side ownership (and the chown would fail anyway), so we skip silently.
+fix_data_dir_ownership() {
+    [ "$(id -u)" = "0" ] || return 0
+
+    for dir in /app/pb_data /app/types; do
+        mkdir -p "$dir"
+        # Skip the (potentially large) recursive chown when the top-level dir is
+        # already owned correctly — the steady state after first run, so normal
+        # restarts pay nothing. A fresh root-owned mount triggers the fix-up.
+        owner=$(stat -c '%u:%g' "$dir" 2>/dev/null || echo '')
+        if [ "$owner" != "1000:1000" ]; then
+            echo "[entrypoint] fixing ownership of $dir (was '$owner') -> $RUN_AS"
+            chown -R "$RUN_AS:$RUN_AS" "$dir"
+        fi
+    done
+}
+
+# Run a tinycld subcommand as the unprivileged runtime user.
+#
+# When the container starts as root we drop privileges with gosu, which preserves
+# the binary's cap_net_bind_service file capability (needed to bind :80/:443
+# under autocert). If we're already non-root — e.g. an operator pinned USER to
+# something else — run the binary directly.
+#
+# This deliberately does NOT exec: the serve loop below inspects the exit code
+# (75 = in-app package-install restart) and the health check runs a copy in the
+# background, so control must return here.
+run_tinycld() {
+    if [ "$(id -u)" = "0" ]; then
+        gosu "$RUN_AS" ./tinycld "$@"
+    else
+        ./tinycld "$@"
+    fi
+}
+
+fix_data_dir_ownership
 
 # Promote the staged release to /app/releases/. Runs on every container
 # start; idempotent.
@@ -229,14 +282,14 @@ fi
 # Serve args are in $@ (positional params) so a multi-domain list survives
 # without re-splitting.
 while true; do
-    ./tinycld serve "$@"
+    run_tinycld serve "$@"
     EXIT_CODE=$?
 
     if [ $EXIT_CODE -eq 75 ]; then
         echo "[entrypoint] Restart requested (exit code 75)"
 
         # Health check: start new binary on a temp port, verify /api/health responds
-        ./tinycld serve --http=127.0.0.1:${HEALTH_PORT} &
+        run_tinycld serve --http=127.0.0.1:${HEALTH_PORT} &
         HEALTH_PID=$!
 
         HEALTHY=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,11 @@ services:
     volumes:
       # Persistent data: PocketBase records, uploads, migrations state.
       # Everything stateful lives here — back this directory up.
+      #
+      # These dirs are created owned by root the first time Docker mounts them;
+      # the container fixes their ownership on startup (it boots as root, chown's
+      # them to its unprivileged runtime user, then drops privileges), so no
+      # manual `chown` is needed before the first `docker compose up`.
       - ./pb_data:/app/pb_data
       # Generated TypeScript types (pbSchema, pbZodSchema). Small, regenerated on migrations.
       - ./types:/app/types


### PR DESCRIPTION
Part of the unified core mailer (see tinycld/tinycld `docs/plans/unified-core-mailer.md`).

`SMTPProvider.Send`/`Configured` now delegate to the core `mailer.SMTPSender`; removes the local direct-MX sender, RFC-5322 builder, and the outbound tests (all relocated to core). Inbound parsing, bounce, domain/DKIM verification, and IMAP config stay in the mail package.

**Requires** the core PR tinycld/tinycld#88 first (this won't compile without `mailer.SMTPSender`).
