### PR TITLE
Print local-dev login credentials after seed/reset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,9 @@ available in production.
 - The logger shows timestamps and colors in development mode
 
 ## Scripts Reference
-- `pnpm run dev` starts Expo + PocketBase together (generator runs first).
+- `pnpm run dev` starts Expo + PocketBase together (generator runs first). It reuses whatever is in `server/pb_data` — it does not seed.
+- `pnpm run db:reset` wipes `server/pb_data`, re-runs migrations, and seeds a test user + org. **Run this once on a fresh checkout to get something to log in with.** It prints a boxed login summary at the end (see "Logging in for local dev" below).
+- `pnpm run db:seed` seeds into the current database without wiping it; also prints the login summary.
 - `pnpm run typecheck` runs `tinycld-pkg typecheck` (tsc for this member).
 - `pnpm run checks` runs lint and typechecks (ecosystem-wide biome + app tsc).
 - `pnpm run lint` (or `pnpm run lint:fix`) runs Biome over the app and every present sibling. Biome lives only in the app shell; `app/biome.json` is the single config for the app **and** every member. Sibling repos do not ship their own `biome.json` or `lint`/`checks` scripts — `pnpm run lint` walks the sibling dirs at their real workspace-root filesystem paths.
@@ -160,6 +162,13 @@ available in production.
 - Keep migrations in `server/pb_migrations/` and describe manual steps in the PR body.
 - Create api routes only as a last resort and after discussion. Prefer to create records using standard useMutation with pbtsdb stores.  If needed we can use golang hooks to observe and modify records as they're created/modified
 - Go server hooks (e.g. CardDAV in the `@tinycld/contacts` sibling's `server/` directory) use SDK methods that bypass PocketBase API rules — they implement equivalent authorization manually. When changing API rules on a collection, check if a Go hook also accesses that collection and update its filters to match.
+
+## Logging in for local dev
+- After `pnpm run db:reset` (or `pnpm run db:seed`) the script prints a boxed summary of the credentials to use — you don't need to read the seed script.
+- Two accounts exist: the **app user** `user@tinycld.org` (what you sign in to TinyCld with) and the **PocketBase superuser** `admin@tinycld.org` (the `/_/` admin UI and the `/setup` superuser dashboard).
+- Both passwords are **generated randomly on first create** and printed in the box. To pin known passwords (e.g. to match an existing `.env` or share across resets), set `TEST_USER_PW` (app user) and `ADMIN_USER_PW` (superuser) in `app/.env`, or pass `--user-pw`. CI sets both so logins are deterministic — don't change that contract.
+- Override the login emails with `TEST_USER_LOGIN` / `ADMIN_USER_LOGIN` in `app/.env`.
+- There's no first-run `…/setup?token=…` link locally: `db:reset` creates the superuser up front (so it can seed), so PocketBase isn't on its first run. That token flow is only for an empty self-hosted instance. The `/setup` link `db:reset` prints goes to the superuser login → dashboard instead.
 
 ## Users & Organizations
 - Users belong to orgs via the `user_org` junction table (many-to-many)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "db:reset": "tsx scripts/reset-dev-db.ts",
         "db:reset:demo": "tsx scripts/reset-demo.ts",
         "db:seed": "tsx scripts/seed-db.ts",
-        "expo:test": "tsx scripts/reset-dev-db.ts --url http://127.0.0.1:7299 --data-dir server/pb_test_data && tsx scripts/dev.ts --no-ssl --port 7200 --pb-data-dir server/pb_test_data",
+        "expo:test": "tsx scripts/reset-dev-db.ts --url http://127.0.0.1:7299 --browse-url http://localhost:7200 --data-dir server/pb_test_data && tsx scripts/dev.ts --no-ssl --port 7200 --pb-data-dir server/pb_test_data",
         "typecheck": "tinycld-pkg typecheck",
         "lint": "biome check . ../core ../contacts ../mail ../calendar ../drive ../calc ../text ../google-takeout-import",
         "lint:fix": "biome check --write . ../core ../contacts ../mail ../calendar ../drive ../calc ../text ../google-takeout-import",

--- a/scripts/__tests__/load-manifest.test.ts
+++ b/scripts/__tests__/load-manifest.test.ts
@@ -1,12 +1,44 @@
-import { describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { loadManifest } from '../load-manifest'
-import { memberDir } from '../paths'
+
+// loadManifest is a dynamic-import wrapper around a member's
+// manifest.ts. The interesting behavior is "find the file then return
+// its default export"; we exercise that against a tmpdir-staged fake
+// member rather than a real installed sibling so the test doesn't pull
+// any feature member into the bootstrap closure.
 
 describe('loadManifest', () => {
-    it('loads the contacts manifest from the linked member', async () => {
-        const m = await loadManifest(memberDir('@tinycld/contacts'))
-        expect(m.slug).toBe('contacts')
-        expect(m.name).toBe('Contacts')
+    let tmp: string
+    beforeEach(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tcld-manifest-'))
+    })
+    afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }))
+
+    it('returns the default export of manifest.ts in the given dir', async () => {
+        // Write a minimal manifest matching the PackageManifest shape
+        // loadManifest's return type promises. The collections sub-
+        // object is the field the original assertion checked, so we
+        // include it to keep that branch covered.
+        fs.writeFileSync(
+            path.join(tmp, 'manifest.ts'),
+            `export default {
+                name: 'Demo',
+                slug: 'demo',
+                version: '0.1.0',
+                description: 'tmpdir fixture',
+                collections: { register: 'collections', types: 'types' },
+            } as const\n`
+        )
+        const m = await loadManifest(tmp)
+        expect(m.slug).toBe('demo')
+        expect(m.name).toBe('Demo')
         expect(m.collections).toMatchObject({ register: 'collections', types: 'types' })
+    })
+
+    it('throws when the dir has no manifest.ts/.js', async () => {
+        await expect(loadManifest(tmp)).rejects.toThrow(/No manifest found/)
     })
 })

