### PR TITLE
chore: align pbtsdb floor to >=0.6.3

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -79,7 +79,7 @@
         "expo-router": "~55.0.14",
         "lib0": "^0.2.117",
         "lucide-react-native": "^1.7.0",
-        "pbtsdb": "^0.6.3",
+        "pbtsdb": ">=0.6.3",
         "pocketbase": "^0.26.8",
         "react": "19.2.0",
         "react-dom": "19.2.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "lucide-react-native": "^1.7.0",
         "markdown-it": "^14.1.1",
         "numfmt": "^3.2.6",
-        "pbtsdb": "^0.6.3",
+        "pbtsdb": ">=0.6.3",
         "pocketbase": "^0.26.8",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-dropcursor": "^1.8.2",


### PR DESCRIPTION
Aligns the pbtsdb peer floor to `>=0.6.3` so the optimistic-mutation revert fix (0.6.3) is uniformly required across the ecosystem. No resolved-version change — the workspace already runs 0.6.3.