### PR TITLE
feat(deploy): bare-metal (no-Docker) install + build scripts

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -87,6 +87,17 @@ with Docker (Hetzner CX-class ≈ €4/mo and up). That file is the source of tr
 for the self-host path and the
 [installation guide](https://tinycld.org/docs/installation).
 
+### Without Docker (bare-metal systemd)
+
+Prefer a single long-lived box with **no container runtime**? See
+[`bare-metal/`](./bare-metal/README.md) — a `systemd` service built from source on
+the host, with the app terminating TLS itself via autocert (no reverse proxy):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/tinycld/tinycld/main/deploy/bare-metal/install.sh \
+  | DOMAIN=tinycld.example.com bash
+```
+
 ## Optional: offload file uploads to S3
 
 The SQLite database always needs the volume above, but **file uploads** can be

--- a/deploy/bare-metal/README.md
+++ b/deploy/bare-metal/README.md
@@ -1,0 +1,127 @@
+# Bare-metal install (Debian/Ubuntu + systemd, no Docker)
+
+Run TinyCld on a plain VPS as a native **systemd** service, built from source on
+the box — no Docker, no Dokku, no reverse proxy. The app terminates TLS itself
+via autocert (Let's Encrypt) and binds `:80`/`:443` directly.
+
+> **These scripts are an example, not a turnkey installer.** `install.sh` and
+> `build.sh` assume a Debian/Ubuntu host on x86-64 and that TinyCld owns
+> `:80`/`:443`. Most real deployments need edits — a different distro or package
+> manager, an ARM box, or running behind an existing reverse proxy / load
+> balancer. Read them before you run them and adapt them to your setup; they're
+> meant as a clear starting point you own.
+
+This is an alternative to the Docker paths ([`docker-compose.yml`](../../docker-compose.yml)
+for a VPS, or the managed-host configs in [`../`](../README.md)). Use it when you
+want a single long-lived box with no container runtime.
+
+## Quick start
+
+On a fresh Debian 12/13 or Ubuntu 22.04+ host, as root:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/tinycld/tinycld/main/deploy/bare-metal/install.sh \
+  | DOMAIN=tinycld.example.com bash
+```
+
+Or clone the repo and run it locally:
+
+```sh
+git clone https://github.com/tinycld/tinycld
+DOMAIN=tinycld.example.com ./tinycld/deploy/bare-metal/install.sh
+```
+
+That installs the toolchain, creates a `tinycld` service user, builds the app
+from `main`, writes a systemd unit, and starts it. Once autocert finishes,
+`https://tinycld.example.com` is live. Follow along with
+`journalctl -u tinycld -f`.
+
+## Requirements
+
+- **A public domain** whose A record points at this host, with **:80 and :443
+  reachable** (autocert uses them to issue + serve the cert). Add **:465/:993**
+  if you enable the mail listeners. Behind NAT, forward those ports.
+- ~2 vCPU / 2 GB RAM and ~20 GB disk. The build (and the in-app package installer)
+  run `expo export` + `go build` on the box, which is memory-hungry — a small box
+  may need swap.
+- Debian/Ubuntu with `apt` and `systemd`. (Other distros: adapt the apt + Go/Node
+  install in `install.sh`.)
+
+## The two scripts
+
+| Script | Role |
+| --- | --- |
+| [`install.sh`](./install.sh) | One-shot installer **and** upgrade path: toolchain, service user, state dirs, low-port sysctl, env file, build, systemd unit, start. Idempotent. |
+| [`build.sh`](./build.sh) | The from-source build only: `bootstrap --assemble-only` → `pnpm install` → `packages:generate` → `expo export` → `go build`, baked to `/opt/tinycld-baked`, plus installing the entrypoint and clearing the stale seeded build. Called by `install.sh`; also runnable on its own to rebuild. |
+
+## Configuration
+
+All via environment variables passed to `install.sh`:
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `DOMAIN` | **required** | Canonical domain; autocert certs + binds it. |
+| `ADDITIONAL_DOMAINS` | — | Comma-separated extra cert domains. |
+| `TINYCLD_VERSION` | `main` | Git ref/tag to build (the shell + every feature). |
+| `TINYCLD_FEATURES` | full set | Space-separated feature members to include. |
+| `SENTRY_DSN` | — | Enables Sentry on **both** the Go server (runtime) and the web bundle (inlined at build time). |
+| `ENV_EXTRA` | — | Newline-separated `KEY=VALUE` lines appended to the service env file — e.g. `MAIL_PROVIDER`, `POSTMARK_SERVER_TOKEN`. |
+
+Example with mail + Sentry:
+
+```sh
+DOMAIN=tinycld.example.com \
+SENTRY_DSN="https://…@…/…" \
+ENV_EXTRA=$'MAIL_PROVIDER=postmark\nPOSTMARK_SERVER_TOKEN=…' \
+  ./deploy/bare-metal/install.sh
+```
+
+## How it runs
+
+```
+/opt/tinycld-baked/        pristine workspace baked by build.sh (the binary +
+                           web bundle + node_modules + feature siblings)
+/opt/tinycld-entrypoint.sh the app's own config/entrypoint.sh (the supervisor)
+/workspace/                state root: pb_data/ (the SQLite DB — back this up!),
+                           releases/, builds/, current -> builds/<id>/tinycld
+/etc/tinycld/tinycld.env   root-only secrets/config, read by the unit
+/etc/systemd/system/tinycld.service
+```
+
+The systemd unit runs **`/opt/tinycld-entrypoint.sh`**, not the binary directly —
+the entrypoint is the supervisor (first-boot seed, web-release promotion, and the
+in-app package installer's exit-75 → health-probe → rollback loop). systemd just
+keeps it alive. It starts as root to fix state-dir ownership, then drops to the
+unprivileged `tinycld` user via `gosu`.
+
+## Updating
+
+Re-run the installer (or `build.sh`) — it rebuilds from `TINYCLD_VERSION` and
+restarts:
+
+```sh
+DOMAIN=tinycld.example.com TINYCLD_VERSION=v0.0.5 ./deploy/bare-metal/install.sh
+```
+
+`build.sh` clears the previous seeded build so the new bake is what gets served
+(the entrypoint otherwise reuses the existing `/workspace/current`). `pb_data` is
+never touched by a rebuild.
+
+> The in-app package installer (the setup dashboard's "install package" flow)
+> rebuilds in place independently of this — it `go build`s a fresh tree under
+> `/workspace/builds/<id>/` and flips `current`. That path is unaffected by these
+> scripts.
+
+## Notes / gotchas
+
+- **Privileged ports without root:** the app drops to an unprivileged user but
+  binds `:80/:443/:465/:993`. `install.sh` sets
+  `net.ipv4.ip_unprivileged_port_start=80` (what Docker effectively does with its
+  default of `0`). A `CAP_NET_BIND_SERVICE` approach does **not** work here —
+  `gosu` clears the ambient set and the entrypoint's per-boot `chown` strips file
+  caps — so the sysctl is the reliable mechanism.
+- **Host toolchain is required, not optional:** the in-app installer runs
+  `pnpm install` + `go build` on the host, so Node, pnpm, Go, and a C toolchain
+  must stay installed even after the initial build.
+- **Back up `/workspace/pb_data`** — it holds the SQLite DB, uploads, and the
+  server's private keys.

--- a/deploy/bare-metal/build.sh
+++ b/deploy/bare-metal/build.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# ⚠️  EXAMPLE SCRIPT — read it and adapt it before you run it.
+#
+# This is a reference implementation of a from-source bare-metal build, not a
+# turnkey installer for every environment. It encodes specific choices that are
+# unlikely to match yours unchanged:
+#   - the host distro / package layout (paired install.sh assumes Debian/Ubuntu
+#     apt + an x86-64 Go toolchain),
+#   - fixed paths and a fixed service user ($BAKED_DIR, $STATE_DIR, $RUN_USER),
+#   - that the app owns :80/:443 itself (autocert), with no reverse proxy.
+# Treat it as a starting point: copy it, read it end to end, and edit it for your
+# OS, architecture, paths, and TLS/proxy setup. The knobs below cover the common
+# cases; anything else, change the script.
+#
+# build.sh — build TinyCld FROM SOURCE on a bare host (no Docker) and bake the
+# result for the systemd service. Mirrors the runtime artifact that
+# ../../Dockerfile produces, but assembled natively.
+#
+# This is the same pipeline the image build runs, just on the host:
+#   bootstrap --assemble-only  ->  pnpm install  ->  packages:generate
+#     ->  expo export (web)  ->  go build (server)  ->  bake to $BAKED_DIR
+#
+# Run as root (it writes $BAKED_DIR and chowns to $RUN_USER); the heavy build
+# steps are dropped to $RUN_USER. Idempotent: re-running rebuilds from the pinned
+# ref and atomically swaps the baked tree. install.sh installs the toolchain this
+# needs and is expected to have run first.
+#
+# Configuration (environment variables; all have sensible defaults):
+#   TINYCLD_VERSION    git ref/tag every repo is cloned at        (default: main)
+#   TINYCLD_FEATURES   space-separated feature members to include
+#                        (default: "mail contacts calendar drive calc text \
+#                                   google-takeout-import")
+#   TINYCLD_REPO_BASE  git base to clone from               (default HTTPS GitHub)
+#   RUN_USER           unprivileged service/build user           (default: tinycld)
+#   BAKED_DIR          where the pristine workspace is baked (default: /opt/tinycld-baked)
+#   STATE_DIR          runtime state root (pb_data/builds/...)    (default: /workspace)
+#   BUILD_DIR          scratch assembly dir            (default: /opt/tinycld-build)
+#   PNPM_VERSION       pnpm to activate via corepack             (default: 11.3.0)
+#   EXPO_PUBLIC_SENTRY_DSN   optional; inlined into the web bundle at export time
+#
+set -euo pipefail
+
+TINYCLD_VERSION="${TINYCLD_VERSION:-main}"
+TINYCLD_FEATURES="${TINYCLD_FEATURES:-mail contacts calendar drive calc text google-takeout-import}"
+export TINYCLD_REPO_BASE="${TINYCLD_REPO_BASE:-https://github.com/tinycld}"
+RUN_USER="${RUN_USER:-tinycld}"
+BAKED_DIR="${BAKED_DIR:-/opt/tinycld-baked}"
+STATE_DIR="${STATE_DIR:-/workspace}"
+BUILD_DIR="${BUILD_DIR:-/opt/tinycld-build}"
+PNPM_VERSION="${PNPM_VERSION:-11.3.0}"
+EXPO_PUBLIC_SENTRY_DSN="${EXPO_PUBLIC_SENTRY_DSN:-}"
+
+log() { echo "[tinycld-build] $*"; }
+export PATH="/usr/local/go/bin:${PATH}"
+
+# ------------------------------------------------------------------------------
+# 1. Assemble + build in a scratch dir owned by $RUN_USER.
+# ------------------------------------------------------------------------------
+log "building TinyCld @ ${TINYCLD_VERSION} (features: ${TINYCLD_FEATURES})"
+
+rm -rf "${BUILD_DIR}.tmp"
+install -d -o "$RUN_USER" -g "$RUN_USER" "${BUILD_DIR}.tmp"
+
+# Pin every cloned repo (the tinycld shell + each feature) to the requested ref.
+with_args=""
+for f in $TINYCLD_FEATURES; do
+    with_args="$with_args --with ${f}@${TINYCLD_VERSION}"
+done
+
+runuser -u "$RUN_USER" -- bash -euo pipefail -s -- \
+    "${BUILD_DIR}.tmp" "$TINYCLD_VERSION" "$PNPM_VERSION" "$with_args" "$EXPO_PUBLIC_SENTRY_DSN" <<'BUILD'
+set -euo pipefail
+SCRATCH="$1"; VERSION="$2"; PNPM_VERSION="$3"; WITH_ARGS="$4"; SENTRY_DSN="$5"
+export TINYCLD_REPO_BASE="${TINYCLD_REPO_BASE:-https://github.com/tinycld}"
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+export PATH="/usr/local/go/bin:${PATH}"
+export NODE_OPTIONS="--max-old-space-size=2048"
+
+cd "$SCRATCH"
+
+echo "[build] bootstrap --assemble-only --with tinycld@${VERSION} ${WITH_ARGS}"
+# The tinycld shell repo is always cloned; pin it to the ref via --with too.
+# shellcheck disable=SC2086
+npx -y @tinycld/bootstrap@latest --assemble-only --with tinycld@"${VERSION}" ${WITH_ARGS}
+
+echo "[build] activating pnpm@${PNPM_VERSION}"
+corepack enable
+corepack prepare "pnpm@${PNPM_VERSION}" --activate
+
+# Pin the pnpm store inside the workspace so the in-app installer reuses it
+# (matches the Dockerfile's storeDir pin). Append to the build copy only.
+printf '\nstoreDir: %s/.pnpm-store\n' "$SCRATCH" >> pnpm-workspace.yaml
+
+# NOT --frozen-lockfile: `bootstrap --assemble-only` does not emit a root
+# pnpm-lock.yaml (it writes package.json + pnpm-workspace.yaml and clones the
+# members; the lockfile is generated here). The Dockerfile uses --frozen-lockfile
+# because its CI context bakes in a pinned lockfile asset, which this does not.
+echo "[build] pnpm install (runs the generator postinstall)"
+pnpm install
+
+cd tinycld
+
+echo "[build] packages:generate"
+pnpm run packages:generate
+
+# Materialize the generator's migration/hook symlinks into real files (the
+# Dockerfile does this before the Go build).
+for d in server/pb_migrations server/pb_hooks; do
+    [ -d "$d" ] || continue
+    find "$d" -type l -exec sh -c 'target=$(readlink -f "$1") && rm "$1" && cp "$target" "$1"' _ {} \;
+done
+
+echo "[build] expo export --platform web"
+export EXPO_PUBLIC_ENV=web
+# Web Sentry DSN is inlined into the bundle at export time. Empty = disabled.
+export EXPO_PUBLIC_SENTRY_DSN="$SENTRY_DSN"
+RID="$(date -u +%Y-%m-%d-%H%M%S)-$(git -C . rev-parse --short HEAD 2>/dev/null || echo deadbeef)"
+export EXPO_PUBLIC_RELEASE_ID="$RID"
+npx expo export --platform web
+mkdir -p release-staging
+mv dist "release-staging/${RID}"
+printf '%s' "$RID" > "release-staging/${RID}/release-id.txt"
+mv "release-staging/${RID}/index.html" "release-staging/${RID}/app.html"
+
+echo "[build] go build server binary"
+cd server
+CGO_ENABLED=1 GOOS=linux go build -o ../tinycld .
+if [ -f go.work ]; then go work sync; fi
+cd ..
+
+echo "[build] assembled tree ready at ${SCRATCH}/tinycld/tinycld"
+BUILD
+
+# ------------------------------------------------------------------------------
+# 2. Promote the scratch tree to $BAKED_DIR atomically.
+#
+# Bake the WHOLE workspace (root manifests + node_modules + every feature sibling
+# + the tinycld member), exactly like the Dockerfile bakes /opt/tinycld-baked:
+# node_modules/@tinycld/<x> are RELATIVE symlinks, so a build dir must contain the
+# entire workspace, not just tinycld/.
+# ------------------------------------------------------------------------------
+log "promoting build to ${BAKED_DIR}"
+rm -rf "${BAKED_DIR}.old"
+[ -e "$BAKED_DIR" ] && mv "$BAKED_DIR" "${BAKED_DIR}.old"
+mv "${BUILD_DIR}.tmp" "$BAKED_DIR"
+chown -R "$RUN_USER:$RUN_USER" "$BAKED_DIR"
+rm -rf "${BAKED_DIR}.old"
+
+# ------------------------------------------------------------------------------
+# 3. Install the entrypoint at the fixed path the systemd unit invokes, and clear
+#    the stale seeded build so the NEW bake is what gets served on restart.
+#
+# The entrypoint's seed_baked_build() short-circuits when $STATE_DIR/current
+# already resolves to a binary — so on an UPDATE it would keep serving the old
+# seeded copy and never re-seed from the freshly-baked tree. Removing the
+# disposable build trees + the current symlink forces a clean re-seed.
+#
+# SAFE: this touches only CODE under $STATE_DIR/builds and the symlink. The
+# database ($STATE_DIR/pb_data) and promoted web bundles ($STATE_DIR/releases)
+# are siblings and are left untouched; the entrypoint re-promotes releases from
+# the new bake on start.
+# ------------------------------------------------------------------------------
+log "installing entrypoint + clearing stale seeded build"
+install -m 0755 -o "$RUN_USER" -g "$RUN_USER" \
+    "${BAKED_DIR}/tinycld/config/entrypoint.sh" /opt/tinycld-entrypoint.sh
+rm -rf "${STATE_DIR}/builds" "${STATE_DIR}/current"
+install -d -o "$RUN_USER" -g "$RUN_USER" "${STATE_DIR}/builds"
+
+log "build complete. start/restart the service to pick it up (systemctl restart tinycld)."

--- a/deploy/bare-metal/install.sh
+++ b/deploy/bare-metal/install.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# ⚠️  EXAMPLE SCRIPT — read it and adapt it before you run it.
+#
+# This is a reference bare-metal installer, not a one-size-fits-all tool. It bakes
+# in choices you will likely need to change for your environment:
+#   - Debian/Ubuntu on x86-64: it uses `apt`, the NodeSource apt repo, and the
+#     linux-amd64 Go tarball. Other distros (RHEL/Alpine/…) or ARM hosts need the
+#     package-install and Go/Node steps rewritten.
+#   - It assumes TinyCld owns :80/:443 and terminates TLS itself via autocert. If
+#     you run behind an existing reverse proxy or load balancer, drop autocert and
+#     the low-port sysctl and serve plain HTTP on :7090 instead.
+#   - It writes a systemd unit and uses fixed paths/user ($STATE_DIR, $BAKED_DIR,
+#     $RUN_USER). Non-systemd init, or different paths, means edits.
+# Copy it, read it end to end, and modify it to fit. It is meant to be a clear
+# starting point you own, not a black box you curl-pipe blindly.
+#
+# install.sh — install TinyCld on a plain Debian/Ubuntu host as a systemd service
+# (no Docker). Installs the runtime + build toolchain, creates the service user
+# and state dirs, allows the unprivileged user to bind low ports, builds the app
+# from source (via build.sh), and writes + starts the systemd unit.
+#
+# Run as root. Idempotent: safe to re-run (it also serves as the upgrade path —
+# re-run after bumping TINYCLD_VERSION to rebuild and restart).
+#
+#   curl -fsSL https://raw.githubusercontent.com/tinycld/tinycld/main/deploy/bare-metal/install.sh \
+#     | DOMAIN=tinycld.example.com bash
+#
+# Or clone the repo and run ./deploy/bare-metal/install.sh with DOMAIN set.
+#
+# Configuration (environment variables):
+#   DOMAIN              REQUIRED. The canonical domain. Autocert provisions a
+#                       Let's Encrypt cert for it and binds :80/:443 directly.
+#   ADDITIONAL_DOMAINS  optional comma-separated extra cert domains.
+#   TINYCLD_VERSION     git ref/tag to build                       (default: main)
+#   TINYCLD_FEATURES    space-separated feature members      (default: the full set)
+#   SENTRY_DSN          optional. Enables Sentry on BOTH the Go server (runtime)
+#                       and the web bundle (inlined at build time).
+#   ENV_EXTRA           optional. Newline-separated KEY=VALUE lines appended to the
+#                       service env file (e.g. MAIL_PROVIDER, POSTMARK_* tokens).
+#   RUN_USER STATE_DIR BAKED_DIR   advanced overrides (see build.sh defaults).
+#
+# TLS: the app terminates TLS itself (autocert) — no nginx/Caddy. Ensure :80 and
+# :443 reach this host (and :465/:993 if you use the mail listeners). For a host
+# behind NAT, forward those ports.
+#
+set -euo pipefail
+
+DOMAIN="${DOMAIN:?Set DOMAIN=your.domain (the canonical domain autocert will cert)}"
+ADDITIONAL_DOMAINS="${ADDITIONAL_DOMAINS:-}"
+TINYCLD_VERSION="${TINYCLD_VERSION:-main}"
+SENTRY_DSN="${SENTRY_DSN:-}"
+ENV_EXTRA="${ENV_EXTRA:-}"
+
+RUN_USER="${RUN_USER:-tinycld}"
+STATE_DIR="${STATE_DIR:-/workspace}"
+BAKED_DIR="${BAKED_DIR:-/opt/tinycld-baked}"
+
+GO_VERSION="${GO_VERSION:-1.25.1}"
+NODE_MAJOR="${NODE_MAJOR:-22}"
+UNPRIV_PORT_START="${UNPRIV_PORT_START:-80}"
+
+ENV_FILE=/etc/tinycld/tinycld.env
+UNIT=/etc/systemd/system/tinycld.service
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+log() { echo "[tinycld-install] $*"; }
+export DEBIAN_FRONTEND=noninteractive
+
+# ------------------------------------------------------------------------------
+# 1. Runtime + build dependencies.
+#
+# TinyCld self-rebuilds: its in-app package installer runs pnpm install + go build
+# + expo export on the HOST, so the host needs the full toolchain, not just a
+# runtime. This is the Dockerfile runtime-stage apt list + Node + Go.
+#   cgo: libmupdf-dev (go-fitz), gcc/g++ (mupdf + goheif/libde265)
+#   sqlite3 CLI: the installer's DB backup step; gosu: privilege drop in entrypoint
+# ------------------------------------------------------------------------------
+log "installing apt packages"
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+    ca-certificates libffi8 libmupdf-dev libcap2-bin curl git \
+    build-essential gcc g++ sqlite3 gnupg gosu rsync
+
+if ! command -v node >/dev/null 2>&1 || [ "$(node -v | cut -c2- | cut -d. -f1)" != "$NODE_MAJOR" ]; then
+    log "installing Node ${NODE_MAJOR}.x"
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+    apt-get install -y --no-install-recommends nodejs
+fi
+corepack enable || true
+
+if [ ! -x /usr/local/go/bin/go ] || ! /usr/local/go/bin/go version | grep -q "go${GO_VERSION}"; then
+    log "installing Go ${GO_VERSION}"
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tgz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tgz && rm -f /tmp/go.tgz
+fi
+[ -f /etc/profile.d/go.sh ] || echo 'export PATH=/usr/local/go/bin:$PATH' > /etc/profile.d/go.sh
+
+# ------------------------------------------------------------------------------
+# 2. Service user + state dirs.
+#
+# A dedicated system user with an AUTO-ALLOCATED uid/gid (do NOT pin 1000 — it is
+# usually the first human login user). TinyCld does not require a specific uid:
+# the entrypoint chowns state to whatever user runs it; the Dockerfile's 1000 is
+# only a bind-mount-ownership convenience.
+# ------------------------------------------------------------------------------
+if ! id -u "$RUN_USER" >/dev/null 2>&1; then
+    log "creating service user ${RUN_USER}"
+    useradd --system --user-group --home-dir "$STATE_DIR" \
+        --no-create-home --shell /usr/sbin/nologin "$RUN_USER"
+fi
+install -d -o "$RUN_USER" -g "$RUN_USER" \
+    "$STATE_DIR" "$STATE_DIR/pb_data" "$STATE_DIR/releases" "$STATE_DIR/builds"
+install -d -m 0755 /etc/tinycld
+
+# ------------------------------------------------------------------------------
+# 3. Let the unprivileged user bind low ports.
+#
+# TinyCld binds :80/:443 (autocert) and :465/:993 (mail) but drops to the
+# unprivileged $RUN_USER (gosu, in the entrypoint). Under Docker this Just Works
+# because containers default net.ipv4.ip_unprivileged_port_start=0. On bare metal
+# it defaults to 1024, AND the entrypoint chowns the build tree on every boot
+# (chown strips file capabilities) — so a CAP_NET_BIND_SERVICE approach (file cap
+# or systemd AmbientCapabilities through gosu, which clears the ambient set)
+# cannot hold. Lowering the unprivileged-port floor mirrors the Docker behavior,
+# needs no caps, and survives every rebuild.
+# ------------------------------------------------------------------------------
+log "setting net.ipv4.ip_unprivileged_port_start=${UNPRIV_PORT_START}"
+echo "net.ipv4.ip_unprivileged_port_start=${UNPRIV_PORT_START}" > /etc/sysctl.d/60-tinycld-lowports.conf
+sysctl -w "net.ipv4.ip_unprivileged_port_start=${UNPRIV_PORT_START}"
+
+# ------------------------------------------------------------------------------
+# 4. Service env file (root-only). Secrets + optional Sentry/extra config.
+# ------------------------------------------------------------------------------
+log "writing ${ENV_FILE}"
+umask 077
+: > "$ENV_FILE"
+if [ -n "$SENTRY_DSN" ]; then
+    echo "SENTRY_DSN=${SENTRY_DSN}" >> "$ENV_FILE"      # server-side (Go) Sentry
+fi
+if [ -n "$ENV_EXTRA" ]; then
+    printf '%s\n' "$ENV_EXTRA" >> "$ENV_FILE"
+fi
+chmod 0600 "$ENV_FILE"
+
+# ------------------------------------------------------------------------------
+# 5. Build from source + bake (build.sh installs /opt/tinycld-entrypoint.sh).
+# ------------------------------------------------------------------------------
+log "building from source (this takes a few minutes)"
+TINYCLD_VERSION="$TINYCLD_VERSION" \
+RUN_USER="$RUN_USER" STATE_DIR="$STATE_DIR" BAKED_DIR="$BAKED_DIR" \
+EXPO_PUBLIC_SENTRY_DSN="$SENTRY_DSN" \
+${TINYCLD_FEATURES:+TINYCLD_FEATURES="$TINYCLD_FEATURES"} \
+    bash "${SCRIPT_DIR}/build.sh"
+
+# ------------------------------------------------------------------------------
+# 6. systemd unit. ExecStart is the ENTRYPOINT (the supervisor), not the binary —
+#    it owns first-boot seeding, release promotion, and the in-app installer's
+#    exit-75 / health-probe / rollback loop. Starts as root so it can chown state
+#    dirs, then drops to $RUN_USER via gosu.
+# ------------------------------------------------------------------------------
+log "writing ${UNIT}"
+cat > "$UNIT" <<EOF
+[Unit]
+Description=TinyCld (${DOMAIN})
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${STATE_DIR}
+Environment=TINYCLD_STATE_DIR=${STATE_DIR}
+Environment=PRIMARY_DOMAIN=${DOMAIN}
+Environment=ADDITIONAL_DOMAINS=${ADDITIONAL_DOMAINS}
+Environment=AUTOCERT_ENABLED=true
+Environment=PUBLIC_SCHEME=https
+EnvironmentFile=${ENV_FILE}
+ExecStart=/opt/tinycld-entrypoint.sh
+Restart=always
+RestartSec=5
+# An in-app rebuild runs expo export + go build on the box; give it room.
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+log "enabling + starting service"
+systemctl daemon-reload
+systemctl enable tinycld
+systemctl restart tinycld
+
+log "done. follow logs with: journalctl -u tinycld -f"
+log "the app is serving https://${DOMAIN} once autocert finishes provisioning."


### PR DESCRIPTION
Adds `deploy/bare-metal/` — a from-source, no-Docker install path for hosts that want a single long-lived box with no container runtime.

## What's here

- **`install.sh`** — provisions the toolchain (Node/Go/cgo deps), a service user, state dirs, the low-port sysctl, the env file, and a systemd unit; builds from source via `build.sh` and starts the service. Idempotent; doubles as the upgrade path.
- **`build.sh`** — assembles + bakes the app natively (`bootstrap --assemble-only` → `pnpm install` → `packages:generate` → `expo export` → `go build`), mirroring the Dockerfile pipeline, then atomically promotes the baked tree.
- **`README.md`** — quick start, config env vars, how it runs, updating, gotchas.

## Framed as an example, not a turnkey installer

Both scripts open with a prominent banner, and the READMEs repeat it: they assume **Debian/Ubuntu on x86-64** and that the app **owns :80/:443** (autocert, no reverse proxy). The banners call out the common things to adapt — different distro/package manager, ARM hosts, or running behind an existing reverse proxy / load balancer — and say to read them before running. The scripts are env-var driven (paths, user, feature set, version, Sentry, extra env) so the common cases are knobs rather than edits.

Verified with `bash -n` on both scripts.

> Companion docs PR: **tinycld/website#9** surfaces this on `tinycld.org/deploy` (a new "Bare metal — no Docker" tier). They ship together.
