### PR TITLE
fix: unblock in-app package install/rebuild + fix post-install website takeover

### DIFF
--- a/core/server/coreserver/app_native_export.go
+++ b/core/server/coreserver/app_native_export.go
@@ -237,13 +237,15 @@ func exportNativeBundles(job *installJob, appDir, buildID, runtimeVersion string
 	for i, p := range platforms {
 		outDir := filepath.Join(appDir, fmt.Sprintf("dist-%s", p))
 		os.RemoveAll(outDir) // clean any prior export
-		// Spread the per-platform exports across the native band
-		// [progNativeStart, progNativeEnd) so the bar advances per platform
-		// without ever exceeding the build pipeline's native ceiling.
+		// Carve the native band [progNativeStart, progNativeEnd) into one
+		// sub-band per platform so each export climbs its own slice from Metro's
+		// bundling progress, without ever exceeding the pipeline's native ceiling.
 		span := progNativeEnd - progNativeStart
-		pct := progNativeStart + (span*i)/len(platforms)
-		emitProgress(job, "Building "+string(p)+" bundle", pct, "Running expo export --platform "+string(p))
-		if cmdOut, err := runCmd(appDir, "pnpm", "exec", "expo", "export", "--platform", string(p), "--output-dir", outDir); err != nil {
+		lo := progNativeStart + (span*i)/len(platforms)
+		hi := progNativeStart + (span*(i+1))/len(platforms)
+		step := "Building " + string(p) + " bundle"
+		emitProgress(job, step, lo, "Running expo export --platform "+string(p))
+		if cmdOut, err := runExportWithProgress(job, lo, hi, step, appDir, "--platform", string(p), "--output-dir", outDir); err != nil {
 			return nil, fmt.Errorf("expo export %s: %v: %s", p, err, cmdOut)
 		}
 		bm, err := parseExportMetadata(outDir, p, buildID, runtimeVersion)

--- a/core/server/coreserver/app_native_export.go
+++ b/core/server/coreserver/app_native_export.go
@@ -268,11 +268,18 @@ func cleanupNativeExportDirs(bundles []bundleMeta) {
 	}
 }
 
-// appVersionFromManifest reads the Expo app version (app.json → expo.version),
-// which is the runtimeVersion under the appVersion policy. app.json may sit at
-// appDir in the runtime image or one level up in dev — try appDir then parent.
+// appVersionFromManifest resolves the Expo app version, which is the
+// runtimeVersion under the appVersion policy. The app's single source of truth
+// is package.json → version: app.config.ts injects it over a static app.json
+// that intentionally carries no expo.version (see app.config.ts). We mirror that
+// here rather than evaluate the TS config — read expo.version from app.json
+// first (in case a build pins it statically), then fall back to package.json's
+// version. Each file may sit at appDir in the runtime image or one level up in
+// dev, so try appDir then its parent for both.
 func appVersionFromManifest(appDir string) string {
-	for _, base := range []string{appDir, filepath.Dir(appDir)} {
+	bases := []string{appDir, filepath.Dir(appDir)}
+
+	for _, base := range bases {
 		raw, err := os.ReadFile(filepath.Join(base, "app.json"))
 		if err != nil {
 			continue
@@ -286,6 +293,22 @@ func appVersionFromManifest(appDir string) string {
 			return cfg.Expo.Version
 		}
 	}
+
+	// app.json had no expo.version — the normal case here, since the version
+	// lives in package.json and is merged in by app.config.ts at config time.
+	for _, base := range bases {
+		raw, err := os.ReadFile(filepath.Join(base, "package.json"))
+		if err != nil {
+			continue
+		}
+		var pkg struct {
+			Version string `json:"version"`
+		}
+		if json.Unmarshal(raw, &pkg) == nil && pkg.Version != "" {
+			return pkg.Version
+		}
+	}
+
 	return ""
 }
 

--- a/core/server/coreserver/app_native_export_test.go
+++ b/core/server/coreserver/app_native_export_test.go
@@ -227,3 +227,57 @@ func TestSerializeBundlesRoundTripsToResolveManifest(t *testing.T) {
 		t.Fatalf("expected manifestNoMatch for mismatched runtime, got %v", s)
 	}
 }
+
+func TestAppVersionFromManifest(t *testing.T) {
+	writeJSON := func(t *testing.T, dir, name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The production shape: app.json carries no expo.version (app.config.ts
+	// injects it from package.json), so the resolver must fall back to
+	// package.json's version.
+	t.Run("falls back to package.json when app.json has no expo.version", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJSON(t, dir, "app.json", `{"expo":{"name":"TinyCld"}}`)
+		writeJSON(t, dir, "package.json", `{"name":"@tinycld/app","version":"2.0.0"}`)
+		if got := appVersionFromManifest(dir); got != "2.0.0" {
+			t.Fatalf("got %q, want 2.0.0", got)
+		}
+	})
+
+	// A statically-pinned expo.version still wins (don't break a build that sets it).
+	t.Run("prefers expo.version when present", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJSON(t, dir, "app.json", `{"expo":{"version":"9.9.9"}}`)
+		writeJSON(t, dir, "package.json", `{"version":"2.0.0"}`)
+		if got := appVersionFromManifest(dir); got != "9.9.9" {
+			t.Fatalf("got %q, want 9.9.9", got)
+		}
+	})
+
+	// Dev layout: manifests live one dir above appDir.
+	t.Run("reads package.json from the parent dir", func(t *testing.T) {
+		parent := t.TempDir()
+		writeJSON(t, parent, "package.json", `{"version":"3.1.4"}`)
+		appDir := filepath.Join(parent, "tinycld")
+		if err := os.MkdirAll(appDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := appVersionFromManifest(appDir); got != "3.1.4" {
+			t.Fatalf("got %q, want 3.1.4", got)
+		}
+	})
+
+	// Neither source has a version → empty (the caller turns this into a loud error).
+	t.Run("returns empty when no version anywhere", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJSON(t, dir, "app.json", `{"expo":{"name":"x"}}`)
+		writeJSON(t, dir, "package.json", `{"name":"x"}`)
+		if got := appVersionFromManifest(dir); got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+}

--- a/core/server/coreserver/rebuild_pipeline.go
+++ b/core/server/coreserver/rebuild_pipeline.go
@@ -20,6 +20,12 @@ type streamingRunner func(onLine func(string), dir, name string, args ...string)
 // progress parsing.
 var pnpmStream streamingRunner = runCmdStreaming
 
+// expoStream is the streaming runner the expo-export steps (web + native) use, so
+// Metro's per-module bundling progress reaches the bar instead of the step sitting
+// frozen for the minutes a cold bundle takes. A package var for the same
+// test-stubbing reason as pnpmStream.
+var expoStream streamingRunner = runCmdStreaming
+
 // pnpmProgressInterval is the minimum gap between forwarded "Progress:" lines.
 // pnpm's non-TTY reporter emits one every few hundred ms on a large graph, which
 // floods the SSE stream and makes the bar look busier than the install actually
@@ -88,9 +94,13 @@ func runBuildPipelineWith(
 	}); err != nil {
 		return buildOutput{}, wrapStep("go build", err)
 	}
-	emitProgress(job, "Exporting web bundle", progExpoWeb, "expo export")
+	// The web bundle owns [progGoBuild, progExpoWeb): runExportWithProgress climbs
+	// the bar through it from Metro's per-module progress so a cold (multi-minute)
+	// bundle visibly advances instead of parking at one value.
+	emitProgress(job, "Exporting web bundle", progGoBuild, "expo export --platform web")
 	if err := timeStep(job, "expo export (web bundle)", func() error {
-		_, e := run(appDir, "pnpm", "exec", "expo", "export", "--platform", "web")
+		_, e := runExportWithProgress(job, progGoBuild, progExpoWeb,
+			"Exporting web bundle", appDir, "--platform", "web")
 		return e
 	}); err != nil {
 		return buildOutput{}, wrapStep("expo export", err)
@@ -227,4 +237,96 @@ func pnpmLineProgress(line string) int {
 	default:
 		return 0
 	}
+}
+
+// runExportWithProgress runs an `expo export` invocation through the streaming
+// runner, forwarding Metro's bundling progress onto the [lo, hi) band so the bar
+// climbs through the (minutes-long, on a cold cache) bundle instead of sitting
+// frozen at lo. step is the SSE step label; args are passed to `pnpm exec expo
+// export …`. Returns the buffered output + error like runCmd.
+func runExportWithProgress(job *installJob, lo, hi int, step, dir string, args ...string) (string, error) {
+	throttle := newPnpmProgressThrottle()
+	return expoStream(
+		func(line string) { reportExpoProgress(job, line, step, lo, hi, throttle) },
+		dir, "pnpm", append([]string{"exec", "expo", "export"}, args...)...,
+	)
+}
+
+// reportExpoProgress maps one `expo export` output line onto the [lo, hi) band.
+// Metro's non-TTY reporter prints per-module bundling lines carrying a running
+// percentage ("Web …entry.js ▓▓░░ 34.5% (1252/2155)"), then a "… Bundled <ms> …"
+// line and a final "Exported: <dir>". We translate the percentage linearly into
+// the band so the bar tracks the actual bundle, and park near the top on the
+// terminal markers. Lines without a recognizable signal keep the bar where it is.
+//
+// The high-frequency percentage lines are throttle-gated (one update per
+// pnpmProgressInterval) exactly like pnpm's "Progress:" lines; the low-frequency
+// "Bundled"/"Exported" markers always pass.
+func reportExpoProgress(job *installJob, line, step string, lo, hi int, throttle *pnpmProgressThrottle) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	frac, isPct := expoLineFraction(line)
+	switch {
+	case isPct:
+		if !throttle.allow(nowFunc()) {
+			return // a percentage line still inside the throttle window — drop it
+		}
+		emitProgress(job, step, bandPct(lo, hi, frac), line)
+	case strings.Contains(line, "Bundled "), strings.HasPrefix(line, "Exported:"):
+		// Bundle finished / written — park just below hi (staging owns hi).
+		emitProgress(job, step, hi-1, line)
+	default:
+		// Asset listings, the per-file output dump, warnings — keep the bar put.
+	}
+}
+
+// expoLineFraction extracts the bundling fraction (0..1) from a Metro progress
+// line of the form "… <NN.N>% (n/total)". Returns ok=false when the line carries
+// no such percentage. Parsed by hand (no regexp) against Metro's stable shape:
+// find "% (" and read the float immediately before the percent sign.
+func expoLineFraction(line string) (float64, bool) {
+	i := strings.Index(line, "% (")
+	if i <= 0 {
+		return 0, false
+	}
+	// Walk back over the number (digits and a single dot) preceding '%'.
+	start := i
+	for start > 0 {
+		c := line[start-1]
+		if (c >= '0' && c <= '9') || c == '.' {
+			start--
+			continue
+		}
+		break
+	}
+	num := line[start:i]
+	if num == "" || num == "." {
+		return 0, false
+	}
+	var pct float64
+	if _, err := fmt.Sscanf(num, "%f", &pct); err != nil {
+		return 0, false
+	}
+	if pct < 0 {
+		pct = 0
+	} else if pct > 100 {
+		pct = 100
+	}
+	return pct / 100, true
+}
+
+// bandPct maps a fraction (0..1) onto [lo, hi), clamped to never reach hi (the
+// next milestone owns hi) so the bar stays monotonic across phase boundaries.
+func bandPct(lo, hi int, frac float64) int {
+	span := hi - lo
+	p := lo + int(frac*float64(span))
+	if p >= hi {
+		p = hi - 1
+	}
+	if p < lo {
+		p = lo
+	}
+	return p
 }

--- a/core/server/coreserver/rebuild_pipeline_test.go
+++ b/core/server/coreserver/rebuild_pipeline_test.go
@@ -14,9 +14,11 @@ func TestRunBuildPipeline_StepOrder(t *testing.T) {
 		calls = append(calls, name+" "+strings.Join(args, " "))
 		return "", nil
 	}
-	// pnpm install runs via the streaming runner — stub it to record the call
-	// alongside the buffered ones so the step-order check still sees "pnpm install".
+	// pnpm install and expo export run via the streaming runners — stub both to
+	// record their calls alongside the buffered ones so the step-order check still
+	// sees "pnpm install" and "expo".
 	defer stubPnpmStream(&calls)()
+	defer stubExpoStream(&calls)()
 	staged := false
 	stage := func(appDir string) (string, error) {
 		staged = true
@@ -85,6 +87,17 @@ func stubPnpmStream(calls *[]string) func() {
 		return "", nil
 	}
 	return func() { pnpmStream = prev }
+}
+
+// stubExpoStream replaces the expo streaming runner with a no-op that records the
+// "pnpm exec expo export …" invocation into calls, and returns a restore func.
+func stubExpoStream(calls *[]string) func() {
+	prev := expoStream
+	expoStream = func(_ func(string), _, name string, args ...string) (string, error) {
+		*calls = append(*calls, name+" "+strings.Join(args, " "))
+		return "", nil
+	}
+	return func() { expoStream = prev }
 }
 
 // TestPnpmLineProgress locks the parser to pnpm's real non-TTY reporter lines
@@ -188,6 +201,99 @@ func TestReportPnpmProgress_Throttled(t *testing.T) {
 	reportPnpmProgress(job, "some postinstall noise", throttle)
 	if got := len(job.LogLines); got != 4 {
 		t.Fatalf("non-milestone line forwarded; total = %d, want 4", got)
+	}
+}
+
+// TestExpoLineFraction locks the parser to Metro's real non-TTY bundling lines
+// (captured from `expo export` without a TTY) so the bar tracks the running
+// percentage and ignores the surrounding asset/file dump.
+func TestExpoLineFraction(t *testing.T) {
+	cases := []struct {
+		line     string
+		wantFrac float64
+		wantOK   bool
+	}{
+		{"Web node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)", 0, true},
+		{"Web node_modules/expo-router/entry.js ▓▓▓▓▓░░░░░░░░░░░ 34.5% (1252/2155)", 0.345, true},
+		{"Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 99.9% (4343/4343)", 0.999, true},
+		{"Web Bundled 10768ms node_modules/expo-router/entry.js (4343 modules)", 0, false},
+		{"Exported: /tmp/dist", 0, false},
+		{"_expo/static/js/web/entry-abc.js (1.3MB)", 0, false}, // size, not a percentage
+		{"", 0, false},
+	}
+	for _, c := range cases {
+		frac, ok := expoLineFraction(c.line)
+		if ok != c.wantOK {
+			t.Errorf("expoLineFraction(%q) ok = %v, want %v", c.line, ok, c.wantOK)
+			continue
+		}
+		if ok && (frac < c.wantFrac-0.001 || frac > c.wantFrac+0.001) {
+			t.Errorf("expoLineFraction(%q) = %v, want ~%v", c.line, frac, c.wantFrac)
+		}
+	}
+}
+
+// TestBandPct checks the fraction→band mapping stays within [lo, hi): 0 maps to
+// lo, a full bundle parks at hi-1 (never hi — the next milestone owns it), and
+// midpoints land proportionally.
+func TestBandPct(t *testing.T) {
+	lo, hi := 60, 72
+	cases := []struct {
+		frac float64
+		want int
+	}{
+		{0, 60},
+		{0.5, 66},
+		{0.999, 71},
+		{1.0, 71},  // clamped below hi
+		{-0.5, 60}, // clamped at lo
+		{2.0, 71},  // clamped below hi
+	}
+	for _, c := range cases {
+		if got := bandPct(lo, hi, c.frac); got != c.want {
+			t.Errorf("bandPct(%d,%d,%v) = %d, want %d", lo, hi, c.frac, got, c.want)
+		}
+	}
+}
+
+// TestReportExpoProgress mirrors the pnpm throttle test: high-frequency
+// percentage lines forward at most one per window and land in-band, while the
+// terminal "Bundled"/"Exported" markers always pass and park at hi-1.
+func TestReportExpoProgress(t *testing.T) {
+	now := time.Unix(0, 0)
+	prev := nowFunc
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = prev }()
+
+	lo, hi := 60, 72
+	job := &installJob{ID: "j", Done: make(chan struct{})}
+	throttle := newPnpmProgressThrottle()
+
+	// A burst of percentage lines within one window — only the first forwards.
+	for i := 0; i < 5; i++ {
+		now = now.Add(200 * time.Millisecond)
+		reportExpoProgress(job, "Web entry.js ▓▓░░ 40.0% (800/2000)", "Exporting web bundle", lo, hi, throttle)
+	}
+	if got := len(job.LogLines); got != 1 {
+		t.Fatalf("percentage burst forwarded %d updates, want 1", got)
+	}
+	if got := job.Progress; got != bandPct(lo, hi, 0.4) {
+		t.Fatalf("first percentage forwarded progress %d, want %d", got, bandPct(lo, hi, 0.4))
+	}
+
+	// The "Bundled" marker is not throttled and parks at hi-1.
+	reportExpoProgress(job, "Web Bundled 10768ms entry.js (4343 modules)", "Exporting web bundle", lo, hi, throttle)
+	if got := len(job.LogLines); got != 2 {
+		t.Fatalf("Bundled marker was throttled; total = %d, want 2", got)
+	}
+	if got := job.Progress; got != hi-1 {
+		t.Fatalf("Bundled marker progress %d, want %d", got, hi-1)
+	}
+
+	// Non-signal lines (the per-file dump) never forward.
+	reportExpoProgress(job, "_expo/static/js/web/entry-abc.js (1.3MB)", "Exporting web bundle", lo, hi, throttle)
+	if got := len(job.LogLines); got != 2 {
+		t.Fatalf("asset listing line forwarded; total = %d, want 2", got)
 	}
 }
 

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -26,6 +26,12 @@ type Options struct {
 	PublicDir    string
 	FallbackFile string
 
+	// WebsiteDir is the marketing website's static root, served BEFORE PublicDir
+	// and the SPA fallback. Kept separate from PublicDir so the app's web export
+	// (which bundles PublicDir) can't absorb the site. Empty disables it (dev /
+	// com mode); org-mode deploys point it at the built Astro site.
+	WebsiteDir string
+
 	// ReleasesDir is the directory containing per-deploy web bundle state.
 	// On a deployed image it lives on the persistent volume and contains:
 	//   - <id>/             one dir per retained release, holding app.html
@@ -206,6 +212,8 @@ func registerFlags(app *pocketbase.PocketBase, opts *Options) {
 		"the directory with the user defined migrations")
 	f.BoolVar(&opts.Automigrate, "automigrate", opts.Automigrate, "enable/disable auto migrations")
 	f.StringVar(&opts.PublicDir, "publicDir", opts.PublicDir, "the directory to serve static files")
+	f.StringVar(&opts.WebsiteDir, "websiteDir", opts.WebsiteDir,
+		"the directory with the marketing website, served before publicDir (empty disables)")
 	f.StringVar(&opts.FallbackFile, "fallbackFile", opts.FallbackFile,
 		"fallback to this file on missing static path for SPA routes")
 	f.StringVar(&opts.ReleasesDir, "releasesDir", opts.ReleasesDir,
@@ -263,7 +271,7 @@ func registerStaticServe(app *pocketbase.PocketBase, opts Options) {
 
 			if !e.Router.HasRoute(http.MethodGet, "/{path...}") {
 				if opts.ReleasesDir != "" {
-					e.Router.Any("/{path...}", StaticWithDynamicFallback(opts.PublicDir, opts.ReleasesDir))
+					e.Router.Any("/{path...}", StaticWithDynamicFallback(opts.PublicDir, opts.WebsiteDir, opts.ReleasesDir))
 				} else {
 					e.Router.Any("/{path...}", StaticWithFallback(opts.PublicDir, opts.FallbackFile))
 				}

--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -1,6 +1,7 @@
 package coreserver
 
 import (
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -29,6 +30,20 @@ func DefaultPublicDir() string {
 		return filepath.Join(dir, "public")
 	}
 	return "./public"
+}
+
+// DefaultWebsiteDir returns the default marketing-website dir, resolved next to
+// the running binary as <binaryDir>/website (or "./website" for `go run`). It is
+// deliberately SEPARATE from DefaultPublicDir(): org-mode deploys copy the built
+// Astro site here, NOT into public/, so the app's `expo export` (which sweeps
+// public/ into its web bundle) never absorbs the website. Empty in dev / com mode
+// where the dir doesn't exist — StaticWithDynamicFallback treats a missing
+// websiteDir as "no website" and serves the app shell as before.
+func DefaultWebsiteDir() string {
+	if dir := binaryDir(); dir != "" {
+		return filepath.Join(dir, "website")
+	}
+	return "./website"
 }
 
 // DefaultReleasesDir returns the releases dir under the STATE root
@@ -110,17 +125,49 @@ func StaticWithFallback(dir string, fallbackFile string) func(*core.RequestEvent
 	}
 }
 
-// StaticWithDynamicFallback serves static files from publicDir (the
-// marketing website + any other in-image content), and on miss falls back
-// to <releasesDir>/current/app.html (the SPA shell from the active
-// release).
+// serveStaticFrom tries to serve `path` (then `path/index.html`) out of fs.
+// Returns true (and writes the response) on a hit, false on a miss. Shared by
+// the website + public lookups so both apply the same path → path/index.html
+// resolution. A nil fs (dir not configured) is always a miss.
+func serveStaticFrom(e *core.RequestEvent, fs fs.FS, path string) (bool, error) {
+	if fs == nil {
+		return false, nil
+	}
+	if f, err := fs.Open(path); err == nil {
+		f.Close()
+		return true, e.FileFS(fs, path)
+	}
+	indexPath := path + "/index.html"
+	if f, err := fs.Open(indexPath); err == nil {
+		f.Close()
+		return true, e.FileFS(fs, indexPath)
+	}
+	return false, nil
+}
+
+// StaticWithDynamicFallback serves static files, then falls back to the active
+// release's SPA shell (<releasesDir>/current/app.html). Lookups are tried in
+// order:
+//
+//  1. websiteDir — the marketing website (org-mode deploys only; "" otherwise).
+//     It lives in its OWN directory, NOT in publicDir, so the app's `expo
+//     export` (which sweeps publicDir into its web bundle) can never pull the
+//     website into the SPA bundle — the bug where every app route rendered the
+//     marketing homepage after an in-app package install.
+//  2. publicDir — the app's own web static files (favicon, sw.js, workers/),
+//     i.e. exactly what Expo emits from the app member's public/ dir.
+//  3. SPA fallback — <releasesDir>/current/app.html for any non-/api/ miss.
 //
 // When releasesDir is empty or its `current` symlink doesn't resolve to a
 // readable app.html, the handler falls back to publicDir/app.html — the
 // legacy behavior used in dev where the volume isn't mounted. Any path
-// not present in either location returns 404.
-func StaticWithDynamicFallback(publicDir, releasesDir string) func(*core.RequestEvent) error {
+// not present in any location returns 404.
+func StaticWithDynamicFallback(publicDir, websiteDir, releasesDir string) func(*core.RequestEvent) error {
 	publicFs := os.DirFS(publicDir)
+	var websiteFs fs.FS
+	if websiteDir != "" {
+		websiteFs = os.DirFS(websiteDir)
+	}
 
 	return func(e *core.RequestEvent) error {
 		if e.Request.Method != http.MethodGet && e.Request.Method != http.MethodHead {
@@ -132,15 +179,12 @@ func StaticWithDynamicFallback(publicDir, releasesDir string) func(*core.Request
 			path = "index.html"
 		}
 
-		if f, err := publicFs.Open(path); err == nil {
-			f.Close()
-			return e.FileFS(publicFs, path)
+		// Website first (org mode), then the app's own public/ files.
+		if hit, err := serveStaticFrom(e, websiteFs, path); hit {
+			return err
 		}
-
-		indexPath := path + "/index.html"
-		if f, err := publicFs.Open(indexPath); err == nil {
-			f.Close()
-			return e.FileFS(publicFs, indexPath)
+		if hit, err := serveStaticFrom(e, publicFs, path); hit {
+			return err
 		}
 
 		// Never serve the SPA HTML fallback for API paths. This catch-all is

--- a/core/server/coreserver/static_test.go
+++ b/core/server/coreserver/static_test.go
@@ -1,0 +1,171 @@
+package coreserver
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// staticDirs builds a publicDir (app's own web static), a websiteDir (marketing
+// site), and a releasesDir with current/app.html (the SPA shell), each populated
+// from the given name→content maps. Any map may be nil/empty. Returns the three
+// dir paths; an empty websiteDir map yields "" (website disabled).
+func staticDirs(t *testing.T, public, website map[string]string, appHTML string) (publicDir, websiteDir, releasesDir string) {
+	t.Helper()
+	write := func(dir string, files map[string]string) {
+		for name, content := range files {
+			p := filepath.Join(dir, name)
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	publicDir = t.TempDir()
+	write(publicDir, public)
+
+	if len(website) > 0 {
+		websiteDir = t.TempDir()
+		write(websiteDir, website)
+	}
+
+	releasesDir = t.TempDir()
+	if appHTML != "" {
+		cur := filepath.Join(releasesDir, "current")
+		if err := os.MkdirAll(cur, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cur, "app.html"), []byte(appHTML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return publicDir, websiteDir, releasesDir
+}
+
+func runStaticScenario(t *testing.T, publicDir, websiteDir, releasesDir string, scenario *tests.ApiScenario) {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		e.Router.RouterGroup.Any("/{path...}", StaticWithDynamicFallback(publicDir, websiteDir, releasesDir))
+		return e.Next()
+	})
+
+	scenario.TestAppFactory = func(_ testing.TB) *tests.TestApp { return app }
+	scenario.DisableTestAppCleanup = true
+	scenario.Test(t)
+}
+
+// TestStatic_AppRouteServesShellNotWebsite is the regression guard for the bug
+// this fix targets: with a marketing site present, an app route (not in website/
+// or public/) must fall through to the SPA shell — NOT render the website
+// homepage. Before the website lived in its own dir, an in-app rebuild's expo
+// export absorbed it into the bundle and every app route served the marketing
+// page.
+func TestStatic_AppRouteServesShellNotWebsite(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		map[string]string{"sw.js": "// service worker"},
+		map[string]string{"index.html": "<html>MARKETING HOME</html>"},
+		"<html>APP SHELL</html>",
+	)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:               "app route falls back to the SPA shell, not the website",
+		Method:             http.MethodGet,
+		URL:                "/a/acme/mail",
+		ExpectedStatus:     http.StatusOK,
+		ExpectedContent:    []string{"APP SHELL"},
+		NotExpectedContent: []string{"MARKETING HOME"},
+	})
+}
+
+func TestStatic_RootServesWebsiteHome(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		map[string]string{"sw.js": "// sw"},
+		map[string]string{"index.html": "<html>MARKETING HOME</html>"},
+		"<html>APP SHELL</html>",
+	)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "/ serves the marketing homepage",
+		Method:          http.MethodGet,
+		URL:             "/",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"MARKETING HOME"},
+	})
+}
+
+func TestStatic_WebsiteSubpageServesFromWebsiteDir(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		nil,
+		map[string]string{"docs/index.html": "<html>DOCS PAGE</html>"},
+		"<html>APP SHELL</html>",
+	)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "/docs resolves to website/docs/index.html",
+		Method:          http.MethodGet,
+		URL:             "/docs",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"DOCS PAGE"},
+	})
+}
+
+func TestStatic_AppOwnPublicFileStillServed(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		map[string]string{"sw.js": "SERVICE_WORKER_BODY"},
+		map[string]string{"index.html": "<html>HOME</html>"},
+		"<html>APP SHELL</html>",
+	)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "the app's own public/ file (sw.js) is served from publicDir",
+		Method:          http.MethodGet,
+		URL:             "/sw.js",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"SERVICE_WORKER_BODY"},
+	})
+}
+
+// TestStatic_NoWebsiteDirStillServesApp confirms dev / com mode (websiteDir
+// empty): / has no website index, so it falls through to the SPA shell.
+func TestStatic_NoWebsiteDirStillServesApp(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		map[string]string{"sw.js": "// sw"},
+		nil, // no website
+		"<html>APP SHELL</html>",
+	)
+	if websiteDir != "" {
+		t.Fatalf("expected empty websiteDir, got %q", websiteDir)
+	}
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "no website: / serves the SPA shell",
+		Method:          http.MethodGet,
+		URL:             "/",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"APP SHELL"},
+	})
+}
+
+func TestStatic_ApiPathNeverServesShell(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		nil,
+		map[string]string{"index.html": "<html>HOME</html>"},
+		"<html>APP SHELL</html>",
+	)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:               "/api/* miss returns JSON 404, never the HTML shell",
+		Method:             http.MethodGet,
+		URL:                "/api/not-yet-registered",
+		ExpectedStatus:     http.StatusNotFound,
+		ExpectedContent:    []string{`"status":404`},
+		NotExpectedContent: []string{"APP SHELL", "HOME"},
+	})
+}

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -114,7 +114,18 @@ function rerootPlugins(plugins: PluginEntry[], appDirName: string): PluginEntry[
 // "couldn't find an ignore file".
 function writeRootBiomeConfig() {
     const appDirName = path.basename(APP_DIR)
-    const canonical = JSON.parse(fs.readFileSync(path.join(APP_DIR, 'biome.json'), 'utf8'))
+    const canonicalPath = path.join(APP_DIR, 'biome.json')
+    // The ws-root biome.json is a dev/CI-only convenience (lets `pnpm run lint`
+    // and the editor LSP resolve rules from a root above the sibling members). A
+    // runtime rebuild — the in-app package installer's postinstall — only runs
+    // `expo export` + `go build` and never lints, and its build tree is assembled
+    // from the deployed image, which doesn't carry the canonical config. Skip
+    // rather than abort the whole generator when it's absent.
+    if (!fs.existsSync(canonicalPath)) {
+        console.warn(`[generate] ${canonicalPath} absent — skipping ws-root biome.json (lint-only)`)
+        return
+    }
+    const canonical = JSON.parse(fs.readFileSync(canonicalPath, 'utf8'))
 
     const config = {
         ...canonical,

--- a/server/main.go
+++ b/server/main.go
@@ -47,6 +47,7 @@ func main() {
 	app := pocketbase.New()
 	coreserver.Register(app, coreserver.Options{
 		PublicDir:      coreserver.DefaultPublicDir(),
+		WebsiteDir:     coreserver.DefaultWebsiteDir(),
 		ReleasesDir:    coreserver.DefaultReleasesDir(),
 		FallbackFile:   "app.html",
 		TypesDir:       coreserver.DefaultTypesDir(),


### PR DESCRIPTION
All tinycld-repo fixes for the in-app package install/rebuild flow on tinycld.org, bundled so they deploy and test together. Each addresses a step where the runtime-rebuild path diverges from dev/CI. **Pairs with tinycld/utils#6** (the `Dockerfile.org` change for #4 — deploy them together).

## 1. Generator crash — missing `biome.json`

The postinstall generator crashed with `ENOENT: ... tinycld/biome.json` at `writeRootBiomeConfig()`. The deployed image doesn't ship `biome.json` (the Dockerfile copies the `tinycld/` member per-subpath and it isn't listed), and `expo export`/`go build` never read it. The ws-root biome config is a dev/CI lint convenience only — skip it with a warning when the canonical config is absent instead of aborting the generator.

## 2. Native export abort — empty `runtimeVersion`

Native OTA export aborted: `empty runtimeVersion: app.json has no expo.version`. The app's version lives in `package.json`, merged in by `app.config.ts` at Expo config time; the static `app.json` has no `expo.version`, and the Go server reads `app.json` directly. `appVersionFromManifest` now falls back to `package.json` → `version`.

## 3. Stream expo export progress to the bar

Both expo export steps ran via the buffered `runCmd`, so the progress bar sat frozen for the minutes a cold Metro bundle takes (~3m on a fresh container). Forward Metro's per-module percentage onto the step's band — same throttle/mechanism as the existing pnpm-install streaming.

## 4. Post-install website takeover (tinycld.org)

After an in-app install, **every page rendered the marketing homepage**. `Dockerfile.org` copied the Astro site into the app member's `public/`, which Expo's web export sweeps into the SPA bundle — so an in-app rebuild's `expo export` (run against the live `public/`) turned the website's `index.html` into the SPA shell. Fix: serve the website from its own `WebsiteDir` (ahead of `publicDir` + SPA fallback); the companion utils PR writes the site to `./website/` instead of `./public/`. The app's `public/` stays Expo-only.

## Verified

- Generator: exits 0 with skip warning when `biome.json` absent; byte-identical output when present.
- Native export: Go test covers the package.json fallback + variants.
- Expo progress: parser tested against real cold-export output; throttle/band tests.
- Website: new static-serving tests incl. a regression guard that an app route serves the SPA shell, not the website.
- Full `coreserver` package + `go vet` (+ `-race` on the streaming tests) pass.

The first two fixes (and #4) take effect on newly built images, not the currently-deployed container.