### PR TITLE
Live install: runtime-image prerequisites, in-place relaunch, and end-to-end test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tmp/
 test-results/
 playwright-report/
 playwright/.cache/
+tests/install/todo-install-logs/
 
 # Local secrets — never commit
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -262,12 +262,27 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Enable corepack so `pnpm` is on PATH for the in-app package installer, which
-# runs `pnpm install` at the workspace root (step 7 of the install pipeline).
-# corepack shims pnpm to the version pinned in the root package.json
-# `packageManager` field. Node ships corepack; the runtime image just activates
-# it (the build stages do the same via `corepack enable`).
-RUN corepack enable
+# Make `pnpm` available on PATH for the in-app package installer, which runs
+# `pnpm install` at the workspace root (step 7 of the install pipeline). Node
+# ships corepack; `corepack enable` only creates a SHIM that lazily downloads
+# pnpm on first use AND prompts for confirmation — which fails non-interactively
+# inside the installer ("! Corepack is about to download …pnpm-11.3.0.tgz",
+# exit 1). So we `corepack prepare … --activate` here to actually fetch + cache
+# the pinned pnpm into the image at build time.
+#
+# COREPACK_HOME must be a shared, world-readable path: corepack caches the
+# prepared pnpm under $COREPACK_HOME (default ~/.cache/node/corepack), and we
+# prepare it here as root but the installer runs pnpm as the unprivileged
+# tinycld user — root's HOME cache is unreadable to tinycld. Point COREPACK_HOME
+# at /opt/corepack (chmod a+rX) and set the SAME env at runtime so the tinycld
+# process resolves the same cache. COREPACK_ENABLE_DOWNLOAD_PROMPT=0 belt-and-
+# suspenders against any later fetch blocking on a prompt. Version matches the
+# root package.json `packageManager` pin.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+ENV COREPACK_HOME=/opt/corepack
+RUN corepack enable \
+    && corepack prepare pnpm@11.3.0 --activate \
+    && chmod -R a+rX /opt/corepack
 
 # Copy Go toolchain from build stage (needed for the in-app package installer's
 # runtime Go-package rebuilds).

--- a/Dockerfile
+++ b/Dockerfile
@@ -327,8 +327,10 @@ COPY --from=go-builder /ws/app/server/tinycld ./tinycld
 COPY --from=web-builder /ws/app/release-staging /workspace/app/release-staging
 RUN mkdir -p /workspace/app/public /workspace/app/releases
 
-# Migrations with symlinks already resolved in web-builder.
-COPY --from=web-builder /ws/app/server/pb_migrations ./pb_migrations
+# Migrations: see the symlink set up after the full server tree is copied
+# below. (The runtime jsvm reads /workspace/app/pb_migrations; the generator +
+# in-app installer write to /workspace/app/server/pb_migrations — we make the
+# former a symlink to the latter so all three agree.)
 
 # Workspace-root files for the runtime scripts + in-app package-install
 # pipeline. These live at the workspace ROOT in the new layout: the root
@@ -384,6 +386,18 @@ COPY --from=web-builder /ws/app/assets ./assets
 # `replace => ../../core/server` and go.work `use ../../node_modules/...` paths
 # resolve against the members + node_modules copied above.
 COPY --from=go-builder /ws/app/server/ ./server/
+
+# Point the runtime migrations dir at the generator/installer's migrations dir.
+# jsvm reads /workspace/app/pb_migrations; the generator (and the in-app
+# installer when it regenerates after installing a package) writes migration
+# symlinks into /workspace/app/server/pb_migrations. Symlinking the former to
+# the latter means a newly-installed package's migrations are immediately
+# visible to the runtime and actually apply on the post-install restart —
+# without this, installed-package migrations land only in server/pb_migrations
+# and silently never run. Build-time (bundled) migrations live in
+# server/pb_migrations too (resolved real files from the go-builder COPY above),
+# so this unifies build + runtime + installer on one directory.
+RUN rm -rf ./pb_migrations && ln -s server/pb_migrations ./pb_migrations
 
 # bundled-packages.json so core's coreserver.SyncBundledPackages can find it at
 # startup. Generated at app/server/bundled-packages.json; the binary reads it

--- a/Dockerfile
+++ b/Dockerfile
@@ -378,10 +378,19 @@ RUN chmod +x ./entrypoint.sh
 # runtime scripts and in-app installer write under the workspace root
 # (node_modules, generated files).
 #
+# The workspace root is `/` itself (the binary is at /app/tinycld, so the
+# installer's wsRoot = filepath.Dir(/app) = /). Installing a NEW package copies
+# its source to /<slug> (e.g. /todo) and edits /pnpm-workspace.yaml — both
+# require the unprivileged tinycld user to write directly in /. Chown `/` itself
+# (non-recursive, so system dirs like /usr,/bin stay root) so member-dir
+# creation and workspace-file edits succeed; without it `cp … /todo/` fails with
+# "Permission denied" at the install pipeline's copy step.
+#
 # Must run BEFORE setcap below — chown strips file capabilities (it resets the
 # security.capability xattr along with ownership), so setcap'ing first then
 # chown'ing would silently wipe the cap.
-RUN chown -R tinycld:tinycld /app \
+RUN chown tinycld:tinycld / \
+    && chown -R tinycld:tinycld /app \
     && chown -R tinycld:tinycld /node_modules /core /contacts /mail /calendar /drive /calc /text /google-takeout-import \
     && chown tinycld:tinycld /package.json /pnpm-lock.yaml /pnpm-workspace.yaml /.npmrc /tinycld.packages.ts \
     && chown -R tinycld:tinycld /scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,9 +245,11 @@ ENV FZ_VERSION="1.25.1"
 # invoke `pnpm exec tsx scripts/<x>.ts` (reset-demo, seed-db), so Node must be on
 # PATH. libcap2-bin (setcap) is needed at image build time below; we keep it
 # available so operators on autocert who use the in-app package installer can
-# manually re-apply the cap to a freshly-rebuilt binary.
+# manually re-apply the cap to a freshly-rebuilt binary. git is required by the
+# in-app package installer: `npm pack <git-spec>` (e.g. github:owner/repo) clones
+# the repo via git, so without it git-spec installs fail with `spawn git ENOENT`.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl gnupg gosu \
+    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl git gnupg gosu \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get autoremove -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,8 +258,14 @@ ENV FZ_VERSION="1.25.1"
 # manifest validation ("requires Phase 3 support"); without g++, the runtime
 # `go build` fails with `exec: "g++": executable file not found`. libmupdf-dev
 # (already listed) supplies the cgo link target.
+#
+# sqlite3 (the CLI) is needed by the installer's database-backup step, which runs
+# `sqlite3 <db> "VACUUM INTO '<backup>'"` for a consistent snapshot before
+# swapping in the rebuilt binary. The Go server embeds a SQLite driver so the CLI
+# was never otherwise required; without it the install fails at "Backing up
+# database" with `exec: "sqlite3": not found`.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl git gcc g++ gnupg gosu \
+    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl git gcc g++ sqlite3 gnupg gosu \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get autoremove -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -381,16 +381,15 @@ RUN chmod +x ./entrypoint.sh
 # The workspace root is `/` itself (the binary is at /app/tinycld, so the
 # installer's wsRoot = filepath.Dir(/app) = /). Installing a NEW package copies
 # its source to /<slug> (e.g. /todo) and edits /pnpm-workspace.yaml — both
-# require the unprivileged tinycld user to write directly in /. Chown `/` itself
-# (non-recursive, so system dirs like /usr,/bin stay root) so member-dir
-# creation and workspace-file edits succeed; without it `cp … /todo/` fails with
-# "Permission denied" at the install pipeline's copy step.
+# require the unprivileged tinycld user to write directly in /. That `/` chown
+# CANNOT be done here: chowning the overlay mount root does not survive a layer
+# commit (it reverts to root:root). It's done at runtime instead, as root, by
+# entrypoint.sh's fix_workspace_root_ownership() before privileges are dropped.
 #
 # Must run BEFORE setcap below — chown strips file capabilities (it resets the
 # security.capability xattr along with ownership), so setcap'ing first then
 # chown'ing would silently wipe the cap.
-RUN chown tinycld:tinycld / \
-    && chown -R tinycld:tinycld /app \
+RUN chown -R tinycld:tinycld /app \
     && chown -R tinycld:tinycld /node_modules /core /contacts /mail /calendar /drive /calc /text /google-takeout-import \
     && chown tinycld:tinycld /package.json /pnpm-lock.yaml /pnpm-workspace.yaml /.npmrc /tinycld.packages.ts \
     && chown -R tinycld:tinycld /scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -297,24 +297,25 @@ ARG TINYCLD_UID=1000
 ARG TINYCLD_GID=1000
 RUN groupadd --system --gid "$TINYCLD_GID" tinycld \
     && useradd --system --uid "$TINYCLD_UID" --gid "$TINYCLD_GID" \
-        --home-dir /app --no-create-home --shell /usr/sbin/nologin tinycld
+        --home-dir /workspace/app --no-create-home --shell /usr/sbin/nologin tinycld
 
-# The runtime app tree lives at /app and mirrors the app member: the server
-# binary, the per-release web bundle, migrations, and the runtime scripts. The
-# workspace-level pieces the runtime scripts and in-app installer need
+# The runtime app tree lives at /workspace/app and mirrors the app member: the
+# server binary, the per-release web bundle, migrations, and the runtime scripts.
+# The workspace-level pieces the runtime scripts and in-app installer need
 # (node_modules, root manifests, tinycld.packages.ts, the sibling members) live
-# one level up at /app/.. (i.e. /), assembled below so that
-# node_modules/@tinycld/<x> symlinks → ../../<x> still resolve.
-WORKDIR /app
+# at /workspace (the parent of /workspace/app), assembled below so that
+# node_modules/@tinycld/<x> symlinks → ../../<x> resolve within /workspace.
+WORKDIR /workspace/app
 
 # Compiled server binary.
 COPY --from=go-builder /ws/app/server/tinycld ./tinycld
 
 # Per-release web bundle, staged by the web-builder. The entrypoint promotes
-# this on container start to /app/releases/. The /app/public/ directory is
-# reserved for the marketing website (populated by tinycld.org's deploy tail).
-COPY --from=web-builder /ws/app/release-staging /app/release-staging
-RUN mkdir -p /app/public /app/releases
+# this on container start to /workspace/app/releases/. The /workspace/app/public/
+# directory is reserved for the marketing website (populated by tinycld.org's
+# deploy tail).
+COPY --from=web-builder /ws/app/release-staging /workspace/app/release-staging
+RUN mkdir -p /workspace/app/public /workspace/app/releases
 
 # Migrations with symlinks already resolved in web-builder.
 COPY --from=web-builder /ws/app/server/pb_migrations ./pb_migrations
