### PR TITLE
chore: add expo-image dependency; tsconfig formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
         "expo-dev-client": "~55.0.32",
         "expo-document-picker": "~55.0.11",
         "expo-file-system": "~55.0.19",
+        "expo-image": "~55.0.11",
         "expo-image-picker": "~55.0.20",
         "expo-linking": "~55.0.15",
         "expo-notifications": "~55.0.22",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,45 +1,21 @@
 {
-  "extends": "expo/tsconfig.base",
-  "compilerOptions": {
-    "strict": true,
-    "module": "Preserve",
-    "moduleResolution": "Bundler",
-    "skipLibCheck": true,
-    "jsx": "react-jsx",
-    "noImplicitAny": false,
-    "types": [
-      "node",
-      "react"
-    ],
-    "lib": [
-      "dom",
-      "esnext"
-    ],
-    "paths": {
-      "~/*": [
-        "./*"
-      ],
-      "@tinycld/app-generated/*": [
-        "./lib/generated/*"
-      ],
-      "@tinycld/core": [
-        "../core/index.ts"
-      ],
-      "@tinycld/core/*": [
-        "../core/*"
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules",
-    ".expo",
-    "dist",
-    "scripts/eas-workspace-files"
-  ],
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    ".expo/types/**/*.ts",
-    "expo-env.d.ts"
-  ]
+    "extends": "expo/tsconfig.base",
+    "compilerOptions": {
+        "strict": true,
+        "module": "Preserve",
+        "moduleResolution": "Bundler",
+        "skipLibCheck": true,
+        "jsx": "react-jsx",
+        "noImplicitAny": false,
+        "types": ["node", "react"],
+        "lib": ["dom", "esnext"],
+        "paths": {
+            "~/*": ["./*"],
+            "@tinycld/app-generated/*": ["./lib/generated/*"],
+            "@tinycld/core": ["../core/index.ts"],
+            "@tinycld/core/*": ["../core/*"]
+        }
+    },
+    "exclude": ["node_modules", ".expo", "dist", "scripts/eas-workspace-files"],
+    "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,45 @@
 {
-    "extends": "expo/tsconfig.base",
-    "compilerOptions": {
-        "strict": true,
-        "module": "Preserve",
-        "moduleResolution": "Bundler",
-        "skipLibCheck": true,
-        "jsx": "react-jsx",
-        "noImplicitAny": false,
-        "types": ["node", "react"],
-        "lib": ["dom", "esnext"],
-        "paths": {
-            "~/*": ["./*"],
-            "@tinycld/app-generated/*": ["./lib/generated/*"],
-            "@tinycld/core": ["../core/index.ts"],
-            "@tinycld/core/*": ["../core/*"]
-        }
-    },
-    "exclude": ["node_modules", ".expo", "dist", "scripts/eas-workspace-files"],
-    "include": ["**/*.ts", "**/*.tsx"]
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "noImplicitAny": false,
+    "types": [
+      "node",
+      "react"
+    ],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "paths": {
+      "~/*": [
+        "./*"
+      ],
+      "@tinycld/app-generated/*": [
+        "./lib/generated/*"
+      ],
+      "@tinycld/core": [
+        "../core/index.ts"
+      ],
+      "@tinycld/core/*": [
+        "../core/*"
+      ]
+    }
+  },
+  "exclude": [
+    "node_modules",
+    ".expo",
+    "dist",
+    "scripts/eas-workspace-files"
+  ],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".expo/types/**/*.ts",
+    "expo-env.d.ts"
+  ]
 }


### PR DESCRIPTION
* Add **expo-image** (`~55.0.11`) — used by the drive list + core `Thumbnail` for cached file thumbnails (peer-declared in core/drive; this is the install-root dependency that satisfies the peer). Supports tinycld/core#34 + the drive mobile PR.
* `tsconfig.json`: reformat to 2-space indentation and add `.expo/types/**/*.ts` + `expo-env.d.ts` to `include`.