### PR TITLE
docs: update README, core README, and packages.md for merged repo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,22 @@ A self-hosted workspace alternative — Expo Router on the front, PocketBase on 
 back, every feature shipped as a separately-installable package. See
 [tinycld.org](https://tinycld.org) for the full story.
 
-This repo (`@tinycld/app`, member name `app`) is the runnable **app shell**: branding,
+This repo (`tinycld`) is the runnable **app shell**: branding,
 Expo native projects, deployment configs, the package generator, and all the heavy
 runtime dependencies. It is the entrypoint for `pnpm run dev` and
 `docker pull ghcr.io/tinycld/tinycld`.
 
-`@tinycld/core` (the shared TypeScript + Go library) is **no longer bundled here** — it
-is its own repo ([tinycld/core](https://github.com/tinycld/core)), cloned as a sibling
-workspace member. Feature packages are siblings too. The whole tree is one npm workspace:
+`@tinycld/core` (the shared TypeScript + Go library) is **part of this repo** — nested at
+`core/` (`tinycld/core/`) and imported as `@tinycld/core`. The `tinycld-pkg` CLI
+(`@tinycld/package-scripts`) is nested at `package-scripts/`. Feature packages are sibling
+repos. The whole tree is one pnpm workspace:
 
 ```
 ~/code/tinycld/
-    app/                     # this repo — the app shell (member "app")
-    core/                    # @tinycld/core (shared lib; its own repo)
-    mail/                    # @tinycld/mail (feature package)
+    tinycld/                 # this repo — the app shell (package "tinycld")
+        core/                # @tinycld/core (shared lib; nested)
+        package-scripts/     # @tinycld/package-scripts — the tinycld-pkg CLI (nested)
+    mail/                    # @tinycld/mail (feature package; sibling repo)
     calendar/                # @tinycld/calendar
     contacts/                # @tinycld/contacts
     drive/                   # @tinycld/drive
@@ -31,22 +33,22 @@ workspace member. Feature packages are siblings too. The whole tree is one npm w
 ```
 
 Everything imports core as `@tinycld/core/*` (and `tinycld.org/core` for Go); resolution
-is by the npm `node_modules/@tinycld/core` symlink (Metro), tsconfig `paths` (typecheck),
+is by the pnpm `node_modules/@tinycld/core` symlink (Metro), tsconfig `paths` (typecheck),
 vitest aliases (tests), and a Go `replace` directive (server).
 
 ## Getting a working tree
 
 This repo is one member of a workspace, not a standalone clone target. Let
-`@tinycld/bootstrap` assemble the workspace root, the app shell, and `@tinycld/core`
-together — it writes the workspace coordination files (`package.json`,
-`tinycld.packages.ts`, shared test stubs) from embedded templates and clones each
-member as a sibling directory:
+`@tinycld/bootstrap` assemble the workspace root and clone this `tinycld` repo
+(which carries `@tinycld/core` + `@tinycld/package-scripts` nested) — it writes the
+workspace coordination files (`package.json`, `tinycld.packages.ts`, shared test
+stubs) from embedded templates and clones each member as a sibling directory:
 
 ```sh
 mkdir ~/code/tinycld && cd ~/code/tinycld
 npx @tinycld/bootstrap@latest --assemble-only --with mail --with contacts
 pnpm install        # links members + runs the generator (postinstall)
-cd app && pnpm run dev
+cd tinycld && pnpm run dev
 ```
 
 Full guide: <https://tinycld.org/docs/getting-started>.
@@ -72,7 +74,7 @@ pnpm run ssl:generate
 
 ## What's where
 
-- **`app/`** — Expo Router routes. `_layout.tsx` calls `configureCore(appConfig)` first, then
+- **`app/`** — Expo Router route tree. `_layout.tsx` calls `configureCore(appConfig)` first, then
   imports core's Providers and mounts the gate.
 - **`lib/app-config.ts`** — `CoreConfig` value handed to core at boot. Branding, server
   shortcuts, Sentry creds, review-mode flags.
@@ -91,16 +93,16 @@ pnpm run ssl:generate
 - **`scripts/dev.ts`** — the dev launcher (proxy + PB + Expo).
 - **`server/main.go`** — load env, init Sentry, build `coreserver.Options`, call
   `coreserver.Register(app, opts)`. Module `tinycld.org/tinycld` with
-  `replace tinycld.org/core => ../../core/server`.
+  `replace tinycld.org/core => ../core/server`.
 - **`server/pb_migrations/`, `server/pb_hooks/`** — landing dirs for symlinks the generator
   populates from core's `server/` plus each linked feature package.
 - **`Dockerfile`, `docker-compose.yml`, `eas.json`** — deployment.
 
 ## Adding / removing feature packages
 
-There is no `packages:link`/`packages:install` step — linking is the npm workspace install.
-The workspace-root `package.json` already lists every known first-party feature, so adding
-one is just cloning the sibling and re-installing. The fastest path is bootstrap:
+There is no `packages:link`/`packages:install` step — linking is the pnpm workspace install.
+`pnpm-workspace.yaml`'s `packages:` list already enumerates every known first-party feature, so
+adding one is just cloning the sibling and re-installing. The fastest path is bootstrap:
 
 ```sh
 cd ~/code/tinycld
@@ -116,8 +118,8 @@ git clone git@github.com:tinycld/<slug>.git <slug>
 pnpm install        # links it + regenerates
 ```
 
-For a third-party package, also add its directory name to the `workspaces` array in
-the workspace-root `package.json` before installing.
+For a third-party package, also add its directory name to the `packages:` list in
+the workspace-root `pnpm-workspace.yaml` before installing.
 
 Remove one by deleting its sibling clone and re-running `pnpm install`. The set of
 linked packages = the set of installed workspace members.
@@ -126,7 +128,7 @@ linked packages = the set of installed workspace members.
 
 ```sh
 cd ~/code/tinycld && pnpm install   # at the workspace root (postinstall runs the generator)
-cd app
+cd tinycld
 pnpm run checks                     # biome + tsc
 pnpm run test                       # vitest (this member)
 pnpm run test:e2e                   # playwright (this member)
@@ -135,7 +137,7 @@ cd server && go build -o tinycld . && ./tinycld --help
 
 Per-member checks run via the `tinycld-pkg` CLI (`@tinycld/package-scripts`): from any
 member dir, `pnpm exec tinycld-pkg check` typechecks + unit-tests just that member;
-`tinycld-pkg check --all` runs every member (app, core, and each feature sibling).
+`tinycld-pkg check --all` runs every member (the `tinycld` shell, core, and each feature sibling).
 
 ## Code style
 

--- a/core/README.md
+++ b/core/README.md
@@ -1,8 +1,8 @@
 # @tinycld/core
 
-The shared runtime + UI library for the TinyCld ecosystem. A standalone git
-repo, cloned as a workspace member sibling of the app shell and the feature
-packages (it is no longer bundled inside the app shell).
+The shared runtime + UI library for the TinyCld ecosystem. A nested member
+at `tinycld/core/` inside the `tinycld` app shell repo — its own package,
+imported as `@tinycld/core`.
 
 It exposes the app-facing surface of core via `@tinycld/core/*` subpaths:
 `~/lib/*`, `~/ui/*`, `~/components/*`, `~/types/*`, the top-level `Providers`,
@@ -15,12 +15,12 @@ thumbnails, render, realtime, sharelink) and core's PocketBase migrations.
 
 ## Layout
 
-Clone the workspace members as siblings under one root:
+Core is nested inside the `tinycld` shell repo; feature packages are sibling
+repos under the same workspace root:
 
 ```sh
-git clone <app-remote>            ~/code/tinycld/app       # the app shell (member "app")
-git clone git@github.com:tinycld/core.git  ~/code/tinycld/core   # this repo
-git clone git@github.com:tinycld/contacts.git ~/code/tinycld/contacts  # any feature package
+git clone git@github.com:tinycld/tinycld.git    ~/code/tinycld/tinycld    # app shell — core lives at tinycld/core/ (this repo)
+git clone git@github.com:tinycld/contacts.git   ~/code/tinycld/contacts   # any feature package
 ```
 
 ## Public surface

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -44,7 +44,7 @@ Three kinds of code live in the ecosystem:
 | Kind | Where it lives | Git | Has `manifest.ts`? | Discovered how |
 |---|---|---|---|---|
 | **App shell** | `tinycld/` | own repo | n/a | it *is* the runner |
-| **`@tinycld/core`** | bundled inside the shell at `tinycld/packages/@tinycld/core/` | **no separate repo** | **no** | wired in explicitly |
+| **`@tinycld/core`** | nested inside the shell repo at `tinycld/core/` | own repo | **no** | wired in explicitly |
 | **Feature packages** | sibling repos (`mail/`, `contacts/`, `calc/`, `calendar/`, `drive/`, `text/`, `google-takeout-import/`) | each its own repo + remote | **yes** | auto-discovered |
 
 The defining structural rule: **a directory is a feature package iff it
@@ -55,14 +55,12 @@ treated as a library, not a feature.
 ~/code/tinycld/                       # pnpm workspace root (package.json + pnpm-workspace.yaml)
     node_modules/
         @tinycld/
-            core     -> ../../tinycld/packages/@tinycld/core  # pnpm workspace symlink
-            mail     -> ../../mail                            # pnpm workspace symlink
+            core     -> ../../tinycld/core  # pnpm workspace symlink
+            mail     -> ../../mail          # pnpm workspace symlink
             contacts -> ../../contacts
             ...
     tinycld/                          # app shell (the only runnable thing)
-        packages/
-            @tinycld/
-                core/                 # bundled library (real dir, no manifest.ts)
+        core/                         # @tinycld/core — nested member (real dir, no manifest.ts)
         node_modules/                 # heavy deps (React/RN/Expo/…) live HERE
         scripts/generate-packages.ts  # the generator
         tinycld.packages.ts           # getPackages() — reads workspace members
@@ -172,22 +170,25 @@ Three rules enforced here:
 
 ### `tsconfig.json`
 
-Siblings extend the app shell's tsconfig and map the import aliases onto the
-bundled core:
+Siblings extend `@tinycld/core/tsconfig.package-base.json` (resolved by package
+name) and declare only their own `~/tinycld/<slug>/*` self-alias. Every
+`@tinycld/*` dependency — `@tinycld/core`, `@tinycld/app-generated`, and any
+cross-sibling dep — resolves **by package name** through the
+`node_modules/@tinycld/*` symlinks + each package's `exports` map under
+`moduleResolution: bundler`, so **no sibling tsconfig needs a `paths` entry for
+any `@tinycld/*` dep**:
 
 ```jsonc
 {
-    "extends": "../tinycld/tsconfig.json",
+    "extends": "@tinycld/core/tsconfig.package-base.json",
     "compilerOptions": {
-        "baseUrl": ".", "rootDir": "..", "noEmit": true, "preserveSymlinks": false,
+        "baseUrl": ".",
         "paths": {
-            "~/tinycld/contacts/*": ["./tinycld/contacts/*"],          // own source
-            "@tinycld/app-generated/*": ["../tinycld/lib/generated/*"], // generator output
-            "@tinycld/core/*": ["../tinycld/packages/@tinycld/core/*"], // core (explicit)
-            "@tinycld/*": ["../tinycld/packages/@tinycld/*"],           // other siblings
-            "~/*": ["../tinycld/packages/@tinycld/core/*"]              // core (~ alias)
+            "~/tinycld/contacts/*": ["./tinycld/contacts/*"] // own source only
         }
-    }
+    },
+    "include": ["tinycld/**/*.ts", "tinycld/**/*.tsx"],
+    "exclude": ["node_modules", "server", "pb-migrations", "tests/**/*.spec.ts"]
 }
 ```
 
@@ -650,9 +651,9 @@ or kill servers manually around a Playwright run.
 Two Go module boundaries, one binary:
 
 - **App** = `tinycld.org/tinycld` (`server/go.mod`), which pulls core via
-  `replace tinycld.org/core => ../packages/@tinycld/core/server`.
+  `replace tinycld.org/core => ../core/server`.
 - **Core** = `tinycld.org/core`
-  (`packages/@tinycld/core/server/go.mod`), exporting
+  (`core/server/go.mod`), exporting
   `coreserver.Register(app, Options)` plus subsystems (`notify`, `push`,
   `mailer`, `audit`, `textextract`, `thumbnails`, `realtime`, `render`).
 - **Each server-bearing sibling** = `tinycld.org/packages/<slug>`, exporting
@@ -763,7 +764,7 @@ Where changes go:
 | Change | Repo to edit |
 |---|---|
 | A feature's behavior | that sibling repo (`mail/`, `calc/`, …) — commit & push there |
-| Shared lib / UI / providers | `tinycld/packages/@tinycld/core/` (bundled in the shell) |
+| Shared lib / UI / providers | `tinycld/core/` (`@tinycld/core`, nested in the shell repo) |
 | Bundler config, scripts, generator, `app/` tree, provider wiring | `tinycld/` (app shell) |
 
 **Never commit generator output.** These paths are gitignored and regenerate


### PR DESCRIPTION
Update the app-shell README, `core/README.md`, and `docs/packages.md` for the merged layout: `@tinycld/core` is a nested member at `tinycld/core/` (not bundled at `tinycld/packages/@tinycld/core/`, not a separate repo). Fixes the package table, layout tree, sibling tsconfig example, and Go module replace paths.