### PR TITLE
fix: stop randomUUID polyfill recursing on non-secure web origins

### DIFF
--- a/lib/polyfill-crypto.ts
+++ b/lib/polyfill-crypto.ts
@@ -1,18 +1,22 @@
 // Side-effect import: installs globalThis.crypto.getRandomValues on RN.
 // No-op on web (the browser already provides it).
 import 'react-native-get-random-values'
-import { randomUUID } from 'expo-crypto'
+import { uuidFromRandomValues } from '@tinycld/core/lib/uuid'
 
-// react-native-get-random-values doesn't install randomUUID, and Hermes
-// has no built-in crypto.randomUUID. Add it from expo-crypto so callers
-// (e.g. @tanstack/db's collection constructor) can rely on the standard
-// Web Crypto API on every platform.
+// react-native-get-random-values doesn't install randomUUID, and Hermes has no
+// built-in crypto.randomUUID. @tanstack/db's collection constructor calls
+// crypto.randomUUID() at module init, so it must exist on every platform.
 //
-// On web the browser already provides crypto.randomUUID — and expo-crypto's
-// web implementation of randomUUID delegates back to globalThis.crypto, so
-// re-assigning would create infinite recursion on first use. The guard
-// makes this a no-op when the host already has its own.
+// We assign a self-contained getRandomValues-based UUID rather than
+// expo-crypto's randomUUID: expo-crypto's *web* implementation delegates back
+// to globalThis.crypto.randomUUID, so installing it as that property creates
+// infinite recursion the first time it's called. That happens on web served
+// over a non-secure origin (plain http on a LAN IP/hostname), where the
+// browser exposes crypto.getRandomValues but not crypto.randomUUID — the guard
+// passes, the delegating shim installs, and the next randomUUID() call blows
+// the stack. uuidFromRandomValues depends only on getRandomValues, so it is
+// safe everywhere.
 const cryptoGlobal = (globalThis as { crypto?: Partial<Crypto> }).crypto
 if (cryptoGlobal && !cryptoGlobal.randomUUID) {
-    cryptoGlobal.randomUUID = randomUUID as Crypto['randomUUID']
+    cryptoGlobal.randomUUID = uuidFromRandomValues as Crypto['randomUUID']
 }


### PR DESCRIPTION
## Problem

Reported in #28: boot fails with `RangeError: Maximum call stack size exceeded` in `randomUUID`, with the stack bouncing between `Object.randomUUID` and `_e.randomUUID` forever.

`lib/polyfill-crypto.ts` installed `expo-crypto`'s **web** `randomUUID` as `crypto.randomUUID`. That implementation delegates back to `globalThis.crypto.randomUUID` — i.e. to itself once installed — so it recurses infinitely.

The guard (`if (!crypto.randomUUID)`) only protects against overwriting a **native** one. But browsers only expose `crypto.randomUUID` in a **secure context** (`https://` or `http://localhost`). A self-hoster reaching the web build over plain `http://` on a LAN IP/hostname has `getRandomValues` but no `randomUUID`, so the guard passes, the delegating shim installs, and the first `randomUUID()` (called by `@tanstack/db`'s collection constructor at module init) overflows the stack — hence "can't get past setup."

## Fix

Install `uuidFromRandomValues` from `@tinycld/core/lib/uuid` instead of expo-crypto's `randomUUID`. It builds an RFC 4122 v4 UUID **solely** from `crypto.getRandomValues` and never reads `crypto.randomUUID`, so there is no delegation and no recursion on any platform. `expo-crypto` is no longer imported here.

## Depends on

tinycld/core#30 — adds the `@tinycld/core/lib/uuid` export this PR imports. **Merge core#30 first** (CI assembles `core@main`).

`tsc --noEmit` clean.

Fixes #28