### PR TITLE
Close right drawer on navigation

### DIFF
--- a/core/tests/unit/use-close-on-navigate.test.tsx
+++ b/core/tests/unit/use-close-on-navigate.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+// Drive usePathname from a mutable module-level value so each test can simulate
+// navigation by changing it between renders. This local mock overrides the
+// constant '/' usePathname from unit-setup.ts for this file only.
+let pathname = '/a/acme/drive'
+vi.mock('expo-router', () => ({ usePathname: () => pathname }))
+
+import { useCloseOnNavigate } from '../../ui/drawer/use-close-on-navigate'
+
+afterEach(() => {
+    pathname = '/a/acme/drive'
+})
+
+test('does not close on the initial mount (opened on the current route)', () => {
+    const onClose = vi.fn()
+    renderHook(() => useCloseOnNavigate(true, onClose))
+    expect(onClose).not.toHaveBeenCalled()
+})
+
+test('closes when the route changes while open', () => {
+    const onClose = vi.fn()
+    const { rerender } = renderHook(() => useCloseOnNavigate(true, onClose))
+    expect(onClose).not.toHaveBeenCalled()
+
+    pathname = '/a/acme/mail'
+    rerender()
+    expect(onClose).toHaveBeenCalledTimes(1)
+})
+
+test('does not close while the drawer is shut, even across navigation', () => {
+    const onClose = vi.fn()
+    const { rerender } = renderHook(({ isOpen }) => useCloseOnNavigate(isOpen, onClose), {
+        initialProps: { isOpen: false },
+    })
+
+    pathname = '/a/acme/mail'
+    rerender({ isOpen: false })
+    expect(onClose).not.toHaveBeenCalled()
+})
+
+test('re-baselines on reopen: opening on a new route does not immediately close', () => {
+    const onClose = vi.fn()
+    const { rerender } = renderHook(({ isOpen }) => useCloseOnNavigate(isOpen, onClose), {
+        initialProps: { isOpen: true },
+    })
+
+    // Close the drawer, then navigate elsewhere while closed.
+    rerender({ isOpen: false })
+    pathname = '/a/acme/calendar'
+    rerender({ isOpen: false })
+    expect(onClose).not.toHaveBeenCalled()
+
+    // Reopening on the new route must treat it as the fresh baseline, not fire.
+    rerender({ isOpen: true })
+    expect(onClose).not.toHaveBeenCalled()
+
+    // ...and a subsequent navigation away from that route still closes it.
+    pathname = '/a/acme/contacts'
+    rerender({ isOpen: true })
+    expect(onClose).toHaveBeenCalledTimes(1)
+})
+
+test('tolerates a missing onClose', () => {
+    const { rerender } = renderHook(() => useCloseOnNavigate(true, undefined))
+    pathname = '/a/acme/mail'
+    expect(() => rerender()).not.toThrow()
+})
+
+test('uses the latest onClose without re-arming on identity change', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender } = renderHook(({ cb }) => useCloseOnNavigate(true, cb), {
+        initialProps: { cb: first },
+    })
+
+    // Swap the callback identity without navigating — must not fire either one.
+    rerender({ cb: second })
+    expect(first).not.toHaveBeenCalled()
+    expect(second).not.toHaveBeenCalled()
+
+    // Now navigate: only the latest callback runs.
+    pathname = '/a/acme/mail'
+    rerender({ cb: second })
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+})

--- a/core/ui/drawer/index.tsx
+++ b/core/ui/drawer/index.tsx
@@ -18,6 +18,7 @@ import Animated, {
     SlideOutRight,
     SlideOutUp,
 } from 'react-native-reanimated'
+import { useCloseOnNavigate } from './use-close-on-navigate'
 
 const SCOPE = 'MODAL'
 
@@ -227,6 +228,7 @@ const Drawer = React.forwardRef<React.ComponentRef<typeof UIDrawer>, IDrawerProp
     ref
 ) {
     useDrawerEscape(props.isOpen, props.onClose)
+    useCloseOnNavigate(props.isOpen, props.onClose)
 
     // Don't mount the gluestack Modal at all while closed. GlueStack's exit
     // handshake runs through RN Animated with useNativeDriver:true, whose

--- a/core/ui/drawer/use-close-on-navigate.ts
+++ b/core/ui/drawer/use-close-on-navigate.ts
@@ -1,0 +1,33 @@
+import { usePathname } from 'expo-router'
+import { useEffect, useRef } from 'react'
+
+// Close an open drawer when the user navigates to a different route. Drawers
+// live at a persistent layout level and hold their open state in a store, so on
+// native — where nothing unmounts them — they otherwise linger across
+// navigation (the left workspace drawer avoids this only because the org layout
+// closes it by hand on every pathname change). The shared Drawer wires this in
+// so every right-anchored drawer is fixed at once: help, drive details, calc
+// pivot / conditional-format / comments, mailbox and members.
+//
+// onClose is read through a ref so a caller passing an inline closure (its
+// identity changing each render) doesn't re-arm the effect; the effect depends
+// only on the pathname. The route at open is the baseline — onClose fires on a
+// genuine change away from it, never on the initial mount — and re-baselines
+// each time the drawer reopens.
+export function useCloseOnNavigate(isOpen: boolean | undefined, onClose?: () => void) {
+    const pathname = usePathname()
+    const onCloseRef = useRef(onClose)
+    onCloseRef.current = onClose
+    // The route the drawer was opened on. While closed it tracks the current
+    // pathname so the next open re-baselines; while open it stays fixed so the
+    // first navigation away registers as a change and fires onClose.
+    const openedAtRef = useRef(pathname)
+
+    useEffect(() => {
+        if (!isOpen) {
+            openedAtRef.current = pathname
+            return
+        }
+        if (pathname !== openedAtRef.current) onCloseRef.current?.()
+    }, [isOpen, pathname])
+}


### PR DESCRIPTION
On native, the help drawer and drive details panel stayed open when navigating to a new screen — they're mounted at a persistent layout level and hold open/closed state in a store, so nothing dismissed them on route change (the left workspace drawer only closes because the org layout does it by hand).

This wires a `useCloseOnNavigate` hook into the shared `Drawer`: it watches `usePathname()` and fires `onClose` when the route changes while the drawer is open. Fixes every right-anchored drawer at once. Includes a unit test for the open/navigate/reopen behavior.