### PR TITLE
feat: generator + docs for per-package version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ server/pb_test_data/
 /server/go.work
 /server/go.work.sum
 /server/bundled-packages.json
+/server/pb_migrations_owner.json
 /server/pb_migrations/
 /server/pb_hooks/
 /server/tinycld

--- a/docs/live-install.md
+++ b/docs/live-install.md
@@ -312,6 +312,84 @@ which removes the `pkg_build` record and the `builds/<id>/` archive. The current
 build can't be deleted. Archived binaries are large (cgo, ~100 MB+), so operators
 should delete builds they no longer need.
 
+## Per-package version changes
+
+Build revert (above) rolls the **whole image** back to an earlier snapshot by
+count (`migrate down N`), superseding everything newer. A **version change**
+(Setup → Versions) instead moves **one package** to any version its source
+publishes — newer (update) or older (downgrade) — leaving every other package's
+schema and data untouched.
+
+### Why the named-migration runner exists
+
+All packages' migrations interleave by timestamp in one `_migrations` table, so
+the count-based `migrate down N` cannot revert just one package's migrations
+without tearing down unrelated ones. `pkg_migrate.go` drives a **named subset**
+instead: it looks each migration up by filename in `core.AppMigrations` (the same
+global list the jsvm plugin registers every `.js` `migrate(up, down)` into) and
+runs its own `Up`/`Down` inside the stock aux+main transaction nesting,
+replicating the `_migrations` insert/delete itself. Because it only ever touches
+the named files for one package, no other package's history or schema is affected.
+
+A key enabler: the **running process** keeps every migration it registered at its
+own startup, regardless of later on-disk file changes — so even after a downgrade
+swaps a package's files to an older version (removing the newer migration files
+from disk), the running binary can still execute the newer migrations' `Down`
+closures.
+
+### Migration → package attribution
+
+The generator (`symlinkServerArtifacts`) emits `server/pb_migrations_owner.json`,
+a `{ migration-file → owning-slug }` map (core migrations owned by `core`), while
+it flattens each package's `pb-migrations/` into the shared dir. The server reads
+it via `migrationsForPackage(slug)` / `packageForMigration(file)`. Each install
+also records its package's own migration files on the `pkg_build` record
+(`pkg_migration_files`), so a version change knows exactly which files to diff.
+
+### The pipeline (`runVersionChangePipeline`)
+
+`POST /api/admin/packages/versions/apply` with `{ changes: [{ slug, targetVersion }] }`
+returns a `jobId` (same SSE progress stream as install). For each change:
+
+1. Re-run the compatibility solver authoritatively against the live registry.
+2. Back up the DB (the downgrade safety net).
+3. `npm pack` / git-fetch the target version, validate its manifest, swap the
+   workspace member files (with a `.bak` restore on rollback).
+4. Regenerate wiring — rewrites the owner map so `migrationsForPackage(slug)`
+   reflects the **target** version's file set.
+5. Diff against the current build's recorded set:
+   upgrade → `applyNamedMigrations(target ∖ current)`;
+   downgrade → `revertNamedMigrations(current ∖ target)`.
+6. `pnpm install`, rebuild the binary (if the package has a server) + web bundle,
+   archive a new build, upsert the registry version, and request the exit-75
+   relaunch.
+
+Any failure unwinds the per-package rollback stack and restores the DB backup.
+The whole operation holds the same `installMu`/`currentJob` single-flight lock as
+install/revert, so version changes can't race them.
+
+Because the deployed image runs with `HooksWatch: true` (JS-hook hot-reload),
+re-running the generator mid-pipeline rewrites the watched `pb_hooks` symlinks,
+which would otherwise make PocketBase's watcher call `app.Restart()` and tear the
+process down between steps. An `OnTerminate` guard
+(`shouldSuppressRestart`) vetoes any in-process restart (`IsRestart`) while a
+package operation holds the single-flight lock; our own intentional relaunch uses
+`os.Exit(75)` (a different path the guard never sees), so it still fires once the
+pipeline finishes.
+
+### Discovery, compatibility, and the drop report
+
+- `GET /api/admin/packages/versions` lists each registry package's available
+  versions (npm registry versions or git tags, inferred from the stored spec),
+  with a short in-memory TTL cache and per-package failure isolation.
+- `POST /api/admin/packages/versions/check` runs the `peerVersions` solver over a
+  proposed `{ slug → version }` set and returns violations; the UI disables Apply
+  while any exist, and the pipeline re-checks before mutating.
+- `POST /api/admin/packages/versions/drop-report` dry-reverts the package's
+  current migrations inside a transaction it rolls back, returning the
+  collections/fields a downgrade would drop — the UI lists them and gates the
+  downgrade behind a typed slug confirmation.
+
 ## Runtime image requirements
 
 The live installer shells out to real tools and needs a workspace it can write

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -276,6 +276,7 @@ export default manifest
 | `server` | Go server extension: `package` is the subdir, `module` is its Go module path. |
 | `build.script` | A build script run before bundling (e.g. an embedded webview bundle). |
 | `dependencies[]` | Other package **slugs** — used to topologically order seeds. |
