### PR TITLE
e2e: wait for post-login redirect to settle in login()

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -52,6 +52,17 @@ export async function login(page: Page) {
     await page.getByPlaceholder('Password').fill(TEST_USER_PASSWORD)
     await page.getByText('Sign in', { exact: true }).last().click()
     await page.waitForURL(/\/a\//, { timeout: 15_000 })
+    // Sign-in lands on /a/<org>, which immediately <Redirect>s to the first nav
+    // package (a potentially heavy screen whose lazy chunk starts streaming).
+    // Wait for that redirect to SETTLE on a package sub-route before returning —
+    // otherwise the next step (often navigateToPackage to a different package)
+    // clicks a rail mid-redirect, and the two contending lazy-chunk loads wedge
+    // in Metro: the target screen never commits and the test times out. When no
+    // package is installed (core's own standalone CI) there's no redirect, so
+    // tolerate staying on the bare org index rather than hanging.
+    await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/[^/?#]+`), { timeout: 30_000 }).catch(() => {
+        /* no nav package to redirect to (standalone core CI) — stay put */
+    })
 }
 
 // Navigate to a package's org-scoped route via the rail link in the app


### PR DESCRIPTION
`login()` returned the moment the URL reached `/a/<org>`, but the org index immediately `<Redirect>`s to the first nav package — a heavy screen whose lazy chunk starts streaming. A test that then called `navigateToPackage()` for a *different* package clicked the rail mid-redirect, and the two contending lazy-chunk loads wedge in Metro: the target screen never commits and the test times out in `beforeEach` (seen in calc/text no-file-panel CI).

This makes `login()` wait for the redirect to settle on a package sub-route before returning, with a fallback that tolerates the bare org index when no package is installed (standalone core CI). Shared helper — benefits every e2e spec.

Validated locally: text + calc no-file-panel suites green; broader text suite (105 tests) green.