### PR TITLE
feat(realtime): force-flush endpoint + template notify event

### DIFF
--- a/core/lib/notify/events.ts
+++ b/core/lib/notify/events.ts
@@ -10,6 +10,7 @@ export type NotificationEvents = {
     'mail.attachments_rejected': { reason: string }
     'drive.save_succeeded': { name: string; folder: string }
     'drive.save_failed': { reason: string }
+    'drive.template_saved': { name: string }
     'import.complete': { source: 'google-takeout' | 'csv'; count: number }
     'import.failed': { source: string; error: string }
     'mutation.error': { operation: string; error: string }

--- a/core/lib/notify/registry.ts
+++ b/core/lib/notify/registry.ts
@@ -21,6 +21,7 @@ export const eventRegistry: Record<NotifyEventName, EventConfig> = {
     'mail.attachments_rejected': { channels: ['toast'], variant: 'error' },
     'drive.save_succeeded': { channels: ['toast'], variant: 'success' },
     'drive.save_failed': { channels: ['toast'], variant: 'error' },
+    'drive.template_saved': { channels: ['toast'], variant: 'success' },
     'import.complete': { channels: ['toast', 'bell'], variant: 'success' },
     'import.failed': { channels: ['toast', 'bell'], variant: 'error' },
     'mutation.error': { channels: ['toast'], variant: 'error' },

--- a/core/server/realtime/authorize.go
+++ b/core/server/realtime/authorize.go
@@ -144,6 +144,16 @@ type RoomKindOptions struct {
 	// this callback.
 	OnEmpty func(roomID string)
 
+	// ForceFlush, if non-nil, synchronously persists the current state of
+	// the given room to durable storage, returning only when the write
+	// has landed (or failed). Wired to SaveCoordinator.FlushNow. The
+	// realtime broker exposes it via POST /api/realtime/{kind}/{id}/flush
+	// so other surfaces (e.g. drive's "Export as template" / "Make a
+	// copy") can guarantee the stored blob reflects live edits before
+	// they read it. Nil for kinds without server-side persistence — the
+	// flush route then 404s for that kind.
+	ForceFlush func(roomID string) error
+
 	// OnConnect, if non-nil, is invoked once per joining client after
 	// MsgAssignID and before sync. The returned bytes are delivered as
 	// a MsgServerHello frame to that client only — useful for

--- a/core/server/realtime/register.go
+++ b/core/server/realtime/register.go
@@ -109,8 +109,46 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 		e.Router.GET("/api/realtime/{roomKind}/{roomID}", func(re *core.RequestEvent) error {
 			return handleConnect(broker, opts, re)
 		})
+		e.Router.POST("/api/realtime/{roomKind}/{roomID}/flush", handleForceFlush)
 		return e.Next()
 	})
+}
+
+// handleForceFlush synchronously persists a room's live state to durable
+// storage. Surfaces that read the stored blob (drive's "Export as
+// template" / "Make a copy") call this first so they don't copy a blob
+// that trails the in-room edits by up to the save debounce window.
+//
+// Authorization reuses the room kind's authenticated Authorize handler —
+// the same gate that admits a WebSocket editor — so only a user allowed
+// to edit the room can force its flush. Anonymous share-session visitors
+// (including read-only link viewers) are rejected: a flush mutates
+// durable storage and must not be reachable without a PB identity.
+func handleForceFlush(re *core.RequestEvent) error {
+	if re.Auth == nil {
+		return re.UnauthorizedError("Authentication required", nil)
+	}
+	kind := re.Request.PathValue("roomKind")
+	roomID := re.Request.PathValue("roomID")
+	if kind == "" || roomID == "" {
+		return re.BadRequestError("roomKind and roomID required", nil)
+	}
+
+	opts, err := optionsFor(kind)
+	if err != nil {
+		return re.NotFoundError(err.Error(), nil)
+	}
+	if opts.ForceFlush == nil {
+		// Kind has no server-side persistence — nothing to flush.
+		return re.NotFoundError("room kind does not support flush", nil)
+	}
+	if err := opts.Authorize(re.Auth, roomID); err != nil {
+		return re.ForbiddenError("Not authorized for this room", err)
+	}
+	if err := opts.ForceFlush(roomID); err != nil {
+		return re.InternalServerError("flush failed", err)
+	}
+	return re.JSON(200, map[string]bool{"flushed": true})
 }
 
 func handleConnect(broker *Broker, opts Options, re *core.RequestEvent) error {

--- a/core/server/realtime/save_coordinator.go
+++ b/core/server/realtime/save_coordinator.go
@@ -444,6 +444,64 @@ func (c *SaveCoordinator) triggerSave(driveItemID, reason string) {
 	}
 }
 
