### PR TITLE
Center text vertically in iOS text inputs

### DIFF
--- a/core/ui/form/NumberInput.tsx
+++ b/core/ui/form/NumberInput.tsx
@@ -1,6 +1,7 @@
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { type Control, type FieldValues, type Path, useController } from 'react-hook-form'
 import { Pressable, TextInput as RNTextInput, Text, View, type ViewProps } from 'react-native'
+import { iosInputCenteringStyle } from './ios-input-style'
 
 export type NumberInputProps<T extends FieldValues = Record<string, unknown>> = {
     name: Path<T>
@@ -87,6 +88,7 @@ export function NumberInput<T extends FieldValues = Record<string, unknown>>({
                     testID={name}
                     placeholderTextColor={placeholderColor}
                     className={`flex-1 border rounded-lg px-3 py-2.5 text-center text-base text-foreground bg-background ${hasError ? 'border-danger' : 'border-border'}`}
+                    style={iosInputCenteringStyle(16)}
                 />
                 <Pressable
                     onPress={handleIncrement}

--- a/core/ui/form/TextInput.tsx
+++ b/core/ui/form/TextInput.tsx
@@ -3,6 +3,7 @@ import type { ComponentType, ReactNode } from 'react'
 import { type Control, type FieldValues, type Path, useController } from 'react-hook-form'
 import type { TextInputProps as RNTextInputProps } from 'react-native'
 import { TextInput as RNTextInput, Text, View, type ViewProps } from 'react-native'
+import { iosInputCenteringStyle } from './ios-input-style'
 
 function LabelRow({
     label,
@@ -82,6 +83,7 @@ export function TextInput<T extends FieldValues = Record<string, unknown>>(
                     secureTextEntry={inputProps.secureTextEntry}
                     placeholderTextColor={placeholderColor}
                     className={`flex-1 border rounded-lg px-3 py-2.5 text-base text-foreground bg-background ${hasError ? 'border-danger' : 'border-border'}`}
+                    style={iosInputCenteringStyle(16)}
                 />
                 {addon}
             </View>

--- a/core/ui/form/ios-input-style.ts
+++ b/core/ui/form/ios-input-style.ts
@@ -1,0 +1,18 @@
+import { Platform, type TextStyle } from 'react-native'
+
+// iOS renders a single-line TextInput's glyph at the TOP of its line box rather
+// than centering it the way Android and the web do. Tailwind/Uniwind's text-*
+// utilities ship a line-height taller than the font (e.g. text-base = 16px font
+// / 24px line-height), so on iOS the text visibly hugs the top of the padded
+// box. Pinning lineHeight close to the font size collapses that extra leading so
+// the glyph centers within the input's vertical padding. Android/web already
+// center, and a single line is unaffected by the smaller line-height there — so
+// this is scoped to iOS to leave those platforms byte-identical.
+//
+// Pass the input's font size (px); lineHeight is set a hair above it to leave
+// room for descenders. Returns undefined off iOS so callers can spread it
+// unconditionally.
+export function iosInputCenteringStyle(fontSize: number): TextStyle | undefined {
+    if (Platform.OS !== 'ios') return undefined
+    return { lineHeight: fontSize + 4 }
+}


### PR DESCRIPTION
On iOS, text in single-line form inputs sat toward the top of the box instead of centered (Android and web were fine).

Cause: Tailwind/Uniwind's `text-base` ships `font-size: 16px` with `line-height: 24px`, and iOS renders a single-line `TextInput` glyph at the top of that line box. Adds a shared `iosInputCenteringStyle(fontSize)` helper that pins `lineHeight` close to the font size **on iOS only** (returns `undefined` elsewhere, so Android/web are unchanged), applied to `TextInput` and `NumberInput`.

Multiline inputs already handle this with `textAlignVertical="top"` and are untouched.