+| `peerVersions` | `{ '<slug or @tinycld/core>': '<semver range>' }` — version-aware compatibility constraints **enforced** by the version-management solver (Setup → Versions). A proposed set of version changes is blocked if it leaves any range unsatisfied. Distinct from `dependencies` (advisory, slug-only). |
 
 A package can contribute **only** a settings panel (no nav, no routes — like
 `@tinycld/google-takeout-import`), or purely `publicRoutes`, or any

--- a/scripts/gen-server.ts
+++ b/scripts/gen-server.ts
@@ -73,6 +73,12 @@ interface BundledPkgInput {
 
 // Emit server/bundled-packages.json — consumed by core's Go
 // coreserver.SyncBundledPackages at boot to seed the pkg_registry collection.
+//
+// `manifestJson` carries the FULL manifest object as a string so the seeded
+// `pkg_registry.manifest_json` matches what an installed package stores (via
+// parseManifestViaNode → upsertPkgRegistry). The compatibility solver reads
+// `peerVersions` out of this; without it, bundled packages would carry no
+// constraints and the solver would silently never block anything.
 export function buildBundledPackages(features: BundledPkgInput[]): string {
     const rows = features.map(f => ({
         name: f.manifest.name,
@@ -82,6 +88,7 @@ export function buildBundledPackages(features: BundledPkgInput[]): string {
         description: f.manifest.description ?? '',
         hasServer: !!f.manifest.server,
         navOrder: f.manifest.nav?.order ?? 0,
+        manifestJson: JSON.stringify(f.manifest),
     }))
     return `${JSON.stringify(rows, null, 2)}\n`
 }

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -174,32 +174,99 @@ function readHelpGroup(src: Feature): HelpGroupInput | null {
 }
 
 // --- 6. server: migration + hook symlinks ------------------------------
+// The symlink merge flattens every package's pb-migrations/ into one directory,
+// which is what PocketBase needs but loses each migration's owning package.
+// Per-package version changes (apply/revert a single package's named migrations
+// without touching others) need that attribution back, so as we link we record a
+// migration-file → owning-slug map and emit it as pb_migrations_owner.json for
+// the Go server to read at boot. Core migrations are owned by slug 'core'.
 function symlinkServerArtifacts(features: Feature[]) {
     fs.mkdirSync(SERVER_DIR, { recursive: true })
     cleanDir(MIGRATIONS_DIR)
     cleanDir(HOOKS_DIR)
+    const migrationOwners: Record<string, string> = {}
+    // Tracks hook filenames across packages to reject cross-package collisions in
+    // the flat HOOKS_DIR (not persisted — purely a guard).
+    const hookOwners: Record<string, string> = {}
     // core migrations first (core has no manifest; include explicitly)
     linkDirContents(
         path.join(memberDir('@tinycld/core'), 'server', 'pb_migrations'),
-        MIGRATIONS_DIR
+        MIGRATIONS_DIR,
+        'core',
+        migrationOwners
     )
     for (const f of features) {
         if (f.manifest.migrations?.directory) {
-            linkDirContents(path.join(f.dir, f.manifest.migrations.directory), MIGRATIONS_DIR)
+            linkDirContents(
+                path.join(f.dir, f.manifest.migrations.directory),
+                MIGRATIONS_DIR,
+                f.manifest.slug,
+                migrationOwners
+            )
         }
         if (f.manifest.hooks?.directory) {
-            linkDirContents(path.join(f.dir, f.manifest.hooks.directory), HOOKS_DIR)
+            linkDirContents(
+                path.join(f.dir, f.manifest.hooks.directory),
+                HOOKS_DIR,
+                f.manifest.slug,
+                hookOwners,
+                'hook'
+            )
         }
     }
+    fs.writeFileSync(
+        path.join(SERVER_DIR, 'pb_migrations_owner.json'),
+        `${JSON.stringify(migrationOwners, null, 2)}\n`
+    )
 }
 
 // Symlink every regular file in `srcDir` into `destDir` (no-op if srcDir absent).
-function linkDirContents(srcDir: string, destDir: string) {
+// When ownerSlug + owners are supplied, each linked filename is recorded as owned
+// by ownerSlug. A filename collision across packages is a hard error: the flat
+// migrations/hooks dirs require globally-unique filenames, and a silent overwrite
+// would mis-attribute the file and let one package clobber another's (for hooks,
+// silently dropping a package's hook). `kind` only labels the error message.
+function linkDirContents(
+    srcDir: string,
+    destDir: string,
+    ownerSlug?: string,
+    owners?: Record<string, string>,
+    kind: 'migration' | 'hook' = 'migration'
+) {
     if (!fs.existsSync(srcDir)) return
     for (const file of fs.readdirSync(srcDir)) {
         const srcPath = path.join(srcDir, file)
         if (!fs.statSync(srcPath).isFile()) continue
+        if (owners && ownerSlug) {
+            if (owners[file] && owners[file] !== ownerSlug) {
+                throw new Error(
+                    `[generate] ${kind} filename collision: '${file}' is provided by both ` +
+                        `'${owners[file]}' and '${ownerSlug}'. ${kind} filenames must be globally unique.`
+                )
+            }
+            owners[file] = ownerSlug
+        }
         replaceSymlink(srcPath, path.join(destDir, file))
+    }
+}
+
+// buildCoreManifest synthesizes a minimal manifest for @tinycld/core (which has
+// no manifest.ts) so it can be seeded into pkg_registry. Only the fields the
+// registry seed + compatibility solver read are populated: name, slug, version,
+// and any peerVersions core itself declares (read from core/package.json under a
+// `tinycld.peerVersions` key, if present). nav is omitted so core never appears
+// in the nav rail.
+function buildCoreManifest(): PackageManifest {
+    const corePkgJson = JSON.parse(
+        fs.readFileSync(path.join(memberDir('@tinycld/core'), 'package.json'), 'utf8')
+    )
+    const peerVersions = corePkgJson.tinycld?.peerVersions as Record<string, string> | undefined
+    return {
+        name: '@tinycld/core',
+        slug: 'core',
+        version: corePkgJson.version ?? '',
+        description: 'Shared core library',
+        ...(peerVersions ? { peerVersions } : {}),
     }
 }
 
@@ -313,9 +380,17 @@ async function main() {
 
     symlinkServerArtifacts(features)
     emitGoWiring(features)
+    // Seed a synthetic `core` manifest so @tinycld/core gets a pkg_registry row.
+    // core has no manifest.ts and isn't a feature, but the compatibility solver
+    // needs core's version resolvable so other packages' `@tinycld/core` peer
+    // ranges can be satisfied (otherwise every such constraint is unsatisfiable).
+    const coreManifest = buildCoreManifest()
     fs.writeFileSync(
         path.join(SERVER_DIR, 'bundled-packages.json'),
-        buildBundledPackages(features.map(f => ({ manifest: f.manifest })))
+        buildBundledPackages([
+            { manifest: coreManifest },
+            ...features.map(f => ({ manifest: f.manifest })),
+        ])
     )
 
     console.log(`Generated config for ${features.length} feature package(s).`)

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -30,6 +30,10 @@ export interface PackageManifest {
     help?: { directory: string }
     repository?: { url: string; issueTemplate?: string }
     dependencies?: string[]
+    // Semver ranges this version requires of other packages / @tinycld/core,
+    // enforced by the version-management compatibility solver. See the
+    // PackageManifest doc in core/lib/packages/types.ts.
+    peerVersions?: Record<string, string>
 }
 
 // Import a member's manifest.ts (ESM default export). This file is run via tsx,


### PR DESCRIPTION
## Overview

Generator, manifest-type, and docs support for the **per-package version management** feature (server + UI live in **tinycld/core#40**).

> Targets `main`, so the diff includes the prior build-history commit plus this work.

## What's included

- **`scripts/generate.ts` / `scripts/gen-server.ts`**
  - Emit `server/pb_migrations_owner.json` (migration file → owning package slug) while symlinking, so the server can attribute migrations to packages.
  - Extend the cross-package filename **collision guard** from migrations to `pb_hooks` too (a duplicate hook filename was previously silently overwritten).
  - Seed a synthetic **`core`** manifest into `bundled-packages.json` so `@tinycld/core` resolves in the compatibility solver.
  - Include each package's full **`manifestJson`** (incl. `peerVersions`) in `bundled-packages.json` so bundled rows carry compat constraints.
- **`scripts/load-manifest.ts`** — add the `peerVersions` manifest field.
- **`.gitignore`** — ignore the generated `server/pb_migrations_owner.json`.
- **`docs/`** — document per-package version changes (named-migration runner, attribution, apply pipeline, discovery/compat/drop-report, the hooks-watcher restart guard) and the `peerVersions` manifest field.

## Companion PR
Pairs with **tinycld/core#40** (the runner, endpoints, UI). The generator output here is what the server reads at boot.