+// FlushNow runs a synchronous flush for the room identified by
+// driveItemID and returns only once the flush has completed (or failed).
+// Unlike the timer-driven triggerSave, it ignores the debounce/ceiling
+// schedule and the dirty flag — callers use it to guarantee the durable
+// blob reflects live edits before reading it (e.g. "Export as template"
+// and "Make a copy", which copy the stored drive_items.file).
+//
+// If the room is not open (no live editor since the last flush), the
+// stored blob is already current, so this is a no-op success. If a
+// timer-driven save is already in flight for the room, FlushNow waits
+// for it to finish rather than running a second concurrent flush — the
+// coordinator never invokes FlushFn for the same room twice in parallel.
+func (c *SaveCoordinator) FlushNow(driveItemID string) error {
+	c.mu.Lock()
+	rs := c.rooms[driveItemID]
+	c.mu.Unlock()
+	if rs == nil {
+		// No open room: the last flush (or teardown) already wrote the
+		// current state to durable storage. Nothing to do.
+		return nil
+	}
+
+	// Wait out any in-flight timer-driven save, then claim the in-flight
+	// slot ourselves so a concurrent triggerSave coalesces behind us
+	// instead of racing the same FlushFn. Spin with a short sleep rather
+	// than a condition variable to keep the existing lock discipline —
+	// flushes are infrequent and brief.
+	for {
+		rs.mu.Lock()
+		if rs.closed {
+			rs.mu.Unlock()
+			return nil
+		}
+		if rs.saveInFlight {
+			rs.mu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+			continue
+		}
+		rs.saveInFlight = true
+		rs.dirty = false
+		handle := rs.handle
+		rs.mu.Unlock()
+
+		err := c.flush(driveItemID, handle)
+
+		rs.mu.Lock()
+		rs.saveInFlight = false
+		if err != nil {
+			// Leave the room marked dirty so the normal retry path picks
+			// it up; FlushNow itself doesn't retry — it reports the error
+			// to its caller, who decides whether to proceed.
+			rs.dirty = true
+		}
+		rs.mu.Unlock()
+		return err
+	}
+}
+
 // giveUpDetail is the full set of facts captured when the coordinator
 // abandons the automatic retry loop for a room. Everything here goes to
 // Sentry so an operator can identify the stuck document and the failing

--- a/core/server/realtime/save_coordinator_test.go
+++ b/core/server/realtime/save_coordinator_test.go
@@ -522,3 +522,42 @@ func TestSaveCoordinatorTruncateErrorIsLoggedAndIgnored(t *testing.T) {
 		t.Fatalf("truncates = %d; want 1 (single attempt, no retry)", got)
 	}
 }
+
+// TestFlushNowNoRoomIsNoop: FlushNow on an unknown room returns nil
+// without invoking the flush — the durable blob is already current.
+func TestFlushNowNoRoomIsNoop(t *testing.T) {
+	fc := newFastCoord(t)
+	if err := fc.c.FlushNow("never-opened"); err != nil {
+		t.Fatalf("FlushNow on missing room = %v; want nil", err)
+	}
+	if got := fc.callCount(); got != 0 {
+		t.Fatalf("flush calls = %d; want 0", got)
+	}
+}
+
+// TestFlushNowRunsFlush: FlushNow on an open room runs the flush
+// synchronously and returns once it has completed.
+func TestFlushNowRunsFlush(t *testing.T) {
+	fc := newFastCoord(t)
+	fc.c.OnRoomCreate("open-room", &stubHandle{}, nil)
+	if err := fc.c.FlushNow("open-room"); err != nil {
+		t.Fatalf("FlushNow = %v; want nil", err)
+	}
+	if got := fc.callCount(); got != 1 {
+		t.Fatalf("flush calls = %d; want 1 (synchronous flush)", got)
+	}
+}
+
+// TestFlushNowPropagatesError: a failing flush surfaces its error to the
+// FlushNow caller and leaves the room dirty for the normal retry path.
+func TestFlushNowPropagatesError(t *testing.T) {
+	flush := func(_ string, _ DocHandle) error {
+		return errors.New("synthetic flush failure")
+	}
+	c := NewSaveCoordinator(flush)
+	c.SetLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.OnRoomCreate("flaky-room", &stubHandle{}, nil)
+	if err := c.FlushNow("flaky-room"); err == nil {
+		t.Fatal("FlushNow = nil; want the flush error")
+	}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -82,6 +82,14 @@ export default defineConfig({
                 find: /^expo-clipboard$/,
                 replacement: path.join(APP_DIR, '..', 'tests', 'expo-clipboard-stub.ts'),
             },
+            // expo-image pulls in expo-modules-core the same way (its Platform
+            // module reads the global __DEV__ at load). A package unit test that
+            // imports a component rendering a Thumbnail / <Image> would crash at
+            // collect time; the stub renders a harmless placeholder.
+            {
+                find: /^expo-image$/,
+                replacement: path.join(APP_DIR, '..', 'tests', 'expo-image-stub.tsx'),
+            },
             // ~/* — package source. Resolved relative to the package's own dir
             // at invocation time via the test root, so we map it dynamically below.
         ],


### PR DESCRIPTION
Adds the server-side machinery that drive-backed document templates need.

- `SaveCoordinator.FlushNow` + `POST /api/realtime/{kind}/{id}/flush` — synchronously persists a room's live Y.Doc to its `drive_items.file` blob, so surfaces that copy the stored bytes (Export as template, Make a copy) capture in-flight edits instead of the last debounced save. Gated by the room kind's authenticated `Authorize`.
- `drive.template_saved` toast event.
- Stubs `expo-image` in unit tests (the Thumbnail/Image chain pulls in expo-modules-core, which reads `__DEV__` at load).

Part of drive-backed templates (paired with PRs in drive, text, calc).