### PR TITLE
Revert login() redirect-settle wait

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -52,17 +52,6 @@ export async function login(page: Page) {
     await page.getByPlaceholder('Password').fill(TEST_USER_PASSWORD)
     await page.getByText('Sign in', { exact: true }).last().click()
     await page.waitForURL(/\/a\//, { timeout: 15_000 })
-    // Sign-in lands on /a/<org>, which immediately <Redirect>s to the first nav
-    // package (a potentially heavy screen whose lazy chunk starts streaming).
-    // Wait for that redirect to SETTLE on a package sub-route before returning —
-    // otherwise the next step (often navigateToPackage to a different package)
-    // clicks a rail mid-redirect, and the two contending lazy-chunk loads wedge
-    // in Metro: the target screen never commits and the test times out. When no
-    // package is installed (core's own standalone CI) there's no redirect, so
-    // tolerate staying on the bare org index rather than hanging.
-    await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/[^/?#]+`), { timeout: 30_000 }).catch(() => {
-        /* no nav package to redirect to (standalone core CI) — stay put */
-    })
 }
 
 // Navigate to a package's org-scoped route via the rail link in the app


### PR DESCRIPTION
Reverts the redirect-settle wait added in #72.

The extra `waitForURL` for a package sub-route consumed the shared 30s `beforeEach` budget (which covers both `login()` and `navigateToPackage()`), tipping heavy-boot packages (text's editor) over the test timeout under CI load.

**Trace evidence** from the failing text run: the page sat on the login form for most of `beforeEach` and only reached the target screen in the final (post-timeout) snapshot — the browser console was clean (no errors), so it's pure boot latency, and the added wait made it worse. Restores the original lean `login()` that passes on text main.