### PR TITLE
fix: dev server not reachable from local app

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -601,7 +601,7 @@ function startProxy(opts: { proxyPort: number; pbPort: number; expoPort: number;
         server = http.createServer(handler)
     }
     server.on('upgrade', onUpgrade)
-    server.listen(opts.proxyPort, '127.0.0.1')
+    server.listen(opts.proxyPort, '0.0.0.0')
     return server
 }
 


### PR DESCRIPTION
The dev server should bind to 0.0.0.0 to be reachable from a locally connected app (e.g. via WiFi or USB cable).