### PR TITLE
fix(setup): admin org creation fails with 400 on first boot

### DIFF
--- a/core/components/setup/OrganizationsTab.tsx
+++ b/core/components/setup/OrganizationsTab.tsx
@@ -423,6 +423,8 @@ function OrgExpandedDetails({ isVisible, org }: { isVisible: boolean; org: OrgEn
                                 label="Email"
                                 keyboardType="email-address"
                                 autoCapitalize="none"
+                                autoComplete="email"
+                                textContentType="emailAddress"
                             />
                         </View>
                         <View className="flex-1 min-w-[200px]">
@@ -432,6 +434,8 @@ function OrgExpandedDetails({ isVisible, org }: { isVisible: boolean; org: OrgEn
                                 label="New Password"
                                 placeholder="Leave blank to keep current"
                                 secureTextEntry
+                                autoComplete="new-password"
+                                textContentType="newPassword"
                             />
                         </View>
                     </View>
@@ -618,6 +622,8 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                                 placeholder="owner@example.com"
                                 keyboardType="email-address"
                                 autoCapitalize="none"
+                                autoComplete="email"
+                                textContentType="emailAddress"
                             />
                         </View>
                         <View className="flex-1 min-w-[200px]">
@@ -627,6 +633,8 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                                 label="Username"
                                 placeholder="jane"
                                 autoCapitalize="none"
+                                autoComplete="username"
+                                textContentType="username"
                                 hint="Must be unique — suggested from the email"
                             />
                         </View>
@@ -637,6 +645,8 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                                 label="Password"
                                 placeholder="At least 8 characters"
                                 secureTextEntry
+                                autoComplete="new-password"
+                                textContentType="newPassword"
                             />
                         </View>
                     </View>

--- a/core/components/setup/SetupDashboard.tsx
+++ b/core/components/setup/SetupDashboard.tsx
@@ -73,7 +73,7 @@ function SetupRail({
     const railText = useThemeColor('rail-text')
 
     return (
-        <View className="w-60 py-6 px-3 gap-1" style={{ backgroundColor: railBg }}>
+        <View className="w-60 h-full py-6 px-3 gap-1" style={{ backgroundColor: railBg }}>
             <View className="flex-row items-center gap-3 px-3 pb-5">
                 <View className="w-9 h-9 rounded-xl items-center justify-center bg-primary">
                     <Text

--- a/core/components/setup/SetupWizard.tsx
+++ b/core/components/setup/SetupWizard.tsx
@@ -142,6 +142,8 @@ export function SetupWizard({ token }: SetupWizardProps) {
                     placeholder="admin@example.com"
                     keyboardType="email-address"
                     autoCapitalize="none"
+                    autoComplete="email"
+                    textContentType="emailAddress"
                 />
 
                 <TextInput
@@ -150,6 +152,8 @@ export function SetupWizard({ token }: SetupWizardProps) {
                     label="Password"
                     placeholder="At least 10 characters"
                     secureTextEntry
+                    autoComplete="new-password"
+                    textContentType="newPassword"
                 />
 
                 <TextInput
@@ -158,6 +162,8 @@ export function SetupWizard({ token }: SetupWizardProps) {
                     label="Confirm Password"
                     placeholder="Repeat password"
                     secureTextEntry
+                    autoComplete="new-password"
+                    textContentType="newPassword"
                 />
 
                 <TextInput

--- a/core/components/setup/SetupWizard.tsx
+++ b/core/components/setup/SetupWizard.tsx
@@ -1,8 +1,8 @@
 import { PB_SERVER_ADDR } from '@tinycld/core/lib/config'
+import { pb as appPb } from '@tinycld/core/lib/pocketbase'
 import { getResolvedAddress } from '@tinycld/core/lib/server-address'
 import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
-import PocketBase from 'pocketbase'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { Platform, Pressable, ScrollView, Text, View } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SetupDashboard } from './SetupDashboard'
@@ -25,11 +25,12 @@ interface SetupWizardProps {
 }
 
 export function SetupWizard({ token }: SetupWizardProps) {
-    const pbRef = useRef<PocketBase | null>(null)
-    if (!pbRef.current) {
-        pbRef.current = new PocketBase(PB_SERVER_ADDR)
-    }
-    const pb = pbRef.current
+    // Drive the dashboard with the shared app pb client (the one pbtsdb stores
+    // write through), not a throwaway instance. /api/setup/init returns a token
+    // minted from the operator's `users` record + super_admins grant; saving it
+    // here authorizes every store write (incl. setting `verified` on a new org
+    // owner) as the super-admin app user.
+    const pb = appPb
 
     const [isComplete, setIsComplete] = useState(false)
     const [submitError, setSubmitError] = useState<string | null>(null)
@@ -81,10 +82,10 @@ export function SetupWizard({ token }: SetupWizardProps) {
                 return
             }
             pb.authStore.save(result.authToken, {
-                id: '',
+                id: result.userId,
                 email: result.email,
-                collectionId: '_superusers',
-                collectionName: '_superusers',
+                collectionId: '_pb_users_auth_',
+                collectionName: 'users',
             })
             setIsComplete(true)
         } catch (err) {

--- a/core/lib/use-superuser-pb.ts
+++ b/core/lib/use-superuser-pb.ts
@@ -1,4 +1,5 @@
 import { PB_SERVER_ADDR } from '@tinycld/core/lib/config'
+import { pb as appPb } from '@tinycld/core/lib/pocketbase'
 import PocketBase from 'pocketbase'
 import { useCallback, useRef, useState } from 'react'
 
@@ -19,6 +20,13 @@ export function useSuperUserPB() {
             setIsLoading(true)
             try {
                 await pb.collection('_superusers').authWithPassword(email, password)
+                // Mirror the superuser token onto the shared app pb client so the
+                // pbtsdb stores the console writes through carry it. Without this
+                // the stores stay anonymous and managed-field writes (e.g. setting
+                // `verified` on a new org owner) fail the users manageRule with a
+                // 400. PB superusers bypass that rule, so the mirrored token
+                // authorizes the create.
+                appPb.authStore.save(pb.authStore.token, pb.authStore.record)
                 setIsAuthenticated(true)
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'Authentication failed'

--- a/core/server/coreserver/setup_bootstrap.go
+++ b/core/server/coreserver/setup_bootstrap.go
@@ -73,11 +73,11 @@ func RegisterSetupBootstrap(app *pocketbase.PocketBase) {
 }
 
 type setupInitRequest struct {
-	Token   string `json:"token"`
-	AppName string `json:"appName"`
-	Email   string `json:"email"`
+	Token    string `json:"token"`
+	AppName  string `json:"appName"`
+	Email    string `json:"email"`
 	Password string `json:"password"`
-	AppURL  string `json:"appUrl"`
+	AppURL   string `json:"appUrl"`
 }
 
 func handleSetupInit(app *pocketbase.PocketBase, re *core.RequestEvent) error {
@@ -119,21 +119,40 @@ func handleSetupInit(app *pocketbase.PocketBase, re *core.RequestEvent) error {
 		})
 	}
 
-	collection, err := app.FindCollectionByNameOrId("_superusers")
+	// Bootstrap two identities for the first operator:
+	//   1. a PocketBase _superusers record — keeps PB's installer satisfied (so
+	//      the setup token isn't re-printed on every reboot), backs the sharelink
+	//      signing key, and remains a recovery login.
+	//   2. a regular `users` record promoted via a `super_admins` row — this is
+	//      the identity the /admin console actually runs as. The console writes
+	//      through the app's pbtsdb stores (the shared app pb client), and those
+	//      writes must carry an auth that satisfies the users `manageRule`
+	//      (@collection.super_admins...) to set managed fields like `verified`
+	//      when creating a pre-verified org owner. A raw _superusers token on a
+	//      throwaway client never reached those stores, which is why org creation
+	//      failed with a 400 on `verified`. We therefore mint the returned auth
+	//      token from the `users` record and the client saves it onto the shared
+	//      pb instance.
+	superusers, err := app.FindCollectionByNameOrId("_superusers")
 	if err != nil {
 		return re.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to find superusers collection.",
 		})
 	}
-
-	record := core.NewRecord(collection)
-	record.SetEmail(req.Email)
-	record.SetPassword(req.Password)
-	record.SetVerified(true)
-
-	if err := app.Save(record); err != nil {
+	superuser := core.NewRecord(superusers)
+	superuser.SetEmail(req.Email)
+	superuser.SetPassword(req.Password)
+	superuser.SetVerified(true)
+	if err := app.Save(superuser); err != nil {
 		return re.JSON(http.StatusInternalServerError, map[string]string{
 			"error": fmt.Sprintf("Failed to create superuser: %v", err),
+		})
+	}
+
+	operator, err := createSuperAdminOperator(app, req.Email, req.Password)
+	if err != nil {
+		return re.JSON(http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("Failed to create admin user: %v", err),
 		})
 	}
 
@@ -154,17 +173,57 @@ func handleSetupInit(app *pocketbase.PocketBase, re *core.RequestEvent) error {
 	setupToken = ""
 	setupTokenMu.Unlock()
 
-	authToken, err := record.NewAuthToken()
+	// Mint the token from the `users` operator (not _superusers) so the console
+	// runs as the super-admin app user and store writes are authorized.
+	authToken, err := operator.NewAuthToken()
 	if err != nil {
 		return re.JSON(http.StatusInternalServerError, map[string]string{
-			"error": "Superuser created but failed to generate auth token.",
+			"error": "Admin user created but failed to generate auth token.",
 		})
 	}
 
 	return re.JSON(http.StatusOK, map[string]string{
 		"authToken": authToken,
 		"email":     req.Email,
+		"userId":    operator.Id,
 	})
+}
+
+// createSuperAdminOperator creates the first operator as a regular `users`
+// record and promotes it via a `super_admins` row. Returns the users record so
+// the caller can mint its auth token. The super_admins createRule is null
+// (superuser-only); this runs in the app's Go context, which bypasses record
+// rules, so the insert is authorized without an authenticated superuser.
+func createSuperAdminOperator(app core.App, email, password string) (*core.Record, error) {
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		return nil, fmt.Errorf("find users collection: %w", err)
+	}
+	username := DeriveUsername(email)
+	operator := core.NewRecord(users)
+	operator.SetEmail(email)
+	operator.SetPassword(password)
+	operator.SetVerified(true)
+	operator.Set("emailVisibility", true)
+	// `name` is required and is a human display label; seed it from the email
+	// local-part (the operator can rename themselves later). `username` is the
+	// unique handle, derived by the shared helper.
+	operator.Set("name", strings.SplitN(email, "@", 2)[0])
+	operator.Set("username", username)
+	if err := app.Save(operator); err != nil {
+		return nil, fmt.Errorf("create users record: %w", err)
+	}
+
+	superAdmins, err := app.FindCollectionByNameOrId("super_admins")
+	if err != nil {
+		return nil, fmt.Errorf("find super_admins collection: %w", err)
+	}
+	grant := core.NewRecord(superAdmins)
+	grant.Set("user", operator.Id)
+	if err := app.Save(grant); err != nil {
+		return nil, fmt.Errorf("create super_admins grant: %w", err)
+	}
+	return operator, nil
 }
 
 func generateToken(bytes int) (string, error) {

--- a/core/server/coreserver/setup_bootstrap_test.go
+++ b/core/server/coreserver/setup_bootstrap_test.go
@@ -1,0 +1,55 @@
+package coreserver
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// The first operator must end up as a regular `users` record promoted via a
+// super_admins row — that is the identity the /admin console runs as, and the
+// one whose token authorizes managed-field writes (e.g. setting `verified` on a
+// new org owner). A raw _superusers token on a throwaway client was the original
+// org-create 400. This locks the bootstrap's user/grant creation at the server
+// layer; the full first-boot → create-org flow is covered by the
+// setup-and-packages install spec.
+func TestCreateSuperAdminOperator(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	createSuperAdminsCollection(t, app, users.Id)
+
+	operator, err := createSuperAdminOperator(app, "operator@example.com", "BootstrapPass1234!")
+	if err != nil {
+		t.Fatalf("createSuperAdminOperator returned error: %v", err)
+	}
+
+	if !operator.Verified() {
+		t.Error("operator should be pre-verified so they can sign in immediately")
+	}
+	if operator.GetString("username") == "" {
+		t.Error("operator must have a username (the field is required)")
+	}
+	if operator.GetString("name") == "" {
+		t.Error("operator must have a name (the field is required)")
+	}
+	if !isSuperAdmin(app, operator.Id) {
+		t.Error("operator must be a super admin (super_admins row should exist)")
+	}
+
+	// The minted auth token must carry the users identity, not _superusers — that
+	// is what lets the console's shared pb client satisfy the users manageRule.
+	if _, err := operator.NewAuthToken(); err != nil {
+		t.Fatalf("operator auth token mint failed: %v", err)
+	}
+	if operator.Collection().Name != "users" {
+		t.Errorf("operator should be a users record, got %q", operator.Collection().Name)
+	}
+}

--- a/core/ui/form/TextInput.tsx
+++ b/core/ui/form/TextInput.tsx
@@ -80,6 +80,11 @@ export function TextInput<T extends FieldValues = Record<string, unknown>>(
                     autoFocus={inputProps.autoFocus}
                     keyboardType={inputProps.keyboardType}
                     autoCapitalize={inputProps.autoCapitalize}
+                    // Forward autofill hints so the browser/keychain treats each
+                    // field correctly. Without these, password managers fall back
+                    // to heuristics and can fill a password field with the email.
+                    autoComplete={inputProps.autoComplete}
+                    textContentType={inputProps.textContentType}
                     secureTextEntry={inputProps.secureTextEntry}
                     placeholderTextColor={placeholderColor}
                     className={`flex-1 border rounded-lg px-3 py-2.5 text-base text-foreground bg-background ${hasError ? 'border-danger' : 'border-border'}`}

--- a/core/ui/form/__tests__/text-input-autofill.test.tsx
+++ b/core/ui/form/__tests__/text-input-autofill.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { useForm } from 'react-hook-form'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { TextInput } from '../TextInput'
+
+// Regression guard for the admin org-create bug: Safari autofilled the password
+// field with the account email because TextInput silently dropped the
+// `autoComplete`/`textContentType` autofill hints (it cherry-picked a fixed
+// prop allowlist instead of forwarding them). With the hints forwarded, the
+// browser/keychain treats each field correctly.
+function Harness(props: { autoComplete?: string; textContentType?: string }) {
+    const { control } = useForm({ defaultValues: { field: '' } })
+    return <TextInput control={control} name="field" label="Field" {...props} />
+}
+
+afterEach(cleanup)
+
+describe('TextInput autofill hints', () => {
+    it('forwards autoComplete to the underlying input', () => {
+        const { container } = render(<Harness autoComplete="new-password" />)
+        const input = container.querySelector('textinput')
+        expect(input?.getAttribute('autoComplete')).toBe('new-password')
+    })
+
+    it('forwards textContentType to the underlying input', () => {
+        const { container } = render(<Harness textContentType="newPassword" />)
+        const input = container.querySelector('textinput')
+        expect(input?.getAttribute('textContentType')).toBe('newPassword')
+    })
+})

--- a/core/ui/form/__tests__/text-input-autofill.test.tsx
+++ b/core/ui/form/__tests__/text-input-autofill.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { cleanup, render } from '@testing-library/react'
 import { useForm } from 'react-hook-form'
+import type { TextInputProps as RNTextInputProps } from 'react-native'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { TextInput } from '../TextInput'
@@ -10,7 +11,10 @@ import { TextInput } from '../TextInput'
 // `autoComplete`/`textContentType` autofill hints (it cherry-picked a fixed
 // prop allowlist instead of forwarding them). With the hints forwarded, the
 // browser/keychain treats each field correctly.
-function Harness(props: { autoComplete?: string; textContentType?: string }) {
+// Use RN's own prop types so the test matches what TextInput forwards (its
+// `autoComplete` is a narrow union, not `string`) — otherwise the harness fails
+// to typecheck under CI's stricter tsc.
+function Harness(props: Pick<RNTextInputProps, 'autoComplete' | 'textContentType'>) {
     const { control } = useForm({ defaultValues: { field: '' } })
     return <TextInput control={control} name="field" label="Field" {...props} />
 }

--- a/tests/install/setup-and-packages.spec.ts
+++ b/tests/install/setup-and-packages.spec.ts
@@ -112,9 +112,16 @@ test.describe('first-run install', () => {
         // Switch to the Organizations section via the nav rail.
         await page.getByText('Organizations', { exact: true }).first().click()
 
-        // Regression test for "Failed to create record. The username field
-        // is required." — the form previously omitted username on the user
-        // create, which is now derived from the email.
+        // Regression test for two org-create failures:
+        //   1. "The username field is required." — the form once omitted
+        //      username (now derived from the email).
+        //   2. A 400 on `verified` ("Values don't match.") — the console wrote
+        //      through an UNAUTHENTICATED app pb client, so setting the managed
+        //      `verified` field on the new owner failed the users manageRule.
+        //      The bootstrap now makes the operator a super_admin app user and
+        //      the console's shared pb client carries that token, authorizing
+        //      the managed-field write. The owner-login step below proves the
+        //      account is actually usable (not just that a row appeared).
         await page.getByRole('button', { name: 'New organization' }).click()
 
         // The create form groups fields under Organization / Owner account
@@ -143,6 +150,22 @@ test.describe('first-run install', () => {
         await expect(page.getByText(TEST_ORG_NAME, { exact: true })).toBeVisible()
         await expect(page.getByText(TEST_ORG_SLUG, { exact: true })).toBeVisible()
         await expect(page.getByText(TEST_ORG_OWNER_EMAIL, { exact: true })).toBeVisible()
+
+        // The owner must be able to sign in with the password just entered —
+        // proves the account is usable, not merely that a row appeared. (The
+        // `verified` 400 regression created no owner at all; a password=email
+        // mix-up would create one that can't log in.) Use a fresh page so the
+        // admin session stays intact for the next serial test.
+        const ownerPage = await page.context().newPage()
+        try {
+            await ownerPage.goto('/')
+            await ownerPage.getByTestId('identifier').fill(TEST_ORG_OWNER_EMAIL)
+            await ownerPage.getByTestId('login-password').fill(TEST_ORG_OWNER_PASSWORD)
+            await ownerPage.getByTestId('login-submit').click()
+            await ownerPage.waitForURL(/\/a\//, { timeout: 30_000 })
+        } finally {
+            await ownerPage.close()
+        }
     })
 
     test('superuser can grant another user super admin', async ({ page }) => {


### PR DESCRIPTION
## Bug

On a fresh deployment, the operator bootstraps via the `/admin` wizard, then creating an organization fails: `POST /api/collections/users/records` → **400**.

## Root cause

The `/admin` console writes through the **shared app `pb` client** (the one the pbtsdb `useStore(...)` collections use). But the superuser token was only ever saved onto a **throwaway `PocketBase` instance** spun up in `SetupWizard` / `useSuperUserPB` — never onto that shared client. So the stores stayed anonymous, and setting the managed `verified` field on the new org owner failed the users `manageRule`:

```json
{"data":{"verified":{"code":"validation_values_mismatch","message":"Values don't match."}},"status":400}
```

Reproduced in a real browser via `setup-and-packages.spec.ts` and confirmed against the live server: the same create payload **fails unauthenticated** but **succeeds with a superuser/super-admin token**.

> Note: the original report's screenshot showed `password = email` in the body — that was browser autofill, a *separate* cosmetic issue, not the cause of the 400. The create fails on `verified` even with a correct password.

## Fix

- **Bootstrap** (`setup_bootstrap.go`): in addition to the `_superusers` row (kept for PB's installer, the sharelink signing key, and recovery), create a regular `users` record + a `super_admins` grant for the first operator, and mint the returned auth token from that **users** record.
- **SetupWizard**: save the token onto the **shared `appPb`** (not a throwaway client), so the console runs as the super-admin app user and every store write is authorized.
- **useSuperUserPB**: mirror a `_superusers` login onto `appPb` for the fallback login path.

The server's `requireAdmin` and the collection rules already admit app super-admins, so this aligns the client auth with the access model the server was already built for.

### Secondary improvements (same area)
- Forward `autoComplete` / `textContentType` through `TextInput` and set proper hints on the setup forms (`new-password` etc.) — fixes the browser autofill that put the email in the password field.
- Stretch the setup rail to `h-full` (the layout bug in the report).

## Tests
- `setup-and-packages.spec.ts`: strengthened the org-create test to assert the **owner can actually log in** (proves the account is usable, not just that a row appeared). Full first-boot flow (bootstrap → list packages → create org → owner login → grant) passes against a freshly built image.
- New Go unit test for the bootstrap user/grant creation.
- `TextInput` unit test for the forwarded autofill hints.