### PR TITLE
ci: bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       # runs to save bandwidth + retention.
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-artifacts
           path: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,10 +59,10 @@ jobs:
           path: ws/app
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ws
           file: ws/app/Dockerfile
@@ -144,7 +144,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.cache_scope }}
           path: /tmp/digests/*
@@ -165,17 +165,17 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -187,7 +187,7 @@ jobs:
 
       - name: Derive tags
         id: tags
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.image.outputs.name }}
           # Disable the auto-flavor that emits :latest for the highest semver.

--- a/.github/workflows/smoke-test-image.yml
+++ b/.github/workflows/smoke-test-image.yml
@@ -63,7 +63,7 @@ jobs:
           echo "Testing ${image}"
 
       - name: Log in to GHCR (read-only)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload Playwright report + container logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-test-artifacts-${{ steps.imgref.outputs.ref }}
           path: |


### PR DESCRIPTION
## Why

GitHub forces Node 20 actions to Node 24 on **2026-06-16** and removes the Node 20 runtime on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The `v0.0.3` docker-publish run surfaced the deprecation annotation.

## What

Bumped every action still on `runs.using: node20` to its latest major:

| Action | From | To |
|---|---|---|
| docker/login-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v6 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

`checkout@v5`, `setup-node@v5`, `setup-go@v6` already run on node24 — untouched.

## Behavior notes

- **upload-artifact@v7**: adds opt-in single-file direct upload; default `archive: true` preserves current behavior.
- **download-artifact@v8**: hash-mismatch now **errors** by default (was a warning) — fail-closed, desirable for the multi-arch digest merge.

Only `uses:` version strings changed across `docker-publish.yml`, `ci.yml`, `smoke-test-image.yml`.