### PR TITLE
biome: make canonical config resolvable from inside any member

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+    "root": false,
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -162,8 +162,12 @@ Three rules enforced here:
   `react-native` / `pbtsdb` / `yjs`, and TypeScript would then see two copies
   of every type and emit hundreds of "Type X is not assignable to type X"
   errors.
-- **No lint/biome/test scripts** — there is one Biome config in the whole
-  ecosystem (`tinycld/biome.json`); siblings don't ship one. The only script
+- **No lint/test scripts** — the canonical Biome config is `tinycld/biome.json`
+  (`root: false`); a minimal `root: true` config at the workspace root extends it
+  (written by bootstrap/the generator, gitignored) so biome resolves from inside
+  any member. A sibling ships **no** `biome.json` by default and inherits those
+  rules; it adds one only to override a rule
+  (`{ "root": false, "extends": ["../tinycld/biome.json"], … }`). The only script
   a sibling carries is `typecheck`.
 
 ### `tsconfig.json`

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -56,12 +56,24 @@ function resolveExportDir(packageDir: string, subpath: string): string | null {
 // the same install that pulls `root: false` also lays down the root config.
 // Bootstrap-owned (gitignored at the ws-root); content is static, so always
 // rewrite.
+//
+// `vcs.root` points at the app member dir (tinycld/), NOT the workspace root:
+// the canonical config relies on `.gitignore` to exclude generated/build
+// artifacts (ios/, .expo, tinycld.config.ts, Podspecs, …), and the only
+// .gitignore that lists them is tinycld/.gitignore. Once canonical is
+// `root: false`, EVERY invocation under the workspace root (including
+// `pnpm run lint` from tinycld/) resolves THIS config as the root and inherits
+// its vcs settings — so this is where useIgnoreFile must be anchored. The bare
+// workspace root has no .gitignore (and in a fresh bootstrap/CI assemble isn't
+// even a git repo), so pointing biome there would make it error
+// "couldn't find an ignore file".
 function writeRootBiomeConfig() {
-    const canonicalRel = `./${path.basename(APP_DIR)}/biome.json`
+    const appDirName = path.basename(APP_DIR)
     const config = {
         $schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
         root: true,
-        extends: [canonicalRel],
+        extends: [`./${appDirName}/biome.json`],
+        vcs: { enabled: true, clientKind: 'git', useIgnoreFile: true, root: appDirName },
     }
     fs.writeFileSync(path.join(WS_ROOT, 'biome.json'), `${JSON.stringify(config, null, 4)}\n`)
 }

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -40,6 +40,32 @@ function resolveExportDir(packageDir: string, subpath: string): string | null {
     return exp.replace(/^\.\//, '').replace(/\/\*\.[^.]+$/, '')
 }
 
+// Write the workspace-root biome.json. Biome only searches UPWARD for config,
+// and the canonical biome.json lives at <ws-root>/tinycld/ — a SIBLING of the
+// feature members, never an ancestor. Without a root config, running biome from
+// inside a member (or via the editor/LSP) finds nothing and falls back to
+// biome's built-in defaults (wrong indent/quotes/semicolons), flooding output
+// with bogus reformatting. This minimal root config makes the canonical config
+// resolvable from anywhere: it's the one `root: true` config, and it `extends`
+// the canonical one (which is `root: false`). Members may drop their own
+// `root: false` biome.json that extends canonical to override rules; most don't.
+//
+// Written every install (not just on bootstrap assemble) so it self-heals: the
+// canonical config's `root: false` ships via the tinycld repo, and a non-root
+// config with no root above it breaks `pnpm run lint` — emitting this here means
+// the same install that pulls `root: false` also lays down the root config.
+// Bootstrap-owned (gitignored at the ws-root); content is static, so always
+// rewrite.
+function writeRootBiomeConfig() {
+    const canonicalRel = `./${path.basename(APP_DIR)}/biome.json`
+    const config = {
+        $schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
+        root: true,
+        extends: [canonicalRel],
+    }
+    fs.writeFileSync(path.join(WS_ROOT, 'biome.json'), `${JSON.stringify(config, null, 4)}\n`)
+}
+
 // Slugs come from trusted manifests, but any code path that joins a slug into
 // a path before rmSync gets this guard as defense-in-depth against a hostile
 // or typo'd manifest escaping the intended base dir.
@@ -419,6 +445,8 @@ async function main() {
             ...features.map(f => ({ manifest: f.manifest })),
         ])
     )
+
+    writeRootBiomeConfig()
 
     console.log(`Generated config for ${features.length} feature package(s).`)
 }


### PR DESCRIPTION
## Problem

Biome searches only **upward** for config, and `tinycld/biome.json` is a *sibling* of the feature members (`mail/`, `drive/`…), never an ancestor. So from inside a member:

- `biome check .` → finds no config → falls back to biome's built-in defaults (2-space, double quotes, semicolons) → floods output with bogus reformatting against the wrong style.
- the editor's biome LSP → same fallback → wrong inline diagnostics / format-on-save.
- single-file checks → same.

Only `tinycld-pkg check` worked, via a cwd trick (run from `tinycld/`, pass the member dir as the arg). This kept tripping us up — people (and Claude) naturally reach for `cd mail && biome check .`.

## Fix

A minimal `root: true` `biome.json` at the **workspace root** that `extends` the canonical config (now flipped to `root: false`). That root config is the resolvable ancestor that makes raw biome work from anywhere — verified for `biome check .`, single-file, and the LSP path.

The **generator** writes it on every install. This is deliberate: a `root: false` config with no root above it breaks `pnpm run lint`, and the `root: false` change ships via this repo — so emitting the root config on the same install that pulls `root: false` makes it self-healing (no re-bootstrap needed). Bootstrap also seeds it on assemble (companion PR in tinycld/bootstrap).

## Member configs are opt-in

A member ships **no** `biome.json` by default and inherits canonical through the root config. A member adds its own only to override a rule:

```jsonc
{ "root": false, "extends": ["../tinycld/biome.json"], "linter": { "rules": { } } }
```

## What does NOT change

`pnpm run lint` stays run from `tinycld/` with its curated arg list. Re-hosting the whole-tree sweep at the workspace root would re-anchor the canonical config's relative ignore globs (`!server`, `!lib/generated`, `!app/a/[orgSlug]/…`) and pull in out-of-scope dirs (measured: 1469 → 1563 files, 1 → 63 findings). Verified `pnpm run lint` output is unchanged (1469 files, clean).

## Notes

- The root `biome.json` is gitignored at the workspace root (bootstrap/generator-owned).
- The live root `CLAUDE.md` (not tracked in any repo) had two stale claims — "Biome is never run by `tinycld-pkg check`" (it is, already) and "members don't depend on `@biomejs/biome`" — fixed in place locally; flagging here so we can decide where that doc should canonically live.

## Verification

- `biome check .` from `mail/` → 125 files, clean
- single file from `drive/` → clean
- `pnpm run lint` → 1469 files, unchanged
- `tinycld-pkg check` from members → biome + tsc + vitest pass
- generator + package-scripts unit tests pass