--- a/scripts/print-box.ts
+++ b/scripts/print-box.ts
@@ -1,0 +1,20 @@
+// A small Unicode box printer for terminal output, mirroring the look of the
+// Go server's printBoxed (core/server/coreserver/setup_bootstrap.go). Used by
+// the seed / db:reset scripts to surface login credentials and setup links so a
+// contributor doesn't have to read source to find them.
+//
+// Box width is sized to the widest line. Lines are left-aligned with a single
+// space of padding inside the border.
+
+export function printBox(lines: string[]): void {
+    const width = Math.max(...lines.map(line => line.length)) + 2
+    const horizontal = '─'.repeat(width)
+
+    const pad = (s: string) => `│ ${s}${' '.repeat(width - s.length - 2)} │`
+
+    process.stdout.write(`\n┌${horizontal}┐\n`)
+    for (const line of lines) {
+        process.stdout.write(`${pad(line)}\n`)
+    }
+    process.stdout.write(`└${horizontal}┘\n\n`)
+}

--- a/scripts/reset-demo.ts
+++ b/scripts/reset-demo.ts
@@ -53,7 +53,10 @@ function parseArgs() {
 
     let url = 'http://127.0.0.1:7100'
     let adminEmail = process.env.ADMIN_USER_LOGIN || 'admin@tinycld.org'
-    let adminPassword = process.env.ADMIN_USER_PW || 'AdminPass1234!'
+    // No hardcoded fallback — this authenticates as an existing superuser, so a
+    // baked-in default would ship a known admin password and only work against
+    // an admin created with it. Require --admin-pw or ADMIN_USER_PW.
+    let adminPassword = process.env.ADMIN_USER_PW || ''
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i]
@@ -73,6 +76,11 @@ function parseArgs() {
                     process.exit(1)
                 }
         }
+    }
+
+    if (!adminPassword) {
+        logError('Superuser password required: pass --admin-pw <pw> or set ADMIN_USER_PW.')
+        process.exit(1)
     }
 
     return { url, adminEmail, adminPassword }
