### PR TITLE
fix(mailer): create email-log parent dir before opening

### DIFF
--- a/core/server/mailer/mailer.go
+++ b/core/server/mailer/mailer.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -182,6 +183,14 @@ func appendToEmailLog(entry loggedEmail) {
 	}
 	fileLogMu.Lock()
 	defer fileLogMu.Unlock()
+
+	// Ensure the parent dir exists: O_CREATE makes the file but not the
+	// directory. In e2e the webServer (and thus PB) can boot and send the
+	// first email before globalSetup has created tmp/, so create it here.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "[mailer] failed to create email log dir %q: %v\n", filepath.Dir(path), err)
+		return
+	}
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {


### PR DESCRIPTION
## Problem

Drive's E2E has been failing on `share-stub-otp-guest.spec.ts` — the test times out waiting for an OTP email that never arrives. Root cause in the logs:

```
[mailer] failed to open email log ".../ws/tinycld/tmp/emails.log": no such file or directory
```

The file-based email log (`TINYCLD_EMAIL_LOG`, used by e2e to assert on sent mail) is opened with `O_CREATE`, which creates the **file** but not its parent **directory**. In e2e the `webServer` boots PocketBase and can send the first email *before* playwright's `globalSetup` has created `tmp/` — so `OpenFile` fails and the email is silently dropped, timing out any OTP-dependent spec.

## Fix

`os.MkdirAll(filepath.Dir(path), …)` before `OpenFile`, so the mailer is robust to webServer/globalSetup ordering regardless of who creates `tmp/` first.

Pre-existing failure (fails on every drive run, before any of the recent layout/import work). Fixing it here unblocks drive's e2e — and therefore calc/text, which assemble drive.

`go build` + `go vet` clean.