### PR TITLE
ci(e2e): use list reporter for named per-test progress in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,15 @@ const PORT = Number(process.env.E2E_PORT ?? 7200)
 const EMAIL_LOG_PATH = path.join(import.meta.dirname, 'tmp', 'emails.log')
 
 export default defineConfig({
+    // Override Playwright's CI default (the `dot` reporter, which prints a bare
+    // `·` per completed test — no name, so a run looks frozen during the cold
+    // Metro compile each worker pays on its first test, then dumps every dot at
+    // once). In non-TTY CI, `list` prints a NAMED line as each test COMPLETES
+    // (`✓ 3 mail › opens thread (4.1s)`) — it doesn't stream a per-test "started"
+    // line (that's TTY-only), but the accruing named lines + durations show
+    // which tests have finished and that the run is progressing. Inherited by
+    // every package's playwright.config.ts.
+    reporter: 'list',
     // Scoped to tests/e2e/ specifically. The tests/install/ tree has
     // its own playwright.config.ts and is invoked separately by the
     // docker smoke-test workflow — leaving testDir at the playwright


### PR DESCRIPTION
## What

Set `reporter: 'list'` in the app-shell `playwright.config.ts` (inherited by all 6 sibling configs).

## Why

Playwright defaults to the `dot` reporter under CI — a bare `·` per completed test, no name. Combined with the cold Metro compile each worker pays on its first test (~30–60s, documented in the per-package `timeout` comments), an e2e run sits silent at `Running N tests using M workers` and then dumps every dot at once when the first tests finally finish. It reads as a hang.

`list` prints a **named** line as each test completes, with its duration (`✓ 3 mail › opens thread (4.1s)`), so the GitHub Actions log shows which tests have finished and that the run is moving.

## Honest scope

In non-TTY CI, `list` is still **completion-driven** — the per-test *started* line is TTY-only. So a slow cold-compile first test still produces a gap before its line lands; this trades unreadable dots for readable named progress, it doesn't eliminate the first-test gap. Verified empirically against playwright 1.60.

No behavior change to the tests themselves.