### PR TITLE
fix(demo-reset): run reset-demo.ts via pnpm exec tsx, not bun

### DIFF
--- a/core/server/coreserver/demo_reset.go
+++ b/core/server/coreserver/demo_reset.go
@@ -120,7 +120,7 @@ func runDemoReset(app *pocketbase.PocketBase) {
 		return
 	}
 
-	cmd := exec.CommandContext(ctx, "bun", "run", "scripts/reset-demo.ts", "--url", url)
+	cmd := exec.CommandContext(ctx, "pnpm", "exec", "tsx", "scripts/reset-demo.ts", "--url", url)
 	cmd.Dir = scriptDir
 	// Pass through env so ADMIN_USER_LOGIN / ADMIN_USER_PW configured for the
 	// container reach the script. The bound URL is passed via --url because

--- a/server/main.go
+++ b/server/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // defaultHTTPAddr is the loopback address tinycld serves on in dev when no
-// --http flag is given. The local-ssl-proxy in `bun run dev` listens on 7090
+// --http flag is given. The local-ssl-proxy in `pnpm run dev` listens on 7090
 // and forwards here, so this needs to match the SSL proxy's --target port.
 const defaultHTTPAddr = "127.0.0.1:7090"
 
@@ -31,7 +31,7 @@ func main() {
 	// explicit address and no domain args. PocketBase's autocert needs
 	// :80/:443 when domain args are present, so we don't override there.
 	// PB's own default for `serve` is 127.0.0.1:8090 — we override to 7090
-	// to match the SSL proxy in `bun run dev`. Injecting through os.Args
+	// to match the SSL proxy in `pnpm run dev`. Injecting through os.Args
 	// (rather than registering a flag default) keeps PB's flag schema
 	// untouched and lets explicit `--http :8090` overrides still work.
 	if coreserver.HasSubcommand("serve") && !coreserver.HasFlag("--http") && !coreserver.HasDomainArgs() {


### PR DESCRIPTION
The nightly **demo-reset cron** was failing:

```
exec: "bun": executable file not found in $PATH
```

`bun` was dropped from the project long ago; the runtime image ships pnpm + tsx + node, and the documented cron runner is `pnpm exec tsx scripts/<x>.ts`. `demo_reset.go` was the last stale `bun` call site.

- `demo_reset.go`: `bun run scripts/reset-demo.ts` → `pnpm exec tsx scripts/reset-demo.ts` (matches the script's own `#!/usr/bin/env -S pnpm exec tsx` shebang and every other script invocation).
- `server/main.go`: fix two stale `bun run dev` comment references → `pnpm run dev`.

Verified `go build ./...` clean. No behavior change beyond the runner.