### PR TITLE
fix(core): decouple sentry from native app-updater + run core tests with app shell

### DIFF
--- a/core/lib/sentry.ts
+++ b/core/lib/sentry.ts
@@ -1,7 +1,6 @@
 declare const __DEV__: boolean
 
 import * as Sentry from '@sentry/react-native'
-import AppUpdater from 'app-updater'
 import { Platform } from 'react-native'
 import { getCoreConfigOptional } from './core-config'
 import { scrubPII } from './sentry-scrub'
@@ -26,6 +25,20 @@ let initialized = false
 function sentryReleaseAndDist(): { release?: string; dist?: string } {
     if (Platform.OS === 'web') return {}
     try {
+        // Lazy require + a minimal local type, NOT a top-level
+        // `import ... from 'app-updater'`: that module is native-only and lives
+        // in the runnable app shell. A static import (value OR type) pulls its
+        // app-shell-resident ambient declaration into the tsconfig program of
+        // every feature that imports captureException (errors.ts → sentry.ts) —
+        // and features can't resolve it standalone, so their typecheck fails with
+        // "Cannot find module 'app-updater'". Typing the require against an inline
+        // interface keeps this file feature-resolvable; the helper only ever runs
+        // on native, where the real module is present.
+        interface BundleInfo {
+            getCurrentBundleId(): string
+            getRuntimeVersion(): string
+        }
+        const AppUpdater = (require('app-updater') as { default: BundleInfo }).default
         const id = AppUpdater.getCurrentBundleId()
         // Embedded (or unknown) → no override; the EAS-uploaded sourcemaps own it.
         if (!id || id.startsWith('embedded')) return {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -103,7 +103,20 @@ export default defineConfig({
     },
     test: {
         environment: 'node',
-        include: ['tests/**/*.test.{ts,tsx}', 'scripts/**/__tests__/**/*.test.{ts,tsx}'],
+        // Core is nested at tinycld/core/ and ships WITH the app shell (it's not a
+        // separately-releasable member, and tinycld-pkg's --all discovery only sees
+        // workspace-root dirs, so core is never its own target). Its tests must
+        // therefore run as part of the app shell's run, or a core regression (e.g.
+        // sentry.ts importing the native-only app-updater) goes uncaught. Feature
+        // configs inherit this config but set `root` to their own dir, so this
+        // `core/**` glob resolves relative to `<feature>/` — which has no core/ —
+        // and matches nothing there; it only picks up files when the run's root is
+        // the app shell. (core/vitest.config.ts still exists for a core-scoped run.)
+        include: [
+            'tests/**/*.test.{ts,tsx}',
+            'scripts/**/__tests__/**/*.test.{ts,tsx}',
+            'core/**/*.test.{ts,tsx}',
+        ],
         // The app shell has no tests/ of its own yet; self-mode `npm test`
         // (tinycld-pkg test from app/) must not fail on an empty match.
         passWithNoTests: true,


### PR DESCRIPTION
Fixes an ecosystem-wide feature-CI break and the test gap that let it land.

**The break:** `core/lib/sentry.ts` imported `app-updater` at the top level (added in `dc4b97f` for OTA sourcemap upload). Since `errors.ts → sentry.ts` and every feature imports `captureException` from `errors.ts`, that pulled the native-only `app-updater` module into each feature's tsconfig program — whose ambient declaration lives in the app shell, not the feature — so **every feature's standalone typecheck failed** with `Cannot find module 'app-updater'`. It surfaced on the first feature PR since `dc4b97f` (drive #32).

**Fix 1 — sentry.ts:** convert the top-level import to a lazy `require` inside `sentryReleaseAndDist()`, typed against a minimal inline interface. The helper only runs on native (where the module exists), so OTA release/dist attribution is unchanged; the compile-time coupling is gone.

**Fix 2 — vitest.config.ts:** add `core/**` to the app shell's test `include`. core is nested in the `tinycld` member and `tinycld-pkg --all` only discovers workspace-root dirs, so **core's tests never ran in `--all`/`pkg:check`** — which is why the sentry regression landed uncaught. Features inherit this config but set their own `root`, so the glob matches nothing in a feature run (verified: no leak, no double-run); it only picks up files when the run's root is the app shell.

**Verified:** app shell typecheck clean; app shell test run 18 → 85 files / 523 tests (core now included, incl. the `app-updater`-mocking `report-reverted`); calc/drive gain 0 core tests; `--all` runs core exactly once, 0 failures; drive's full `tinycld-pkg check` now passes.

Should land before/with drive #32 — drive CI clones core fresh from this repo's `main`.