### PR TITLE
fix(e2e): stop drive sidebar-chunk wedge; de-barrel lucide

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -4,6 +4,9 @@ module.exports = function (api) {
         presets: [['babel-preset-expo', { unstable_transformImportMeta: true }]],
         plugins: [
             stripImportMetaInNodeModules,
+            // Split lucide-react-native barrel imports into per-icon deep imports
+            // so Metro (no tree-shaking) doesn't bundle all ~1700 icons.
+            './scripts/babel-plugin-lucide-deep-imports.cjs',
             'react-native-reanimated/plugin',
         ],
     }

--- a/core/components/workspace/LazySidebarBoundary.tsx
+++ b/core/components/workspace/LazySidebarBoundary.tsx
@@ -74,15 +74,19 @@ class SidebarErrorBoundary extends Component<
 /**
  * Resilient wrapper for a lazily-loaded package sidebar.
  *
- * Two failure modes are handled, both observed under heavy CI contention where
- * the sidebar's Suspense boundary otherwise stays stuck on its skeleton forever:
+ * Two failure modes are handled, both of which otherwise leave the sidebar's
+ * Suspense boundary stuck on its skeleton forever:
  *
  *   1. The lazy `import()` REJECTS → SidebarErrorBoundary catches it and we
  *      remount to retry the import.
  *   2. The chunk loads (HTTP 200) but the boundary never commits the child — the
- *      Suspense sits in the fallback indefinitely. An error boundary can't see
- *      this (nothing threw), so a watchdog remounts the subtree if we're still
- *      showing the fallback after `stuckTimeoutMs`, re-triggering resolution.
+ *      Suspense sits in the fallback indefinitely. This shows up when an
+ *      in-flight chunk load is interrupted (e.g. a second navigation to the same
+ *      route fires while the first is still streaming the chunk, as happens when
+ *      a post-login redirect and an explicit nav race). An error boundary can't
+ *      see this (nothing threw), so a watchdog remounts the subtree if we're
+ *      still showing the fallback after `stuckTimeoutMs`, re-triggering
+ *      resolution.
  *
  * Each remount bumps `attempt`, which is the React key on the Suspense subtree —
  * a new key forces a fresh mount (and a fresh `import()` attempt). Retries are

--- a/core/components/workspace/PackageSidebar.tsx
+++ b/core/components/workspace/PackageSidebar.tsx
@@ -39,7 +39,8 @@ export function PackageSidebar({ width }: PackageSidebarProps) {
                     // LazySidebarBoundary owns the Suspense + recovery: it
                     // retries the lazy import if it rejects, and remounts if the
                     // boundary gets wedged in the skeleton without ever
-                    // committing (seen under heavy CI contention). See that file.
+                    // committing (e.g. when an in-flight chunk load is
+                    // interrupted by another navigation). See that file.
                     <LazySidebarBoundary
                         slug={pkg.slug}
                         fallback={<SkeletonSidebar width={width} />}

--- a/lucide-icons.d.ts
+++ b/lucide-icons.d.ts
@@ -1,0 +1,14 @@
+// Ambient declaration for lucide per-icon deep imports.
+//
+// We import individual icons as `lucide-react-native/icons/<kebab>` to avoid
+// pulling the whole ~1700-icon barrel into the bundle (Metro doesn't tree-shake;
+// see metro.config.cjs, which remaps this specifier to the real per-icon module).
+// lucide's `exports` map only publishes `.` and `./icons`, so TypeScript can't
+// resolve the bare deep path on its own — declare it here. Each icon module has
+// a default export of the standard lucide component type.
+declare module 'lucide-react-native/icons/*' {
+    import type { LucideIcon } from 'lucide-react-native'
+
+    const icon: LucideIcon
+    export default icon
+}

--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -28,6 +28,30 @@ const APP_GENERATED_DIR = path.join(__dirname, 'lib', 'generated')
 const APP_UPDATER_DIR = path.join(__dirname, 'modules', 'app-updater')
 const APP_UPDATER_WEB_STUB = path.join(APP_UPDATER_DIR, 'index.web.ts')
 const APP_UPDATER_NATIVE_ENTRY = path.join(APP_UPDATER_DIR, 'index.ts')
+
+// Per-icon deep imports for lucide-react-native. Importing named icons from the
+// package root (`import { Folder } from 'lucide-react-native'`) pulls the whole
+// ~1700-icon barrel into the bundle — Metro doesn't tree-shake, so a handful of
+// icons costs ~3.3 MB. Each icon also exists as its own module
+// (dist/esm/icons/<kebab>.mjs, default export), but lucide's `exports` map only
+// publishes `.` and `./icons`, so a bare deep specifier throws
+// ERR_PACKAGE_PATH_NOT_EXPORTED. We map `lucide-react-native/icons/<kebab>` to
+// the real per-icon file ourselves, bypassing the exports gate. The
+// babel-plugin-lucide-deep-imports rewrite (and the generated package-icons map)
+// emit this specifier so only referenced icons get bundled.
+//
+// lucide's exports map is strict — even `./package.json` and `./dist/*` throw —
+// so resolve the allowed main entry and walk up to the package root, then point
+// at the ESM per-icon dir (the same build the `module`/`browser` entry uses).
+const LUCIDE_PKG_ROOT = (() => {
+    let dir = path.dirname(require.resolve('lucide-react-native'))
+    while (path.basename(dir) !== 'lucide-react-native' && dir !== path.dirname(dir)) {
+        dir = path.dirname(dir)
+    }
+    return dir
+})()
+const LUCIDE_ICONS_DIR = path.join(LUCIDE_PKG_ROOT, 'dist', 'esm', 'icons')
+const LUCIDE_ICON_PREFIX = 'lucide-react-native/icons/'
 const originalResolveRequest = config.resolver.resolveRequest
 config.resolver.resolveRequest = (context, moduleName, platform) => {
     if (moduleName.startsWith('@tinycld/app-generated/')) {
@@ -37,6 +61,14 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
     if (moduleName === 'app-updater') {
         const target = platform === 'web' ? APP_UPDATER_WEB_STUB : APP_UPDATER_NATIVE_ENTRY
         return context.resolveRequest(context, target, platform)
+    }
+    if (moduleName.startsWith(LUCIDE_ICON_PREFIX)) {
+        const icon = moduleName.slice(LUCIDE_ICON_PREFIX.length)
+        return context.resolveRequest(
+            context,
+            path.join(LUCIDE_ICONS_DIR, `${icon}.mjs`),
+            platform
+        )
     }
     return (originalResolveRequest ?? context.resolveRequest)(context, moduleName, platform)
 }

--- a/scripts/__tests__/gen-icons.test.ts
+++ b/scripts/__tests__/gen-icons.test.ts
@@ -28,8 +28,8 @@ describe('buildPackageIconsSource', () => {
             { name: '@tinycld/mail', manifest: { nav: { icon: 'mail' } } },
             { name: '@tinycld/drive', manifest: { nav: { icon: 'hard-drive' } } },
         ])
-        expect(src).toContain('Mail,')
-        expect(src).toContain('HardDrive,')
+        expect(src).toContain("import Mail from 'lucide-react-native/icons/mail'")
+        expect(src).toContain("import HardDrive from 'lucide-react-native/icons/hard-drive'")
         expect(src).toContain("'hard-drive': HardDrive")
         expect(src).toContain('mail: Mail')
         // sorted alphabetically: hard-drive (h) before mail (m)
@@ -41,8 +41,9 @@ describe('buildPackageIconsSource', () => {
             { name: '@tinycld/a', manifest: { nav: { icon: 'mail' } } },
             { name: '@tinycld/b', manifest: { nav: { icon: 'mail' } } },
         ])
-        // One indented import line, one indented map entry.
-        const importMatches = src.match(/^ {4}Mail,$/gm) ?? []
+        // One per-icon deep import, one indented map entry.
+        const importMatches =
+            src.match(/^import Mail from 'lucide-react-native\/icons\/mail'$/gm) ?? []
         const mapMatches = src.match(/^ {4}mail: Mail,$/gm) ?? []
         expect(importMatches.length).toBe(1)
         expect(mapMatches.length).toBe(1)
@@ -53,7 +54,7 @@ describe('buildPackageIconsSource', () => {
             { name: '@tinycld/settings-only', manifest: {} },
             { name: '@tinycld/mail', manifest: { nav: { icon: 'mail' } } },
         ])
-        expect(src).toContain('Mail,')
+        expect(src).toContain("import Mail from 'lucide-react-native/icons/mail'")
         expect(src).toContain('mail: Mail')
     })
 

--- a/scripts/babel-plugin-lucide-deep-imports.cjs
+++ b/scripts/babel-plugin-lucide-deep-imports.cjs
@@ -1,0 +1,121 @@
+// Babel plugin: rewrite barrel imports of lucide-react-native into per-icon
+// deep imports so Metro (which doesn't tree-shake) only bundles the icons a file
+// actually uses.
+//
+//   import { Folder, CircleHelp, type LucideIcon } from 'lucide-react-native'
+//     ->
+//   import type { LucideIcon } from 'lucide-react-native'
+//   import Folder from 'lucide-react-native/icons/folder'
+//   import CircleHelp from 'lucide-react-native/icons/circle-question-mark'
+//
+// The `lucide-react-native/icons/<kebab>` specifier is remapped to the real
+// per-icon module by metro.config.cjs (lucide's exports map blocks the bare deep
+// path). Without this, a handful of named icons drags the whole ~1700-icon
+// barrel (~3.3 MB) into every chunk that imports them.
+//
+// The identifier -> icon-file map (including every lucide alias, e.g.
+// HelpCircle/CircleHelp -> circle-question-mark) is parsed once from lucide's
+// own barrel re-export statements, so it stays correct across lucide versions
+// without hand-maintained tables.
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const SOURCE = 'lucide-react-native'
+const ICON_SPECIFIER_BASE = `${SOURCE}/icons/`
+
+// Build { ExportedName: 'kebab-file' } from lucide's barrel. Resolve the package
+// via its allowed main entry, then walk up to the package root (the exports map
+// blocks resolving ./package.json or ./dist/* directly).
+function buildIconMap() {
+    let dir = path.dirname(require.resolve(SOURCE))
+    while (path.basename(dir) !== SOURCE && dir !== path.dirname(dir)) {
+        dir = path.dirname(dir)
+    }
+    const barrelPath = path.join(dir, 'dist', 'esm', `${SOURCE}.mjs`)
+    const barrel = fs.readFileSync(barrelPath, 'utf8')
+    // Matches: export { default as A, default as B } from './icons/<file>.mjs'
+    const reExport = /export\s*\{([^}]*)\}\s*from\s*'\.\/icons\/([a-z0-9-]+)\.mjs'/g
+    const map = new Map()
+    let m
+    while ((m = reExport.exec(barrel))) {
+        const file = m[2]
+        for (const part of m[1].split(',')) {
+            const named = part.trim().match(/default as ([A-Za-z0-9_]+)/)
+            if (named) map.set(named[1], file)
+        }
+    }
+    if (map.size === 0) {
+        throw new Error(
+            `[lucide-deep-imports] parsed 0 icons from ${barrelPath} — lucide layout changed?`
+        )
+    }
+    return map
+}
+
+let ICON_MAP = null
+
+module.exports = function lucideDeepImports({ types: t }) {
+    if (!ICON_MAP) ICON_MAP = buildIconMap()
+
+    return {
+        name: 'lucide-deep-imports',
+        visitor: {
+            ImportDeclaration(p) {
+                if (p.node.source.value !== SOURCE) return
+                // A whole-module type import (`import type { X } from 'lucide…'`)
+                // is erased at compile — leave it on the barrel untouched.
+                if (p.node.importKind === 'type') return
+
+                const typeSpecifiers = [] // keep on the barrel (types, erased)
+                const iconImports = [] // new per-icon default imports
+                const keepOnBarrel = [] // anything we can't safely rewrite
+
+                for (const spec of p.node.specifiers) {
+                    // Only named imports are rewritable; a default or namespace
+                    // import of lucide isn't an icon, so leave the decl alone.
+                    if (!t.isImportSpecifier(spec)) return
+                    const imported = t.isIdentifier(spec.imported)
+                        ? spec.imported.name
+                        : spec.imported.value
+                    if (spec.importKind === 'type') {
+                        // Moving this into an `import type { … }` declaration, so
+                        // drop the per-specifier `type` keyword (else it emits the
+                        // invalid `import type { type LucideIcon }`).
+                        spec.importKind = null
+                        typeSpecifiers.push(spec)
+                        continue
+                    }
+                    const file = ICON_MAP.get(imported)
+                    if (!file) {
+                        // Unknown identifier (not an icon, or a non-icon value
+                        // export) — keep it on the barrel so behavior is unchanged.
+                        keepOnBarrel.push(spec)
+                        continue
+                    }
+                    iconImports.push(
+                        t.importDeclaration(
+                            [t.importDefaultSpecifier(t.identifier(spec.local.name))],
+                            t.stringLiteral(`${ICON_SPECIFIER_BASE}${file}`)
+                        )
+                    )
+                }
+
+                if (iconImports.length === 0) return // nothing to split
+
+                const replacements = [...iconImports]
+                if (typeSpecifiers.length > 0) {
+                    const typeDecl = t.importDeclaration(typeSpecifiers, t.stringLiteral(SOURCE))
+                    typeDecl.importKind = 'type'
+                    replacements.push(typeDecl)
+                }
+                if (keepOnBarrel.length > 0) {
+                    replacements.push(
+                        t.importDeclaration(keepOnBarrel, t.stringLiteral(SOURCE))
+                    )
+                }
+                p.replaceWithMultiple(replacements)
+            },
+        },
+    }
+}

--- a/scripts/gen-icons.ts
+++ b/scripts/gen-icons.ts
@@ -108,10 +108,16 @@ export function buildPackageIconsSource(features: IconFeatureInput[]): string {
         return lines.join('\n')
     }
 
-    lines.push('import {')
-    for (const p of pascalNames) lines.push(`    ${p},`)
-    lines.push('    type LucideIcon,')
-    lines.push("} from 'lucide-react-native'")
+    // Per-icon deep imports (not the `{ ... } from 'lucide-react-native'`
+    // barrel): the barrel drags all ~1700 icons into the bundle since Metro
+    // doesn't tree-shake. `lucide-react-native/icons/<kebab>` is remapped to the
+    // single icon module by metro.config.cjs (lucide's exports map blocks the
+    // bare deep path). `type LucideIcon` stays a type-only import from the root —
+    // erased at compile, so it costs nothing at runtime.
+    lines.push("import type { LucideIcon } from 'lucide-react-native'")
+    for (let i = 0; i < used.length; i++) {
+        lines.push(`import ${pascalNames[i]} from 'lucide-react-native/icons/${used[i].kebab}'`)
+    }
     lines.push('')
     lines.push('export const packageIcons: Record<string, LucideIcon> = {')
     for (let i = 0; i < used.length; i++) {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -85,16 +85,45 @@ export async function login(page: Page) {
 //
 // `pkg` is the lowercase slug (mail, calendar, drive, ...).
 export async function navigateToPackage(page: Page, pkg: string, options?: { waitFor?: Locator }) {
-    // Match by URL prefix rather than exact href: some packages (calc,
-    // text, …) rewrite their rail link to deep-link the user's last
-    // visited file (e.g. /a/<org>/calc/<id>), so the rail anchor no
-    // longer matches the bare /a/<org>/<pkg> URL. Prefix match keeps
-    // this working regardless of whether the rail item is bare or
-    // deep-linked.
-    const railLink = page.locator(`a[href^="/a/${ORG_SLUG}/${pkg}"]`).first()
-    await railLink.waitFor({ state: 'visible' })
-    await railLink.click()
-    await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/${pkg}(/|$|\\?)`))
+    const onTarget = new RegExp(`/a/${ORG_SLUG}/${pkg}(/|$|\\?)`)
+    // Skip the rail-click when we're already on (or already redirecting to) the
+    // target package. login() returns the moment the URL hits /a/<org>, but the
+    // org index then <Redirect>s to the first nav package — which IS this package
+    // when it's the only/first one installed (e.g. drive in its own CI, where no
+    // other nav package exists). Clicking the rail in that window fires a SECOND
+    // navigation to the same route while the first is still streaming its lazy
+    // chunks, and that interruption wedges the screen/sidebar chunk in Metro
+    // ("loaded but never committed" → the sidebar watchdog remounts for ~45s →
+    // the list lands scrolled and double-clicks misfire). When we're already
+    // headed there, wait for the route + the caller's element instead of
+    // re-navigating.
+    let alreadyThere = onTarget.test(page.url())
+    // Only when sitting on the bare org index (/a/<org> with no package segment)
+    // might an auto-redirect to this package be in flight — wait briefly to catch
+    // it. Anywhere else we're not auto-heading here, so skip the wait (no latency
+    // penalty on the common cross-package navigation) and click the rail.
+    if (!alreadyThere && new RegExp(`/a/${ORG_SLUG}(/|$|\\?)?$`).test(page.url())) {
+        await page
+            .waitForURL(onTarget, { timeout: 2000 })
+            .then(() => {
+                alreadyThere = true
+            })
+            .catch(() => {
+                /* redirect went elsewhere; fall through to the rail click */
+            })
+    }
+    if (!alreadyThere) {
+        // Match by URL prefix rather than exact href: some packages (calc,
+        // text, …) rewrite their rail link to deep-link the user's last
+        // visited file (e.g. /a/<org>/calc/<id>), so the rail anchor no
+        // longer matches the bare /a/<org>/<pkg> URL. Prefix match keeps
+        // this working regardless of whether the rail item is bare or
+        // deep-linked.
+        const railLink = page.locator(`a[href^="/a/${ORG_SLUG}/${pkg}"]`).first()
+        await railLink.waitFor({ state: 'visible' })
+        await railLink.click()
+        await page.waitForURL(onTarget)
+    }
     if (options?.waitFor) {
         await options.waitFor.waitFor({ state: 'visible' })
     }


### PR DESCRIPTION
Fixes the flaky drive e2e (sidebar 'chunk loaded but never committed' → LazySidebarBoundary remounts ~45s → list lands scrolled / double-clicks misfire).

1. `navigateToPackage` skips a redundant second navigation when the post-login org-index redirect is already heading to the target package (the case when it's the only/first nav package, e.g. drive in its own CI). The redundant rail-click interrupted the in-flight lazy chunk — the wedge trigger.
2. De-barrel `lucide-react-native` via a babel plugin + metro resolver: per-icon deep imports instead of the ~1700-icon barrel (Metro doesn't tree-shake). Entry bundle ~3 MB smaller. Parses lucide's barrel for the authoritative alias map (27 icons are renames).

Also corrects the LazySidebarBoundary/PackageSidebar comments that blamed 'CI contention'.