@@ -117,6 +125,7 @@ async function main() {
         // back to a random password (the normal /api/demo/start flow doesn't
         // need a known password).
         userPassword: process.env.REVIEW_DEMO_PASSWORD ?? '',
+        userPasswordExplicit: (process.env.REVIEW_DEMO_PASSWORD ?? '') !== '',
         isDemo: true,
         orgSlug: DEMO_ORG_SLUG,
         orgName: DEMO_ORG_NAME,

--- a/scripts/reset-dev-db.ts
+++ b/scripts/reset-dev-db.ts
@@ -10,6 +10,10 @@
  *
  * Options:
  *   --url <url>        PocketBase URL (default: http://127.0.0.1:7100)
+ *   --browse-url <url> URL the developer opens in the browser (the dev proxy).
+ *                      Defaults to --url with 127.0.0.1 → localhost. Set this
+ *                      when PB sits behind a proxy on a different port (e.g.
+ *                      the expo:test flow seeds PB on :7299 but browses :7200).
  *   --data-dir <dir>   Data directory (default: server/pb_data)
  *   --skip-build       Skip building PocketBase
  *   --keep-running     Keep server running after seeding (default: false)
@@ -21,6 +25,7 @@
  */
 
 import { spawn, spawnSync } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
@@ -40,6 +45,7 @@ try {
 
 interface Config {
     url: string
+    browseUrl: string | null
     dataDir: string
     skipBuild: boolean
     keepRunning: boolean
@@ -49,6 +55,7 @@ function parseArgs(): Config {
     const args = process.argv.slice(2)
     const config: Config = {
         url: 'http://127.0.0.1:7100',
+        browseUrl: null,
         dataDir: 'server/pb_data',
         skipBuild: false,
         keepRunning: false,
@@ -59,6 +66,9 @@ function parseArgs(): Config {
         switch (arg) {
             case '--url':
                 config.url = args[++i]
+                break
+            case '--browse-url':
+                config.browseUrl = args[++i]
                 break
             case '--data-dir':
                 config.dataDir = args[++i]
@@ -89,6 +99,11 @@ const PB_HOST = parsedUrl.hostname
 const PB_PORT = parseInt(parsedUrl.port || '8090', 10)
 const PB_DATA_DIR = path.join(process.cwd(), CONFIG.dataDir)
 const PB_BINARY = path.join(process.cwd(), 'server/app')
+
+// The URL the developer actually opens. Prefer an explicit --browse-url (the
+// dev proxy, which may live on a different port than PB), otherwise fall back to
+// the PB URL with 127.0.0.1 → localhost for readability.
+const BROWSE_URL = (CONFIG.browseUrl ?? PB_URL.replace('127.0.0.1', 'localhost')).replace(/\/$/, '')
 
 async function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms))
@@ -156,16 +171,41 @@ function buildPocketBase(): void {
     log('Build complete')
 }
 
-function getCredentials(): { email: string; password: string } {
+// A reasonably strong random password for a freshly-created superuser when the
+// operator didn't supply one. Not hardcoded — a baked-in default would ship a
+// known admin password to anyone who runs the reset without setting the env.
+function generateAdminPassword(): string {
+    const bytes = randomBytes(18).toString('base64url')
+    return `Tc!${bytes}`
+}
+
+// Resolve once per process: getCredentials() is called several times (create,
+// seed, summary) and a fresh random each call would diverge — we'd create the
+// superuser with one password and then fail to auth/seed with another.
+let resolvedCredentials: { email: string; password: string; generated: boolean } | null = null
+
+function getCredentials(): { email: string; password: string; generated: boolean } {
+    if (resolvedCredentials) return resolvedCredentials
     const email =
-        process.env.POCKETBASE_EMAIL || process.env.SEED_ADMIN_EMAIL || 'admin@tinycld.org'
-    const password =
-        process.env.POCKETBASE_PASSWORD || process.env.SEED_ADMIN_PW || 'AdminPass1234!'
-    return { email, password }
+        process.env.POCKETBASE_EMAIL ||
+        process.env.SEED_ADMIN_EMAIL ||
+        process.env.ADMIN_USER_LOGIN ||
+        'admin@tinycld.org'
+    // ADMIN_USER_PW is the var CI sets and the e2e superuser helpers read (via
+    // POCKETBASE_PASSWORD || 'AdminPass1234!'), so honor it here too — otherwise
+    // a fresh random would be created that those helpers can't authenticate.
+    const supplied =
+        process.env.POCKETBASE_PASSWORD ||
+        process.env.SEED_ADMIN_PW ||
+        process.env.ADMIN_USER_PW ||
+        ''
+    const password = supplied || generateAdminPassword()
+    resolvedCredentials = { email, password, generated: supplied === '' }
+    return resolvedCredentials
 }
 
 function createSuperuser(): void {
-    const { email, password } = getCredentials()
+    const { email, password, generated } = getCredentials()
     log('Creating superuser:', email)
 
     const result = spawnSync(
@@ -178,7 +218,19 @@ function createSuperuser(): void {
     if (result.status !== 0) {
         throw new Error('Failed to create superuser')
     }
+
+    // Surface a generated password once so the operator can actually log in.
+    // Supplied passwords (env/CI) are never echoed.
+    if (generated) {
+        log('Generated superuser password (set POCKETBASE_PASSWORD to override):')
+        log(`  ${email} / ${password}`)
+    }
 }
+
+// When false, PB's stdout is consumed but not echoed — see the relay comment in
+// startPocketBase. Flipped off before printing the credential boxes so PB's
+// async logs don't land between the box borders. stderr is always echoed.
+let relayPbStdout = true
 
 async function startPocketBase(): Promise<ReturnType<typeof spawn>> {
     log(`Starting PocketBase at ${PB_HOST}:${PB_PORT}...`)
@@ -210,8 +262,14 @@ async function startPocketBase(): Promise<ReturnType<typeof spawn>> {
     // When the readiness probe times out, having these lines in the CI log
     // is the difference between a one-line "failed to start" and a real
     // diagnosis.
+    // Relay PB's (chatty) stdout through a mutable `relay` flag rather than a
+    // detachable listener. When we silence PB (before printing the boxed
+    // summaries) we flip relay=false but KEEP consuming the pipe — detaching
+    // the reader instead would let PB's stdout buffer fill and make it emit
+    // "dropping unclosed output" warnings mid-box. stderr is always relayed so
+    // a genuine error is never swallowed.
     pb.stdout?.on('data', data => {
-        log('[pocketbase]', data.toString().trimEnd())
+        if (relayPbStdout) log('[pocketbase]', data.toString().trimEnd())
     })
 
     pb.stderr?.on('data', data => {
@@ -279,7 +337,13 @@ async function runSeedScript(): Promise<void> {
                 // --preserve-symlinks Node resolves seed.ts to its
                 // realpath inside the sibling repo and can't find peer
                 // deps (exceljs, etc.) in the app shell's node_modules.
-                env: { ...process.env, NODE_OPTIONS: '--preserve-symlinks' },
+                // TINYCLD_BROWSE_URL tells the seed's login summary which URL
+                // the developer browses (the proxy), not PB's internal port.
+                env: {
+                    ...process.env,
+                    NODE_OPTIONS: '--preserve-symlinks',
+                    TINYCLD_BROWSE_URL: BROWSE_URL,
+                },
             }
         )
 
@@ -311,6 +375,13 @@ async function main() {
             throw new Error('PocketBase failed to start within timeout')
         }
         log('PocketBase is ready')
+
+        // Silence PB's stdout before seeding so the seed's login-summary box
+        // isn't interleaved with PB's async SQL logs. The seed prints its own
+        // [seed] progress; PB errors still surface via stderr, and a failed
+        // seed exits non-zero (thrown below). The box itself (app + superuser
+        // creds, the /_/ and /setup URLs) is printed by the seed script.
+        relayPbStdout = false
 
         await runSeedScript()
 

--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -33,6 +33,7 @@
 import { deriveSeeds } from '@tinycld/core/lib/packages/derive-seeds'
 import PocketBase from 'pocketbase'
 import { tinycldSeeds } from '../tinycld.seeds'
+import { printBox } from './print-box'
 
 function log(...args: unknown[]) {
     process.stdout.write(`[seed] ${args.join(' ')}\n`)
@@ -59,17 +60,30 @@ interface SeedConfig {
     userUsername: string
     userName: string
     userPassword: string
+    // True when the password came from an explicit source (--user-pw, or the
+    // TEST_USER_PW / REVIEW_DEMO_PASSWORD env vars) rather than being left
+    // unset. When false and we're creating a brand-new user, we mint a random
+    // password instead of falling back to a shared literal — see seedForUser.
+    userPasswordExplicit: boolean
     isDemo: boolean
     orgSlug: string
     orgName: string
     seedSecondOrg: boolean
 }
 
+// What seedForUser resolved for the app user, so the caller can print an
+// accurate login summary. `password` is null when the user already existed and
+// we left their credential untouched (we can't know it).
+interface SeedLoginResult {
+    created: boolean
+    userEmail: string
+    password: string | null
+}
+
 const TEST_DEFAULTS = {
     userEmail: process.env.TEST_USER_LOGIN || 'user@tinycld.org',
     userUsername: process.env.TEST_USER_USERNAME || 'tester',
     userName: 'Test User',
-    userPassword: process.env.TEST_USER_PW || 'TestUser1234!',
     orgSlug: 'test-org',
     orgName: 'Test Organization',
 }
@@ -104,7 +118,12 @@ function parseArgs(): SeedConfig {
 
     let url = 'http://127.0.0.1:7100'
     let adminEmail = process.env.ADMIN_USER_LOGIN || 'admin@tinycld.org'
-    let adminPassword = process.env.ADMIN_USER_PW || 'AdminPass1234!'
+    // No hardcoded fallback — this script authenticates as an EXISTING superuser,
+    // so a baked-in default would (a) ship a known admin password and (b) only
+    // ever work against an admin created with that same default. Require it via
+    // --admin-pw or ADMIN_USER_PW. reset-dev-db.ts passes the (possibly random)
+    // password it created the superuser with; CI sets ADMIN_USER_PW.
+    let adminPassword = process.env.ADMIN_USER_PW || ''
 
     if (args.includes('--help')) process.exit(0)
 
@@ -155,7 +174,23 @@ function parseArgs(): SeedConfig {
         }
     }
 
+    if (!adminPassword) {
+        logError('Superuser password required: pass --admin-pw <pw> or set ADMIN_USER_PW.')
+        process.exit(1)
+    }
+
     const defaults = mode === 'demo' ? DEMO_DEFAULTS : TEST_DEFAULTS
+
+    // An explicit password comes from --user-pw, or from the mode's env var
+    // (TEST_USER_PW in test mode — set by CI — or REVIEW_DEMO_PASSWORD in demo
+    // mode for App Review). When none is set, userPassword is '' and seedForUser
+    // mints a random one on create rather than reusing a shared literal.
+    const envPassword =
+        mode === 'test'
+            ? (process.env.TEST_USER_PW ?? '')
+            : (process.env.REVIEW_DEMO_PASSWORD ?? '')
+    const userPassword = overrides.userPassword ?? envPassword
+
     return {
         url,
         adminEmail,
@@ -164,11 +199,8 @@ function parseArgs(): SeedConfig {
         userEmail: overrides.userEmail ?? defaults.userEmail,
         userUsername: overrides.userUsername ?? defaults.userUsername,
         userName: overrides.userName ?? defaults.userName,
-        userPassword:
-            overrides.userPassword ??
-            (mode === 'test'
-                ? TEST_DEFAULTS.userPassword
-                : (process.env.REVIEW_DEMO_PASSWORD ?? '')),
+        userPassword,
+        userPasswordExplicit: userPassword !== '',
         isDemo: mode === 'demo',
         orgSlug: overrides.orgSlug ?? defaults.orgSlug,
         orgName: overrides.orgName ?? defaults.orgName,
@@ -178,6 +210,15 @@ function parseArgs(): SeedConfig {
 
 function htmlBlob(html: string) {
     return new File([html], 'body.html', { type: 'text/html' })
+}
+
+// A random password that satisfies PocketBase's auth rules (>=8 chars, mixed
+// case + digit + symbol). Used when seeding a brand-new local user with no
+// explicit password configured, so each fresh checkout gets a unique
+// credential that's printed once rather than a shared literal.
+function generatePassword(): string {
+    const rand = () => Math.random().toString(36).slice(2, 10)
+    return `Dev${rand()}${rand()}!`
 }
 
 // PocketBase's `getFirstListItem` rejects with a 404 ClientResponseError when
@@ -458,7 +499,7 @@ async function seedSecondOrg(pb: PocketBase, ctx: OrgSeedContext) {
  *
  * Exported so reset-demo.ts can re-seed without shelling out.
  */
-export async function seedForUser(pb: PocketBase, config: SeedConfig) {
+export async function seedForUser(pb: PocketBase, config: SeedConfig): Promise<SeedLoginResult> {
     // Find first; only branch into create when the lookup specifically returns
     // nothing. Catching around the update too would mask a real failure (e.g.
     // a server-side guard rejecting the write) and silently fall through to a
@@ -474,9 +515,18 @@ export async function seedForUser(pb: PocketBase, config: SeedConfig) {
     }
 
     let user: { id: string }
+    const login: SeedLoginResult = {
+        created: !existingUser,
+        userEmail: config.userEmail,
+        password: null,
+    }
     if (existingUser) {
         user = existingUser
         log('Found existing user:', config.userUsername)
+        // A pre-existing non-demo user keeps whatever password it already has;
+        // we don't know (and won't reset) it. If a password was passed
+        // explicitly the caller knows it, so report that; otherwise null.
+        if (config.userPasswordExplicit) login.password = config.userPassword
         if (config.isDemo) {
             // The singleton demo account is shared across all anonymous
             // visitors. Any field a previous visitor edited (name via direct
@@ -488,9 +538,9 @@ export async function seedForUser(pb: PocketBase, config: SeedConfig) {
             // passed) we set that stable password so App Review can sign in
             // directly. Otherwise reroll to a random value — the normal
             // /api/demo/start token flow doesn't need a known password.
-            const newPassword =
-                config.userPassword ||
-                `Demo${Math.random().toString(36).slice(2, 10)}${Math.random().toString(36).slice(2, 10)}!`
+            const newPassword = config.userPasswordExplicit
+                ? config.userPassword
+                : generatePassword()
             await pb.collection('users').update(user.id, {
                 is_demo: true,
                 email: config.userEmail,
@@ -498,17 +548,17 @@ export async function seedForUser(pb: PocketBase, config: SeedConfig) {
                 password: newPassword,
                 passwordConfirm: newPassword,
             })
+            login.password = newPassword
         }
     } else {
         log('Creating user:', config.userUsername)
-        // Auth collections require *some* password. In demo mode the user
-        // normally signs in via /api/demo/start tokens, not credentials, so
-        // a random password is fine — but if REVIEW_DEMO_PASSWORD was set
-        // (or --user-pw was passed), config.userPassword is non-empty and we
-        // use that so App Review can sign in directly.
-        const password =
-            config.userPassword ||
-            `Demo${Math.random().toString(36).slice(2, 10)}${Math.random().toString(36).slice(2, 10)}!`
+        // Auth collections require *some* password. When one was provided
+        // explicitly (--user-pw, or the TEST_USER_PW / REVIEW_DEMO_PASSWORD env
+        // vars — CI sets TEST_USER_PW so e2e logins keep working) we use it.
+        // Otherwise mint a random one and surface it in the login summary so a
+        // fresh local checkout has a unique, discoverable credential.
+        const password = config.userPasswordExplicit ? config.userPassword : generatePassword()
+        login.password = password
         user = await pb.collection('users').create({
             username: config.userUsername,
             email: config.userEmail,
@@ -609,6 +659,8 @@ export async function seedForUser(pb: PocketBase, config: SeedConfig) {
             userOrg: userOrg2,
         })
     }
+
+    return login
 }
 
 export async function authSuperuser(config: {
@@ -623,12 +675,46 @@ export async function authSuperuser(config: {
     return pb
 }
 
+// The URL a developer actually opens in the browser. The PB connection URL
+// often binds 127.0.0.1; localhost reads better and is what the docs use. When
+// a caller (reset-dev-db.ts) fronts PB with a proxy on a different port, it
+// passes the real browse URL via $TINYCLD_BROWSE_URL so the printed links point
+// where the user browses rather than at PB's internal port.
+function browseUrl(pbUrl: string): string {
+    const override = process.env.TINYCLD_BROWSE_URL
+    if (override) return override.replace(/\/$/, '')
+    return pbUrl.replace('127.0.0.1', 'localhost').replace(/\/$/, '')
+}
+
+function printLoginSummary(config: SeedConfig, login: SeedLoginResult): void {
+    const url = browseUrl(config.url)
+    const appPassword =
+        login.password ?? '(unchanged — use the password from when this user was created)'
+
+    printBox([
+        'Seed complete — log in with:',
+        '',
+        'App  (sign in to TinyCld)',
+        `  ${url}`,
+        `  user:     ${login.userEmail}`,
+        `  password: ${appPassword}`,
+        '',
+        'Superuser  (PocketBase /_/ dashboard, and /setup to manage orgs & packages)',
+        `  ${url}/setup`,
+        `  user:     ${config.adminEmail}`,
+        `  password: ${config.adminPassword}`,
+        '',
+        `Org:  ${config.orgSlug}`,
+    ])
+}
+
 async function main() {
     const config = parseArgs()
     log(`Mode: ${config.mode} (user=${config.userEmail}, org=${config.orgSlug})`)
     const pb = await authSuperuser(config)
-    await seedForUser(pb, config)
+    const login = await seedForUser(pb, config)
     log('Seeding complete!')
+    printLoginSummary(config, login)
     process.exit(0)
 }
 


### PR DESCRIPTION
Closes #32.

Following the docs to set up local dev left contributors unable to find the login: `db:reset` creates the PocketBase superuser up front (so it can seed), which suppresses PocketBase's first-run `/setup?token` URL — and the seeded app-user credentials were only discoverable by reading `seed-db.ts`.

## What changed

`db:reset` and `db:seed` now print a single boxed login summary at the end of the run:

```
┌─────────────────────────────────────────────────────────────────────────────┐
│ Seed complete — log in with:                                                │
│                                                                             │
│ App  (sign in to TinyCld)                                                   │
│   http://localhost:7100                                                      │
│   user:     user@tinycld.org                                                │
│   password: Devy52nqiuqzj6umahy!                                            │
│                                                                             │
│ Superuser  (PocketBase /_/ dashboard, and /setup to manage orgs & packages) │
│   http://localhost:7100/setup                                               │
│   user:     admin@tinycld.org                                               │
│   password: Tc!H-3TzYvi5RtVYpTeq5MnwmRy                                     │
│                                                                             │
│ Org:  test-org                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

- **`seed-db.ts`** generates a random app-user password when creating a brand-new user with no explicit password, and prints the boxed summary. An explicit password (`--user-pw` / `TEST_USER_PW` / `REVIEW_DEMO_PASSWORD`) is still honored unchanged, so CI/e2e logins stay deterministic.
- **`reset-dev-db.ts`** generates a random superuser password when `ADMIN_USER_PW` is unset and forwards it to the seed. Adds `--browse-url` so the printed links target the dev proxy, not PB's internal port (`expo:test` passes the proxy URL). Silences PB's chatty stdout during seeding so the box renders cleanly.
- **`print-box.ts`** (new) — shared Unicode box printer mirroring the Go `printBoxed`.
- **`CONTRIBUTING.md`** — documents the credentials, the env overrides, and why the first-run `/setup?token` URL doesn't appear locally.

There's also a small unrelated test commit (`load-manifest.test.ts` now stages a tmpdir fixture instead of relying on the installed `@tinycld/contacts` member).

Companion docs PR: tinycld/website#7

## Verification

- `pnpm run db:reset` prints one clean box (app + superuser logins, `/_/` + `/setup`), generated passwords, clean exit.
- `tinycld-pkg typecheck` ✓, `pnpm run lint` (1455 files) ✓, `load-manifest` test ✓.
- Self-host path intact: a truly-empty `pb_data` + `pnpm run dev` (no reset) still prints PB's first-run `/setup?token` URL.
