### PR TITLE
chore: require pbtsdb >=0.6 (realtime delete-echo fix)

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -79,7 +79,7 @@
         "expo-router": "~55.0.14",
         "lib0": "^0.2.117",
         "lucide-react-native": "^1.7.0",
-        "pbtsdb": "^0.5.0",
+        "pbtsdb": "^0.6.0",
         "pocketbase": "^0.26.8",
         "react": "19.2.0",
         "react-dom": "19.2.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "lucide-react-native": "^1.7.0",
         "markdown-it": "^14.1.1",
         "numfmt": "^3.2.6",
-        "pbtsdb": "^0.5.0",
+        "pbtsdb": "^0.6.0",
         "pocketbase": "^0.26.8",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-dropcursor": "^1.8.2",


### PR DESCRIPTION
pbtsdb 0.6.0 makes the realtime `delete` handler idempotent — it tolerates a delete echo for an already-removed record instead of throwing `DeleteOperationItemNotFoundError`. Unhandled, that throw raised an Expo LogBox overlay that intercepted clicks and caused unrelated, concurrently-running E2E tests to time out (seen on drive CI, run 27503518754).

Bumps core + app pbtsdb floors to `^0.6.0` so the fixed version is assembled.

Verified locally: the move-dialog and context-menu failures (the LogBox class) are gone after the bump.