### PR TITLE
refactor(core): expose app vitest config as @tinycld/core/vitest-config

### DIFF
--- a/core/e2e-helpers.ts
+++ b/core/e2e-helpers.ts
@@ -1,0 +1,10 @@
+// Re-export the app shell's canonical Playwright e2e helpers (login,
+// navigateToPackage, clickSidebarItem, ORG_SLUG, …) under a @tinycld/* name so
+// feature siblings' e2e specs import them by package specifier —
+// `@tinycld/core/e2e-helpers` — instead of a cross-member relative path
+// (`../../tinycld/tests/e2e/helpers`), which the standalone-member reorg exists
+// to eliminate. Playwright has no `~/` alias, so package-name resolution is the
+// only non-relative option. The explicit `.ts` extension is required because
+// siblings reach this through core's exports map, so the re-export is resolved
+// by Node's ESM loader (no extension inference); see vitest-config.ts.
+export * from '../tests/e2e/helpers.ts'

--- a/core/e2e-imap-helpers.ts
+++ b/core/e2e-imap-helpers.ts
@@ -1,0 +1,5 @@
+// Re-export the app shell's IMAP e2e helpers under a @tinycld/* name so mail's
+// e2e specs import them by package specifier (`@tinycld/core/e2e-imap-helpers`)
+// instead of `../../tinycld/tests/e2e/imap-helpers`. See e2e-helpers.ts for the
+// rationale and why the explicit `.ts` extension is required.
+export * from '../tests/e2e/imap-helpers.ts'

--- a/core/package.json
+++ b/core/package.json
@@ -38,7 +38,8 @@
         ],
         "./Providers": "./components/Providers.tsx",
         "./tsconfig.package-base.json": "./tsconfig.package-base.json",
-        "./uniwind-types": "./uniwind-types.d.ts"
+        "./uniwind-types": "./uniwind-types.d.ts",
+        "./vitest-config": "./vitest-config.ts"
     },
     "scripts": {
         "typecheck": "tinycld-pkg typecheck",

--- a/core/package.json
+++ b/core/package.json
@@ -39,7 +39,10 @@
         "./Providers": "./components/Providers.tsx",
         "./tsconfig.package-base.json": "./tsconfig.package-base.json",
         "./uniwind-types": "./uniwind-types.d.ts",
-        "./vitest-config": "./vitest-config.ts"
+        "./vitest-config": "./vitest-config.ts",
+        "./playwright-config": "./playwright-config.ts",
+        "./e2e-helpers": "./e2e-helpers.ts",
+        "./e2e-imap-helpers": "./e2e-imap-helpers.ts"
     },
     "scripts": {
         "typecheck": "tinycld-pkg typecheck",

--- a/core/playwright-config.ts
+++ b/core/playwright-config.ts
@@ -1,0 +1,8 @@
+// Re-export the app shell's canonical Playwright config under a @tinycld/* name
+// so feature siblings inherit it by package specifier —
+// `@tinycld/core/playwright-config` — instead of a cross-member relative path
+// (`../tinycld/playwright.config`), which the standalone-member reorg exists to
+// eliminate. The explicit `.ts` extension is required because siblings reach
+// this through core's exports map, so the re-export is resolved by Node's ESM
+// loader (no extension inference); see vitest-config.ts for the full rationale.
+export { default } from '../playwright.config.ts'

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -15,6 +15,14 @@
         "moduleResolution": "bundler",
         "customConditions": ["react-native"],
         "noEmit": true,
+        // vitest-config.ts re-exports the app shell's config by explicit `.ts`
+        // path (`../vitest.config.ts`). The extension is required because feature
+        // siblings reach the shim through core's package `exports` map, so its
+        // re-export is resolved by Node's ESM loader (which doesn't infer
+        // extensions) rather than vite. noEmit + bundler resolution make this the
+        // TS-intended config for importing `.ts` directly, not a workaround.
+        // Scoped to core's own compile; siblings extend tsconfig.package-base.json.
+        "allowImportingTsExtensions": true,
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "target": "ESNext",

--- a/core/vitest-config.ts
+++ b/core/vitest-config.ts
@@ -1,0 +1,9 @@
+// Re-export the app shell's canonical vitest config under a @tinycld/* name so
+// feature siblings inherit it by package specifier — `@tinycld/core/vitest-config`
+// — instead of a cross-member relative path (`../tinycld/vitest.config`), which
+// the standalone-member reorg exists to eliminate. The explicit `.ts` extension
+// is required: siblings reach this file through core's package exports map, so
+// the re-export resolves via Node's ESM loader (no extension inference). core is
+// nested inside the tinycld member, so `../vitest.config.ts` is an in-repo path —
+// the one place that cross-file coupling is allowed to live.
+export { default } from '../vitest.config.ts'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,11 @@
         "strict": true,
         "module": "Preserve",
         "moduleResolution": "Bundler",
+        // The app's `include` pulls in nested core/, incl. core/vitest-config.ts,
+        // which re-exports the app config by explicit `.ts` path. typecheck runs
+        // `tsc --noEmit`, so allowing the extension here is valid and matches
+        // core/tsconfig.json. See core/vitest-config.ts for why the extension.
+        "allowImportingTsExtensions": true,
         "skipLibCheck": true,
         "jsx": "react-jsx",
         "noImplicitAny": false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitest/config'
 // `include` glob (or a positional filter) at one package's tests/, but always
 // resolve through these aliases so cross-package `@tinycld/core/*` imports and
 // the `~/*` package-source alias work identically everywhere.
-const APP_DIR = __dirname
+const APP_DIR = import.meta.dirname
 const CORE_DIR = path.join(APP_DIR, 'core')
 
 export default defineConfig({


### PR DESCRIPTION
## What

Adds `@tinycld/core/vitest-config` — a re-export shim (`core/vitest-config.ts`) plus a `./vitest-config` entry in core's `exports` map — so feature siblings can inherit the app shell's canonical vitest config **by package name**.

## Why

Every sibling's `vitest.config.ts` did `import appConfig from '../tinycld/vitest.config'` — a cross-member `../<member>/` relative reach. The standalone-member reorg exists specifically to eliminate that: cross-member dependencies should resolve by `@tinycld/*` name (via the `node_modules/@tinycld/*` symlinks + `exports` maps), never by walking up and across the workspace tree.

## Notes

- The shim's own `../vitest.config.ts` import is **in-repo** (core is nested inside the tinycld member) — the one place that coupling is allowed to live.
- Switched the app config's `APP_DIR` from `__dirname` → `import.meta.dirname`: the CJS global isn't injected when the config is pulled in transitively through the ESM re-export; `import.meta.dirname` works in both the direct-load (app/core) and re-exported (siblings) contexts.

## Dependency

The 7 sibling repos have matching commits switching to `@tinycld/core/vitest-config`. **This PR must merge first** — the siblings' CI assembles `tinycld@main`, so the shim must be on main before their configs can resolve it.

Verified: core (278 tests), app shell, and all 7 siblings' unit suites pass against the new path.