@@ -324,30 +325,32 @@ COPY --from=web-builder /ws/app/server/pb_migrations ./pb_migrations
 # package.json / pnpm-lock.yaml / pnpm-workspace.yaml / .npmrc, the hoisted
 # node_modules (with the @tinycld/<x> member symlinks), tinycld.packages.ts, and
 # scripts/link-members.ts (the in-app installer's postinstall re-runs it). They
-# sit one directory above the app tree so the symlinks (node_modules/@tinycld/<x>
-# → ../../<x>) still point at the sibling members copied below.
-COPY --from=web-builder /ws/package.json /ws/pnpm-lock.yaml /ws/pnpm-workspace.yaml /ws/.npmrc /
-COPY --from=web-builder /ws/tinycld.packages.ts /tinycld.packages.ts
-COPY --from=web-builder /ws/scripts /scripts
-COPY --from=web-builder /ws/node_modules /node_modules
+# sit at /workspace (one directory above /workspace/app) so the symlinks
+# (node_modules/@tinycld/<x> → ../../<x>) still point at the sibling members
+# copied below.
+COPY --from=web-builder /ws/package.json /ws/pnpm-lock.yaml /ws/pnpm-workspace.yaml /ws/.npmrc /workspace/
+COPY --from=web-builder /ws/tinycld.packages.ts /workspace/tinycld.packages.ts
+COPY --from=web-builder /ws/scripts /workspace/scripts
+COPY --from=web-builder /ws/node_modules /workspace/node_modules
 # package-scripts (the tinycld-pkg CLI) now lives inside the app member, so the
 # node_modules/@tinycld/package-scripts symlink resolves to ../../app/package-scripts
-# (i.e. /app/package-scripts at runtime, WORKDIR /app). Land it there.
+# (i.e. /workspace/app/package-scripts at runtime, WORKDIR /workspace/app). Land it there.
 COPY --from=web-builder /ws/app/package-scripts ./package-scripts
 
 # Sibling members. seed-db.ts (run by the reset-demo cron) imports
 # ../tinycld.seeds → each @tinycld/<feature>/seed, resolved through the
 # node_modules symlinks (node_modules/@tinycld/<x> → ../../<x>) into these
-# member dirs; core supplies the runtime libs they import. They sit at / so
-# the symlinks resolve (/node_modules/@tinycld/<x> → /<x>).
-COPY --from=web-builder /ws/core /core
-COPY --from=web-builder /ws/contacts /contacts
-COPY --from=web-builder /ws/mail /mail
-COPY --from=web-builder /ws/calendar /calendar
-COPY --from=web-builder /ws/drive /drive
-COPY --from=web-builder /ws/calc /calc
-COPY --from=web-builder /ws/text /text
-COPY --from=web-builder /ws/google-takeout-import /google-takeout-import
+# member dirs; core supplies the runtime libs they import. They sit at
+# /workspace so the symlinks resolve (/workspace/node_modules/@tinycld/<x>
+# → /workspace/<x>).
+COPY --from=web-builder /ws/core /workspace/core
+COPY --from=web-builder /ws/contacts /workspace/contacts
+COPY --from=web-builder /ws/mail /workspace/mail
+COPY --from=web-builder /ws/calendar /workspace/calendar
+COPY --from=web-builder /ws/drive /workspace/drive
+COPY --from=web-builder /ws/calc /workspace/calc
+COPY --from=web-builder /ws/text /workspace/text
+COPY --from=web-builder /ws/google-takeout-import /workspace/google-takeout-import
 
 # app-member files the runtime needs:
 #   - tinycld.config.ts / tinycld.seeds.ts: imported by seed-db.ts at runtime.
@@ -374,40 +377,31 @@ COPY --from=go-builder /ws/app/server/ ./server/
 
 # bundled-packages.json so core's coreserver.SyncBundledPackages can find it at
 # startup. Generated at app/server/bundled-packages.json; the binary reads it
-# relative to its own dir, so place a copy at /app for the boot-time seed.
+# relative to its own dir, so place a copy at /workspace/app for the boot-time seed.
 COPY --from=web-builder /ws/app/server/bundled-packages.json ./bundled-packages.json
 
-# Data dir (PB writes /app/pb_data relative to cwd) + the generated-types dir.
+# Data dir (PB writes pb_data relative to cwd) + the generated-types dir.
 # coreserver.DefaultTypesDir() resolves to <binaryDir>/../../core/types — with
-# the binary at /app/tinycld that is /core/types — where the schema hook writes
-# pbSchema.ts / pbZodSchema.ts at boot. Create it so the write succeeds.
-RUN mkdir -p /app/pb_data /core/types
+# the binary at /workspace/app/tinycld that is /workspace/core/types — where the
+# schema hook writes pbSchema.ts / pbZodSchema.ts at boot. Create it so the
+# write succeeds.
+RUN mkdir -p /workspace/app/pb_data /workspace/core/types
 
 
 COPY app/config/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 
-# Hand the entire app tree AND the workspace-root state to the tinycld user.
-# pb_data/ and types/ are bind-mount targets whose mount-time ownership is the
-# host's responsibility. The chown spans / one level up too, because the
-# runtime scripts and in-app installer write under the workspace root
-# (node_modules, generated files).
-#
-# The workspace root is `/` itself (the binary is at /app/tinycld, so the
-# installer's wsRoot = filepath.Dir(/app) = /). Installing a NEW package copies
-# its source to /<slug> (e.g. /todo) and edits /pnpm-workspace.yaml — both
-# require the unprivileged tinycld user to write directly in /. That `/` chown
-# CANNOT be done here: chowning the overlay mount root does not survive a layer
-# commit (it reverts to root:root). It's done at runtime instead, as root, by
-# entrypoint.sh's fix_workspace_root_ownership() before privileges are dropped.
+# Hand the entire workspace tree to the tinycld user with a single build-time
+# chown. Because /workspace is an ordinary subdirectory (not the overlay mount
+# root /), this chown PERSISTS through the layer commit — unlike a chown of /
+# which reverts to root:root. So no runtime chown is needed for workspace paths;
+# only bind-mounted data dirs (/workspace/app/pb_data, /workspace/core/types)
+# need fixing at runtime when Docker creates them owned by root.
 #
 # Must run BEFORE setcap below — chown strips file capabilities (it resets the
 # security.capability xattr along with ownership), so setcap'ing first then
 # chown'ing would silently wipe the cap.
-RUN chown -R tinycld:tinycld /app \
-    && chown -R tinycld:tinycld /node_modules /core /contacts /mail /calendar /drive /calc /text /google-takeout-import \
-    && chown tinycld:tinycld /package.json /pnpm-lock.yaml /pnpm-workspace.yaml /.npmrc /tinycld.packages.ts \
-    && chown -R tinycld:tinycld /scripts
+RUN chown -R tinycld:tinycld /workspace
 
 # Grant cap_net_bind_service so the non-root user can bind :80/:443 when
 # autocert is on (AUTOCERT_ENABLED=true with PRIMARY_DOMAIN set). The plain-HTTP
@@ -427,13 +421,13 @@ RUN setcap 'cap_net_bind_service=+ep' ./tinycld
 EXPOSE 7090 80 443 993 465
 
 # The container starts as root so the entrypoint can fix ownership of the
-# bind-mounted data dirs (/app/pb_data, /app/types) before the server runs.
-# When a host bind-mount target doesn't exist yet, Docker creates it owned by
-# root; the unprivileged tinycld user then can't open the SQLite DB ("unable to
-# open database file (14)") and the container crash-loops. entrypoint.sh
-# chown's those dirs to tinycld and drops to uid 1000 via gosu for the server
-# itself, so nothing privileged actually runs the application. See the
-# fix_data_dir_ownership() function in entrypoint.sh.
+# bind-mounted data dirs (/workspace/app/pb_data, /workspace/core/types) before
+# the server runs. When a host bind-mount target doesn't exist yet, Docker
+# creates it owned by root; the unprivileged tinycld user then can't open the
+# SQLite DB ("unable to open database file (14)") and the container crash-loops.
+# entrypoint.sh chown's those dirs to tinycld and drops to uid 1000 via gosu
+# for the server itself, so nothing privileged actually runs the application.
+# See the fix_data_dir_ownership() function in entrypoint.sh.
 USER root
 
 # The server process still runs as uid 1000 (tinycld) — the entrypoint drops

--- a/Dockerfile
+++ b/Dockerfile
@@ -248,14 +248,18 @@ ENV FZ_VERSION="1.25.1"
 # manually re-apply the cap to a freshly-rebuilt binary. git is required by the
 # in-app package installer: `npm pack <git-spec>` (e.g. github:owner/repo) clones
 # the repo via git, so without it git-spec installs fail with `spawn git ENOENT`.
-# gcc is required to install a package that ships a Go server: the installer's
-# checkGoBuildPrereqs() gate needs both `go` (from the copied toolchain) and a C
-# compiler on PATH, and the server binary is built with CGO_ENABLED=1 (it links
-# libmupdf via go-fitz). Without gcc, server packages are rejected at manifest
-# validation ("requires Phase 3 support"). libmupdf-dev (already listed) supplies
-# the cgo link target.
+# gcc AND g++ are required to install a package that ships a Go server: the
+# installer's checkGoBuildPrereqs() gate needs `go` (from the copied toolchain)
+# plus a C compiler, and the server is built with CGO_ENABLED=1. The cgo set
+# needs BOTH compilers — gcc for libmupdf (go-fitz) and g++ for goheif/libde265
+# (HEIF decode, which shells out to g++). The build-stage go-builder gets both
+# from the golang:trixie base (build-essential); the slim runtime base has
+# neither, so add them explicitly. Without gcc, server packages are rejected at
+# manifest validation ("requires Phase 3 support"); without g++, the runtime
+# `go build` fails with `exec: "g++": executable file not found`. libmupdf-dev
+# (already listed) supplies the cgo link target.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl git gcc gnupg gosu \
+    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl git gcc g++ gnupg gosu \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get autoremove -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -248,13 +248,26 @@ ENV FZ_VERSION="1.25.1"
 # manually re-apply the cap to a freshly-rebuilt binary. git is required by the
 # in-app package installer: `npm pack <git-spec>` (e.g. github:owner/repo) clones
 # the repo via git, so without it git-spec installs fail with `spawn git ENOENT`.
+# gcc is required to install a package that ships a Go server: the installer's
+# checkGoBuildPrereqs() gate needs both `go` (from the copied toolchain) and a C
+# compiler on PATH, and the server binary is built with CGO_ENABLED=1 (it links
+# libmupdf via go-fitz). Without gcc, server packages are rejected at manifest
+# validation ("requires Phase 3 support"). libmupdf-dev (already listed) supplies
+# the cgo link target.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl git gnupg gosu \
+    && apt-get install -y --no-install-recommends ca-certificates libffi8 libmupdf-dev libcap2-bin curl git gcc gnupg gosu \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Enable corepack so `pnpm` is on PATH for the in-app package installer, which
+# runs `pnpm install` at the workspace root (step 7 of the install pipeline).
+# corepack shims pnpm to the version pinned in the root package.json
+# `packageManager` field. Node ships corepack; the runtime image just activates
+# it (the build stages do the same via `corepack enable`).
+RUN corepack enable
 
 # Copy Go toolchain from build stage (needed for the in-app package installer's
 # runtime Go-package rebuilds).

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -282,8 +282,15 @@ fi
 # Serve args are in $@ (positional params) so a multi-domain list survives
 # without re-splitting.
 while true; do
