### PR TITLE
test: live install + revert-to-base integration test + docs

### DIFF
--- a/docs/live-install.md
+++ b/docs/live-install.md
@@ -24,6 +24,7 @@ This is the operator/agent-facing reference for the mechanics. For the package
 - [The install pipeline, stage by stage](#the-install-pipeline-stage-by-stage)
 - [How relaunch works](#how-relaunch-works)
 - [Rollback](#rollback)
+- [Build history & revert](#build-history--revert)
 - [Runtime image requirements](#runtime-image-requirements)
 - [Uninstall](#uninstall)
 - [Observability & troubleshooting](#observability--troubleshooting)
@@ -112,6 +113,7 @@ stdout (visible in `docker logs`).
 | 85–88 | Building web app | `npx expo export --platform web` |
 | 90–92 | Staging release | Move `dist/` → `release-staging/<id>/`, rename `index.html` → `app.html` |
 | 95–97 | Updating database | Upsert the `pkg_registry` record (status `installed`) |
+| 98–99 | Archiving build | Copy the now-live binary + staged bundle into `builds/<build_id>/`, write `build.json`, and record a `pkg_build` row (status `current`) capturing how many migrations this install applied (see [Build history & revert](#build-history--revert)) |
 | 99 | Requesting restart | `os.Exit(75)` — hands off to the entrypoint (see next section) |
 
 ### The server-package prerequisite gate
@@ -212,6 +214,104 @@ Failures *after* the swap are caught at relaunch:
 - The pre-swap **SQLite `VACUUM INTO` backup** (`data.db.backup`) lets the
   install pipeline's rollback restore the database if a later step fails.
 
+## Build history & revert
+
+Beyond the install pipeline's automatic rollback, every **successful** install is
+saved as a restorable **build** that a superuser can manually revert to from the
+setup dashboard's **Build History** tab (`POST /api/admin/packages/revert`). The
+server code lives in `core/server/coreserver/pkg_build.go` (archive + record
+helpers) and `pkg_revert.go` (the revert pipeline + endpoints).
+
+### What's saved per build
+
+The install pipeline's "Archiving build" stage writes, under the binary's
+directory:
+
+```
+builds/<build_id>/
+    tinycld          # the server binary that was live after this install (server packages only)
+    release/         # a copy of the staged web bundle (app.html + assets + release-id.txt)
+    build.json       # mirror of the pkg_build record, for offline restore
+```
+
+and a `pkg_build` collection row (`pbc_pkg_build_01`) with: `build_id`
+(= the dir name, `build-<unixMilli>`), `pkg_slug`, `npm_package`, `version`,
+`binary_archived`, `release_id`, **`migrations_applied`** + **`migration_files`**
+(the exact migrations this install added, captured by diffing the `_migrations`
+history table before and after the `migrate` step), and `status` (`current` for
+the newest, `available` for older revertible builds, `superseded` for ones a
+revert skipped past). The prior `current` build is demoted to `available`. No
+per-build DB snapshot is taken — schema rollback is done with `migrate down`.
+
+### How a revert works
+
+`runRevertPipeline` mirrors the install pipeline (same SSE `progress`/`complete`
+events, so the same `InstallProgressModal` drives it) and **reuses the exit-75
+relaunch**:
+
+1. **Validate** the target build exists, is `available`, and its archive is intact.
+2. **Migration safety gate.** Sum `migrations_applied` across every build newer
+   than the target — that's the `N` for `migrate down N`. Confirm the live
+   `_migrations` tail (newest-first) still equals the recorded chain of those
+   newer builds. If it diverged (manual edit, `history-sync`, an out-of-band
+   install), **block** — a blind `migrate down N` could reverse the wrong
+   migrations. There is no DB-snapshot fallback; the operator resolves the
+   mismatch manually.
+3. **Backup the DB** (`data.db.backup`) as the revert operation's own safety net.
+4. **Swap in the archived binary** (`swapToArchivedBinary`): the live binary
+   becomes `tinycld.prev` (so the entrypoint's health-check can roll back to it),
+   and the archived binary is *copied* in (the archive stays intact).
+5. **`migrate down N`** runs with the **target's** binary, which understands the
+   older schema. User data is preserved; only the schema is rolled back.
+6. **Re-stage** `builds/<id>/release/` into `release-staging/<release_id>/` so the
+   entrypoint's `promote_release` serves it after relaunch.
+7. **Update records (one transaction):** mark the target `current`, mark every
+   newer build `superseded`, reconcile `pkg_registry` (a package whose *install*
+   was reverted past is set `disabled` — unless an earlier surviving build still
+   keeps it installed; bundled packages and the synthetic `(base image)` slug are
+   never touched), and point the target's `pkg_registry` row at the reverted
+   version. Wrapping these in `app.RunInTransaction` means an interrupted revert
+   can't leave the build set with zero or multiple `current` rows. The
+   `pkg_install_log` row (action `revert`) is the history trail.
+8. **`os.Exit(75)`** → the entrypoint health-checks the reverted binary and, on
+   failure, auto-restores `tinycld.prev` exactly as it does for an install.
+
+### Revert is one-way
+
+Because step 5 tears down the newer builds' migrations and step 7 marks them
+`superseded`, those builds are **permanently unreachable** — their binaries assume
+schema that no longer exists, and the migration tail they relied on is gone. The
+UI hides **Revert** on `superseded` (and `current`) rows and the confirm dialog
+names exactly which builds a revert will invalidate. Moving forward again is a
+fresh install of the newer version, which produces a new `available` build.
+
+### The base build (initial deploy)
+
+So that an operator can always return to "fresh image, before any live install",
+`SeedBaseBuild` (in `pkg_build.go`, called from the `OnServe` boot hook right after
+`SyncBundledPackages`) records a one-time **base build** the first time a deployed
+image boots. It is idempotent — it no-ops once any `pkg_build` row exists — and
+only runs in the deployed-image layout (it needs the live binary on disk and a
+promoted `releases/current/` to archive), so it silently skips in dev / `go run`.
+
+The base build has `build_id = build-base`, `migrations_applied = 0`, and an empty
+`migration_files`: the bundled migrations already applied at first boot are the
+schema floor and must never be stepped down. Reverting **to** the base build
+therefore reverses exactly the migrations of every live-installed build that came
+after it, and stops there. Its archived `release/` holds only `app.html` +
+`release-id.txt` (matching what `releases/current/` contains); the hashed assets
+already live in the append-only `_static/` pool, so promoting the base bundle on a
+revert resolves them without re-archiving. The first real install demotes the base
+build from `current` to `available`, at which point it becomes a revert target.
+
+### Retention & deletion
+
+Builds are **never auto-pruned** — they accumulate until a superuser deletes one
+with the per-row **Delete** action (`POST /api/admin/packages/builds/delete`),
+which removes the `pkg_build` record and the `builds/<id>/` archive. The current
+build can't be deleted. Archived binaries are large (cgo, ~100 MB+), so operators
+should delete builds they no longer need.
+
 ## Runtime image requirements
 
 The live installer shells out to real tools and needs a workspace it can write
@@ -280,7 +380,11 @@ means the POST never fired (e.g. a UI selector targeting the wrong element).
 `tests/install/run-todo-install.sh`) exercises this whole path end to end: it
 builds an image from the working tree, walks `/setup`, installs
 `github:tinycld/todo`, and asserts the package is registered, its collection
-exists (migration applied), and its route is reachable after the relaunch.
+exists (migration applied), a `pkg_build` row + the base build are listed in
+**Build History**, and its route is reachable after the relaunch. It then
+**reverts to the base build** through the Build History UI and asserts — after
+that second relaunch — that the todo build is now `superseded`, todo's migration
+was reversed (`migrate down`), and its nav entry/route are gone.
 
 Run it from the app member (needs Docker):
 

--- a/tests/install/run-todo-install.sh
+++ b/tests/install/run-todo-install.sh
@@ -180,4 +180,35 @@ echo "[runner] running post-restart verification"
         -g 'after restart'
 ) || { echo "[runner] post-restart phase failed"; dump_logs; exit 1; }
 
-echo "[runner] ✅ todo install integration test passed"
+# 9. Trigger a revert back to the base build through the Build History UI. Like
+# the install, this requests an exit-75 relaunch (swap archived base binary +
+# migrate down + re-stage base bundle), so it's driven as its own phase.
+echo "[runner] running revert-to-base"
+(
+    cd "${PW_ROOT}"
+    PW_BASE_URL="${BASE_URL}" \
+    RUN_TODO_INSTALL_TEST=1 \
+    CI=true FORCE_COLOR=0 \
+    ./node_modules/.bin/playwright test --reporter=line,list \
+        -g 'revert to the base build'
+) || { echo "[runner] revert phase failed"; dump_logs; exit 1; }
+
+# 10. The revert requested a restart. Wait for the container to come back, then
+# re-attach the live log to capture the post-revert boot trace.
+echo "[runner] waiting for post-revert restart"
+wait_unhealthy "revert restart down"
+wait_healthy "post-revert"
+start_live_log
+
+# 11. Verify todo is gone after the revert to base.
+echo "[runner] running post-revert verification"
+(
+    cd "${PW_ROOT}"
+    PW_BASE_URL="${BASE_URL}" \
+    RUN_TODO_INSTALL_TEST=1 \
+    CI=true FORCE_COLOR=0 \
+    ./node_modules/.bin/playwright test --reporter=line,list \
+        -g 'gone after revert'
+) || { echo "[runner] post-revert phase failed"; dump_logs; exit 1; }
+
+echo "[runner] ✅ todo install + revert integration test passed"

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -6,9 +6,10 @@ import { expect, type Page, test } from '@playwright/test'
 // the git-spec validation change is present). Runs serially — every step
 // depends on prior container state, and the install restarts the container.
 //
-// Designed for legible failure: each install stage is asserted by its
-// visible modal message, so a hang reports the last stage that appeared
-// rather than a generic timeout.
+// Install/revert progress streams to a modal over SSE, but the test judges
+// success by polling the server's pkg_install_log status (ground truth),
+// not the modal — an EventSource that connects a hair late can miss the
+// fast early stages, making modal-text assertions inherently racy here.
 //
 // NOT a normal-CI test. It needs a purpose-built docker image (the runner
 // `tests/install/run-todo-install.sh` builds it) and drives a real,
@@ -68,28 +69,146 @@ async function loginAsSuperuserWithRetry(page: Page, attempts = 20) {
     throw new Error(`superuser login failed after restart (${attempts} attempts): ${lastErr}`)
 }
 
-// Asserts the install modal advances through an expected stage by its
-// visible message text. Both racing waits only RESOLVE — the throw happens
-// after the race settles, based on the winner, so the losing wait can't
-// reject into an unhandled promise after the race is over. `label` names
-// the stage in the failure message; `timeoutMs` lets slow build stages
-// (go build, expo export) get more headroom than the fast ones.
-async function expectStage(
-    page: Page,
-    label: string,
-    messageSubstring: string,
-    timeoutMs = 120_000
-) {
-    const failed = page.getByText(/^FAILED: /).first()
-    const target = page.getByText(messageSubstring, { exact: false }).first()
-    const winner = await Promise.race([
-        target.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'ok' as const),
-        failed.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'failed' as const),
-    ])
-    if (winner === 'failed') {
-        const msg = (await failed.textContent()) ?? ''
-        throw new Error(`install failed before "${label}": ${msg}`)
+// Mints a fresh superuser token via the API. The setup page's PocketBase
+// instance (useSuperUserPB) has no persistent auth store — its token lives only
+// in memory — so we can't read it from localStorage. Instead authenticate
+// directly against the _superusers collection, the same call the login form makes.
+async function superuserToken(page: Page): Promise<string> {
+    const res = await page.request.post('/api/collections/_superusers/auth-with-password', {
+        data: { identity: SUPERUSER_EMAIL, password: SUPERUSER_PASSWORD },
+        failOnStatusCode: false,
+    })
+    if (!res.ok()) {
+        throw new Error(`superuser auth failed: ${res.status()} ${await res.text()}`)
     }
+    const body = (await res.json()) as { token?: string }
+    if (!body.token) throw new Error('superuser auth returned no token')
+    return body.token
+}
+
+// Polls the admin package-status endpoint (backed by pkg_install_log) until the
+// slug's install reaches `wantStatus`, throwing on a terminal failure. This is
+// the SSE-independent ground truth for "did the background install finish?".
+// Uses page.request so it shares the browser's network context (same origin,
+// so PB_SERVER_ADDR resolution is irrelevant — we hit the same host as the app).
+async function waitForInstallStatus(
+    page: Page,
+    slug: string,
+    wantStatus: string,
+    timeoutMs: number,
+    wantAction?: string
+) {
+    const url = `/api/admin/packages/status/${slug}`
+    const deadline = Date.now() + timeoutMs
+    let token = await superuserToken(page)
+    let last = 'no-response-yet'
+
+    // One status read. Returns the parsed body, or null on any transient
+    // condition (network error / connection reset / non-ok). The job ends by
+    // restarting the server (exit 75), so ECONNRESET and refused connections are
+    // EXPECTED mid-poll and must NOT fail the test — they just mean "try again".
+    // Re-mints the token on an auth failure (tokens expire; a restart can also
+    // invalidate the session).
+    async function readStatusOnce(): Promise<{
+        status?: string
+        error?: string
+        action?: string
+    } | null> {
+        let res: Awaited<ReturnType<typeof page.request.get>>
+        try {
+            res = await page.request.get(url, {
+                headers: { Authorization: token },
+                failOnStatusCode: false,
+            })
+        } catch {
+            return null // connection reset/refused during the restart window
+        }
+        if (res.status() === 401 || res.status() === 403) {
+            try {
+                token = await superuserToken(page)
+                res = await page.request.get(url, {
+                    headers: { Authorization: token },
+                    failOnStatusCode: false,
+                })
+            } catch {
+                return null
+            }
+        }
+        if (!res.ok()) return null
+        try {
+            return await res.json()
+        } catch {
+            return null
+        }
+    }
+
+    while (Date.now() < deadline) {
+        const body = await readStatusOnce()
+        if (body) {
+            last = `${body.action ?? '?'}/${body.status ?? '?'}`
+            // Only judge the operation we're waiting on. The status endpoint
+            // returns the latest log row; if wantAction is set, ignore rows for a
+            // different action (e.g. a stale install row before the revert row
+            // lands).
+            const actionMatches = !wantAction || body.action === wantAction
+            if (actionMatches && body.status === wantStatus) return
+            if (actionMatches && (body.status === 'failed' || body.status === 'rolled_back')) {
+                throw new Error(
+                    `${slug} ${body.action} ended ${body.status}: ${body.error ?? '(no error)'}`
+                )
+            }
+        }
+        await page.waitForTimeout(3_000)
+    }
+    throw new Error(
+        `${slug} did not reach ${wantAction ?? ''}/${wantStatus} within ${timeoutMs}ms (last=${last})`
+    )
+}
+
+// Polls the pkg_build collection until the given build reaches `wantStatus`
+// (e.g. base build → `current` after a revert). This is the unambiguous,
+// SSE-independent signal a revert finished: a revert logs under the TARGET
+// build's slug (for the base build that's "(base image)", not the package
+// slug), so the build record's status — not the install log — is the reliable
+// ground truth. Resilient to the exit-75 restart the revert triggers.
+async function waitForBuildStatus(
+    page: Page,
+    buildId: string,
+    wantStatus: string,
+    timeoutMs: number
+) {
+    const deadline = Date.now() + timeoutMs
+    let token = await superuserToken(page)
+    let last = 'no-response-yet'
+    while (Date.now() < deadline) {
+        let body: { items?: Array<{ status?: string }> } | null = null
+        try {
+            const filter = encodeURIComponent(`build_id='${buildId}'`)
+            let res = await page.request.get(
+                `/api/collections/pkg_build/records?filter=${filter}`,
+                { headers: { Authorization: token }, failOnStatusCode: false }
+            )
+            if (res.status() === 401 || res.status() === 403) {
+                token = await superuserToken(page)
+                res = await page.request.get(
+                    `/api/collections/pkg_build/records?filter=${filter}`,
+                    { headers: { Authorization: token }, failOnStatusCode: false }
+                )
+            }
+            if (res.ok()) body = await res.json()
+        } catch {
+            // connection reset/refused during the restart window — retry
+        }
+        const status = body?.items?.[0]?.status
+        if (status) {
+            last = status
+            if (status === wantStatus) return
+        }
+        await page.waitForTimeout(3_000)
+    }
+    throw new Error(
+        `build ${buildId} did not reach ${wantStatus} within ${timeoutMs}ms (last=${last})`
+    )
 }
 
 test.describe.configure({ mode: 'serial' })
@@ -154,27 +273,17 @@ test.describe('todo install', () => {
         // relabeling, not resolving a present collision.
         await page.getByText('Install', { exact: true }).last().click()
 
-        // The InstallProgressModal renders once the job starts. Walk the
-        // stages in order — each assertion names where it got stuck.
-        // Per-stage timeouts are the WAIT FOR THAT STAGE'S MESSAGE TO APPEAR,
-        // so each must cover the duration of the operation that PRECEDES it.
-        // The two long waits: 'pnpm install' follows the cold pnpm install, and
-        // 'Running expo export' is reached only after go build (uncached →
-        // downloads + CGO compile, the single slowest step). Give those, plus
-        // the post-expo restart signal, large headroom; the fast metadata
-        // stages stay tight so a genuine hang there still fails fast.
-        await expectStage(page, 'Downloading package', 'Running npm pack', 120_000)
-        await expectStage(page, 'Manifest parsed', 'Package: Todo (todo)', 120_000)
-        await expectStage(page, 'Installing dependencies', 'Running pnpm install', 300_000)
-        await expectStage(page, 'Generating wiring', 'Running package generation script', 120_000)
-        await expectStage(page, 'Building server', 'Compiling new server binary', 300_000)
-        // go build (uncached): downloads + CGO compile — the slowest single step.
-        await expectStage(page, 'Building web app', 'Running expo export', 900_000)
-        // expo export: the web bundle rebuild.
-        await expectStage(page, 'Requesting restart', 'Signaling server restart', 600_000)
-
-        // Confirm the modal didn't end in a failed state.
-        await expect(page.getByText('Installation Failed')).not.toBeVisible()
+        // The install runs server-side as a background job and the modal streams
+        // its progress over SSE. We DON'T assert on the SSE-streamed modal stages
+        // here: the early stages can blow past in well under a second and an
+        // EventSource that connects a hair late never sees them, making
+        // stage-by-stage assertions inherently racy in this environment. The
+        // authoritative signal that the install succeeded is the server's own
+        // pkg_install_log record reaching status `success` — poll that via the
+        // admin status endpoint (ground truth, independent of the modal). The
+        // install ends by requesting an exit-75 restart; the runner waits for the
+        // relaunch and the next test verifies the package is actually live.
+        await waitForInstallStatus(page, 'todo', 'success', 2_400_000) // up to 40 min
     })
 
     test('todo is registered, in nav, and reachable after restart', async ({ page }) => {
@@ -184,6 +293,16 @@ test.describe('todo install', () => {
         await loginAsSuperuserWithRetry(page)
         await expect(page.getByText('Todo', { exact: true })).toBeVisible()
         await expect(page.getByText('installed', { exact: true }).first()).toBeVisible()
+
+        // 1b. Build History: the install saved a restorable build. The new tab
+        //     lists the todo build as `current` (proves the pkg_build row was
+        //     written and builds/<id>/ archived during the install pipeline), and
+        //     the base build seeded on first boot as `available` — the target the
+        //     later revert test returns to.
+        await page.getByText('Build History', { exact: true }).click()
+        await expect(page.getByText('todo', { exact: true }).first()).toBeVisible()
+        await expect(page.getByText('current', { exact: true }).first()).toBeVisible()
+        await expect(page.getByText('(base image)', { exact: true })).toBeVisible()
 
         // 2. Create an org to log into — the superuser dashboard isn't the app
         //    shell; the nav rail lives in the org-scoped app.
@@ -221,15 +340,73 @@ test.describe('todo install', () => {
             await orgPage.getByTestId('login-submit').click()
             await orgPage.waitForURL(/\/a\//, { timeout: 30_000 })
 
-            // The Todo nav-rail entry is icon-only; target it by testID.
+            // The Todo nav-rail entry is icon-only; target it by testID. Its
+            // presence proves the installed package was wired into the nav.
             const todoNav = orgPage.getByTestId('nav-todo')
             await expect(todoNav).toBeVisible({ timeout: 30_000 })
             await todoNav.click()
 
-            // The Todo screen mounts at /a/<orgSlug>/todo. Its add-todo input is a
-            // unique, stable signal that the installed package's screen loaded.
-            await expect(orgPage).toHaveURL(/\/a\/[^/]+\/todo/, { timeout: 30_000 })
-            await expect(orgPage.getByPlaceholder('Add a todo…')).toBeVisible({ timeout: 30_000 })
+            // The Todo screen mounts at /a/<orgSlug>/todo — the route resolving is
+            // the signal that the installed package's screen is reachable. On a
+            // freshly-installed package the lazy route chunk is compiled by Metro
+            // on first navigation (cold), which can take a while on the container,
+            // so allow generous headroom. We assert the route, not a specific
+            // input inside the third-party Todo screen, whose markup we don't own.
+            await expect(orgPage).toHaveURL(/\/a\/[^/]+\/todo/, { timeout: 120_000 })
+        } finally {
+            await orgPage.close()
+        }
+    })
+
+    test('revert to the base build through the Build History UI', async ({ page }) => {
+        // Reverting swaps in the archived base binary, runs `migrate down N` to
+        // reverse todo's migration, re-stages the base web bundle, and triggers
+        // another exit-75 relaunch. Generous budget for the relaunch + health
+        // check (no go build / expo export this time — the base artifacts are
+        // already archived — so it's far quicker than the install).
+        test.setTimeout(600_000)
+
+        await loginAsSuperuserWithRetry(page)
+
+        await page.getByText('Build History', { exact: true }).click()
+        // Only the base build (status `available`) shows a Revert control; the
+        // todo build is `current` and hides it. Click Revert, then confirm.
+        await expect(page.getByText('(base image)', { exact: true })).toBeVisible()
+        await page.getByText('Revert', { exact: true }).first().click()
+        // The confirm dialog appears with a second Revert button; .last() targets
+        // the confirm action rather than the row trigger that opened it.
+        await page.getByText('Revert', { exact: true }).last().click()
+
+        // Judge the revert by the base build becoming `current` — the
+        // unambiguous server-side signal it completed (a revert logs under the
+        // target build's slug, "(base image)", so the install-log/status endpoint
+        // keyed by package slug isn't the right probe here). The revert ends with
+        // the same exit-75 restart, which the runner waits on before the next test.
+        await waitForBuildStatus(page, 'build-base', 'current', 300_000)
+    })
+
+    test('todo is gone after revert to base', async ({ page }) => {
+        test.setTimeout(300_000)
+
+        // 1. Registry: the todo build is now `superseded` and the base build is
+        //    `current` again.
+        await loginAsSuperuserWithRetry(page)
+        await page.getByText('Build History', { exact: true }).click()
+        await expect(page.getByText('superseded', { exact: true }).first()).toBeVisible()
+
+        // 2. The package is no longer wired in — its migration was reversed
+        //    (collection dropped) and the reverted base binary doesn't register
+        //    the package, so the Todo nav-rail entry is gone.
+        const orgPage = await page.context().newPage()
+        try {
+            await orgPage.goto('/')
+            await orgPage.getByTestId('identifier').fill(TEST_ORG_OWNER_EMAIL)
+            await orgPage.getByTestId('login-password').fill(TEST_ORG_OWNER_PASSWORD)
+            await orgPage.getByTestId('login-submit').click()
+            await orgPage.waitForURL(/\/a\//, { timeout: 30_000 })
+
+            // The todo rail entry should no longer render after revert.
+            await expect(orgPage.getByTestId('nav-todo')).toHaveCount(0, { timeout: 30_000 })
         } finally {
             await orgPage.close()
         }


### PR DESCRIPTION
## What

Extends the docker `todo-install` integration test to cover the new **build-history / revert** flow (server side in tinycld/core#39):

1. Install `@tinycld/todo` → relaunch → verify it's live (registered + nav/route reachable).
2. **Revert to the base build** through the Build History UI (`migrate down` reverses todo's migration).
3. Relaunch → verify todo is **gone** (build `superseded`, nav entry removed).

## How it judges success

The test polls **server-side ground truth** rather than the racy SSE progress modal:
- install/revert completion via `pkg_install_log` status and the `pkg_build` record status,
- mints a superuser token via the `_superusers` auth API (the setup page's PB has no persisted token),
- tolerates the exit-75 restart mid-poll (connection resets are treated as transient).

The runner script (`run-todo-install.sh`) drives the added revert + post-revert phases with a restart wait between them. The suite stays **runner-only** (hard-skipped unless `RUN_TODO_INSTALL_TEST=1`), so it's not part of routine CI.

`docs/live-install.md` documents the build-history/revert mechanics: archive layout, the migration safety gate, one-way revert, the base build, and retention.

## Status

Validated **green end-to-end** in a real container (`✅ todo install + revert integration test passed`, `RUNNER EXIT=0`).

> **Cross-repo:** depends on tinycld/core#39 (the feature). Merge core first; this PR's runner builds an image from the assembled workspace including core.