### PR TITLE
refactor(core): expose CalDAV e2e helpers as @tinycld/core/e2e-caldav-helpers

### DIFF
--- a/core/e2e-caldav-helpers.ts
+++ b/core/e2e-caldav-helpers.ts
@@ -1,0 +1,6 @@
+// Re-export the app shell's CalDAV e2e helpers under a @tinycld/* name so
+// calendar's e2e specs import them by package specifier
+// (`@tinycld/core/e2e-caldav-helpers`) instead of
+// `../../tinycld/tests/e2e/caldav-helpers`. See e2e-helpers.ts for the rationale
+// and why the explicit `.ts` extension is required.
+export * from '../tests/e2e/caldav-helpers.ts'

--- a/core/package.json
+++ b/core/package.json
@@ -42,7 +42,8 @@
         "./vitest-config": "./vitest-config.ts",
         "./playwright-config": "./playwright-config.ts",
         "./e2e-helpers": "./e2e-helpers.ts",
-        "./e2e-imap-helpers": "./e2e-imap-helpers.ts"
+        "./e2e-imap-helpers": "./e2e-imap-helpers.ts",
+        "./e2e-caldav-helpers": "./e2e-caldav-helpers.ts"
     },
     "scripts": {
         "typecheck": "tinycld-pkg typecheck",


### PR DESCRIPTION
Adds `@tinycld/core/e2e-caldav-helpers` — a re-export shim + exports entry — so calendar's e2e specs import the app shell's CalDAV helpers by package name instead of `../../tinycld/tests/e2e/caldav-helpers`.

Same pattern as the `e2e-helpers` / `e2e-imap-helpers` shims (rides on the existing `allowImportingTsExtensions` flag). Needed before calendar's import-cleanup PR can resolve the specifier in CI.