### PR TITLE
Require pbtsdb >=0.6.3 (optimistic-move revert fix)

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -79,7 +79,7 @@
         "expo-router": "~55.0.14",
         "lib0": "^0.2.117",
         "lucide-react-native": "^1.7.0",
-        "pbtsdb": "^0.6.0",
+        "pbtsdb": "^0.6.3",
         "pocketbase": "^0.26.8",
         "react": "19.2.0",
         "react-dom": "19.2.0",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
         "@tinycld/core": "*"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.4.10",
+        "@biomejs/biome": "~2.4.10",
         "@playwright/test": "^1.52.0",
         "@react-native-community/cli": "^20.1.2",
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "lucide-react-native": "^1.7.0",
         "markdown-it": "^14.1.1",
         "numfmt": "^3.2.6",
-        "pbtsdb": "^0.6.0",
+        "pbtsdb": "^0.6.3",
         "pocketbase": "^0.26.8",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-dropcursor": "^1.8.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -104,7 +104,5 @@ export default defineConfig({
     // ws/<pkg>/test-results/ + playwright-report/) keep working with NO changes.
     // CI runs on Linux (inotify, and Watchman typically absent on the runners),
     // so it does not hit the macOS FSEvents recrawl this guards against.
-    ...(process.env.CI
-        ? {}
-        : { outputDir: path.join('/tmp', 'tinycld-pw-artifacts') }),
+    ...(process.env.CI ? {} : { outputDir: path.join('/tmp', 'tinycld-pw-artifacts') }),
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -86,4 +86,25 @@ export default defineConfig({
     // resolves a relative globalSetup against the INHERITING config's dir —
     // so a relative './tests/...' would break for contacts/etc. Pin it here.
     globalSetup: path.join(import.meta.dirname, 'tests', 'playwright-global-setup.ts'),
+    // outputDir — where Playwright writes its per-test scratch
+    // (.playwright-artifacts-N/, live video/screenshot buffers) AND the
+    // retain-on-failure artifacts.
+    //
+    // LOCAL (macOS): write OUTSIDE the watched workspace tree. Playwright's
+    // transient artifact churn during every run (even passing tests buffer
+    // video/screenshots live, then discard) floods macOS FSEvents; the kernel
+    // drops events (UserDropped), forcing Watchman to recrawl the ~100k-file
+    // monorepo — which is what makes `expo query` stall for 60s. Relocating the
+    // scratch off the watched filesystem removes the flood at its source.
+    // ignore_dirs in .watchmanconfig can't fix this: it stops Watchman INDEXING
+    // those paths, not the kernel FSEvents stream that overflows.
+    //
+    // CI: leave Playwright's default (<inheriting-config-dir>/test-results) so
+    // the per-package workflows' upload-artifact steps (which read
+    // ws/<pkg>/test-results/ + playwright-report/) keep working with NO changes.
+    // CI runs on Linux (inotify, and Watchman typically absent on the runners),
+    // so it does not hit the macOS FSEvents recrawl this guards against.
+    ...(process.env.CI
+        ? {}
+        : { outputDir: path.join('/tmp', 'tinycld-pw-artifacts') }),
 })

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -91,6 +91,14 @@ function resolveUseSsl(): boolean {
 // returns 503 for any request targeted at Expo until you start one
 // yourself, so the app keeps working as soon as you do.
 const skipExpo = process.argv.includes('--no-expo')
+
+// --clear (alias --reset-cache) wipes Metro's transform cache on startup by
+// passing `expo start --clear`. OPT-IN: a normal start reuses the persistent
+// Metro cache (in $TMPDIR/metro-cache), so the bundler doesn't rebuild from
+// scratch — and you don't pay the "Bundler cache is empty, rebuilding" minute —
+// every launch. Reach for this only after a dep/transformer change or when
+// chasing a stale-cache bug.
+const clearCache = process.argv.includes('--clear') || process.argv.includes('--reset-cache')
 const skipPbWatch = process.argv.includes('--no-pb-watch')
 
 const useSsl = resolveUseSsl()
@@ -466,7 +474,12 @@ function spawnExpo(expoPort: number, onReady: () => void): ChildProcess {
     const nodeOptions = existingNodeOptions.includes('--max-old-space-size')
         ? existingNodeOptions
         : `${existingNodeOptions} ${heapFlag}`.trim()
-    const child = spawn('npx', ['expo', 'start', '--clear', '--port', String(expoPort)], {
+    // --clear is opt-in (see `clearCache` above): omit it so Metro reuses its
+    // persistent cache across restarts. Pass --clear/--reset-cache to the dev
+    // script to force a cold rebuild.
+    const expoArgs = ['expo', 'start', '--port', String(expoPort)]
+    if (clearCache) expoArgs.splice(2, 0, '--clear')
+    const child = spawn('npx', expoArgs, {
         cwd: ROOT,
         stdio: ['inherit', 'pipe', 'pipe'],
         env: { ...process.env, NODE_OPTIONS: nodeOptions },


### PR DESCRIPTION
Bumps the `pbtsdb` floor to `^0.6.3` in the app shell and core.

0.6.3 fixes an on-demand sync race where a stale single-row read could revert a just-settled optimistic mutation (the drive drag-to-move snap-back). The guard now drops equal-/older-`updated` query-result writes for rows with a pending/just-settled optimistic mutation.

Also includes two local dev-ergonomics tweaks:
- `playwright.config.ts`: relocate Playwright's scratch/artifacts off the watched tree on macOS (avoids the FSEvents flood -> Watchman recrawl). CI unchanged.
- `scripts/dev.ts`: make Metro `--clear` opt-in so a normal start reuses the transform cache.