### PR TITLE
feat: bake release manifest into image + stamp version inventory

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -128,28 +128,26 @@ jobs:
 
       # Derive OCI labels (standard image.* + custom tinycld.packages) from the
       # pinned manifest so `docker inspect` and registry UIs show exactly which
-      # package versions this image bundles. `org.tinycld.packages` is a compact
-      # comma-separated app=tag,member=tag list.
+      # package versions this image bundles. The inventory (key=value lines) is
+      # produced by app/scripts/release-image-inventory.sh — the SAME script the
+      # merge job uses for index annotations, so labels and annotations can't
+      # drift. `org.tinycld.packages` is a compact app=tag,member=tag list.
       - name: Compute image labels
         id: labels
         working-directory: ws
         run: |
           set -euo pipefail
-          MANIFEST=".release-assets/manifest.json"
-          APP_TAG=$(jq -r '.appTag' "$MANIFEST")
-          APP_SHA=$(jq -r '.appSha' "$MANIFEST")
-          RELEASED_AT=$(jq -r '.releasedAt' "$MANIFEST")
-          PKGS=$(jq -r '[ "app=" + .appTag ] + [ .members[] | .name + "=" + .tag ] | join(",")' "$MANIFEST")
+          # build-push-action's `labels:` input takes the same newline-delimited
+          # key=value format the script emits, so pass it straight through.
+          app/scripts/release-image-inventory.sh \
+            .release-assets/manifest.json "${GITHUB_REPOSITORY}" > /tmp/image-inventory.txt
           {
             echo "labels<<EOF"
-            echo "org.opencontainers.image.version=${APP_TAG}"
-            echo "org.opencontainers.image.revision=${APP_SHA}"
-            echo "org.opencontainers.image.created=${RELEASED_AT}"
-            echo "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
-            echo "org.tinycld.packages=${PKGS}"
+            cat /tmp/image-inventory.txt
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-          echo "Packages: ${PKGS}"
+          echo "Inventory:"
+          cat /tmp/image-inventory.txt
 
       - name: Build and push by digest
         id: build
@@ -216,10 +214,14 @@ jobs:
         run: echo "name=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/tinycld" >> "$GITHUB_OUTPUT"
 
       # Per-arch labels live on the child manifests; the multi-arch index needs
-      # annotations set explicitly. Re-download the pinned manifest (this job has
-      # no ws/ checkout) and build the same inventory as index annotations.
+      # annotations set explicitly. This job has no ws/ checkout, so re-download
+      # the pinned manifest AND the inventory script from the release tag's tree,
+      # then build the same key=value inventory the per-arch labels used (one
+      # source of truth — app/scripts/release-image-inventory.sh). The args are
+      # written to a FILE the create step reads directly; nothing is round-tripped
+      # through a `${{ }}`-interpolated shell string, so a value containing shell
+      # metacharacters can't be re-split or injected.
       - name: Compute index annotations
-        id: annotations
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -227,20 +229,17 @@ jobs:
           TAG="${GITHUB_REF_NAME:-${{ github.event.release.tag_name }}}"
           mkdir -p /tmp/rel
           gh release download "${TAG}" -R "${GITHUB_REPOSITORY}" -p manifest.json --dir /tmp/rel
-          MANIFEST="/tmp/rel/manifest.json"
-          APP_TAG=$(jq -r '.appTag' "$MANIFEST")
-          APP_SHA=$(jq -r '.appSha' "$MANIFEST")
-          RELEASED_AT=$(jq -r '.releasedAt' "$MANIFEST")
-          PKGS=$(jq -r '[ "app=" + .appTag ] + [ .members[] | .name + "=" + .tag ] | join(",")' "$MANIFEST")
-          {
-            echo "args<<EOF"
-            echo "--annotation=index:org.opencontainers.image.version=${APP_TAG}"
-            echo "--annotation=index:org.opencontainers.image.revision=${APP_SHA}"
-            echo "--annotation=index:org.opencontainers.image.created=${RELEASED_AT}"
-            echo "--annotation=index:org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
-            echo "--annotation=index:org.tinycld.packages=${PKGS}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          # Fetch the inventory script from the tagged commit so the merge job
+          # uses the exact same logic as the per-arch build (no ws/ checkout here).
+          gh api "repos/${GITHUB_REPOSITORY}/contents/app/scripts/release-image-inventory.sh?ref=${TAG}" \
+            -H 'Accept: application/vnd.github.raw' > /tmp/release-image-inventory.sh
+          chmod +x /tmp/release-image-inventory.sh
+          # One --annotation=index:<k>=<v> arg per inventory line, written to a
+          # file the create step reads with `read -r` (no eval, no word-splitting).
+          /tmp/release-image-inventory.sh /tmp/rel/manifest.json "${GITHUB_REPOSITORY}" \
+            | sed 's/^/--annotation=index:/' > /tmp/index-annotations.txt
+          echo "Index annotations:"
+          cat /tmp/index-annotations.txt
 
       - name: Derive tags
         id: tags
@@ -286,12 +285,15 @@ jobs:
           done
 
           # Index annotations carry the package-version inventory on the
-          # multi-arch manifest list itself (one --annotation arg per line).
+          # multi-arch manifest list itself — one --annotation arg per line of
+          # the file the previous step wrote. Reading from a file (not a
+          # `${{ }}`-interpolated string) keeps each arg a single shell word
+          # even if a value ever contained whitespace or metacharacters.
           annotation_args=()
           while IFS= read -r ann; do
             [ -z "$ann" ] && continue
             annotation_args+=("$ann")
-          done <<< '${{ steps.annotations.outputs.args }}'
+          done < /tmp/index-annotations.txt
 
           docker buildx imagetools create "${annotation_args[@]}" $tag_args $src_args
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -121,6 +121,35 @@ jobs:
           # Drop the pinned lockfile into the workspace root so the Dockerfile's
           # `pnpm install --frozen-lockfile` reproduces the exact dependency set.
           cp "${LOCKFILE}" pnpm-lock.yaml
+          # Hand the manifest to the Docker build so it's baked into the image
+          # and served by /api/release (the About panel reads it). The wildcard
+          # COPY in the Dockerfile makes it optional, so this is the only wiring.
+          cp "${MANIFEST}" app/.release-manifest
+
+      # Derive OCI labels (standard image.* + custom tinycld.packages) from the
+      # pinned manifest so `docker inspect` and registry UIs show exactly which
+      # package versions this image bundles. `org.tinycld.packages` is a compact
+      # comma-separated app=tag,member=tag list.
+      - name: Compute image labels
+        id: labels
+        working-directory: ws
+        run: |
+          set -euo pipefail
+          MANIFEST=".release-assets/manifest.json"
+          APP_TAG=$(jq -r '.appTag' "$MANIFEST")
+          APP_SHA=$(jq -r '.appSha' "$MANIFEST")
+          RELEASED_AT=$(jq -r '.releasedAt' "$MANIFEST")
+          PKGS=$(jq -r '[ "app=" + .appTag ] + [ .members[] | .name + "=" + .tag ] | join(",")' "$MANIFEST")
+          {
+            echo "labels<<EOF"
+            echo "org.opencontainers.image.version=${APP_TAG}"
+            echo "org.opencontainers.image.revision=${APP_SHA}"
+            echo "org.opencontainers.image.created=${RELEASED_AT}"
+            echo "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+            echo "org.tinycld.packages=${PKGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Packages: ${PKGS}"
 
       - name: Build and push by digest
         id: build
@@ -129,6 +158,7 @@ jobs:
           context: ws
           file: ws/app/Dockerfile
           platforms: ${{ matrix.platform }}
+          labels: ${{ steps.labels.outputs.labels }}
           # Cache scoped per-platform so the two jobs don't trample each
           # other's layers. Cache hit speeds repeat builds dramatically.
           cache-from: type=gha,scope=${{ matrix.cache_scope }}
@@ -185,6 +215,33 @@ jobs:
         id: image
         run: echo "name=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/tinycld" >> "$GITHUB_OUTPUT"
 
+      # Per-arch labels live on the child manifests; the multi-arch index needs
+      # annotations set explicitly. Re-download the pinned manifest (this job has
+      # no ws/ checkout) and build the same inventory as index annotations.
+      - name: Compute index annotations
+        id: annotations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME:-${{ github.event.release.tag_name }}}"
+          mkdir -p /tmp/rel
+          gh release download "${TAG}" -R "${GITHUB_REPOSITORY}" -p manifest.json --dir /tmp/rel
+          MANIFEST="/tmp/rel/manifest.json"
+          APP_TAG=$(jq -r '.appTag' "$MANIFEST")
+          APP_SHA=$(jq -r '.appSha' "$MANIFEST")
+          RELEASED_AT=$(jq -r '.releasedAt' "$MANIFEST")
+          PKGS=$(jq -r '[ "app=" + .appTag ] + [ .members[] | .name + "=" + .tag ] | join(",")' "$MANIFEST")
+          {
+            echo "args<<EOF"
+            echo "--annotation=index:org.opencontainers.image.version=${APP_TAG}"
+            echo "--annotation=index:org.opencontainers.image.revision=${APP_SHA}"
+            echo "--annotation=index:org.opencontainers.image.created=${RELEASED_AT}"
+            echo "--annotation=index:org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+            echo "--annotation=index:org.tinycld.packages=${PKGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Derive tags
         id: tags
         uses: docker/metadata-action@v5
@@ -228,7 +285,15 @@ jobs:
             src_args="$src_args ${{ steps.image.outputs.name }}@sha256:${f}"
           done
 
-          docker buildx imagetools create $tag_args $src_args
+          # Index annotations carry the package-version inventory on the
+          # multi-arch manifest list itself (one --annotation arg per line).
+          annotation_args=()
+          while IFS= read -r ann; do
+            [ -z "$ann" ] && continue
+            annotation_args+=("$ann")
+          done <<< '${{ steps.annotations.outputs.args }}'
+
+          docker buildx imagetools create "${annotation_args[@]}" $tag_args $src_args
 
       - name: Inspect published manifest
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,11 @@ server/pb_test_data/
 /installed-packages.json
 /.package-links.json
 
+# Transient release artifacts written into the app member by CI/deploy tooling
+# right before `docker build` (never committed).
+/.release-id
+/.release-manifest
+
 # Native projects — regenerated on demand by `expo prebuild`
 ios/
 android/

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,6 +136,13 @@ ENV NODE_OPTIONS="--max-old-space-size=2048"
 # (a hand-run `docker build`), the RUN below derives an id internally.
 COPY app/.release-id* ./app/
 
+# Bring in .release-manifest, the pinned-release manifest the release pipeline
+# uploads as a GitHub Release asset (utils/lib/pin-release.ts). CI copies it to
+# app/.release-manifest before `docker build`; the RUN below stages it next to
+# release-id.txt so the Go /api/release handler can serve it. The wildcard makes
+# it optional — local/hand-run builds with no manifest still build cleanly.
+COPY app/.release-manifest* ./app/
+
 # Resolve effective release id and stage the dist tree under
 # app/release-staging/<id>/. Done in one shell so the resolved id is consistent
 # across all steps. The web build runs from the app member (WORKDIR /ws/app):
@@ -159,6 +166,10 @@ RUN set -eu \
     && mkdir -p /ws/app/release-staging \
     && mv /ws/app/dist "/ws/app/release-staging/$rid" \
     && printf '%s' "$rid" > "/ws/app/release-staging/$rid/release-id.txt" \
+    && if [ -s .release-manifest ]; then \
+        cp .release-manifest "/ws/app/release-staging/$rid/manifest.json"; \
+        rm -f .release-manifest; \
+    fi \
     && mv "/ws/app/release-staging/$rid/index.html" "/ws/app/release-staging/$rid/app.html"
 
 

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -143,11 +143,16 @@ promote_release() {
     fi
 
     if [ ! -d "$dst" ]; then
-        echo "[entrypoint] promoting release $release_id ($src -> $dst, app.html + release-id.txt only)"
+        echo "[entrypoint] promoting release $release_id ($src -> $dst, app.html + release-id.txt + manifest.json)"
         rm -rf "$dst.tmp"
         mkdir "$dst.tmp"
         cp -a "$src/app.html" "$dst.tmp/"
         cp -a "$src/release-id.txt" "$dst.tmp/"
+        # manifest.json is present only on release builds (pinned-release recipe);
+        # the /api/release handler degrades gracefully when it's absent.
+        if [ -f "$src/manifest.json" ]; then
+            cp -a "$src/manifest.json" "$dst.tmp/"
+        fi
         mv "$dst.tmp" "$dst"
         echo "[entrypoint] promotion complete; size=$(du -sh "$dst" 2>/dev/null | cut -f1)"
     else

--- a/scripts/release-image-inventory.sh
+++ b/scripts/release-image-inventory.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Emit the OCI image-inventory key=value pairs derived from a pinned-release
+# manifest.json (produced by utils/lib/pin-release.ts and uploaded as a GitHub
+# Release asset). One source of truth for BOTH consumers in docker-publish.yml:
+#
+#   - the per-arch build, which feeds these as `labels:` to build-push-action
+#   - the merge job, which turns them into `--annotation=index:<k>=<v>` args on
+#     the multi-arch manifest list
+#
+# Keeping the jq here (rather than duplicated inline in two workflow steps)
+# stops the two consumers from silently drifting — labels and index annotations
+# must stay identical.
+#
+# Usage:  release-image-inventory.sh <manifest.json> <repository>
+#   <manifest.json>  path to the downloaded manifest
+#   <repository>     owner/repo, for the image.source label (pass $GITHUB_REPOSITORY)
+#
+# Output: lines of `key=value`, e.g.
+#   org.opencontainers.image.version=v0.0.4
+#   org.tinycld.packages=app=v0.0.4,mail=v0.0.2,...
+#
+# org.tinycld.packages is a compact comma-separated app=tag,member=tag list.
+set -euo pipefail
+
+MANIFEST="${1:?usage: release-image-inventory.sh <manifest.json> <repository>}"
+REPOSITORY="${2:?usage: release-image-inventory.sh <manifest.json> <repository>}"
+
+APP_TAG=$(jq -r '.appTag' "$MANIFEST")
+APP_SHA=$(jq -r '.appSha' "$MANIFEST")
+RELEASED_AT=$(jq -r '.releasedAt' "$MANIFEST")
+PKGS=$(jq -r '[ "app=" + .appTag ] + [ .members[] | .name + "=" + .tag ] | join(",")' "$MANIFEST")
+
+cat <<EOF
+org.opencontainers.image.version=${APP_TAG}
+org.opencontainers.image.revision=${APP_SHA}
+org.opencontainers.image.created=${RELEASED_AT}
+org.opencontainers.image.source=https://github.com/${REPOSITORY}
+org.tinycld.packages=${PKGS}
+EOF


### PR DESCRIPTION
## What

Bakes the pinned-release `manifest.json` into the image and stamps the package-version inventory onto the published image.

- **Dockerfile**: optional wildcard `COPY app/.release-manifest*` (so non-release/hand-run builds still build) + stages it next to `release-id.txt` in `release-staging/$rid/`.
- **entrypoint.sh**: promotes `manifest.json` into `releases/current/` alongside `app.html` + `release-id.txt`, so `/api/release` can serve it.
- **docker-publish.yml**: copies the manifest into the build context; stamps OCI labels per arch (`org.opencontainers.image.version/revision/created/source` + `org.tinycld.packages`); re-downloads the manifest in the merge job to set the same as **index annotations** on the multi-arch manifest.
- **.gitignore**: ignore the transient `.release-id` / `.release-manifest`.

## Why

The release pipeline already pins each package and uploads the manifest as a Release asset; this carries it into the image so it's visible via `docker inspect` and at runtime.

## Coordinated PRs

- `tinycld/core` — `/api/release` endpoint + About panel that reads the baked-in manifest
- `tinycld/utils` — appends the version table to the GitHub Release notes

## Testing

CI-only bash (Dockerfile branches, entrypoint copy, workflow annotation parsing) validated via `bash -n` and dry-run simulations; `docker-publish.yml` parses as valid YAML. Full exercise happens on the next real release.