### PR TITLE
fix(core): resilient package sidebar mount + drop e2e retries

### DIFF
--- a/core/components/workspace/LazySidebarBoundary.tsx
+++ b/core/components/workspace/LazySidebarBoundary.tsx
@@ -1,0 +1,121 @@
+import {
+    Component,
+    type ReactNode,
+    Suspense,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react'
+import { nextAttempt, shouldRetryOnTimeout } from './lazy-sidebar-retry'
+
+interface LazySidebarBoundaryProps {
+    /** Skeleton shown while the lazy chunk loads (Suspense fallback). */
+    fallback: ReactNode
+    /** The lazy sidebar subtree. */
+    children: ReactNode
+    /** How long to wait in the fallback before forcing a remount (ms). */
+    stuckTimeoutMs?: number
+    /** Max remount attempts before giving up and surfacing the error/skeleton. */
+    maxRetries?: number
+}
+
+interface ErrorState {
+    hasError: boolean
+}
+
+/**
+ * Internal error boundary: a lazy `import()` that REJECTS (Metro chunk fetch /
+ * module-eval failure) makes React.lazy throw on render. Without a boundary that
+ * error propagates and the sidebar is gone for the session. We catch it and ask
+ * the parent to remount (which re-invokes the import).
+ */
+class SidebarErrorBoundary extends Component<
+    { onError: () => void; children: ReactNode },
+    ErrorState
+> {
+    state: ErrorState = { hasError: false }
+
+    static getDerivedStateFromError(): ErrorState {
+        return { hasError: true }
+    }
+
+    componentDidCatch() {
+        this.props.onError()
+    }
+
+    render() {
+        // While errored we render nothing; the parent's remount swaps in a fresh
+        // subtree (new key) and resets this boundary with it.
+        if (this.state.hasError) return null
+        return this.props.children
+    }
+}
+
+/**
+ * Resilient wrapper for a lazily-loaded package sidebar.
+ *
+ * Two failure modes are handled, both observed under heavy CI contention where
+ * the sidebar's Suspense boundary otherwise stays stuck on its skeleton forever:
+ *
+ *   1. The lazy `import()` REJECTS → SidebarErrorBoundary catches it and we
+ *      remount to retry the import.
+ *   2. The chunk loads (HTTP 200) but the boundary never commits the child — the
+ *      Suspense sits in the fallback indefinitely. An error boundary can't see
+ *      this (nothing threw), so a watchdog remounts the subtree if we're still
+ *      showing the fallback after `stuckTimeoutMs`, re-triggering resolution.
+ *
+ * Each remount bumps `attempt`, which is the React key on the Suspense subtree —
+ * a new key forces a fresh mount (and a fresh `import()` attempt). Retries are
+ * capped so a genuinely-broken chunk doesn't loop forever.
+ */
+export function LazySidebarBoundary({
+    fallback,
+    children,
+    stuckTimeoutMs = 15_000,
+    maxRetries = 3,
+}: LazySidebarBoundaryProps) {
+    const [attempt, setAttempt] = useState(0)
+    // Flipped true by the child once it actually mounts (see MountedSignal); the
+    // watchdog only remounts while still false (i.e. still showing the skeleton).
+    const mountedRef = useRef(false)
+
+    const retry = useCallback(() => {
+        setAttempt(a => nextAttempt(a, maxRetries))
+    }, [maxRetries])
+
+    const onMounted = useCallback(() => {
+        mountedRef.current = true
+    }, [])
+
+    useEffect(() => {
+        mountedRef.current = false
+        if (attempt >= maxRetries) return
+        // Watchdog: if we're still in the fallback after the timeout, remount to
+        // re-trigger the lazy import. Re-armed each attempt.
+        const id = setTimeout(() => {
+            if (shouldRetryOnTimeout(mountedRef.current, attempt, maxRetries)) retry()
+        }, stuckTimeoutMs)
+        return () => clearTimeout(id)
+    }, [attempt, maxRetries, stuckTimeoutMs, retry])
+
+    return (
+        <SidebarErrorBoundary key={attempt} onError={retry}>
+            <Suspense fallback={fallback}>
+                <MountedSignal onMounted={onMounted}>{children}</MountedSignal>
+            </Suspense>
+        </SidebarErrorBoundary>
+    )
+}
+
+/**
+ * Marks the lazy subtree as committed. Once Suspense unsuspends and this renders,
+ * it flips the parent's mounted flag (in an effect, after commit) so the watchdog
+ * stands down. Rendering only `children` keeps the tree otherwise unchanged.
+ */
+function MountedSignal({ onMounted, children }: { onMounted: () => void; children: ReactNode }) {
+    useEffect(() => {
+        onMounted()
+    }, [onMounted])
+    return <>{children}</>
+}

--- a/core/components/workspace/LazySidebarBoundary.tsx
+++ b/core/components/workspace/LazySidebarBoundary.tsx
@@ -1,5 +1,7 @@
+import { captureException } from '@tinycld/core/lib/errors'
 import {
     Component,
+    type ErrorInfo,
     type ReactNode,
     Suspense,
     useCallback,
@@ -9,11 +11,27 @@ import {
 } from 'react'
 import { nextAttempt, shouldRetryOnTimeout } from './lazy-sidebar-retry'
 
+// Copious logging around sidebar-mount failures: when this boundary has to
+// recover, the next person debugging CI (or a user report) needs to see exactly
+// what happened — which slug, which failure mode, which attempt — not a silent
+// retry. `pkgSlug` is threaded in so every line names the package.
+function logSidebar(slug: string | undefined, msg: string, extra?: Record<string, unknown>) {
+    // __DEV__-guarded per house rule (no unguarded console). CI runs the dev
+    // bundle (Development-level warnings: ON), so these lines DO surface in CI
+    // failure logs — which is exactly where a wedged sidebar gets diagnosed.
+    // Production reporting goes through captureException at the call sites.
+    if (!__DEV__) return
+    const tag = `[sidebar-boundary${slug ? `:${slug}` : ''}]`
+    console.warn(tag, msg, extra ?? '')
+}
+
 interface LazySidebarBoundaryProps {
     /** Skeleton shown while the lazy chunk loads (Suspense fallback). */
     fallback: ReactNode
     /** The lazy sidebar subtree. */
     children: ReactNode
+    /** Package slug, for log/Sentry context (which sidebar failed). */
+    slug?: string
     /** How long to wait in the fallback before forcing a remount (ms). */
     stuckTimeoutMs?: number
     /** Max remount attempts before giving up and surfacing the error/skeleton. */
@@ -31,7 +49,7 @@ interface ErrorState {
  * the parent to remount (which re-invokes the import).
  */
 class SidebarErrorBoundary extends Component<
-    { onError: () => void; children: ReactNode },
+    { onError: (error: Error, info: ErrorInfo) => void; children: ReactNode },
     ErrorState
 > {
     state: ErrorState = { hasError: false }
@@ -40,8 +58,8 @@ class SidebarErrorBoundary extends Component<
         return { hasError: true }
     }
 
-    componentDidCatch() {
-        this.props.onError()
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        this.props.onError(error, info)
     }
 
     render() {
@@ -72,6 +90,7 @@ class SidebarErrorBoundary extends Component<
 export function LazySidebarBoundary({
     fallback,
     children,
+    slug,
     stuckTimeoutMs = 15_000,
     maxRetries = 3,
 }: LazySidebarBoundaryProps) {
@@ -80,13 +99,60 @@ export function LazySidebarBoundary({
     // watchdog only remounts while still false (i.e. still showing the skeleton).
     const mountedRef = useRef(false)
 
-    const retry = useCallback(() => {
-        setAttempt(a => nextAttempt(a, maxRetries))
-    }, [maxRetries])
+    const retry = useCallback(
+        (reason: string) => {
+            setAttempt(a => {
+                const next = nextAttempt(a, maxRetries)
+                if (next === a) {
+                    // Cap hit: stop retrying. This is the user-visible broken
+                    // state (sidebar stays a skeleton) — shout about it.
+                    logSidebar(slug, `giving up after ${a} attempt(s) — ${reason}`, {
+                        attempt: a,
+                        maxRetries,
+                    })
+                    captureException('workspace.sidebar.mount-failed', new Error(reason), {
+                        slug,
+                        attempts: a,
+                        maxRetries,
+                    })
+                } else {
+                    logSidebar(slug, `retrying (attempt ${next}/${maxRetries}) — ${reason}`, {
+                        from: a,
+                        to: next,
+                    })
+                }
+                return next
+            })
+        },
+        [maxRetries, slug]
+    )
 
     const onMounted = useCallback(() => {
         mountedRef.current = true
-    }, [])
+        if (attempt > 0) {
+            logSidebar(slug, `recovered: sidebar mounted on attempt ${attempt}`, { attempt })
+        }
+    }, [attempt, slug])
+
+    // Surface the actual error a rejecting lazy import threw, with React's
+    // component stack — this is the single most useful artifact when a sidebar
+    // chunk fails to load/evaluate.
+    const onError = useCallback(
+        (error: Error, info: ErrorInfo) => {
+            logSidebar(slug, 'lazy sidebar threw while mounting', {
+                error: String(error?.stack || error),
+                componentStack: info?.componentStack,
+                attempt,
+            })
+            captureException('workspace.sidebar.lazy-threw', error, {
+                slug,
+                attempt,
+                componentStack: info?.componentStack,
+            })
+            retry(`import threw: ${error?.message ?? error}`)
+        },
+        [slug, attempt, retry]
+    )
 
     useEffect(() => {
         mountedRef.current = false
@@ -94,13 +160,20 @@ export function LazySidebarBoundary({
         // Watchdog: if we're still in the fallback after the timeout, remount to
         // re-trigger the lazy import. Re-armed each attempt.
         const id = setTimeout(() => {
-            if (shouldRetryOnTimeout(mountedRef.current, attempt, maxRetries)) retry()
+            if (shouldRetryOnTimeout(mountedRef.current, attempt, maxRetries)) {
+                logSidebar(
+                    slug,
+                    `still on skeleton after ${stuckTimeoutMs}ms — chunk loaded but never committed; remounting`,
+                    { attempt }
+                )
+                retry(`stuck on skeleton for ${stuckTimeoutMs}ms`)
+            }
         }, stuckTimeoutMs)
         return () => clearTimeout(id)
-    }, [attempt, maxRetries, stuckTimeoutMs, retry])
+    }, [attempt, maxRetries, stuckTimeoutMs, retry, slug])
 
     return (
-        <SidebarErrorBoundary key={attempt} onError={retry}>
+        <SidebarErrorBoundary key={attempt} onError={onError}>
             <Suspense fallback={fallback}>
                 <MountedSignal onMounted={onMounted}>{children}</MountedSignal>
             </Suspense>

--- a/core/components/workspace/PackageSidebar.tsx
+++ b/core/components/workspace/PackageSidebar.tsx
@@ -2,8 +2,8 @@ import { packageSidebars } from '@tinycld/core/lib/packages/derive-components'
 import { usePackage } from '@tinycld/core/lib/packages/use-packages'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
-import { Suspense } from 'react'
 import { Platform, View } from 'react-native'
+import { LazySidebarBoundary } from './LazySidebarBoundary'
 import { SkeletonSidebar } from './SkeletonLayout'
 
 interface PackageSidebarProps {
@@ -36,7 +36,11 @@ export function PackageSidebar({ width }: PackageSidebarProps) {
         >
             <View style={{ width, flex: 1, minHeight: 0 }}>
                 {SidebarComponent ? (
-                    <Suspense fallback={<SkeletonSidebar width={width} />}>
+                    // LazySidebarBoundary owns the Suspense + recovery: it
+                    // retries the lazy import if it rejects, and remounts if the
+                    // boundary gets wedged in the skeleton without ever
+                    // committing (seen under heavy CI contention). See that file.
+                    <LazySidebarBoundary fallback={<SkeletonSidebar width={width} />}>
                         {/*
                             testID="package-sidebar-mounted" is the
                             stable signal e2e helpers use to know the
@@ -55,7 +59,7 @@ export function PackageSidebar({ width }: PackageSidebarProps) {
                         >
                             <SidebarComponent isCollapsed={false} />
                         </View>
-                    </Suspense>
+                    </LazySidebarBoundary>
                 ) : null}
             </View>
         </View>

--- a/core/components/workspace/PackageSidebar.tsx
+++ b/core/components/workspace/PackageSidebar.tsx
@@ -40,7 +40,10 @@ export function PackageSidebar({ width }: PackageSidebarProps) {
                     // retries the lazy import if it rejects, and remounts if the
                     // boundary gets wedged in the skeleton without ever
                     // committing (seen under heavy CI contention). See that file.
-                    <LazySidebarBoundary fallback={<SkeletonSidebar width={width} />}>
+                    <LazySidebarBoundary
+                        slug={pkg.slug}
+                        fallback={<SkeletonSidebar width={width} />}
+                    >
                         {/*
                             testID="package-sidebar-mounted" is the
                             stable signal e2e helpers use to know the

--- a/core/components/workspace/lazy-sidebar-retry.test.ts
+++ b/core/components/workspace/lazy-sidebar-retry.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { nextAttempt, shouldRetryOnTimeout } from './lazy-sidebar-retry'
+
+describe('nextAttempt', () => {
+    it('increments while under the cap', () => {
+        expect(nextAttempt(0, 3)).toBe(1)
+        expect(nextAttempt(1, 3)).toBe(2)
+        expect(nextAttempt(2, 3)).toBe(3)
+    })
+
+    it('stops at the cap so a broken chunk does not loop forever', () => {
+        expect(nextAttempt(3, 3)).toBe(3)
+        expect(nextAttempt(4, 3)).toBe(4) // already past cap → unchanged, never grows
+    })
+
+    it('honors a zero-retry cap (no recovery)', () => {
+        expect(nextAttempt(0, 0)).toBe(0)
+    })
+})
+
+describe('shouldRetryOnTimeout', () => {
+    it('retries when still in the skeleton and under the cap', () => {
+        expect(shouldRetryOnTimeout(false, 0, 3)).toBe(true)
+        expect(shouldRetryOnTimeout(false, 2, 3)).toBe(true)
+    })
+
+    it('never tears down a committed sidebar', () => {
+        // mounted=true → the real sidebar is showing; the watchdog must stand down.
+        expect(shouldRetryOnTimeout(true, 0, 3)).toBe(false)
+        expect(shouldRetryOnTimeout(true, 2, 3)).toBe(false)
+    })
+
+    it('gives up once retries are exhausted', () => {
+        expect(shouldRetryOnTimeout(false, 3, 3)).toBe(false)
+        expect(shouldRetryOnTimeout(false, 4, 3)).toBe(false)
+    })
+})

--- a/core/components/workspace/lazy-sidebar-retry.ts
+++ b/core/components/workspace/lazy-sidebar-retry.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure retry/watchdog decisions for LazySidebarBoundary, split out so the
+ * recovery rules can be unit-tested without rendering React (the boundary's
+ * real failure modes — a Metro chunk race — only reproduce under load).
+ */
+
+/**
+ * The attempt counter after a retry: increments while under the cap, otherwise
+ * stays put so a genuinely-broken chunk doesn't loop forever. The counter
+ * doubles as the React key on the Suspense subtree, so a change forces a
+ * remount (and a fresh lazy `import()`); no change means "give up".
+ */
+export function nextAttempt(attempt: number, maxRetries: number): number {
+    return attempt < maxRetries ? attempt + 1 : attempt
+}
+
+/**
+ * Whether the watchdog should remount when its timer fires: only if the subtree
+ * still hasn't committed (`mounted` false — still in the skeleton) AND we have
+ * retries left. A committed sidebar (mounted true) must never be torn down.
+ */
+export function shouldRetryOnTimeout(
+    mounted: boolean,
+    attempt: number,
+    maxRetries: number
+): boolean {
+    if (mounted) return false
+    return attempt < maxRetries
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,18 +26,12 @@ export default defineConfig({
     // which tests have finished and that the run is progressing. Inherited by
     // every package's playwright.config.ts.
     reporter: 'list',
-    // Retry failed specs on CI only. The 2-core ubuntu runner pays a cold
-    // Metro lazy-chunk compile on each worker's first navigation into a
-    // package route; under parallel load that compile occasionally blows
-    // past the per-test budget (e.g. a beforeEach waiting for the package
-    // sidebar to mount, or a post-reload route re-mount), failing an
-    // otherwise-correct test. Retries re-run only the failed spec — with a
-    // now-warm chunk cache — so a one-off cold-compile timeout self-heals,
-    // while a genuine regression still fails all attempts. Trace/video are
-    // retain-on-failure, so the final failing attempt is always captured.
-    // 0 retries locally keeps `reuseExistingServer` runs fast and surfaces
-    // real failures immediately. Inherited by every package's config.
-    retries: process.env.CI ? 2 : 0,
+    // No retries. A test must pass on its first attempt; a flake is a bug in the
+    // test (or the code) to fix at the source, not to paper over by re-running
+    // until it's green. Trace/video are retain-on-failure, so the failing
+    // attempt is always captured for diagnosis. Inherited by every package's
+    // config.
+    retries: 0,
     // Scoped to tests/e2e/ specifically. The tests/install/ tree has
     // its own playwright.config.ts and is invoked separately by the
     // docker smoke-test workflow — leaving testDir at the playwright


### PR DESCRIPTION
## Why

Drive E2E (and other member suites) intermittently failed on CI with the package sidebar's `package-sidebar-mounted` signal never appearing — a 90s `beforeEach` timeout. Artifacts showed the `sidebar.bundle` loaded (HTTP 200, ~2s) and the sidebar's hooks ran, but the `React.lazy` Suspense boundary stayed wedged on its `SkeletonSidebar` fallback with no error thrown. It's not a slow chunk or a crash — the boundary just never commits under contention.

## What

- **`LazySidebarBoundary`** wraps the lazy package sidebar with two recovery paths:
  - an error boundary that retries the import if it **rejects**, and
  - a watchdog that **remounts** (re-triggering the lazy import) if the boundary is still in the fallback after a timeout without committing.
  - Retries are capped so a genuinely-broken chunk can't loop. Pure decisions (`nextAttempt`, `shouldRetryOnTimeout`) are extracted and unit-tested.
- **`retries: 0`** in the canonical playwright config (was `CI ? 2 : 0`). A test must pass first try; a flake is a bug to fix at the source. Trace/video stay retain-on-failure.

## Verified

- core lint + typecheck clean; 410 core unit tests pass (incl. 6 new).
- drive section-heading + drive-1 e2e: 16/16 pass locally at `--workers=2 --fully-parallel`, sidebar mounts normally (no regression).