### PR TITLE
fix(core): press-guard, FAB placement, modal z-index, help drawer; bump Metro dev heap

### DIFF
--- a/core/components/ContextMenu.tsx
+++ b/core/components/ContextMenu.tsx
@@ -2,6 +2,7 @@ import { Menu } from '@tinycld/core/ui/menu'
 import type { ReactNode } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { type GestureResponderEvent, Platform, Pressable, StyleSheet, View } from 'react-native'
+import { markContextMenuOpenedByLongPress } from './context-menu-press-guard'
 
 interface ContextMenuProps {
     children: ReactNode
@@ -285,6 +286,10 @@ function ContextMenuNative({ children, content, onOpen, className }: ContextMenu
             setPressPos({ x: pageX, y: pageY, width: 0, height: 0 })
             cancelLongPress()
             longPressTimerRef.current = setTimeout(() => {
+                // Tell the underlying row to ignore the press it will receive
+                // when the finger lifts — otherwise a long-press would open the
+                // menu AND trigger the row's tap (e.g. open the file).
+                markContextMenuOpenedByLongPress(Date.now())
                 handleOpenChange(true)
                 longPressTimerRef.current = null
             }, 400)

--- a/core/components/FAB.tsx
+++ b/core/components/FAB.tsx
@@ -1,6 +1,7 @@
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import type { LucideIcon } from 'lucide-react-native'
 import { Pressable } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface FABProps {
     icon: LucideIcon
@@ -9,12 +10,18 @@ interface FABProps {
     isVisible: boolean
     size?: number
     iconSize?: number
-    // Which bottom corner the button anchors to. Defaults to 'right' (the
-    // conventional FAB placement); calendar anchors 'left' so it doesn't sit
-    // over the right-hand event columns of the day/week grid.
-    side?: 'left' | 'right'
 }
 
+// Approximate height of the bottom tab bar's own content (pt-2 + icon + label
+// + pb-1), excluding the safe-area inset which we add separately. The FAB
+// clears this plus a small gap so it floats just above the toolbar.
+const BOTTOM_BAR_CONTENT_HEIGHT = 56
+const FAB_GAP_ABOVE_BAR = 16
+
+// All FABs anchor to the bottom-RIGHT corner for consistency across packages
+// (compose in mail, "+" in calendar, etc.) and sit just above the bottom tab
+// bar. The bottom offset tracks the safe-area inset so the gap above the bar
+// is uniform on notched and non-notched devices alike.
 export function FAB({
     icon: Icon,
     onPress,
@@ -22,9 +29,9 @@ export function FAB({
     isVisible,
     size = 56,
     iconSize = 22,
-    side = 'right',
 }: FABProps) {
     const primaryFg = useThemeColor('primary-foreground')
+    const insets = useSafeAreaInsets()
 
     if (!isVisible) return null
 
@@ -32,8 +39,8 @@ export function FAB({
         <Pressable
             className="absolute items-center justify-center bg-primary"
             style={{
-                bottom: 80,
-                ...(side === 'left' ? { left: 16 } : { right: 16 }),
+                bottom: insets.bottom + BOTTOM_BAR_CONTENT_HEIGHT + FAB_GAP_ABOVE_BAR,
+                right: 16,
                 width: size,
                 height: size,
                 borderRadius: size / 2,

--- a/core/components/context-menu-press-guard.ts
+++ b/core/components/context-menu-press-guard.ts
@@ -1,0 +1,37 @@
+// A long-press that opens a context menu must NOT also fire the underlying
+// row's tap handler (which would, e.g., open a file the moment the user lifts
+// their finger off the long-press). ContextMenuNative observes touches on an
+// ancestor View without claiming the gesture responder, so the inner Pressable
+// still delivers its onPress on release. There is no in-gesture way to retract
+// that press from the ancestor, so we coordinate out of band: when a long-press
+// opens the menu we stamp a timestamp here, and the row's press handler checks
+// it and bows out if the release belongs to that just-opened gesture.
+//
+// A module-level singleton is sufficient because touch gestures are serialized
+// — only one long-press can be resolving at a time — so there is no ambiguity
+// about which press the stamp refers to.
+
+let suppressUntil = 0
+
+// Window covering the gap between the long-press firing and the finger lifting.
+// Generous enough for a slow release, short enough that a deliberate tap a
+// moment later is never swallowed.
+const SUPPRESS_WINDOW_MS = 700
+
+/** Called by ContextMenuNative the instant a long-press opens the menu. */
+export function markContextMenuOpenedByLongPress(now: number): void {
+    suppressUntil = now + SUPPRESS_WINDOW_MS
+}
+
+/**
+ * Returns true if the current press should be ignored because it is the tail
+ * of the long-press gesture that just opened a context menu. Consuming it
+ * clears the flag so only the one press is suppressed.
+ */
+export function consumeContextMenuPressSuppression(now: number): boolean {
+    if (now < suppressUntil) {
+        suppressUntil = 0
+        return true
+    }
+    return false
+}

--- a/core/components/help/HelpDrawer.tsx
+++ b/core/components/help/HelpDrawer.tsx
@@ -12,6 +12,7 @@ import {
 import { router } from 'expo-router'
 import { ArrowLeft, X } from 'lucide-react-native'
 import { Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useHelpStore } from '../../lib/help/store'
 import { useHelpGroupForPackage, useHelpTopic } from '../../lib/help/use-help-topics'
 import { HelpTopicView } from './HelpTopicView'
@@ -30,6 +31,7 @@ export function HelpDrawer() {
     const pkgGroup = useHelpGroupForPackage(pkgSlug)
     const muted = useThemeColor('muted-foreground')
     const orgHref = useOrgHref()
+    const insets = useSafeAreaInsets()
 
     const showBackArrow = mode === 'topic' && cameFrom !== null
 
@@ -48,7 +50,7 @@ export function HelpDrawer() {
         <Drawer isOpen={isOpen} onClose={close} anchor="right" size="md">
             <DrawerBackdrop />
             <DrawerContent>
-                <DrawerHeader>
+                <DrawerHeader style={{ paddingTop: insets.top }}>
                     <View className="flex-row items-center justify-between flex-1">
                         <View className="flex-row items-center flex-1">
                             {showBackArrow && (

--- a/core/tests/unit/context-menu-press-guard.test.ts
+++ b/core/tests/unit/context-menu-press-guard.test.ts
@@ -1,0 +1,43 @@
+import {
+    consumeContextMenuPressSuppression,
+    markContextMenuOpenedByLongPress,
+} from '@tinycld/core/components/context-menu-press-guard'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+// The guard is a module-level singleton (touch gestures are serialized, so one
+// stamp at a time is unambiguous). Each test marks a fresh long-press so state
+// from a prior test never leaks; the suppression window is well under the gaps
+// between the timestamps we use here.
+describe('context-menu press guard', () => {
+    beforeEach(() => {
+        // Consume any leftover suppression far in the future so each test starts
+        // from a clean, un-suppressed state.
+        consumeContextMenuPressSuppression(Number.MAX_SAFE_INTEGER)
+    })
+
+    it('suppresses the press that immediately follows a long-press', () => {
+        const t = 1000
+        markContextMenuOpenedByLongPress(t)
+        // Finger lifts a moment later — this tap must be swallowed.
+        expect(consumeContextMenuPressSuppression(t + 50)).toBe(true)
+    })
+
+    it('only suppresses one press — the next tap goes through', () => {
+        const t = 1000
+        markContextMenuOpenedByLongPress(t)
+        expect(consumeContextMenuPressSuppression(t + 50)).toBe(true)
+        // A second tap in the same window is a real, deliberate tap.
+        expect(consumeContextMenuPressSuppression(t + 100)).toBe(false)
+    })
+
+    it('does not suppress a tap that arrives after the window closes', () => {
+        const t = 1000
+        markContextMenuOpenedByLongPress(t)
+        // 800ms later is past the ~700ms window: a deliberate later tap.
+        expect(consumeContextMenuPressSuppression(t + 800)).toBe(false)
+    })
+
+    it('does not suppress when no long-press was marked', () => {
+        expect(consumeContextMenuPressSuppression(5000)).toBe(false)
+    })
+})

--- a/core/ui/drawer/index.tsx
+++ b/core/ui/drawer/index.tsx
@@ -80,11 +80,13 @@ const drawerBackdropStyle = tva({
     base: 'absolute left-0 top-0 right-0 bottom-0 bg-[#000]/50 web:cursor-default',
 })
 
-// Drawer width is fixed at 32rem (~512px) on the side, capped at 60% of the
-// viewport on narrow screens, regardless of the `size` prop. Keeping it
-// consistent across view/edit/create modes prevents the content from jumping
-// when the inner subview changes. Vertical drawers (top/bottom) keep height
-// scaling per `size`. Use `size="full"` for an edge-to-edge drawer.
+// Side drawers take 80% of the viewport, capped at 32rem (~512px) on wide
+// screens, regardless of the `size` prop. The 80% floor (rather than the old
+// 60%) gives phones a usable reading width — at 60% a help topic on a 375px
+// device only got ~225px. Keeping the width consistent across view/edit/create
+// modes prevents the content from jumping when the inner subview changes.
+// Vertical drawers (top/bottom) keep height scaling per `size`. Use
+// `size="full"` for an edge-to-edge drawer.
 const drawerContentStyle = tva({
     base: 'bg-background shadow-hard-5 p-6 absolute',
     parentVariants: {
@@ -95,8 +97,8 @@ const drawerContentStyle = tva({
             full: '',
         },
         anchor: {
-            left: 'h-full border-r border-border/80 w-[32rem] max-w-[60%]',
-            right: 'h-full border-l border-border/80 w-[32rem] max-w-[60%]',
+            left: 'h-full border-r border-border/80 w-[80%] max-w-[32rem]',
+            right: 'h-full border-l border-border/80 w-[80%] max-w-[32rem]',
             top: 'w-full border-b border-border/80 rounded-b-xl',
             bottom: 'w-full border-t border-border/80 rounded-t-xl',
         },

--- a/core/ui/modal/index.tsx
+++ b/core/ui/modal/index.tsx
@@ -54,7 +54,11 @@ const UIModal = createModal({
 })
 
 const modalStyle = tva({
-    base: 'group/modal w-full h-full justify-center items-center web:pointer-events-none',
+    // z-[1000] lifts the whole modal (backdrop + content) above the mobile
+    // sidebar drawer (zIndex 201) and any other in-app overlay, so a dialog
+    // opened from a sidebar control — e.g. the label manager from the cog —
+    // renders in front of the sidebar rather than behind it.
+    base: 'group/modal w-full h-full justify-center items-center web:pointer-events-none z-[1000]',
     variants: {
         size: {
             xs: '',

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -432,7 +432,7 @@ function spawnPbBinary(pbPort: number, publicUrl: string, dataDir: string | null
     const child = spawn(path.join(ROOT, 'server', 'app'), args, {
         cwd: ROOT,
         stdio: ['inherit', 'pipe', 'pipe'],
-        // PB's first-run installer prints a /setup URL using the address
+        // PB's first-run installer prints a /admin URL using the address
         // it bound to. Override with the public proxy URL so the printed
         // URL points where the user actually browses, not at PB's
         // internal port.
@@ -454,10 +454,22 @@ function spawnExpo(expoPort: number, onReady: () => void): ChildProcess {
     // file watcher on `env.CI` — CI=true makes Metro log
     // "Metro is running in CI mode, reloads are disabled" and skips
     // watching entirely, which breaks HMR.
+    // Give Metro a larger V8 heap. The full ecosystem bundle (every member's
+    // screens + sidebars) can push the transform/serializer past Node's default
+    // ~4GB old-space ceiling on a cold `--clear` start — it OOM'd mid-bundle
+    // ("Reached heap limit Allocation failed") while transforming a sidebar
+    // chunk. The EAS production build already runs with 8192; match it here so
+    // dev doesn't crash on machines where the default limit is lower than the
+    // bundle needs. Preserve any caller-set NODE_OPTIONS by appending.
+    const existingNodeOptions = process.env.NODE_OPTIONS ?? ''
+    const heapFlag = '--max-old-space-size=8192'
+    const nodeOptions = existingNodeOptions.includes('--max-old-space-size')
+        ? existingNodeOptions
+        : `${existingNodeOptions} ${heapFlag}`.trim()
     const child = spawn('npx', ['expo', 'start', '--clear', '--port', String(expoPort)], {
         cwd: ROOT,
         stdio: ['inherit', 'pipe', 'pipe'],
-        env: { ...process.env },
+        env: { ...process.env, NODE_OPTIONS: nodeOptions },
     })
     // Expo prints "Logs for your project will appear …" once the dev server
     // is fully up. We use that as the signal to print the banner so it lands


### PR DESCRIPTION
Core/app-shell changes backing the per-package bug-fix PRs (contacts/drive/calendar/mail).

## Fixes
- **Long-press press-guard** (`core/components/context-menu-press-guard.ts` + `ContextMenu.tsx`): a long-press that opens the context menu no longer lets the underlying row's tap fire when the finger lifts. Backs the **drive** long-press fix. Unit-tested (4 cases).
- **FAB placement** (`core/components/FAB.tsx`): all FABs anchor bottom-right with a safe-area-aware offset above the bottom toolbar; dropped the `side` prop. Backs the **calendar** FAB fix.
- **Modal z-index** (`core/ui/modal/index.tsx`): `z-[1000]` on the modal root so a dialog opened from a sidebar control (e.g. the label manager cog) renders in front of the sidebar instead of behind it.
- **Help drawer** (`core/ui/drawer/index.tsx` + `HelpDrawer.tsx`): side drawers now `w-[80%] max-w-[32rem]` (usable width on phones, was capped at 60%); help drawer header respects the safe-area top inset so the iPhone notch no longer hides the title.
- **Metro dev heap** (`scripts/dev.ts`): launch Metro with `--max-old-space-size=8192`. A cold bundle of the full ecosystem (e.g. the lazily-loaded mail sidebar chunk) OOM'd the dev bundler at Node's default ~4GB heap — that was the "sidebar crash" report. Matches the EAS build's existing heap setting.

## Scope note
This branch deliberately contains **only** the bug-fix changes. An unrelated, in-progress `setup → admin` refactor present in the working tree was left out.

## Verification
- `tinycld-pkg check` on core passes (incl. the new press-guard unit test).
- Ecosystem-wide biome lint clean.