-    run_tinycld serve "$@"
-    EXIT_CODE=$?
+    # Capture the serve exit code WITHOUT letting `set -e` abort the script.
+    # The in-app installer signals a restart by exiting the serve process with
+    # code 75; under `set -e` a bare `run_tinycld serve` would make the shell
+    # exit immediately on that non-zero code, before the 75-handling below ever
+    # runs (the container would just exit 75 instead of restarting in place).
+    # `|| EXIT_CODE=$?` swallows the non-zero for set -e and records the code;
+    # reset to 0 first so a clean exit is captured too.
+    EXIT_CODE=0
+    run_tinycld serve "$@" || EXIT_CODE=$?
 
     if [ $EXIT_CODE -eq 75 ]; then
         echo "[entrypoint] Restart requested (exit code 75)"

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -25,7 +25,7 @@ echo "[entrypoint] starting; pwd=$(pwd) user=$(id -un) uid=$(id -u)"
 fix_data_dir_ownership() {
     [ "$(id -u)" = "0" ] || return 0
 
-    for dir in /app/pb_data /app/types; do
+    for dir in /workspace/app/pb_data /workspace/app/types; do
         mkdir -p "$dir"
         # Skip the (potentially large) recursive chown when the top-level dir is
         # already owned correctly — the steady state after first run, so normal
@@ -36,26 +36,6 @@ fix_data_dir_ownership() {
             chown -R "$RUN_AS:$RUN_AS" "$dir"
         fi
     done
-}
-
-# Make the workspace root (`/`) writable by the runtime user so the in-app
-# package installer can create new member directories there (it copies a new
-# package's source to /<slug> and edits /pnpm-workspace.yaml; wsRoot is `/`
-# because the binary lives at /app/tinycld).
-#
-# This CANNOT be done at image-build time: a `chown`/`chmod` of `/` does not
-# survive a Docker layer commit (the overlay mount root reverts to root:root).
-# So we do it here at runtime, as root, on the live filesystem — which does
-# persist for the container's lifetime — before dropping to RUN_AS. Idempotent
-# and cheap (single, non-recursive chown), so it's fine on every boot.
-fix_workspace_root_ownership() {
-    [ "$(id -u)" = "0" ] || return 0
-
-    owner=$(stat -c '%u:%g' / 2>/dev/null || echo '')
-    if [ "$owner" != "1000:1000" ]; then
-        echo "[entrypoint] making workspace root / writable by $RUN_AS (was '$owner')"
-        chown "$RUN_AS:$RUN_AS" /
-    fi
 }
 
 # Run a tinycld subcommand as the unprivileged runtime user.
@@ -77,18 +57,17 @@ run_tinycld() {
 }
 
 fix_data_dir_ownership
-fix_workspace_root_ownership
 
-# Promote the staged release to /app/releases/. Runs on every container
-# start; idempotent.
+# Promote the staged release to /workspace/app/releases/. Runs on every
+# container start; idempotent.
 #
-# /app/releases is typically the container's writable layer (compose-style
-# deploys) and starts empty on every fresh container; Dokku-style deploys
-# may back it with a persistent volume so old releases survive container
-# replacement. Either way the promote logic below is the same: copy the
-# staged tree off the image, swap the `current` symlink atomically.
+# /workspace/app/releases is typically the container's writable layer
+# (compose-style deploys) and starts empty on every fresh container; Dokku-style
+# deploys may back it with a persistent volume so old releases survive container
+# replacement. Either way the promote logic below is the same: copy the staged
+# tree off the image, swap the `current` symlink atomically.
 #
-# Layout produced under /app/releases/:
+# Layout produced under /workspace/app/releases/:
 #   <id>/             per-release dir: app.html + release-id.txt
 #   _static/          cross-release asset pool:
 #     _expo/static/...    (content-hashed, immutable)
@@ -102,8 +81,8 @@ fix_workspace_root_ownership
 # old entries. The Go server serves /_expo/static/ and /assets/ from
 # _static/ directly — there is no per-request release lookup.
 promote_release() {
-    staging_dir=/app/release-staging
-    releases_dir=/app/releases
+    staging_dir=/workspace/app/release-staging
+    releases_dir=/workspace/app/releases
     pool_dir="$releases_dir/_static"
 
     echo "[entrypoint] promote_release: staging=$staging_dir releases=$releases_dir"

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -12,8 +12,9 @@ echo "[entrypoint] starting; pwd=$(pwd) user=$(id -un) uid=$(id -u)"
 
 # Ensure the bind-mounted data directories are writable by the runtime user.
 #
-# When a host bind-mount target (./pb_data, ./types in docker-compose.yml)
-# doesn't exist yet, the Docker daemon creates it owned by root:root. The
+# When a host bind-mount target (./pb_data → /workspace/app/pb_data and
+# ./types → /workspace/core/types in docker-compose.yml) doesn't exist yet, the
+# Docker daemon creates it owned by root:root. The
 # unprivileged tinycld user then can't open the SQLite database — PocketBase
 # fails with "unable to open database file (14)" and the container crash-loops.
 # Reported in https://github.com/tinycld/app/issues/26.
@@ -25,7 +26,7 @@ echo "[entrypoint] starting; pwd=$(pwd) user=$(id -un) uid=$(id -u)"
 fix_data_dir_ownership() {
     [ "$(id -u)" = "0" ] || return 0
 
-    for dir in /workspace/app/pb_data /workspace/app/types; do
+    for dir in /workspace/app/pb_data /workspace/core/types; do
         mkdir -p "$dir"
         # Skip the (potentially large) recursive chown when the top-level dir is
         # already owned correctly — the steady state after first run, so normal

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -295,8 +295,20 @@ while true; do
     if [ $EXIT_CODE -eq 75 ]; then
         echo "[entrypoint] Restart requested (exit code 75)"
 
-        # Health check: start new binary on a temp port, verify /api/health responds
-        run_tinycld serve --http=127.0.0.1:${HEALTH_PORT} &
+        # Health check: start the new binary on a temp HTTP port and verify
+        # /api/health responds. Disable the mail package's IMAP (:993) and SMTP
+        # (:465) listeners FOR THE PROBE ONLY via IMAP_ENABLED/SMTP_ENABLED=false
+        # — otherwise the probe binds those fixed ports, and after we kill it the
+        # ports aren't released before the real server restarts, so the restart
+        # crashes with "listen tcp :993: bind: address already in use". The probe
+        # only needs the HTTP listener to answer /api/health. The real serve
+        # below (the `continue`d loop iteration) starts with mail enabled as
+        # normal. Export the vars inside a backgrounded subshell so gosu passes
+        # them to the child and they don't leak to the real server.
+        (
+            export IMAP_ENABLED=false SMTP_ENABLED=false
+            run_tinycld serve --http=127.0.0.1:${HEALTH_PORT}
+        ) &
         HEALTH_PID=$!
 
         HEALTHY=false

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -38,6 +38,26 @@ fix_data_dir_ownership() {
     done
 }
 
+# Make the workspace root (`/`) writable by the runtime user so the in-app
+# package installer can create new member directories there (it copies a new
+# package's source to /<slug> and edits /pnpm-workspace.yaml; wsRoot is `/`
+# because the binary lives at /app/tinycld).
+#
+# This CANNOT be done at image-build time: a `chown`/`chmod` of `/` does not
+# survive a Docker layer commit (the overlay mount root reverts to root:root).
+# So we do it here at runtime, as root, on the live filesystem — which does
+# persist for the container's lifetime — before dropping to RUN_AS. Idempotent
+# and cheap (single, non-recursive chown), so it's fine on every boot.
+fix_workspace_root_ownership() {
+    [ "$(id -u)" = "0" ] || return 0
+
+    owner=$(stat -c '%u:%g' / 2>/dev/null || echo '')
+    if [ "$owner" != "1000:1000" ]; then
+        echo "[entrypoint] making workspace root / writable by $RUN_AS (was '$owner')"
+        chown "$RUN_AS:$RUN_AS" /
+    fi
+}
+
 # Run a tinycld subcommand as the unprivileged runtime user.
 #
 # When the container starts as root we drop privileges with gosu, which preserves
@@ -57,6 +77,7 @@ run_tinycld() {
 }
 
 fix_data_dir_ownership
+fix_workspace_root_ownership
 
 # Promote the staged release to /app/releases/. Runs on every container
 # start; idempotent.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,6 @@ services:
       # the container fixes their ownership on startup (it boots as root, chown's
       # them to its unprivileged runtime user, then drops privileges), so no
       # manual `chown` is needed before the first `docker compose up`.
-      - ./pb_data:/app/pb_data
+      - ./pb_data:/workspace/app/pb_data
       # Generated TypeScript types (pbSchema, pbZodSchema). Small, regenerated on migrations.
-      - ./types:/app/types
+      - ./types:/workspace/core/types

--- a/docs/live-install.md
+++ b/docs/live-install.md
@@ -1,0 +1,286 @@
+# Live Package Install & Relaunch
+
+How the in-app package installer fetches, builds, and activates a feature
+package **inside a running production container** — and how the container
+relaunches itself onto the rebuilt server + web bundle without external
+orchestration.
+
+This is the operator/agent-facing reference for the mechanics. For the package
+*format* (manifests, the generator, route re-exports) see
+[`packages.md`](./packages.md).
+
+> **Scope.** This describes the runtime install pipeline driven from the setup
+> dashboard (`POST /api/admin/packages/install`), implemented in
+> `core/server/coreserver/pkg_install.go` + `pkg_go_build.go` +
+> `pkg_restart.go`, and the relaunch handled by `app/config/entrypoint.sh`.
+> It does NOT cover the build-time bundling done by `app/Dockerfile` (that
+> assembles the *initial* image; the live installer adds packages to an
+> already-running one).
+
+## Contents
+
+- [The big picture](#the-big-picture)
+- [Entry points](#entry-points)
+- [The install pipeline, stage by stage](#the-install-pipeline-stage-by-stage)
+- [How relaunch works](#how-relaunch-works)
+- [Rollback](#rollback)
+- [Runtime image requirements](#runtime-image-requirements)
+- [Uninstall](#uninstall)
+- [Observability & troubleshooting](#observability--troubleshooting)
+
+## The big picture
+
+A TinyCld image ships with a set of **bundled** packages baked in at build time.
+The live installer lets a superuser add *more* packages to a running container —
+including third-party packages with their own Go server code — entirely
+in-place:
+
+1. The package source is fetched (npm registry **or** a git spec) and copied
+   into the workspace as a new member.
+2. The workspace is re-linked (`pnpm install`) and the generator re-runs,
+   materializing the new package's routes, config, migrations, and Go wiring.
+3. If the package ships a Go server, a **new server binary is compiled** from
+   the now-larger workspace and swapped in (with a DB backup first).
+4. The web bundle is rebuilt (`expo export`) and staged.
+5. The running server **exits with code 75**, and `entrypoint.sh` catches that,
+   health-checks the new binary, and **restarts the server in place** onto the
+   new binary + promoted web bundle.
+
+The whole thing runs as the unprivileged `tinycld` user inside the container.
+The workspace root is `/workspace` (the binary lives at
+`/workspace/app/tinycld`, so the installer derives `wsRoot = /workspace`); new
+members land at `/workspace/<slug>`.
+
+## Entry points
+
+The installer is registered in `pkg_install.go::RegisterPackageInstallEndpoints`
+under `/api/admin/packages` (all require superuser auth):
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/install` | Body `{ "npmPackage": "<spec>" }` — start an install job. Returns `202 { "jobId" }`. |
+| `POST` | `/uninstall` | Body `{ "slug": "<slug>" }` — start an uninstall job. |
+| `GET` | `/events/{jobId}` | Server-Sent Events stream of progress for a job (`progress` + `complete` events). Auth via header or `?token=` (EventSource can't send headers). |
+| `GET` | `/status/{slug}` | Last recorded install-log status for a slug. |
+
+Only **one** install/uninstall job runs at a time; a second request while one is
+in flight returns `409` with the current job's info.
+
+The setup dashboard's **Packages → Install** form (`PackageManager.tsx`) POSTs
+the spec and then opens an SSE connection to render `InstallProgressModal`.
+
+### Accepted specs
+
+`<spec>` is whatever `npm pack` understands, validated by
+`validatePackageSpec`:
+
+- a bare npm name — `@tinycld/mail`, `mail`, `mail@1.2.3`
+- a git spec — `github:owner/repo`, `gitlab:owner/repo`,
+  `bitbucket:owner/repo`, the `owner/repo` shorthand, `git+https://…`,
+  `git+ssh://…`, `https://….git`
+
+Specs are rejected if they start with `-` (flag injection) or contain shell
+metacharacters/whitespace. Anything outside the `@tinycld/` npm scope (every
+git spec included) is flagged **untrusted** and surfaces a "proceed with
+caution" warning — install only packages you trust, since installing one
+compiles and runs its server code.
+
+## The install pipeline, stage by stage
+
+A background goroutine (`runInstallPipeline`) drives the install and emits an
+SSE `progress` event at each step. The percentages double as a legible failure
+map — a hang or error reports the last stage reached. Each step also logs to
+stdout (visible in `docker logs`).
+
+| % | Stage | What happens |
+| --- | --- | --- |
+| 5 | Validating package name | `validatePackageSpec(spec)` |
+| 8 | Security warning | Emitted only for non-`@tinycld/` specs |
+| 15 | Downloading package | `npm pack <spec>` into a temp dir (clones via `git` for git specs) |
+| 20–30 | Parsing manifest | Untar the `package/`-prefixed tarball, parse `manifest.ts` |
+| 33–35 | Validating manifest | Required fields, slug shape, server prereqs (see below) |
+| 38–40 | Installing files | `cp -a` the extracted source to `/workspace/<slug>` |
+| 43–45 | Updating workspace | Add the member to `package.json` + `pnpm-workspace.yaml` |
+| 50–55 | Installing dependencies | `CI=true pnpm install --no-frozen-lockfile` at `/workspace` |
+| 60–65 | Generating wiring | `npx tsx scripts/generate.ts` — routes, config, migration symlinks, Go `go.work` |
+| 67 | Updating Go modules | `go work sync` (server packages only) |
+| 70 | Building server | `CGO_ENABLED=1 go build -o tinycld.new .` (server packages only) |
+| 73 | Validating binary | Run `tinycld.new --help` to confirm the build produced a working executable (the real boot health-check happens later, at relaunch) |
+| 75 | Backing up database | `sqlite3 <db> "VACUUM INTO 'data.db.backup'"` |
+| 77 | Swapping binary | `tinycld → tinycld.prev`, `tinycld.new → tinycld` (atomic renames) |
+| 80–83 | Running migrations | `<binary> migrate` — applies the package's `pb-migrations` |
+| 85–88 | Building web app | `npx expo export --platform web` |
+| 90–92 | Staging release | Move `dist/` → `release-staging/<id>/`, rename `index.html` → `app.html` |
+| 95–97 | Updating database | Upsert the `pkg_registry` record (status `installed`) |
+| 99 | Requesting restart | `os.Exit(75)` — hands off to the entrypoint (see next section) |
+
+### The server-package prerequisite gate
+
+A package that declares a `server` in its manifest can only be installed if the
+runtime has a Go toolchain: `validateManifest` calls `checkGoBuildPrereqs`,
+which requires both `go` **and** a C compiler on `PATH`. If either is missing,
+the install fails at the **Validating manifest** step with *"package … has
+server components which require Phase 3 support"*. Pure-frontend packages skip
+the Go build / binary-swap steps entirely.
+
+### Migrations apply through a shared directory
+
+The generator (re-run at the **Generating wiring** step) symlinks the new
+package's `pb-migrations` into `/workspace/app/server/pb_migrations`. The
+runtime jsvm plugin reads `/workspace/app/pb_migrations`, which the image makes
+a **symlink** to `server/pb_migrations` — so build-time (bundled), runtime, and
+installer-added migrations all share one directory and the **Running
+migrations** step actually applies the new package's migrations.
+
+## How relaunch works
+
+The installer never restarts the container from the outside. It signals the
+running server to exit with a sentinel code, and the entrypoint's supervisor
+loop does the relaunch.
+
+### 1. The server signals (exit 75)
+
+`requestRestart` (`pkg_restart.go`) writes a `pb_data/.restart-requested`
+marker and calls `os.Exit(75)`. In dev mode it logs and returns instead (you
+restart manually).
+
+### 2. The entrypoint catches it
+
+`entrypoint.sh` runs the server in a supervisor loop:
+
+```sh
+while true; do
+    EXIT_CODE=0
+    run_tinycld serve "$@" || EXIT_CODE=$?      # gosu → unprivileged tinycld
+    if [ $EXIT_CODE -eq 75 ]; then
+        # ... health-check + restart (below) ...
+        continue
+    fi
+    exit $EXIT_CODE                              # any other code = real exit
+done
+```
+
+The `|| EXIT_CODE=$?` is load-bearing: the script runs under `set -e`, so a
+bare `run_tinycld serve` would let the shell abort on the non-zero 75 *before*
+the restart logic — the container would just exit 75 instead of relaunching.
+
+### 3. Health-check the new binary
+
+Before committing to the swap, the entrypoint boots the **new** binary on a
+throwaway port (`127.0.0.1:19876`) and polls `/api/health` for up to 10s:
+
+```sh
+(
+    export IMAP_ENABLED=false SMTP_ENABLED=false
+    run_tinycld serve --http=127.0.0.1:19876
+) &
+HEALTH_PID=$!
+```
+
+`IMAP_ENABLED=false SMTP_ENABLED=false` are essential: a full `serve` also binds
+the mail package's fixed IMAP `:993` / SMTP `:465` ports. Without disabling
+them, the probe holds those ports, and after it's killed they aren't released
+before the real server restarts — the relaunch then dies with *"listen tcp
+:993: bind: address already in use."* The probe only needs the HTTP listener to
+answer the health check.
+
+### 4. Promote the web bundle and restart
+
+- **Health passes** → kill the probe and `continue` the loop. The next
+  iteration re-runs `serve` with mail enabled as normal, now executing the
+  swapped-in binary.
+- On that next boot the entrypoint's `promote_release` finds the staged
+  `release-staging/<id>/` (with its `app.html` + `release-id.txt`), merges its
+  hashed assets into the cross-release `_static/` pool, and atomically points
+  `releases/current` at the new release. The SPA fallback then serves the new
+  `app.html`.
+
+The container's uptime does **not** reset — it's the same container, the same
+PID 1 entrypoint, looping onto a new server process.
+
+## Rollback
+
+Failures before the binary swap (validation, download, build) just abort the
+job and run a rollback stack that undoes each completed step (remove the copied
+member dir, restore `package.json`/`pnpm-workspace.yaml`, re-run the generator).
+
+Failures *after* the swap are caught at relaunch:
+
+- If the **health-check fails**, the entrypoint restores the previous binary
+  (`mv tinycld tinycld.failed; mv tinycld.prev tinycld`) and continues onto the
+  old binary.
+- The pre-swap **SQLite `VACUUM INTO` backup** (`data.db.backup`) lets the
+  install pipeline's rollback restore the database if a later step fails.
+
+## Runtime image requirements
+
+The live installer shells out to real tools and needs a workspace it can write
+to. The runtime image (`app/Dockerfile`) provides:
+
+- **Tools on `PATH`:** `git` (git-spec `npm pack`), `node`/`npm`/`npx`,
+  `pnpm` (pre-activated into a shared `COREPACK_HOME=/opt/corepack` so the
+  unprivileged user finds it without a network fetch/prompt), the Go toolchain
+  plus `gcc` **and** `g++` (the server's cgo set links libmupdf *and*
+  goheif/libde265), `sqlite3` (the DB-backup `VACUUM INTO`), and `tar`/`cp`.
+- **A writable workspace:** the whole tree lives under `/workspace`, owned by
+  the `tinycld` runtime user, so the installer can create `/workspace/<slug>`
+  and rewrite the workspace manifests. (The workspace is *not* at the
+  filesystem root `/` — that would be root-owned and unwritable, and would also
+  break pnpm's same-filesystem linkability probe.)
+- **`pnpm` runs with `CI=true`** so `pnpm install` doesn't block on an
+  interactive node_modules-purge confirmation.
+
+> **Note.** The runtime image ships no Go module cache, so a server-package
+> `go build` downloads its dependencies from the network. Installing a server
+> package therefore needs outbound network access and can take several minutes.
+
+## Uninstall
+
+`POST /api/admin/packages/uninstall` with `{ "slug" }` runs the inverse
+pipeline (`runUninstallPipeline`): verify the package isn't bundled (bundled
+packages can't be uninstalled), remove `/workspace/<slug>`, drop the member from
+the workspace manifests, `pnpm install`, regenerate, rebuild + stage the web
+bundle, mark the `pkg_registry` record `disabled`, and request the same exit-75
+relaunch. Uninstall does **not** rebuild the Go binary — a disabled package's
+server code simply stops being registered after the regenerate + restart.
+
+## Observability & troubleshooting
+
+Every stage and every shelled-out command is echoed to the server's stdout, so
+`docker logs <container>` is a full install trace:
+
+```
+[pkg_install] [job_…] [50%] Installing dependencies: Running pnpm install
+[pkg_install] $ (cd /workspace && CI=true pnpm install --no-frozen-lockfile)
+[pkg_install] output of pnpm:
+…
+[pkg_install] [job_…] COMPLETE status=success
+```
+
+The same per-stage detail streams over the SSE endpoint to the progress modal,
+and a permanent record is written to the `pkg_install_log` collection
+(`action`, `status`, `error`, `log`, timestamps).
+
+The relaunch is equally legible — look for:
+
+```
+[entrypoint] Restart requested (exit code 75)
+[entrypoint] Health check passed, restarting server
+[entrypoint] promoting release <id> …
+… Server started at http://0.0.0.0:7090
+```
+
+A relaunch that crashes on `:993` means the health-check probe ran without the
+mail listeners disabled; an install that hangs with an empty `pkg_install_log`
+means the POST never fired (e.g. a UI selector targeting the wrong element).
+
+### Integration test
+
+`tests/install/todo-install.spec.ts` (driven by
+`tests/install/run-todo-install.sh`) exercises this whole path end to end: it
+builds an image from the working tree, walks `/setup`, installs
+`github:tinycld/todo`, and asserts the package is registered, its collection
+exists (migration applied), and its route is reachable after the relaunch. It is
+**runner-only** — gated behind `RUN_TODO_INSTALL_TEST=1` and excluded from
+normal CI — because it builds a purpose-made image and runs a real
+minutes-long install.

--- a/docs/live-install.md
+++ b/docs/live-install.md
@@ -280,7 +280,43 @@ means the POST never fired (e.g. a UI selector targeting the wrong element).
 `tests/install/run-todo-install.sh`) exercises this whole path end to end: it
 builds an image from the working tree, walks `/setup`, installs
 `github:tinycld/todo`, and asserts the package is registered, its collection
-exists (migration applied), and its route is reachable after the relaunch. It is
-**runner-only** — gated behind `RUN_TODO_INSTALL_TEST=1` and excluded from
-normal CI — because it builds a purpose-made image and runs a real
-minutes-long install.
+exists (migration applied), and its route is reachable after the relaunch.
+
+Run it from the app member (needs Docker):
+
+```sh
+cd app
+bash tests/install/run-todo-install.sh
+```
+
+The runner builds the image from the current working tree, boots it, scrapes the
+setup token from the container logs, and drives the Playwright spec in a
+standalone sandbox. Env knobs:
+
+| Var | Effect |
+| --- | --- |
+| `IMAGE=<tag>` | Skip the build and test an existing image tag (e.g. one you built earlier). |
+| `KEEP=1` | Leave the container running after the run for manual inspection. |
+| `PW_BASE_URL` | Override the container URL (default `http://localhost:7090`). |
+
+```sh
+# Reuse an already-built image and leave it up to poke at afterwards:
+IMAGE=tinycld-todo-test KEEP=1 bash tests/install/run-todo-install.sh
+```
+
+The spec is **runner-only** — it hard-skips unless `RUN_TODO_INSTALL_TEST=1` is
+set (the runner sets it) and lives outside `tests/e2e/`, so it never runs in the
+normal `tinycld-pkg test:e2e` suite or the docker smoke workflow. It builds a
+purpose-made image and runs a real, minutes-long install (the server `go build`
+downloads its deps from the network), so it's not part of routine CI.
+
+Because the install can outlast Playwright's wait on a cold `go build`, the
+authoritative result is the container log, not the Playwright exit code:
+
+```sh
+docker logs tinycld-todo-test | grep -E 'COMPLETE status=|Restart requested|Server started'
+```
+
+A successful run shows `COMPLETE status=success`, then the relaunch
+(`Restart requested` → `Health check passed` → a fresh `Server started`), with
+the container still up and `Todo` present in `pkg_registry` as `installed`.

--- a/tests/install/run-todo-install.sh
+++ b/tests/install/run-todo-install.sh
@@ -57,6 +57,25 @@ wait_healthy() {
     return 1
 }
 
+# Wait for the server to go DOWN after a restart was requested. Returns as
+# soon as /api/health stops responding. If it never goes down within the
+# window (a restart faster than our poll, or one we missed), warn and return
+# 0 — the subsequent wait_healthy still gates on the server being back up, so
+# the worst case is we proceed against a server that never actually restarted,
+# which the post-restart test's own login-retry loop will still exercise.
+wait_unhealthy() {
+    local label="$1"
+    for i in $(seq 1 60); do
+        if ! curl -sf "${BASE_URL}/api/health" >/dev/null 2>&1; then
+            echo "[runner] ${label}: server went down after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "[runner] WARN: ${label}: server never went down within 60s (fast or missed restart)"
+    return 0
+}
+
 # 1. Build image from the working tree (unless IMAGE points at an existing tag).
 if [ "${BUILD_IMAGE}" = "1" ]; then
     echo "[runner] building ${IMAGE} from ${WS_ROOT}"
@@ -116,8 +135,8 @@ echo "[runner] running bootstrap + install"
 
 # 7. The install requested a restart. Wait for the container to come back.
 echo "[runner] waiting for post-install restart"
-sleep 5  # let the container actually exit before re-polling
-wait_healthy "post-restart"
+wait_unhealthy "restart down"   # observe the old server exit first
+wait_healthy "post-restart"     # then wait for the new binary to come up
 
 # 8. Run the post-restart verification test.
 echo "[runner] running post-restart verification"

--- a/tests/install/run-todo-install.sh
+++ b/tests/install/run-todo-install.sh
@@ -155,6 +155,7 @@ echo "[runner] running bootstrap + install"
     cd "${PW_ROOT}"
     PW_BASE_URL="${BASE_URL}" \
     PW_TODO_SETUP_TOKEN="${TOKEN}" \
+    RUN_TODO_INSTALL_TEST=1 \
     CI=true FORCE_COLOR=0 \
     ./node_modules/.bin/playwright test --reporter=line,list \
         -g 'bootstrap|install @tinycld/todo'
@@ -173,6 +174,7 @@ echo "[runner] running post-restart verification"
 (
     cd "${PW_ROOT}"
     PW_BASE_URL="${BASE_URL}" \
+    RUN_TODO_INSTALL_TEST=1 \
     CI=true FORCE_COLOR=0 \
     ./node_modules/.bin/playwright test --reporter=line,list \
         -g 'after restart'

--- a/tests/install/run-todo-install.sh
+++ b/tests/install/run-todo-install.sh
@@ -19,6 +19,8 @@ WS_ROOT="$(cd "${APP_DIR}/.." && pwd)"
 CONTAINER=tinycld-todo-test
 BASE_URL="${PW_BASE_URL:-http://localhost:7090}"
 LOG_DIR="${SCRIPT_DIR}/todo-install-logs"
+LIVE_LOG="${LOG_DIR}/container.live.log"
+TAIL_PID=""
 
 # IMAGE defaults to a local build tag; if the caller sets IMAGE we skip the build.
 BUILD_IMAGE=1
@@ -29,18 +31,39 @@ else
 fi
 
 cleanup() {
+    # Stop the live log tail first so it doesn't dangle.
+    if [ -n "${TAIL_PID}" ]; then
+        kill "${TAIL_PID}" >/dev/null 2>&1 || true
+    fi
     if [ "${KEEP:-}" = "1" ]; then
         echo "[runner] KEEP=1 — leaving container ${CONTAINER} up"
+        echo "[runner] live container log: ${LIVE_LOG}"
         return
     fi
     docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
+# Start streaming the container's stdout/stderr to a file in the background so
+# the full install trace (npm pack / pnpm / go build / expo, now echoed to the
+# server's stdout) is captured LIVE — even if the test later hangs. A final
+# dump_logs still snapshots the complete log on failure.
+start_live_log() {
+    mkdir -p "${LOG_DIR}"
+    : > "${LIVE_LOG}"
+    docker logs -f "${CONTAINER}" >> "${LIVE_LOG}" 2>&1 &
+    TAIL_PID=$!
+    echo "[runner] streaming container logs → ${LIVE_LOG} (pid ${TAIL_PID})"
+}
+
 dump_logs() {
     mkdir -p "${LOG_DIR}"
     docker logs "${CONTAINER}" > "${LOG_DIR}/container.log" 2>&1 || true
     echo "[runner] container logs → ${LOG_DIR}/container.log"
+    echo "[runner] (live trace also at ${LIVE_LOG})"
+    echo "[runner] --- last 40 lines of container log ---"
+    tail -40 "${LOG_DIR}/container.log" || true
+    echo "[runner] --- end container log tail ---"
 }
 
 wait_healthy() {
@@ -92,6 +115,10 @@ fi
 docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 docker run -d --name "${CONTAINER}" -p 7090:7090 "${IMAGE}"
 
+# 2a. Begin streaming container logs to a file immediately, so we capture the
+# full install trace live even if a later step hangs.
+start_live_log
+
 # 3. Wait for first-boot health.
 wait_healthy "first boot"
 
@@ -129,14 +156,17 @@ echo "[runner] running bootstrap + install"
     PW_BASE_URL="${BASE_URL}" \
     PW_TODO_SETUP_TOKEN="${TOKEN}" \
     CI=true FORCE_COLOR=0 \
-    ./node_modules/.bin/playwright test --reporter=line \
+    ./node_modules/.bin/playwright test --reporter=line,list \
         -g 'bootstrap|install @tinycld/todo'
 ) || { echo "[runner] install phase failed"; dump_logs; exit 1; }
 
 # 7. The install requested a restart. Wait for the container to come back.
+# The restart kills the `docker logs -f` stream, so re-attach it after the
+# container is healthy again to keep capturing the post-restart boot trace.
 echo "[runner] waiting for post-install restart"
 wait_unhealthy "restart down"   # observe the old server exit first
 wait_healthy "post-restart"     # then wait for the new binary to come up
+start_live_log                  # re-attach the live log to the restarted container
 
 # 8. Run the post-restart verification test.
 echo "[runner] running post-restart verification"
@@ -144,7 +174,7 @@ echo "[runner] running post-restart verification"
     cd "${PW_ROOT}"
     PW_BASE_URL="${BASE_URL}" \
     CI=true FORCE_COLOR=0 \
-    ./node_modules/.bin/playwright test --reporter=line \
+    ./node_modules/.bin/playwright test --reporter=line,list \
         -g 'after restart'
 ) || { echo "[runner] post-restart phase failed"; dump_logs; exit 1; }
 

--- a/tests/install/run-todo-install.sh
+++ b/tests/install/run-todo-install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Local runner for the todo-install integration test. Builds a TinyCld
+# image from the CURRENT working tree (so the git-spec validation change is
+# present), boots it, scrapes the setup token, runs the Playwright spec in a
+# standalone sandbox, and tears the container down.
+#
+# Env knobs:
+#   IMAGE=<tag>   Skip the build and test an existing image tag.
+#   KEEP=1        Leave the container running after the run (manual debug).
+#   PW_BASE_URL   Override the base URL (default http://localhost:7090).
+set -euo pipefail
+
+# Resolve paths. This script lives at app/tests/install/; the app member is
+# two levels up, and the workspace root (the docker build context) is three.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WS_ROOT="$(cd "${APP_DIR}/.." && pwd)"
+
+CONTAINER=tinycld-todo-test
+BASE_URL="${PW_BASE_URL:-http://localhost:7090}"
+LOG_DIR="${SCRIPT_DIR}/todo-install-logs"
+
+# IMAGE defaults to a local build tag; if the caller sets IMAGE we skip the build.
+BUILD_IMAGE=1
+if [ -n "${IMAGE:-}" ]; then
+    BUILD_IMAGE=0
+else
+    IMAGE=tinycld-todo-test
+fi
+
+cleanup() {
+    if [ "${KEEP:-}" = "1" ]; then
+        echo "[runner] KEEP=1 — leaving container ${CONTAINER} up"
+        return
+    fi
+    docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+dump_logs() {
+    mkdir -p "${LOG_DIR}"
+    docker logs "${CONTAINER}" > "${LOG_DIR}/container.log" 2>&1 || true
+    echo "[runner] container logs → ${LOG_DIR}/container.log"
+}
+
+wait_healthy() {
+    local label="$1"
+    for i in $(seq 1 120); do
+        if curl -sf "${BASE_URL}/api/health" >/dev/null 2>&1; then
+            echo "[runner] ${label}: healthy after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "[runner] ERROR: ${label}: container never became healthy" >&2
+    dump_logs
+    return 1
+}
+
+# 1. Build image from the working tree (unless IMAGE points at an existing tag).
+if [ "${BUILD_IMAGE}" = "1" ]; then
+    echo "[runner] building ${IMAGE} from ${WS_ROOT}"
+    echo "[runner] NOTE: the build context is the assembled workspace root."
+    echo "[runner] If 'pnpm install --frozen-lockfile' fails on a missing member,"
+    echo "[runner] the local workspace has members the Dockerfile doesn't COPY —"
+    echo "[runner] that surfaces here as a build failure, by design."
+    docker build -f "${APP_DIR}/Dockerfile" -t "${IMAGE}" "${WS_ROOT}"
+else
+    echo "[runner] using existing image ${IMAGE} (skipping build)"
+fi
+
+# 2. Boot.
+docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+docker run -d --name "${CONTAINER}" -p 7090:7090 "${IMAGE}"
+
+# 3. Wait for first-boot health.
+wait_healthy "first boot"
+
+# 4. Scrape the setup token from logs.
+TOKEN=$(docker logs "${CONTAINER}" 2>&1 | grep -oE 'token=[a-f0-9]+' | head -1 | cut -d= -f2 || true)
+if [ -z "${TOKEN}" ]; then
+    echo "[runner] ERROR: no setup token printed in logs" >&2
+    dump_logs
+    exit 1
+fi
+echo "[runner] scraped setup token (${#TOKEN} chars)"
+
+# 5. Build the standalone Playwright sandbox (mirrors smoke-test-image.yml):
+#    @playwright/test installed locally + the spec + config copied in + a
+#    minimal tsconfig so the TS loader doesn't walk up to app/tsconfig.json.
+PW_VER=$(node -e "console.log(require('${APP_DIR}/package.json').devDependencies['@playwright/test'].replace(/^[\^~>=<]+/, ''))")
+PW_ROOT=$(mktemp -d)
+echo "[runner] sandbox at ${PW_ROOT} (playwright ${PW_VER})"
+(
+    cd "${PW_ROOT}"
+    npm init -y >/dev/null
+    npm install --ignore-scripts "@playwright/test@${PW_VER}" >/dev/null 2>&1
+    cat > tsconfig.json <<'TSCFG'
+{ "compilerOptions": { "target": "es2022", "module": "commonjs", "moduleResolution": "node", "esModuleInterop": true, "strict": false, "skipLibCheck": true } }
+TSCFG
+    cp "${SCRIPT_DIR}/playwright.config.ts" .
+    cp "${SCRIPT_DIR}/todo-install.spec.ts" .
+    ./node_modules/.bin/playwright install --with-deps chromium >/dev/null
+)
+
+# 6. Run bootstrap + install tests (everything except the post-restart check).
+echo "[runner] running bootstrap + install"
+(
+    cd "${PW_ROOT}"
+    PW_BASE_URL="${BASE_URL}" \
+    PW_TODO_SETUP_TOKEN="${TOKEN}" \
+    CI=true FORCE_COLOR=0 \
+    ./node_modules/.bin/playwright test --reporter=line \
+        -g 'bootstrap|install @tinycld/todo'
+) || { echo "[runner] install phase failed"; dump_logs; exit 1; }
+
+# 7. The install requested a restart. Wait for the container to come back.
+echo "[runner] waiting for post-install restart"
+sleep 5  # let the container actually exit before re-polling
+wait_healthy "post-restart"
+
+# 8. Run the post-restart verification test.
+echo "[runner] running post-restart verification"
+(
+    cd "${PW_ROOT}"
+    PW_BASE_URL="${BASE_URL}" \
+    CI=true FORCE_COLOR=0 \
+    ./node_modules/.bin/playwright test --reporter=line \
+        -g 'after restart'
+) || { echo "[runner] post-restart phase failed"; dump_logs; exit 1; }
+
+echo "[runner] ✅ todo install integration test passed"

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -9,6 +9,18 @@ import { expect, type Page, test } from '@playwright/test'
 // Designed for legible failure: each install stage is asserted by its
 // visible modal message, so a hang reports the last stage that appeared
 // rather than a generic timeout.
+//
+// NOT a normal-CI test. It needs a purpose-built docker image (the runner
+// `tests/install/run-todo-install.sh` builds it) and drives a real,
+// minutes-long install (npm pack → pnpm → go build → expo export → restart).
+// It is excluded from `tinycld-pkg test:e2e` by living outside tests/e2e/, and
+// from the docker smoke workflow (which copies only setup-and-packages.spec.ts).
+// As belt-and-suspenders we ALSO hard-skip the whole suite unless the runner
+// opts in via RUN_TODO_INSTALL_TEST=1, so it can never run accidentally if some
+// future config globs tests/install/ into a CI suite. The skip is asserted in a
+// beforeAll inside the describe (below) so every test in the file is skipped as
+// a group when the opt-in is absent.
+const RUN_INSTALL_TEST = process.env.RUN_TODO_INSTALL_TEST === '1'
 
 const SETUP_TOKEN = process.env.PW_TODO_SETUP_TOKEN
 
@@ -83,6 +95,16 @@ async function expectStage(
 test.describe.configure({ mode: 'serial' })
 
 test.describe('todo install', () => {
+    // Hard opt-in gate: this whole suite is runner-only (see the file header).
+    // Without RUN_TODO_INSTALL_TEST=1 every test is skipped, so the spec can't
+    // run in a normal CI suite even if its directory gets globbed in.
+    test.beforeAll(() => {
+        test.skip(
+            !RUN_INSTALL_TEST,
+            'todo-install is runner-only — set RUN_TODO_INSTALL_TEST=1 (run-todo-install.sh does)'
+        )
+    })
+
     test('bootstrap superuser via /setup wizard', async ({ page }) => {
         test.skip(
             !SETUP_TOKEN,
@@ -109,7 +131,13 @@ test.describe('todo install', () => {
     })
 
     test('install @tinycld/todo from github through the installer UI', async ({ page }) => {
-        test.setTimeout(1_800_000) // 30 min: go build + expo export dominate
+        // Generous overall budget: the runtime image has no Go module cache, so
+        // the installer's `go build` downloads hundreds of MB AND compiles
+        // (CGO/cgo links mupdf + libde265) — minutes on its own — and `expo
+        // export` is another multi-minute web build. 45 min covers a cold run on
+        // a slow network without the outer test timeout pre-empting the
+        // per-stage, stage-named timeouts below.
+        test.setTimeout(2_700_000) // 45 min
 
         await loginAsSuperuser(page)
 
@@ -128,13 +156,22 @@ test.describe('todo install', () => {
 
         // The InstallProgressModal renders once the job starts. Walk the
         // stages in order — each assertion names where it got stuck.
+        // Per-stage timeouts are the WAIT FOR THAT STAGE'S MESSAGE TO APPEAR,
+        // so each must cover the duration of the operation that PRECEDES it.
+        // The two long waits: 'pnpm install' follows the cold pnpm install, and
+        // 'Running expo export' is reached only after go build (uncached →
+        // downloads + CGO compile, the single slowest step). Give those, plus
+        // the post-expo restart signal, large headroom; the fast metadata
+        // stages stay tight so a genuine hang there still fails fast.
         await expectStage(page, 'Downloading package', 'Running npm pack', 120_000)
         await expectStage(page, 'Manifest parsed', 'Package: Todo (todo)', 120_000)
         await expectStage(page, 'Installing dependencies', 'Running pnpm install', 300_000)
         await expectStage(page, 'Generating wiring', 'Running package generation script', 120_000)
-        await expectStage(page, 'Building server', 'Compiling new server binary', 420_000)
-        await expectStage(page, 'Building web app', 'Running expo export', 420_000)
-        await expectStage(page, 'Requesting restart', 'Signaling server restart', 120_000)
+        await expectStage(page, 'Building server', 'Compiling new server binary', 300_000)
+        // go build (uncached): downloads + CGO compile — the slowest single step.
+        await expectStage(page, 'Building web app', 'Running expo export', 900_000)
+        // expo export: the web bundle rebuild.
+        await expectStage(page, 'Requesting restart', 'Signaling server restart', 600_000)
 
         // Confirm the modal didn't end in a failed state.
         await expect(page.getByText('Installation Failed')).not.toBeVisible()

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -34,23 +34,27 @@ async function loginAsSuperuser(page: Page) {
 }
 
 // Asserts the install modal advances through an expected stage by its
-// VISIBLE message text (step.message, not the short step name). If a
-// FAILED line appears first, throws with the failing message so the
-// output names the stage that broke. `label` is the human stage name
-// for the error string.
-async function expectStage(page: Page, label: string, messageSubstring: string) {
-    const failed = page.getByText(/^FAILED: /)
+// visible message text. Both racing waits only RESOLVE — the throw happens
+// after the race settles, based on the winner, so the losing wait can't
+// reject into an unhandled promise after the race is over. `label` names
+// the stage in the failure message; `timeoutMs` lets slow build stages
+// (go build, expo export) get more headroom than the fast ones.
+async function expectStage(
+    page: Page,
+    label: string,
+    messageSubstring: string,
+    timeoutMs = 120_000
+) {
+    const failed = page.getByText(/^FAILED: /).first()
     const target = page.getByText(messageSubstring, { exact: false }).first()
-    await Promise.race([
-        target.waitFor({ state: 'visible', timeout: 300_000 }),
-        failed
-            .first()
-            .waitFor({ state: 'visible', timeout: 300_000 })
-            .then(async () => {
-                const msg = (await failed.first().textContent()) ?? ''
-                throw new Error(`install failed before "${label}": ${msg}`)
-            }),
+    const winner = await Promise.race([
+        target.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'ok' as const),
+        failed.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'failed' as const),
     ])
+    if (winner === 'failed') {
+        const msg = (await failed.textContent()) ?? ''
+        throw new Error(`install failed before "${label}": ${msg}`)
+    }
 }
 
 test.describe.configure({ mode: 'serial' })
@@ -82,7 +86,7 @@ test.describe('todo install', () => {
     })
 
     test('install @tinycld/todo from github through the installer UI', async ({ page }) => {
-        test.setTimeout(900_000) // go build + expo export are minutes-long
+        test.setTimeout(1_800_000) // 30 min: go build + expo export dominate
 
         await loginAsSuperuser(page)
 
@@ -91,19 +95,20 @@ test.describe('todo install', () => {
         await page
             .getByRole('textbox', { name: 'npm Package Name', exact: true })
             .fill(TODO_SPEC)
-        // The form's submit button shares the 'Install' label; click the one
-        // inside the install form (the second match, after the toggle).
+        // When the form is open the toggle button reads 'Cancel', so only the
+        // form's submit button reads 'Install' here; .last() is defensive
+        // against future relabeling, not resolving a present collision.
         await page.getByRole('button', { name: 'Install', exact: true }).last().click()
 
         // The InstallProgressModal renders once the job starts. Walk the
         // stages in order — each assertion names where it got stuck.
-        await expectStage(page, 'Downloading package', 'Running npm pack')
-        await expectStage(page, 'Manifest parsed', 'Package: Todo (todo)')
-        await expectStage(page, 'Installing dependencies', 'Running pnpm install')
-        await expectStage(page, 'Generating wiring', 'Running package generation script')
-        await expectStage(page, 'Building server', 'Compiling new server binary')
-        await expectStage(page, 'Building web app', 'Running expo export')
-        await expectStage(page, 'Requesting restart', 'Signaling server restart')
+        await expectStage(page, 'Downloading package', 'Running npm pack', 120_000)
+        await expectStage(page, 'Manifest parsed', 'Package: Todo (todo)', 120_000)
+        await expectStage(page, 'Installing dependencies', 'Running pnpm install', 300_000)
+        await expectStage(page, 'Generating wiring', 'Running package generation script', 120_000)
+        await expectStage(page, 'Building server', 'Compiling new server binary', 420_000)
+        await expectStage(page, 'Building web app', 'Running expo export', 420_000)
+        await expectStage(page, 'Requesting restart', 'Signaling server restart', 120_000)
 
         // Confirm the modal didn't end in a failed state.
         await expect(page.getByText('Installation Failed')).not.toBeVisible()

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -114,12 +114,17 @@ test.describe('todo install', () => {
         await loginAsSuperuser(page)
 
         // Login lands on the Packages tab. Open the install form, then submit.
-        await page.getByRole('button', { name: 'Install', exact: true }).click()
+        // PackageManager's Install controls are Pressable+Text with no
+        // accessibilityRole, so on RN Web they expose as plain text, not
+        // buttons — getByRole('button', { name: 'Install' }) matches nothing.
+        // Target by text instead. The field DOES expose a role (TextInput sets
+        // accessibilityLabel), so getByRole('textbox', …) is correct there.
+        await page.getByText('Install', { exact: true }).click()
         await page.getByRole('textbox', { name: 'npm Package Name', exact: true }).fill(TODO_SPEC)
-        // When the form is open the toggle button reads 'Cancel', so only the
-        // form's submit button reads 'Install' here; .last() is defensive
-        // against future relabeling, not resolving a present collision.
-        await page.getByRole('button', { name: 'Install', exact: true }).last().click()
+        // When the form is open the toggle's text flips to 'Cancel', so only the
+        // form's submit reads 'Install'; .last() is defensive against future
+        // relabeling, not resolving a present collision.
+        await page.getByText('Install', { exact: true }).last().click()
 
         // The InstallProgressModal renders once the job starts. Walk the
         // stages in order — each assertion names where it got stuck.

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -33,6 +33,22 @@ async function loginAsSuperuser(page: Page) {
     await expect(page.getByText('Organizations', { exact: true })).toBeVisible()
 }
 
+// After the install-triggered restart the server may briefly refuse
+// connections. Retry the superuser login a few times before giving up.
+async function loginAsSuperuserWithRetry(page: Page, attempts = 10) {
+    let lastErr: unknown
+    for (let i = 0; i < attempts; i++) {
+        try {
+            await loginAsSuperuser(page)
+            return
+        } catch (err) {
+            lastErr = err
+            await page.waitForTimeout(3_000)
+        }
+    }
+    throw new Error(`superuser login failed after restart (${attempts} attempts): ${lastErr}`)
+}
+
 // Asserts the install modal advances through an expected stage by its
 // visible message text. Both racing waits only RESOLVE — the throw happens
 // after the race settles, based on the winner, so the losing wait can't
@@ -92,9 +108,7 @@ test.describe('todo install', () => {
 
         // Login lands on the Packages tab. Open the install form, then submit.
         await page.getByRole('button', { name: 'Install', exact: true }).click()
-        await page
-            .getByRole('textbox', { name: 'npm Package Name', exact: true })
-            .fill(TODO_SPEC)
+        await page.getByRole('textbox', { name: 'npm Package Name', exact: true }).fill(TODO_SPEC)
         // When the form is open the toggle button reads 'Cancel', so only the
         // form's submit button reads 'Install' here; .last() is defensive
         // against future relabeling, not resolving a present collision.
@@ -112,5 +126,56 @@ test.describe('todo install', () => {
 
         // Confirm the modal didn't end in a failed state.
         await expect(page.getByText('Installation Failed')).not.toBeVisible()
+    })
+
+    test('todo is registered, in nav, and reachable after restart', async ({ page }) => {
+        test.setTimeout(180_000)
+
+        // 1. Registry: Todo appears on the Packages tab with an installed badge.
+        await loginAsSuperuserWithRetry(page)
+        await expect(page.getByText('Todo', { exact: true })).toBeVisible()
+        await expect(page.getByText('installed', { exact: true }).first()).toBeVisible()
+
+        // 2. Create an org to log into — the superuser dashboard isn't the app
+        //    shell; the nav rail lives in the org-scoped app.
+        await page.getByText('Organizations', { exact: true }).first().click()
+        await page.getByRole('button', { name: 'New Organization' }).click()
+        await page
+            .getByRole('textbox', { name: 'Organization Name', exact: true })
+            .fill(TEST_ORG_NAME)
+        await page.getByRole('textbox', { name: 'Slug', exact: true }).fill(TEST_ORG_SLUG)
+        await page
+            .getByRole('textbox', { name: 'Owner Name', exact: true })
+            .fill(TEST_ORG_OWNER_NAME)
+        await page
+            .getByRole('textbox', { name: 'Owner Email', exact: true })
+            .fill(TEST_ORG_OWNER_EMAIL)
+        await page
+            .getByRole('textbox', { name: 'Owner Password', exact: true })
+            .fill(TEST_ORG_OWNER_PASSWORD)
+        await page
+            .getByRole('textbox', { name: 'Mail Domain', exact: true })
+            .fill(TEST_ORG_MAIL_DOMAIN)
+        await page.getByRole('button', { name: 'Create Organization' }).click()
+        await expect(page.getByText(TEST_ORG_NAME, { exact: true })).toBeVisible()
+
+        // 3. Nav + reachable screen: log into the org as the owner, confirm the
+        //    Todo rail entry renders and its screen mounts.
+        const orgPage = await page.context().newPage()
+        await orgPage.goto('/')
+        await orgPage.getByTestId('identifier').fill(TEST_ORG_OWNER_EMAIL)
+        await orgPage.getByTestId('login-password').fill(TEST_ORG_OWNER_PASSWORD)
+        await orgPage.getByTestId('login-submit').click()
+        await orgPage.waitForURL(/\/a\//, { timeout: 30_000 })
+
+        // The Todo nav-rail entry is icon-only; target it by testID.
+        const todoNav = orgPage.getByTestId('nav-todo')
+        await expect(todoNav).toBeVisible({ timeout: 30_000 })
+        await todoNav.click()
+
+        // The Todo screen mounts at /a/<orgSlug>/todo. Its add-todo input is a
+        // unique, stable signal that the package's bundled screen loaded.
+        await expect(orgPage).toHaveURL(/\/a\/[^/]+\/todo/, { timeout: 30_000 })
+        await expect(orgPage.getByPlaceholder('Add a todo…')).toBeVisible({ timeout: 30_000 })
     })
 })

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -1,0 +1,111 @@
+import { expect, type Page, test } from '@playwright/test'
+
+// Integration test for installing @tinycld/todo from GitHub through the
+// real in-app package installer. Boots against an already-running
+// container (the runner script builds the image from the working tree so
+// the git-spec validation change is present). Runs serially — every step
+// depends on prior container state, and the install restarts the container.
+//
+// Designed for legible failure: each install stage is asserted by its
+// visible modal message, so a hang reports the last stage that appeared
+// rather than a generic timeout.
+
+const SETUP_TOKEN = process.env.PW_TODO_SETUP_TOKEN
+
+const SUPERUSER_EMAIL = 'todo-smoke@example.com'
+const SUPERUSER_PASSWORD = 'TodoSmoke1234!'
+
+const TODO_SPEC = 'github:tinycld/todo'
+
+const TEST_ORG_NAME = 'Todo Org'
+const TEST_ORG_SLUG = 'todo-org'
+const TEST_ORG_OWNER_NAME = 'Todo Owner'
+const TEST_ORG_OWNER_EMAIL = 'owner@todo.example'
+const TEST_ORG_OWNER_PASSWORD = 'OwnerPass1234!'
+const TEST_ORG_MAIL_DOMAIN = 'todo.example'
+
+async function loginAsSuperuser(page: Page) {
+    await page.goto('/setup')
+    await expect(page.getByText('Superuser Login')).toBeVisible()
+    await page.getByRole('textbox', { name: 'Email', exact: true }).fill(SUPERUSER_EMAIL)
+    await page.getByRole('textbox', { name: 'Password', exact: true }).fill(SUPERUSER_PASSWORD)
+    await page.getByRole('button', { name: 'Sign in' }).click()
+    await expect(page.getByText('Organizations', { exact: true })).toBeVisible()
+}
+
+// Asserts the install modal advances through an expected stage by its
+// VISIBLE message text (step.message, not the short step name). If a
+// FAILED line appears first, throws with the failing message so the
+// output names the stage that broke. `label` is the human stage name
+// for the error string.
+async function expectStage(page: Page, label: string, messageSubstring: string) {
+    const failed = page.getByText(/^FAILED: /)
+    const target = page.getByText(messageSubstring, { exact: false }).first()
+    await Promise.race([
+        target.waitFor({ state: 'visible', timeout: 300_000 }),
+        failed
+            .first()
+            .waitFor({ state: 'visible', timeout: 300_000 })
+            .then(async () => {
+                const msg = (await failed.first().textContent()) ?? ''
+                throw new Error(`install failed before "${label}": ${msg}`)
+            }),
+    ])
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('todo install', () => {
+    test('bootstrap superuser via /setup wizard', async ({ page }) => {
+        test.skip(
+            !SETUP_TOKEN,
+            'PW_TODO_SETUP_TOKEN not set — the runner must scrape it from `docker logs`'
+        )
+
+        await page.goto(`/setup?token=${SETUP_TOKEN}`)
+        await expect(page.getByText('Welcome to TinyCld')).toBeVisible()
+
+        await page
+            .getByRole('textbox', { name: 'Application Name', exact: true })
+            .fill('Todo TinyCld')
+        await page.getByRole('textbox', { name: 'Email', exact: true }).fill(SUPERUSER_EMAIL)
+        await page.getByRole('textbox', { name: 'Password', exact: true }).fill(SUPERUSER_PASSWORD)
+        await page
+            .getByRole('textbox', { name: 'Confirm Password', exact: true })
+            .fill(SUPERUSER_PASSWORD)
+        await page
+            .getByRole('textbox', { name: 'App URL', exact: true })
+            .fill('http://localhost:7090')
+
+        await page.getByRole('button', { name: 'Create Account & Continue' }).click()
+        await expect(page.getByText('No organizations yet.')).toBeVisible()
+    })
+
+    test('install @tinycld/todo from github through the installer UI', async ({ page }) => {
+        test.setTimeout(900_000) // go build + expo export are minutes-long
+
+        await loginAsSuperuser(page)
+
+        // Login lands on the Packages tab. Open the install form, then submit.
+        await page.getByRole('button', { name: 'Install', exact: true }).click()
+        await page
+            .getByRole('textbox', { name: 'npm Package Name', exact: true })
+            .fill(TODO_SPEC)
+        // The form's submit button shares the 'Install' label; click the one
+        // inside the install form (the second match, after the toggle).
+        await page.getByRole('button', { name: 'Install', exact: true }).last().click()
+
+        // The InstallProgressModal renders once the job starts. Walk the
+        // stages in order — each assertion names where it got stuck.
+        await expectStage(page, 'Downloading package', 'Running npm pack')
+        await expectStage(page, 'Manifest parsed', 'Package: Todo (todo)')
+        await expectStage(page, 'Installing dependencies', 'Running pnpm install')
+        await expectStage(page, 'Generating wiring', 'Running package generation script')
+        await expectStage(page, 'Building server', 'Compiling new server binary')
+        await expectStage(page, 'Building web app', 'Running expo export')
+        await expectStage(page, 'Requesting restart', 'Signaling server restart')
+
+        // Confirm the modal didn't end in a failed state.
+        await expect(page.getByText('Installation Failed')).not.toBeVisible()
+    })
+})

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -24,22 +24,29 @@ const TEST_ORG_OWNER_EMAIL = 'owner@todo.example'
 const TEST_ORG_OWNER_PASSWORD = 'OwnerPass1234!'
 const TEST_ORG_MAIL_DOMAIN = 'todo.example'
 
-async function loginAsSuperuser(page: Page) {
-    await page.goto('/setup')
-    await expect(page.getByText('Superuser Login')).toBeVisible()
+async function loginAsSuperuser(page: Page, timeoutMs?: number) {
+    await page.goto('/setup', timeoutMs ? { timeout: timeoutMs } : undefined)
+    await expect(page.getByText('Superuser Login')).toBeVisible(
+        timeoutMs ? { timeout: timeoutMs } : undefined
+    )
     await page.getByRole('textbox', { name: 'Email', exact: true }).fill(SUPERUSER_EMAIL)
     await page.getByRole('textbox', { name: 'Password', exact: true }).fill(SUPERUSER_PASSWORD)
     await page.getByRole('button', { name: 'Sign in' }).click()
-    await expect(page.getByText('Organizations', { exact: true })).toBeVisible()
+    await expect(page.getByText('Organizations', { exact: true })).toBeVisible(
+        timeoutMs ? { timeout: timeoutMs } : undefined
+    )
 }
 
 // After the install-triggered restart the server may briefly refuse
 // connections. Retry the superuser login a few times before giving up.
-async function loginAsSuperuserWithRetry(page: Page, attempts = 10) {
+async function loginAsSuperuserWithRetry(page: Page, attempts = 20) {
     let lastErr: unknown
     for (let i = 0; i < attempts; i++) {
         try {
-            await loginAsSuperuser(page)
+            // Short per-attempt timeout so a still-restarting server fails
+            // fast and the loop actually iterates, instead of one attempt
+            // eating the whole budget under the default ~30s timeouts.
+            await loginAsSuperuser(page, 8_000)
             return
         } catch (err) {
             lastErr = err
@@ -129,7 +136,7 @@ test.describe('todo install', () => {
     })
 
     test('todo is registered, in nav, and reachable after restart', async ({ page }) => {
-        test.setTimeout(180_000)
+        test.setTimeout(300_000)
 
         // 1. Registry: Todo appears on the Packages tab with an installed badge.
         await loginAsSuperuserWithRetry(page)
@@ -161,21 +168,28 @@ test.describe('todo install', () => {
 
         // 3. Nav + reachable screen: log into the org as the owner, confirm the
         //    Todo rail entry renders and its screen mounts.
+        // Fresh page for the org-owner session. It shares this context's
+        // cookies/storage with `page` (partial isolation), which is fine —
+        // we only need a clean tab to drive the org-user login.
         const orgPage = await page.context().newPage()
-        await orgPage.goto('/')
-        await orgPage.getByTestId('identifier').fill(TEST_ORG_OWNER_EMAIL)
-        await orgPage.getByTestId('login-password').fill(TEST_ORG_OWNER_PASSWORD)
-        await orgPage.getByTestId('login-submit').click()
-        await orgPage.waitForURL(/\/a\//, { timeout: 30_000 })
+        try {
+            await orgPage.goto('/')
+            await orgPage.getByTestId('identifier').fill(TEST_ORG_OWNER_EMAIL)
+            await orgPage.getByTestId('login-password').fill(TEST_ORG_OWNER_PASSWORD)
+            await orgPage.getByTestId('login-submit').click()
+            await orgPage.waitForURL(/\/a\//, { timeout: 30_000 })
 
-        // The Todo nav-rail entry is icon-only; target it by testID.
-        const todoNav = orgPage.getByTestId('nav-todo')
-        await expect(todoNav).toBeVisible({ timeout: 30_000 })
-        await todoNav.click()
+            // The Todo nav-rail entry is icon-only; target it by testID.
+            const todoNav = orgPage.getByTestId('nav-todo')
+            await expect(todoNav).toBeVisible({ timeout: 30_000 })
+            await todoNav.click()
 
-        // The Todo screen mounts at /a/<orgSlug>/todo. Its add-todo input is a
-        // unique, stable signal that the package's bundled screen loaded.
-        await expect(orgPage).toHaveURL(/\/a\/[^/]+\/todo/, { timeout: 30_000 })
-        await expect(orgPage.getByPlaceholder('Add a todo…')).toBeVisible({ timeout: 30_000 })
+            // The Todo screen mounts at /a/<orgSlug>/todo. Its add-todo input is a
+            // unique, stable signal that the installed package's screen loaded.
+            await expect(orgPage).toHaveURL(/\/a\/[^/]+\/todo/, { timeout: 30_000 })
+            await expect(orgPage.getByPlaceholder('Add a todo…')).toBeVisible({ timeout: 30_000 })
+        } finally {
+            await orgPage.close()
+        }
     })
 })


### PR DESCRIPTION
Makes the in-app installer able to fetch, build, and **relaunch onto** a git-sourced package with a Go server, inside a running container. Paired with **tinycld/core#37** (the install-pipeline server logic); both are needed together.

This is the first end-to-end exercise of the install pipeline (the old smoke test only checked *bundled* packages), so it surfaced a stack of latent runtime/image gaps. Each was found by installing `github:tinycld/todo` and watching it fail at a concrete stage.

## Runtime image (`Dockerfile`)
- Add the tools the installer shells out to: **`git`** (git-spec `npm pack`), **`gcc` + `g++`** (the server's cgo links libmupdf *and* goheif/libde265), **`sqlite3`** (DB-backup `VACUUM INTO`), and **`pnpm`** pre-activated into a shared `COREPACK_HOME=/opt/corepack` (so the unprivileged user finds it without a network fetch/prompt).
- **Move the workspace root from `/` to `/workspace`** — the root-cause fix. With the workspace at the system root it was root-owned and unwritable by the runtime user, and broke pnpm's same-filesystem linkability probe. `wsRoot` derives from the binary path, so this needs no Go change; the whole tree becomes one `tinycld`-owned dir.
- **Symlink `pb_migrations → server/pb_migrations`** so an installed package's migrations actually reach the runtime jsvm dir and apply.

## Entrypoint (`config/entrypoint.sh`)
- **Capture the serve exit code without `set -e` aborting** — the installer signals a relaunch via `os.Exit(75)`; a bare `run_tinycld serve` under `set -e` made the container exit 75 instead of restarting in place.
- **Disable mail listeners in the restart health-check probe** (`IMAP_ENABLED=false SMTP_ENABLED=false`) so it doesn't hold IMAP `:993`/SMTP `:465` and crash the real relaunch with "address already in use".

## UI
- Target PackageManager's Install controls by **text** (they're text-Pressables, not `role=button` on RN Web).

## Test (`tests/install/`)
- `todo-install.spec.ts` + `run-todo-install.sh`: build an image from the working tree, walk `/setup`, install `github:tinycld/todo`, and verify it's registered, its collection exists (migration applied), and its route is reachable after the relaunch. **Runner-only** — gated behind `RUN_TODO_INSTALL_TEST=1`, outside `tests/e2e/`, so it never runs in normal CI.

## Docs
- `docs/live-install.md` — how the live install + relaunch works, the stage-by-stage pipeline, runtime requirements, and how to run the test.

## Note for review
Two early commits (`324ad99`, `8ce9844` — the build-time + runtime `chown /` attempts) are **superseded** by the `/workspace` move (`7e8b3b3`) and are harmless; candidates to squash out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)