### PR TITLE
fix: don't 500 granting super admin as a PB superuser

### DIFF
--- a/core/server/coreserver/pkg_install_auth_test.go
+++ b/core/server/coreserver/pkg_install_auth_test.go
@@ -74,6 +74,24 @@ func newGuardUser(t *testing.T, app core.App, email string) *core.Record {
 	return user
 }
 
+// newSuperuserRecord creates a PB superuser and returns the record, for tests
+// that need to set re.Auth to a superuser identity (whose id lives in the
+// _superusers collection, not users).
+func newSuperuserRecord(t *testing.T, app core.App, email string) *core.Record {
+	t.Helper()
+	supers, err := app.FindCollectionByNameOrId(core.CollectionNameSuperusers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	su := core.NewRecord(supers)
+	su.SetEmail(email)
+	su.SetPassword("Superuser1234!")
+	if err := app.Save(su); err != nil {
+		t.Fatalf("save superuser: %v", err)
+	}
+	return su
+}
+
 // grantSuperAdmin inserts a super_admins row for the given user.
 func grantSuperAdmin(t *testing.T, app core.App, userID string) {
 	t.Helper()

--- a/core/server/coreserver/super_admins.go
+++ b/core/server/coreserver/super_admins.go
@@ -108,9 +108,11 @@ func handleGrantSuperAdmin(app core.App, re *core.RequestEvent) error {
 
 	record := core.NewRecord(collection)
 	record.Set("user", user.Id)
-	// re.Auth is nil for a PB-superuser request (no app-user identity); leave
-	// created_by empty in that case rather than recording a non-user id.
-	if re.Auth != nil {
+	// created_by is a relation into the users collection. A PB-superuser request
+	// still carries a non-nil re.Auth (its id lives in _superusers, not users),
+	// so recording it here fails the relation validation with a 500. Only stamp
+	// created_by for an app-user grantor; leave it empty for a superuser.
+	if re.Auth != nil && !re.Auth.IsSuperuser() {
 		record.Set("created_by", re.Auth.Id)
 	}
 	if err := app.Save(record); err != nil {

--- a/core/server/coreserver/super_admins_test.go
+++ b/core/server/coreserver/super_admins_test.go
@@ -66,6 +66,63 @@ func TestHandleGrantSuperAdmin_ByEmail(t *testing.T) {
 	}
 }
 
+// TestHandleGrantSuperAdmin_AsSuperuserGrantor is the regression guard for the
+// grant 500: when the request is authenticated as a PB superuser, re.Auth is
+// non-nil (its id lives in _superusers, NOT users), so blindly stamping it into
+// created_by — a relation into users — fails relation validation and 500s. The
+// handler must skip created_by for a superuser grantor. The /admin console logs
+// in as the PB superuser, so this is the common path the bug report hit.
+func TestHandleGrantSuperAdmin_AsSuperuserGrantor(t *testing.T) {
+	app, _ := newSuperAdminsTestApp(t)
+	user := newGuardUser(t, app, "grantedbysuper@test.local")
+
+	re := newJSONRequestEvent(app, "POST", `{"email":"grantedbysuper@test.local"}`)
+	re.Auth = newSuperuserRecord(t, app, "granting-super@test.local")
+
+	if err := handleGrantSuperAdmin(app, re); err != nil {
+		t.Fatalf("grant by a superuser grantor returned error (the 500 regression): %v", err)
+	}
+	if !isSuperAdmin(app, user.Id) {
+		t.Fatal("user should be a super admin after a superuser-initiated grant")
+	}
+
+	// created_by must be empty — the superuser's id is not a valid users relation.
+	rec, err := app.FindFirstRecordByFilter(
+		"super_admins", "user = {:user}", map[string]any{"user": user.Id})
+	if err != nil {
+		t.Fatalf("find granted row: %v", err)
+	}
+	if got := rec.GetString("created_by"); got != "" {
+		t.Fatalf("created_by should be empty for a superuser grantor, got %q", got)
+	}
+}
+
+// TestHandleGrantSuperAdmin_AsAppUserGrantor pins the complementary case: an
+// app-user grantor (an existing super admin minting another) IS recorded in
+// created_by, since their id is a valid users relation.
+func TestHandleGrantSuperAdmin_AsAppUserGrantor(t *testing.T) {
+	app, _ := newSuperAdminsTestApp(t)
+	grantor := newGuardUser(t, app, "appgrantor@test.local")
+	grantSuperAdmin(t, app, grantor.Id)
+	target := newGuardUser(t, app, "appgranted@test.local")
+
+	re := newJSONRequestEvent(app, "POST", `{"email":"appgranted@test.local"}`)
+	re.Auth = grantor
+
+	if err := handleGrantSuperAdmin(app, re); err != nil {
+		t.Fatalf("grant by an app-user grantor returned error: %v", err)
+	}
+
+	rec, err := app.FindFirstRecordByFilter(
+		"super_admins", "user = {:user}", map[string]any{"user": target.Id})
+	if err != nil {
+		t.Fatalf("find granted row: %v", err)
+	}
+	if got := rec.GetString("created_by"); got != grantor.Id {
+		t.Fatalf("created_by = %q, want grantor id %q", got, grantor.Id)
+	}
+}
+
 func TestHandleGrantSuperAdmin_DuplicateRejected(t *testing.T) {
 	app, _ := newSuperAdminsTestApp(t)
 	user := newGuardUser(t, app, "dupe@test.local")

--- a/tests/install/setup-and-packages.spec.ts
+++ b/tests/install/setup-and-packages.spec.ts
@@ -144,4 +144,32 @@ test.describe('first-run install', () => {
         await expect(page.getByText(TEST_ORG_SLUG, { exact: true })).toBeVisible()
         await expect(page.getByText(TEST_ORG_OWNER_EMAIL, { exact: true })).toBeVisible()
     })
+
+    test('superuser can grant another user super admin', async ({ page }) => {
+        await loginAsSuperuser(page)
+
+        // Regression test for the grant 500: a PB-superuser grantor carries a
+        // non-nil auth identity whose id lives in _superusers, NOT users. The
+        // handler stamped that id into super_admins.created_by (a users relation),
+        // which failed relation validation and returned a 500 the dev console
+        // never surfaced (it only reached Sentry/the _logs DB). Granting while
+        // logged in as the superuser — the common /admin path — is exactly this.
+        //
+        // Grant the org owner created by the previous (serial) test; that user
+        // already exists, so this exercises the grant-an-existing-user path.
+        await page.getByText('Super Admins', { exact: true }).first().click()
+
+        // Wait for the section to mount (the grant CTA) before interacting.
+        await expect(page.getByRole('button', { name: 'Grant access' })).toBeVisible()
+
+        await page.getByRole('button', { name: 'Grant access' }).click()
+        await page.getByPlaceholder('person@example.com').fill(TEST_ORG_OWNER_EMAIL)
+        await page.getByRole('button', { name: 'Grant super admin' }).click()
+
+        // On success the form closes, the roster refetches, and the granted user
+        // appears as a row. Before the fix this never happened — the POST 500'd
+        // and the email surfaced as an inline form error instead. Asserting the
+        // owner's row (not just "not empty") makes the regression signal precise.
+        await expect(page.getByText(TEST_ORG_OWNER_EMAIL, { exact: true })).toBeVisible()
+    })
 })


### PR DESCRIPTION
## Problem

Granting a user super admin from `/admin` returned a 500, with nothing logged.

`handleGrantSuperAdmin` set `super_admins.created_by` to `re.Auth.Id`. That field is a relation into the **users** collection, but a PB-superuser request (the usual `/admin` login) carries a non-nil `re.Auth` whose id lives in `_superusers` — so `app.Save` failed relation validation and 500'd. The old `if re.Auth != nil` guard didn't exclude superusers, and the code comment claiming `re.Auth` is nil for superusers was wrong (`HasSuperuserAuth()` is `e.Auth != nil && e.Auth.IsSuperuser()`).

It hid because granting *as an app user* works (their id is a valid users relation), and the existing unit tests built `re.Auth == nil`.

**Why nothing logged:** PB writes 5xx to the `_logs` DB, not stdout, and the Sentry middleware drops events when `SENTRY_DSN` is unset (dev).

## Fix

Only stamp `created_by` for an app-user grantor; leave it empty for a superuser:

```go
if re.Auth != nil && !re.Auth.IsSuperuser() {
    record.Set("created_by", re.Auth.Id)
}
```

## Tests

- Go: `TestHandleGrantSuperAdmin_AsSuperuserGrantor` (confirmed to fail with the exact 500 when the fix is reverted) and `_AsAppUserGrantor` (asserts `created_by` is stamped for app users).
- E2E: grant test added to the docker smoke suite (`tests/install/setup-and-packages.spec.ts`) — the only suite with a known PB-superuser password.

Full `coreserver` suite green; vet/gofmt/biome/tsc clean.