### PR TITLE
feat: system settings — move service config (Sentry, VAPID, mail) out of env vars into /admin

### DIFF
--- a/core/components/setup/SettingsTab.tsx
+++ b/core/components/setup/SettingsTab.tsx
@@ -1,9 +1,11 @@
+import { PB_SERVER_ADDR } from '@tinycld/core/lib/config'
 import { packageSystemSettings } from '@tinycld/core/lib/packages/derive-components'
+import { pb as appPb } from '@tinycld/core/lib/pocketbase'
 import { Button, ButtonText } from '@tinycld/core/ui/button'
 import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
-import { type ReactNode, Suspense } from 'react'
+import { type ReactNode, Suspense, useState } from 'react'
 import type { Control, FieldValues, Path } from 'react-hook-form'
-import { ActivityIndicator, Text, View } from 'react-native'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { PageHeader, SectionLabel } from './console-ui'
 import { type SettingRow, useSystemSettings } from './system-settings-store'
 
@@ -93,41 +95,133 @@ function SentrySettings() {
 
 const vapidSchema = z.object({
     publicKey: z.string(),
-    // A secret field: blank means "leave the stored value unchanged" (write-only),
-    // so it's always optional in the form.
+    // A secret field: blank means "leave the stored value unchanged" (write-only).
     privateKey: z.string(),
     subject: z.union([z.string().url('Use a URL or mailto: URI'), z.literal('')]),
 })
 
+// The operator never needs to READ the VAPID keys: the server signs with the
+// private key and the browser receives the public key through the push-subscribe
+// flow. So the common path is one click — generate AND persist server-side, with
+// the private key never reaching the client. Pasting an existing pair (migration
+// from another deployment) stays available behind a disclosure.
 function VapidSettings() {
     const { byKey, upsert } = useSystemSettings()
     const publicKey = byKey.get('vapid.public_key')
     const privateKey = byKey.get('vapid.private_key')
     const subject = byKey.get('vapid.subject')
+    const configured = Boolean(publicKey?.value && privateKey?.value)
 
+    const [generateError, setGenerateError] = useState<string | null>(null)
+    const [isGenerating, setIsGenerating] = useState(false)
+    const [showPaste, setShowPaste] = useState(false)
+
+    // Generate + persist in one action. The endpoint writes both keys server-side
+    // and returns only the public key; the live query refreshes the status below.
+    // Replacing the keys invalidates existing browser push subscriptions, so this
+    // is a deliberate action.
+    const generate = async () => {
+        setGenerateError(null)
+        setIsGenerating(true)
+        try {
+            const res = await fetch(`${PB_SERVER_ADDR}/api/admin/vapid/generate`, {
+                method: 'POST',
+                headers: { Authorization: appPb.authStore.token },
+            })
+            if (!res.ok) {
+                const data = (await res.json().catch(() => ({}))) as { error?: string }
+                throw new Error(data.error ?? 'Failed to generate keys')
+            }
+        } catch (err) {
+            setGenerateError(err instanceof Error ? err.message : 'Failed to generate keys')
+        } finally {
+            setIsGenerating(false)
+        }
+    }
+
+    return (
+        <Panel label="Web push (VAPID)">
+            <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
+                The keypair browser push notifications are signed with. Generating replaces any
+                existing keys and invalidates current push subscriptions.
+            </Text>
+            <View className="flex-row items-center gap-2">
+                <Text
+                    style={{ fontSize: 13 }}
+                    className={configured ? 'text-success' : 'text-muted-foreground'}
+                >
+                    {configured ? 'Configured ✓' : 'Not configured'}
+                </Text>
+            </View>
+            {generateError && (
+                <View className="rounded-lg p-2 bg-danger-soft">
+                    <Text className="text-xs text-danger">{generateError}</Text>
+                </View>
+            )}
+            <View className="flex-row">
+                <Button
+                    testID="vapid-generate"
+                    onPress={generate}
+                    size="sm"
+                    isDisabled={isGenerating}
+                >
+                    <ButtonText>
+                        {isGenerating
+                            ? 'Generating…'
+                            : configured
+                              ? 'Regenerate keypair'
+                              : 'Generate keypair'}
+                    </ButtonText>
+                </Button>
+            </View>
+
+            <Pressable onPress={() => setShowPaste(v => !v)} accessibilityRole="button">
+                <Text className="text-muted-foreground" style={{ fontSize: 12.5 }}>
+                    {showPaste ? '▾' : '▸'} Use existing keys (migrate from another deployment)
+                </Text>
+            </Pressable>
+            <VapidPaste
+                isVisible={showPaste}
+                upsert={upsert}
+                privateKey={privateKey}
+                subject={subject}
+            />
+        </Panel>
+    )
+}
+
+// VapidPaste is the bring-your-own escape hatch: paste a pre-existing keypair
+// (e.g. when migrating off the old env-var deployment so existing push
+// subscriptions keep working). Same write-only treatment for the private key.
+function VapidPaste({
+    isVisible,
+    upsert,
+    privateKey,
+    subject,
+}: {
+    isVisible: boolean
+    upsert: ReturnType<typeof useSystemSettings>['upsert']
+    privateKey: SettingRow | undefined
+    subject: SettingRow | undefined
+}) {
     const {
         control,
         handleSubmit,
         formState: { errors, isSubmitting, isSubmitted },
     } = useForm({
         resolver: zodResolver(vapidSchema),
-        // The secret privateKey is NEVER seeded into the form — see SecretField.
-        values: {
-            publicKey: publicKey?.value ?? '',
-            privateKey: '',
-            subject: subject?.value ?? '',
-        },
+        values: { publicKey: '', privateKey: '', subject: subject?.value ?? '' },
         mode: 'onChange',
     })
 
     const onSubmit = handleSubmit(async data => {
-        await upsert.mutateAsync({
-            key: 'vapid.public_key',
-            value: data.publicKey,
-            isSecret: false,
-        })
-        // Write-only secret: only persist a non-empty private key, so saving the
-        // form without re-entering it leaves the stored key untouched.
+        if (data.publicKey.trim() !== '') {
+            await upsert.mutateAsync({
+                key: 'vapid.public_key',
+                value: data.publicKey,
+                isSecret: false,
+            })
+        }
         if (data.privateKey.trim() !== '') {
             await upsert.mutateAsync({
                 key: 'vapid.private_key',
@@ -138,19 +232,17 @@ function VapidSettings() {
         await upsert.mutateAsync({ key: 'vapid.subject', value: data.subject, isSecret: false })
     })
 
+    if (!isVisible) return null
+
     return (
-        <Panel label="Web push (VAPID)">
-            <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
-                The VAPID keypair browser push notifications are signed with. Generate a pair once
-                per deployment; the private key is stored write-only.
-            </Text>
+        <View className="gap-3 pt-1">
             <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
             <TextInput
                 control={control}
                 name="publicKey"
                 label="Public key"
                 autoCapitalize="none"
-                hint="Public value — shipped to the browser to subscribe."
+                hint="Leave blank to keep the current public key."
             />
             <SecretField
                 control={control}
@@ -171,7 +263,7 @@ function VapidSettings() {
                 isPending={upsert.isPending}
                 isDisabled={isSubmitting}
             />
-        </Panel>
+        </View>
     )
 }
 

--- a/core/components/setup/SettingsTab.tsx
+++ b/core/components/setup/SettingsTab.tsx
@@ -7,7 +7,13 @@ import { type ReactNode, Suspense, useState } from 'react'
 import type { Control, FieldValues, Path } from 'react-hook-form'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { PageHeader, SectionLabel } from './console-ui'
-import { type SettingRow, useSystemSettings } from './system-settings-store'
+import {
+    type SettingRow,
+    sentryDsnSchema,
+    shouldPersistSecret,
+    vapidSubjectSchema,
+} from './system-settings-logic'
+import { useSystemSettings } from './system-settings-store'
 
 export function SettingsTab({ isVisible }: { isVisible: boolean }) {
     if (!isVisible) return null
@@ -33,11 +39,7 @@ function Panel({ label, children }: { label: string; children: ReactNode }) {
     )
 }
 
-const sentrySchema = z.object({
-    // Empty clears the DSN (disables error reporting). Otherwise require a URL so
-    // a typo'd value surfaces before it silently drops events.
-    dsn: z.union([z.string().url('Enter a valid Sentry DSN URL'), z.literal('')]),
-})
+const sentrySchema = z.object({ dsn: sentryDsnSchema })
 
 function SentrySettings() {
     const { byKey, upsert } = useSystemSettings()
@@ -97,7 +99,7 @@ const vapidSchema = z.object({
     publicKey: z.string(),
     // A secret field: blank means "leave the stored value unchanged" (write-only).
     privateKey: z.string(),
-    subject: z.union([z.string().url('Use a URL or mailto: URI'), z.literal('')]),
+    subject: vapidSubjectSchema,
 })
 
 // The operator never needs to READ the VAPID keys: the server signs with the
@@ -222,7 +224,7 @@ function VapidPaste({
                 isSecret: false,
             })
         }
-        if (data.privateKey.trim() !== '') {
+        if (shouldPersistSecret(data.privateKey)) {
             await upsert.mutateAsync({
                 key: 'vapid.private_key',
                 value: data.privateKey,

--- a/core/components/setup/SettingsTab.tsx
+++ b/core/components/setup/SettingsTab.tsx
@@ -1,0 +1,143 @@
+import { eq } from '@tanstack/db'
+import { useLiveQuery } from '@tanstack/react-db'
+import { mutation, useMutation } from '@tinycld/core/lib/mutations'
+import { packageSystemSettings } from '@tinycld/core/lib/packages/derive-components'
+import { useStore } from '@tinycld/core/lib/pocketbase'
+import { Button, ButtonText } from '@tinycld/core/ui/button'
+import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
+import { newRecordId } from 'pbtsdb/core'
+import { Suspense } from 'react'
+import { ActivityIndicator, Text, View } from 'react-native'
+import { PageHeader, SectionLabel } from './console-ui'
+
+export function SettingsTab({ isVisible }: { isVisible: boolean }) {
+    if (!isVisible) return null
+    return (
+        <View className="gap-6">
+            <PageHeader
+                title="Settings"
+                subtitle="System-wide configuration for this deployment. These apply to the entire system, not a single organization."
+            />
+            <SentrySettings />
+            <PackageSettings />
+        </View>
+    )
+}
+
+const SENTRY_DSN_KEY = 'sentry.dsn'
+
+const sentrySchema = z.object({
+    // Empty clears the DSN (disables error reporting). Otherwise require a URL so
+    // a typo'd value surfaces before it silently drops events.
+    dsn: z.union([z.string().url('Enter a valid Sentry DSN URL'), z.literal('')]),
+})
+
+function SentrySettings() {
+    const [systemSettings] = useStore('system_settings')
+
+    const { data: rows = [] } = useLiveQuery(query =>
+        query.from({ s: systemSettings }).where(({ s }) => eq(s.key, SENTRY_DSN_KEY))
+    )
+    const existing = rows[0]
+
+    const {
+        control,
+        handleSubmit,
+        setError,
+        formState: { errors, isSubmitting, isSubmitted, isDirty },
+    } = useForm({
+        resolver: zodResolver(sentrySchema),
+        // `values` (not defaultValues) so the field reactively re-syncs when the
+        // stored DSN loads async or changes server-side — RHF resets to it while
+        // leaving a user's in-progress edit dirty. Avoids a useEffect+reset sync.
+        values: { dsn: existing?.value ?? '' },
+        mode: 'onChange',
+    })
+
+    const save = useMutation({
+        mutationFn: mutation(function* (data: z.infer<typeof sentrySchema>) {
+            if (existing) {
+                yield systemSettings.update(existing.id, draft => {
+                    draft.value = data.dsn
+                })
+            } else {
+                yield systemSettings.insert({
+                    id: newRecordId(),
+                    key: SENTRY_DSN_KEY,
+                    value: data.dsn,
+                    is_secret: false,
+                } as never)
+            }
+        }),
+        onError: err =>
+            setError('dsn', {
+                message: err instanceof Error ? err.message : 'Failed to save',
+            }),
+    })
+
+    const onSubmit = handleSubmit(data => save.mutate(data))
+
+    return (
+        <View className="gap-4 p-5 rounded-2xl bg-surface-secondary border border-border">
+            <SectionLabel>Error reporting (Sentry)</SectionLabel>
+            <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
+                The DSN errors are reported to. Leave blank to disable. Web clients pick up a change
+                on their next load; native apps on their next build.
+            </Text>
+            <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
+            <TextInput
+                control={control}
+                name="dsn"
+                label="Sentry DSN"
+                placeholder="https://…@…ingest.sentry.io/…"
+                autoCapitalize="none"
+                hint="Public value — safe to expose in the web client."
+            />
+            <View className="flex-row justify-end">
+                <Button
+                    testID="sentry-dsn-save"
+                    onPress={onSubmit}
+                    size="sm"
+                    isDisabled={isSubmitting || !isDirty}
+                >
+                    <ButtonText>{save.isPending ? 'Saving…' : 'Save'}</ButtonText>
+                </Button>
+            </View>
+        </View>
+    )
+}
+
+// Panels contributed by installed packages via their manifest `systemSettings`
+// (e.g. mail's provider credentials). Each is a lazy component; render it in
+// Suspense, grouped under its package name. Empty when no package contributes one.
+function PackageSettings() {
+    if (packageSystemSettings.length === 0) return null
+    return (
+        <>
+            {packageSystemSettings.map(group =>
+                group.panels.map(panel => {
+                    const Panel = panel.Component
+                    return (
+                        <View
+                            key={`${group.pkgSlug}:${panel.slug}`}
+                            className="gap-4 p-5 rounded-2xl bg-surface-secondary border border-border"
+                        >
+                            <SectionLabel>
+                                {group.packageName} — {panel.label}
+                            </SectionLabel>
+                            <Suspense
+                                fallback={
+                                    <View className="py-6 items-center">
+                                        <ActivityIndicator />
+                                    </View>
+                                }
+                            >
+                                <Panel />
+                            </Suspense>
+                        </View>
+                    )
+                })
+            )}
+        </>
+    )
+}

--- a/core/components/setup/SettingsTab.tsx
+++ b/core/components/setup/SettingsTab.tsx
@@ -1,14 +1,11 @@
-import { eq } from '@tanstack/db'
-import { useLiveQuery } from '@tanstack/react-db'
-import { mutation, useMutation } from '@tinycld/core/lib/mutations'
 import { packageSystemSettings } from '@tinycld/core/lib/packages/derive-components'
-import { useStore } from '@tinycld/core/lib/pocketbase'
 import { Button, ButtonText } from '@tinycld/core/ui/button'
 import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
-import { newRecordId } from 'pbtsdb/core'
-import { Suspense } from 'react'
+import { type ReactNode, Suspense } from 'react'
+import type { Control, FieldValues, Path } from 'react-hook-form'
 import { ActivityIndicator, Text, View } from 'react-native'
 import { PageHeader, SectionLabel } from './console-ui'
+import { type SettingRow, useSystemSettings } from './system-settings-store'
 
 export function SettingsTab({ isVisible }: { isVisible: boolean }) {
     if (!isVisible) return null
@@ -19,12 +16,20 @@ export function SettingsTab({ isVisible }: { isVisible: boolean }) {
                 subtitle="System-wide configuration for this deployment. These apply to the entire system, not a single organization."
             />
             <SentrySettings />
+            <VapidSettings />
             <PackageSettings />
         </View>
     )
 }
 
-const SENTRY_DSN_KEY = 'sentry.dsn'
+function Panel({ label, children }: { label: string; children: ReactNode }) {
+    return (
+        <View className="gap-4 p-5 rounded-2xl bg-surface-secondary border border-border">
+            <SectionLabel>{label}</SectionLabel>
+            {children}
+        </View>
+    )
+}
 
 const sentrySchema = z.object({
     // Empty clears the DSN (disables error reporting). Otherwise require a URL so
@@ -33,12 +38,8 @@ const sentrySchema = z.object({
 })
 
 function SentrySettings() {
-    const [systemSettings] = useStore('system_settings')
-
-    const { data: rows = [] } = useLiveQuery(query =>
-        query.from({ s: systemSettings }).where(({ s }) => eq(s.key, SENTRY_DSN_KEY))
-    )
-    const existing = rows[0]
+    const { byKey, upsert } = useSystemSettings()
+    const existing = byKey.get('sentry.dsn')
 
     const {
         control,
@@ -48,38 +49,25 @@ function SentrySettings() {
     } = useForm({
         resolver: zodResolver(sentrySchema),
         // `values` (not defaultValues) so the field reactively re-syncs when the
-        // stored DSN loads async or changes server-side — RHF resets to it while
-        // leaving a user's in-progress edit dirty. Avoids a useEffect+reset sync.
+        // stored DSN loads async or changes server-side. Avoids a useEffect+reset.
         values: { dsn: existing?.value ?? '' },
         mode: 'onChange',
     })
 
-    const save = useMutation({
-        mutationFn: mutation(function* (data: z.infer<typeof sentrySchema>) {
-            if (existing) {
-                yield systemSettings.update(existing.id, draft => {
-                    draft.value = data.dsn
-                })
-            } else {
-                yield systemSettings.insert({
-                    id: newRecordId(),
-                    key: SENTRY_DSN_KEY,
-                    value: data.dsn,
-                    is_secret: false,
-                } as never)
+    const onSubmit = handleSubmit(data =>
+        upsert.mutate(
+            { key: 'sentry.dsn', value: data.dsn, isSecret: false },
+            {
+                onError: err =>
+                    setError('dsn', {
+                        message: err instanceof Error ? err.message : 'Failed to save',
+                    }),
             }
-        }),
-        onError: err =>
-            setError('dsn', {
-                message: err instanceof Error ? err.message : 'Failed to save',
-            }),
-    })
-
-    const onSubmit = handleSubmit(data => save.mutate(data))
+        )
+    )
 
     return (
-        <View className="gap-4 p-5 rounded-2xl bg-surface-secondary border border-border">
-            <SectionLabel>Error reporting (Sentry)</SectionLabel>
+        <Panel label="Error reporting (Sentry)">
             <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
                 The DSN errors are reported to. Leave blank to disable. Web clients pick up a change
                 on their next load; native apps on their next build.
@@ -93,16 +81,152 @@ function SentrySettings() {
                 autoCapitalize="none"
                 hint="Public value — safe to expose in the web client."
             />
-            <View className="flex-row justify-end">
-                <Button
-                    testID="sentry-dsn-save"
-                    onPress={onSubmit}
-                    size="sm"
-                    isDisabled={isSubmitting || !isDirty}
-                >
-                    <ButtonText>{save.isPending ? 'Saving…' : 'Save'}</ButtonText>
-                </Button>
-            </View>
+            <SaveRow
+                testID="sentry-dsn-save"
+                onPress={onSubmit}
+                isPending={upsert.isPending}
+                isDisabled={isSubmitting || !isDirty}
+            />
+        </Panel>
+    )
+}
+
+const vapidSchema = z.object({
+    publicKey: z.string(),
+    // A secret field: blank means "leave the stored value unchanged" (write-only),
+    // so it's always optional in the form.
+    privateKey: z.string(),
+    subject: z.union([z.string().url('Use a URL or mailto: URI'), z.literal('')]),
+})
+
+function VapidSettings() {
+    const { byKey, upsert } = useSystemSettings()
+    const publicKey = byKey.get('vapid.public_key')
+    const privateKey = byKey.get('vapid.private_key')
+    const subject = byKey.get('vapid.subject')
+
+    const {
+        control,
+        handleSubmit,
+        formState: { errors, isSubmitting, isSubmitted },
+    } = useForm({
+        resolver: zodResolver(vapidSchema),
+        // The secret privateKey is NEVER seeded into the form — see SecretField.
+        values: {
+            publicKey: publicKey?.value ?? '',
+            privateKey: '',
+            subject: subject?.value ?? '',
+        },
+        mode: 'onChange',
+    })
+
+    const onSubmit = handleSubmit(async data => {
+        await upsert.mutateAsync({
+            key: 'vapid.public_key',
+            value: data.publicKey,
+            isSecret: false,
+        })
+        // Write-only secret: only persist a non-empty private key, so saving the
+        // form without re-entering it leaves the stored key untouched.
+        if (data.privateKey.trim() !== '') {
+            await upsert.mutateAsync({
+                key: 'vapid.private_key',
+                value: data.privateKey,
+                isSecret: true,
+            })
+        }
+        await upsert.mutateAsync({ key: 'vapid.subject', value: data.subject, isSecret: false })
+    })
+
+    return (
+        <Panel label="Web push (VAPID)">
+            <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
+                The VAPID keypair browser push notifications are signed with. Generate a pair once
+                per deployment; the private key is stored write-only.
+            </Text>
+            <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
+            <TextInput
+                control={control}
+                name="publicKey"
+                label="Public key"
+                autoCapitalize="none"
+                hint="Public value — shipped to the browser to subscribe."
+            />
+            <SecretField
+                control={control}
+                name="privateKey"
+                label="Private key"
+                existing={privateKey}
+            />
+            <TextInput
+                control={control}
+                name="subject"
+                label="Subject"
+                placeholder="mailto:admin@example.com"
+                autoCapitalize="none"
+            />
+            <SaveRow
+                testID="vapid-save"
+                onPress={onSubmit}
+                isPending={upsert.isPending}
+                isDisabled={isSubmitting}
+            />
+        </Panel>
+    )
+}
+
+// SecretField renders a write-only input for a secret system setting. It NEVER
+// seeds the stored value into the field (the value would otherwise round-trip
+// through the DOM); instead it shows whether a value is configured and a hint
+// that leaving it blank keeps the current one. Submitting blank means "unchanged"
+// — the caller must skip the write when the field is empty.
+function SecretField<T extends FieldValues>({
+    control,
+    name,
+    label,
+    existing,
+}: {
+    control: Control<T>
+    name: Path<T>
+    label: string
+    existing: SettingRow | undefined
+}) {
+    const configured = Boolean(existing?.value)
+    return (
+        <View className="gap-1.5">
+            <TextInput
+                control={control}
+                name={name}
+                label={label}
+                placeholder={configured ? '•••••••• (configured)' : 'Not set'}
+                secureTextEntry
+                autoCapitalize="none"
+                hint={
+                    configured
+                        ? 'Configured. Enter a new value to replace it; leave blank to keep it.'
+                        : 'Not set.'
+                }
+            />
+        </View>
+    )
+}
+
+function SaveRow({
+    testID,
+    onPress,
+    isPending,
+    isDisabled,
+}: {
+    testID: string
+    onPress: () => void
+    isPending: boolean
+    isDisabled: boolean
+}) {
+    return (
+        <View className="flex-row justify-end">
+            <Button testID={testID} onPress={onPress} size="sm" isDisabled={isDisabled}>
+                <ButtonText>{isPending ? 'Saving…' : 'Save'}</ButtonText>
+            </Button>
         </View>
     )
 }
@@ -116,15 +240,12 @@ function PackageSettings() {
         <>
             {packageSystemSettings.map(group =>
                 group.panels.map(panel => {
-                    const Panel = panel.Component
+                    const PanelComponent = panel.Component
                     return (
-                        <View
+                        <Panel
                             key={`${group.pkgSlug}:${panel.slug}`}
-                            className="gap-4 p-5 rounded-2xl bg-surface-secondary border border-border"
+                            label={`${group.packageName} — ${panel.label}`}
                         >
-                            <SectionLabel>
-                                {group.packageName} — {panel.label}
-                            </SectionLabel>
                             <Suspense
                                 fallback={
                                     <View className="py-6 items-center">
@@ -132,9 +253,9 @@ function PackageSettings() {
                                     </View>
                                 }
                             >
-                                <Panel />
+                                <PanelComponent />
                             </Suspense>
-                        </View>
+                        </Panel>
                     )
                 })
             )}

--- a/core/components/setup/SetupDashboard.tsx
+++ b/core/components/setup/SetupDashboard.tsx
@@ -1,5 +1,12 @@
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
-import { Building2, History, type LucideIcon, Package, ShieldCheck } from 'lucide-react-native'
+import {
+    Building2,
+    History,
+    type LucideIcon,
+    Package,
+    Settings,
+    ShieldCheck,
+} from 'lucide-react-native'
 import type PocketBase from 'pocketbase'
 import { useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
@@ -7,9 +14,10 @@ import { DraxProvider } from 'react-native-drax'
 import { BuildHistoryTab } from './BuildHistoryTab'
 import { OrganizationsTab } from './OrganizationsTab'
 import { PackageManager } from './PackageManager'
+import { SettingsTab } from './SettingsTab'
 import { SuperAdminsTab } from './SuperAdminsTab'
 
-type SetupTab = 'organizations' | 'packages' | 'builds' | 'super-admins'
+type SetupTab = 'organizations' | 'packages' | 'builds' | 'super-admins' | 'settings'
 
 interface NavEntry {
     tab: SetupTab
@@ -25,6 +33,7 @@ const NAV: NavEntry[] = [
     { tab: 'packages', label: 'Packages', crumb: 'packages', Icon: Package },
     { tab: 'builds', label: 'Build History', crumb: 'build history', Icon: History },
     { tab: 'super-admins', label: 'Super Admins', crumb: 'super admins', Icon: ShieldCheck },
+    { tab: 'settings', label: 'Settings', crumb: 'settings', Icon: Settings },
 ]
 
 interface SetupDashboardProps {
@@ -54,6 +63,7 @@ export function SetupDashboard({ pb, defaultTab = 'packages' }: SetupDashboardPr
                             <PackagesTab isVisible={activeTab === 'packages'} pb={pb} />
                             <BuildHistoryTab isVisible={activeTab === 'builds'} pb={pb} />
                             <SuperAdminsTab isVisible={activeTab === 'super-admins'} pb={pb} />
+                            <SettingsTab isVisible={activeTab === 'settings'} />
                         </View>
                     </ScrollView>
                 </View>

--- a/core/components/setup/__tests__/system-settings-logic.test.ts
+++ b/core/components/setup/__tests__/system-settings-logic.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+    rowsToMap,
+    sentryDsnSchema,
+    shouldPersistSecret,
+    vapidSubjectSchema,
+} from '../system-settings-logic'
+
+describe('rowsToMap', () => {
+    it('keys rows by their `key` and carries the secret flag', () => {
+        const m = rowsToMap([
+            { key: 'sentry.dsn', id: 'a', value: 'https://x/1', is_secret: false },
+            { key: 'vapid.private_key', id: 'b', value: 'priv', is_secret: true },
+        ])
+        expect(m.get('sentry.dsn')).toEqual({ id: 'a', value: 'https://x/1', isSecret: false })
+        expect(m.get('vapid.private_key')?.isSecret).toBe(true)
+        expect(m.get('missing')).toBeUndefined()
+    })
+})
+
+describe('shouldPersistSecret', () => {
+    it('persists a non-empty value', () => {
+        expect(shouldPersistSecret('a-real-token')).toBe(true)
+    })
+    it('treats blank / whitespace as "leave unchanged" (write-only)', () => {
+        expect(shouldPersistSecret('')).toBe(false)
+        expect(shouldPersistSecret('   ')).toBe(false)
+    })
+})
+
+describe('sentryDsnSchema', () => {
+    it('accepts a valid URL and blank (blank = disabled)', () => {
+        expect(sentryDsnSchema.safeParse('https://k@o1.ingest.sentry.io/1').success).toBe(true)
+        expect(sentryDsnSchema.safeParse('').success).toBe(true)
+    })
+    it('rejects a non-URL', () => {
+        expect(sentryDsnSchema.safeParse('not-a-url').success).toBe(false)
+    })
+})
+
+describe('vapidSubjectSchema', () => {
+    it('accepts a mailto: URL and blank', () => {
+        expect(vapidSubjectSchema.safeParse('mailto:admin@example.com').success).toBe(true)
+        expect(vapidSubjectSchema.safeParse('').success).toBe(true)
+    })
+    it('rejects a bare string', () => {
+        expect(vapidSubjectSchema.safeParse('admin').success).toBe(false)
+    })
+})

--- a/core/components/setup/system-settings-logic.ts
+++ b/core/components/setup/system-settings-logic.ts
@@ -1,0 +1,40 @@
+import { z } from '@tinycld/core/ui/form'
+
+// Pure, React/pbtsdb-free logic behind the /admin Settings panels, so the
+// field-level rules (upsert decision, write-only secret handling, validation)
+// are unit-testable without rendering or mocking the store.
+
+export interface SettingRow {
+    id: string
+    value: string
+    isSecret: boolean
+}
+
+/** Map a raw system_settings row list to key → SettingRow. */
+export function rowsToMap(
+    rows: ReadonlyArray<{ key: string; id: string; value: string; is_secret: boolean }>
+): Map<string, SettingRow> {
+    return new Map(rows.map(r => [r.key, { id: r.id, value: r.value, isSecret: r.is_secret }]))
+}
+
+/**
+ * Whether a secret field's submitted value should be written. Write-only fields
+ * treat blank as "leave the stored value unchanged" — so we persist only a
+ * non-empty (trimmed) value. Non-secret fields always persist (caller decides).
+ */
+export function shouldPersistSecret(submitted: string): boolean {
+    return submitted.trim() !== ''
+}
+
+// Field schemas (exported for unit tests + reuse). Blank is allowed where it
+// means "disable" (Sentry) or "unchanged" (secret-adjacent), validated as a URL
+// otherwise so a typo surfaces before it silently misbehaves.
+export const sentryDsnSchema = z.union([
+    z.string().url('Enter a valid Sentry DSN URL'),
+    z.literal(''),
+])
+
+export const vapidSubjectSchema = z.union([
+    z.string().url('Use a URL or mailto: URI'),
+    z.literal(''),
+])

--- a/core/components/setup/system-settings-store.ts
+++ b/core/components/setup/system-settings-store.ts
@@ -1,0 +1,47 @@
+import { useLiveQuery } from '@tanstack/react-db'
+import { mutation, useMutation } from '@tinycld/core/lib/mutations'
+import { useStore } from '@tinycld/core/lib/pocketbase'
+import { newRecordId } from 'pbtsdb/core'
+
+export interface SettingRow {
+    id: string
+    value: string
+    isSecret: boolean
+}
+
+/**
+ * Read/write access to the system_settings collection for the /admin Settings
+ * console. Returns a key→row map of everything currently stored and an `upsert`
+ * mutation (update existing row by id, or insert a new one). System-scoped, so a
+ * plain useLiveQuery (not useOrgLiveQuery). The console runs as a super-admin app
+ * user, so the collection rules authorize these writes.
+ */
+export function useSystemSettings() {
+    const [systemSettings] = useStore('system_settings')
+
+    const { data: rows = [] } = useLiveQuery(query => query.from({ s: systemSettings }))
+
+    const byKey = new Map<string, SettingRow>(
+        rows.map(r => [r.key, { id: r.id, value: r.value, isSecret: r.is_secret }])
+    )
+
+    const upsert = useMutation({
+        mutationFn: mutation(function* (input: { key: string; value: string; isSecret: boolean }) {
+            const existing = byKey.get(input.key)
+            if (existing) {
+                yield systemSettings.update(existing.id, draft => {
+                    draft.value = input.value
+                })
+            } else {
+                yield systemSettings.insert({
+                    id: newRecordId(),
+                    key: input.key,
+                    value: input.value,
+                    is_secret: input.isSecret,
+                } as never)
+            }
+        }),
+    })
+
+    return { byKey, upsert }
+}

--- a/core/components/setup/system-settings-store.ts
+++ b/core/components/setup/system-settings-store.ts
@@ -2,12 +2,9 @@ import { useLiveQuery } from '@tanstack/react-db'
 import { mutation, useMutation } from '@tinycld/core/lib/mutations'
 import { useStore } from '@tinycld/core/lib/pocketbase'
 import { newRecordId } from 'pbtsdb/core'
+import { rowsToMap, type SettingRow } from './system-settings-logic'
 
-export interface SettingRow {
-    id: string
-    value: string
-    isSecret: boolean
-}
+export type { SettingRow }
 
 /**
  * Read/write access to the system_settings collection for the /admin Settings
@@ -21,9 +18,7 @@ export function useSystemSettings() {
 
     const { data: rows = [] } = useLiveQuery(query => query.from({ s: systemSettings }))
 
-    const byKey = new Map<string, SettingRow>(
-        rows.map(r => [r.key, { id: r.id, value: r.value, isSecret: r.is_secret }])
-    )
+    const byKey = rowsToMap(rows)
 
     const upsert = useMutation({
         mutationFn: mutation(function* (input: { key: string; value: string; isSecret: boolean }) {

--- a/core/components/workspace/LoginModal.tsx
+++ b/core/components/workspace/LoginModal.tsx
@@ -3,6 +3,7 @@ import { ReviewModeHints } from '@tinycld/core/components/connect/ReviewModeHint
 import { useAuth } from '@tinycld/core/lib/auth'
 import { navigateToOrg } from '@tinycld/core/lib/org-url'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { router } from 'expo-router'
 import { useState } from 'react'
 import {
     ActivityIndicator,
@@ -36,6 +37,10 @@ export function LoginModal() {
             setIsSubmitting(false)
         } else if (result.user?.primaryOrgSlug) {
             navigateToOrg(result.user.primaryOrgSlug)
+        } else if (result.user) {
+            // Signed in but no org (a super admin with no membership) — send them
+            // to the admin console, where they manage orgs/packages.
+            router.replace('/admin')
         }
     }
 

--- a/core/lib/packages/__tests__/derive-components.test.ts
+++ b/core/lib/packages/__tests__/derive-components.test.ts
@@ -4,6 +4,7 @@ import {
     deriveSettings,
     deriveSidebarContributions,
     deriveSidebars,
+    deriveSystemSettings,
 } from '../derive-components'
 
 const A = () => null
@@ -43,6 +44,27 @@ describe('derive-components', () => {
         expect(g[0].pkgSlug).toBe('mail')
         expect(g[0].packageName).toBe('Mail')
         expect(g[0].panels[0].slug).toBe('provider')
+    })
+
+    it('groups system-settings panels by package, skipping packages with none', () => {
+        const g = deriveSystemSettings([
+            {
+                manifest: { name: 'Mail', slug: 'mail', nav: { icon: 'mail' } },
+                systemSettings: [{ slug: 'provider', label: 'Mail Provider', Component: A }],
+            },
+            { manifest: { name: 'Calc', slug: 'calc' } },
+            // settings (org-scoped) present but no systemSettings → still skipped
+            {
+                manifest: { name: 'Drive', slug: 'drive' },
+                settings: [{ slug: 'x', label: 'X', Component: P }],
+            },
+        ] as never)
+        expect(g).toHaveLength(1)
+        expect(g[0].pkgSlug).toBe('mail')
+        expect(g[0].packageName).toBe('Mail')
+        expect(g[0].icon).toBe('mail')
+        expect(g[0].panels[0].slug).toBe('provider')
+        expect(g[0].panels[0].Component).toBe(A)
     })
 
     describe('deriveSidebarContributions', () => {

--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -23,6 +23,13 @@ export interface PackageSettingsPanel {
     label: string
     Component: ComponentType | LazyExoticComponent<ComponentType>
 }
+// System-wide settings panel (the /admin Settings section). Same shape as a
+// per-org settings panel but rendered system-scoped, not per org.
+export interface PackageSystemSettingsPanel {
+    slug: string
+    label: string
+    Component: ComponentType | LazyExoticComponent<ComponentType>
+}
 export interface SidebarContribution {
     target: string
     slot: string
@@ -65,6 +72,7 @@ export interface PackageEntry<S extends SchemaDeclaration, R> {
         | LazyExoticComponent<ComponentType<PackageProviderProps>>
         | null
     settings?: PackageSettingsPanel[]
+    systemSettings?: PackageSystemSettingsPanel[]
     sidebarContributions?: SidebarContribution[]
     seed?: (pb: PocketBase, ctx: SeedContext) => Promise<void>
 }
@@ -86,6 +94,7 @@ export function definePackageEntry<S extends SchemaDeclaration>() {
         sidebar?: PackageEntry<S, R>['sidebar']
         provider?: PackageEntry<S, R>['provider']
         settings?: PackageEntry<S, R>['settings']
+        systemSettings?: PackageEntry<S, R>['systemSettings']
         sidebarContributions?: PackageEntry<S, R>['sidebarContributions']
         seed?: PackageEntry<S, R>['seed']
     }): PackageEntry<S, R> => entry as unknown as PackageEntry<S, R>

--- a/core/lib/packages/derive-components.ts
+++ b/core/lib/packages/derive-components.ts
@@ -1,7 +1,11 @@
 import { tinycldConfig } from '@tinycld/app-generated/tinycld-config'
 import { type ComponentType, type LazyExoticComponent, lazy, type ReactNode } from 'react'
 import { ADMIN_PACKAGE_SLUG } from './builtin-admin'
-import type { PackageSettingsPanel, SidebarContribution } from './config-types'
+import type {
+    PackageSettingsPanel,
+    PackageSystemSettingsPanel,
+    SidebarContribution,
+} from './config-types'
 
 interface SidebarProps {
     isCollapsed: boolean
@@ -58,6 +62,40 @@ export function deriveSettings(entries: readonly SettingsEntryLike[]): PackageSe
                 pkgSlug: e.manifest.slug,
                 icon: e.manifest.nav?.icon,
                 panels: e.settings,
+            })
+        }
+    }
+    return out
+}
+
+export interface PackageSystemSettingsGroup {
+    packageName: string
+    pkgSlug: string
+    icon: string | undefined
+    panels: PackageSystemSettingsPanel[]
+}
+
+type SystemSettingsEntryLike = {
+    manifest: { name: string; slug: string; nav?: { icon?: string } }
+    systemSettings?: PackageSystemSettingsPanel[]
+}
+
+/**
+ * System-wide settings panels grouped by package, omitting packages that
+ * contribute none. Mirrors deriveSettings but for the /admin Settings section
+ * (system scope, not org scope).
+ */
+export function deriveSystemSettings(
+    entries: readonly SystemSettingsEntryLike[]
+): PackageSystemSettingsGroup[] {
+    const out: PackageSystemSettingsGroup[] = []
+    for (const e of entries) {
+        if (e.systemSettings && e.systemSettings.length > 0) {
+            out.push({
+                packageName: e.manifest.name,
+                pkgSlug: e.manifest.slug,
+                icon: e.manifest.nav?.icon,
+                panels: e.systemSettings,
             })
         }
     }
@@ -124,4 +162,5 @@ export const packageSidebars: Record<string, SidebarComp | null> = {
 }
 export const packageProviders = deriveProviders(tinycldConfig)
 export const packageSettings = deriveSettings(tinycldConfig)
+export const packageSystemSettings = deriveSystemSettings(tinycldConfig)
 export const packageSidebarContributions = deriveSidebarContributions(tinycldConfig)

--- a/core/lib/packages/types.ts
+++ b/core/lib/packages/types.ts
@@ -48,6 +48,21 @@ export interface PackageManifest {
     }[]
 
     /**
+     * System-wide settings panels this package contributes to the /admin
+     * Settings section (deployment/system scope — NOT org-scoped like
+     * `settings`). Same shape and lazy-component resolution as `settings`:
+     * `component` is a package-exports subpath (e.g.
+     * `'system-settings/provider'`). Used for "use-your-own-service" config a
+     * host owns (mail provider creds, etc.). Rendered only in the super-admin
+     * console; values are stored system-wide, not per org.
+     */
+    systemSettings?: {
+        slug: string
+        component: string
+        label: string
+    }[]
+
+    /**
      * Names of sidebar slots this package exposes. Other packages target these
      * names from their `sidebarContributions`. Each name must be unique within
      * the manifest; the generator errors on duplicates and on contributions

--- a/core/lib/pocketbase.ts
+++ b/core/lib/pocketbase.ts
@@ -241,6 +241,14 @@ const super_admins = newCollection('super_admins', {
     ...indexing,
 })
 
+// System-wide configuration (Sentry, web-push, mail provider creds). Read/written
+// by the /admin Settings console; the server reads it through SystemConfig. See
+// the create_system_settings migration.
+const system_settings = newCollection('system_settings', {
+    omitOnInsert: ['created', 'updated'],
+    ...indexing,
+})
+
 const audit_logs = newCollection('audit_logs', {
     omitOnInsert: ['created', 'updated'],
     expand: { actor: users },
@@ -285,6 +293,7 @@ const coreStores = {
     pkg_install_log,
     notifications,
     super_admins,
+    system_settings,
 }
 export type CoreStores = typeof coreStores
 

--- a/core/lib/stores/__tests__/auth-store-login.test.ts
+++ b/core/lib/stores/__tests__/auth-store-login.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock PocketBase so login() runs without a live server. authWithPassword's
+// return shape drives the org-resolution branch under test.
+const mockAuthStoreClear = vi.fn()
+const mockAuthWithPassword = vi.fn()
+
+vi.mock('@tinycld/core/lib/pocketbase', () => ({
+    PB_SERVER_ADDR: 'http://localhost:8090',
+    pb: {
+        authStore: {
+            save: vi.fn(),
+            clear: mockAuthStoreClear,
+            onChange: vi.fn(() => () => {}),
+            token: null as string | null,
+            record: null,
+        },
+        collection: vi.fn(() => ({
+            authWithPassword: mockAuthWithPassword,
+        })),
+    },
+    authStoreReady: Promise.resolve(),
+    getUserFromAuthStore: vi.fn(() => null),
+    fetchAndSeedUserOrg: vi.fn(() => Promise.resolve()),
+    preloadStores: vi.fn(() => Promise.resolve()),
+    seedUserOrg: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+    default: {
+        getItem: vi.fn(() => Promise.resolve(null)),
+        setItem: vi.fn(() => Promise.resolve()),
+        removeItem: vi.fn(() => Promise.resolve()),
+    },
+}))
+
+vi.mock('@tinycld/core/lib/errors', () => ({ captureException: vi.fn() }))
+
+vi.mock('@tinycld/core/lib/store', () => ({
+    create: () => (fn: unknown) => {
+        let state = {} as Record<string, unknown>
+        const set = (patch: Record<string, unknown>) => {
+            state = { ...state, ...patch }
+        }
+        const get = () => state
+        type Factory = (
+            set: (patch: Record<string, unknown>) => void,
+            get: () => Record<string, unknown>
+        ) => Record<string, unknown>
+        const methods = (fn as Factory)(set, get)
+        state = { ...state, ...methods }
+        const store = (selector: (s: typeof state) => unknown) => selector(state)
+        store.getState = () => state
+        store.setState = (patch: Record<string, unknown>) => {
+            state = { ...state, ...patch }
+        }
+        return store
+    },
+    persist: <T>(fn: T) => fn,
+    asyncStorage: undefined,
+}))
+
+const ORG_USER = {
+    record: {
+        id: 'u1',
+        name: 'Owner',
+        email: 'owner@example.com',
+        expand: {
+            user_org_via_user: [{ id: 'uo1', expand: { org: { id: 'o1', slug: 'acme' } } }],
+        },
+    },
+}
+const SUPER_ADMIN_NO_ORG = {
+    record: {
+        id: 'admin1',
+        name: 'admin',
+        email: 'admin@tinycld.org',
+        expand: { super_admins_via_user: { id: 'sa1' } }, // present → super admin; no user_org
+    },
+}
+const REGULAR_NO_ORG = {
+    record: { id: 'u2', name: 'Nobody', email: 'nobody@example.com', expand: {} },
+}
+
+describe('auth-store login() org resolution', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: store login signature is broad here
+    let login: (id: string, pw: string) => Promise<{ user: any; error: string | null }>
+
+    beforeEach(async () => {
+        vi.resetModules()
+        mockAuthStoreClear.mockClear()
+        mockAuthWithPassword.mockReset()
+        const mod = await import('../auth-store')
+        // biome-ignore lint/suspicious/noExplicitAny: test harness reaches the store action
+        login = (mod as any).useAuthStore.getState().login
+    })
+
+    afterEach(() => vi.clearAllMocks())
+
+    it('signs in a user with an org and returns its slug', async () => {
+        mockAuthWithPassword.mockResolvedValue(ORG_USER)
+        const res = await login('owner@example.com', 'pw')
+        expect(res.error).toBeNull()
+        expect(res.user?.primaryOrgSlug).toBe('acme')
+    })
+
+    // login() clears auth once at the start of every attempt; the meaningful
+    // difference is whether the no-org branch clears AGAIN (rejecting) or keeps
+    // the freshly-authed session (super admin).
+    it('signs in a super admin with NO org: no error, no slug, session kept', async () => {
+        mockAuthWithPassword.mockResolvedValue(SUPER_ADMIN_NO_ORG)
+        const res = await login('admin@tinycld.org', 'pw')
+        expect(res.error).toBeNull()
+        expect(res.user).not.toBeNull()
+        expect(res.user?.primaryOrgSlug).toBeUndefined()
+        // Only the start-of-login clear — the session is NOT torn down.
+        expect(mockAuthStoreClear).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects a regular user with no org and clears the session', async () => {
+        mockAuthWithPassword.mockResolvedValue(REGULAR_NO_ORG)
+        const res = await login('nobody@example.com', 'pw')
+        expect(res.user).toBeNull()
+        expect(res.error).toBe('No organization associated with this account')
+        // Start-of-login clear + the rejection clear.
+        expect(mockAuthStoreClear).toHaveBeenCalledTimes(2)
+    })
+})

--- a/core/lib/stores/auth-store.ts
+++ b/core/lib/stores/auth-store.ts
@@ -128,15 +128,36 @@ export const useAuthStore = create<AuthStoreState>()((set, get) => ({
                 Users & {
                     expand?: {
                         user_org_via_user?: UserOrgExpanded[]
+                        super_admins_via_user?: { id: string }
                     }
                 }
             >(identifier, password, {
-                expand: 'user_org_via_user.org',
+                expand: 'user_org_via_user.org,super_admins_via_user',
             })
             const userOrgs = authData.record.expand?.user_org_via_user ?? []
             const firstUserOrgWithSlug = userOrgs.find(uo => uo.expand?.org?.slug)
+            // super_admins is a self-read junction; presence of the back-relation
+            // means this user is a super admin.
+            const isSuperAdmin = Boolean(authData.record.expand?.super_admins_via_user)
 
             if (!firstUserOrgWithSlug?.expand?.org) {
+                // A super admin with no org membership is a valid state (e.g. the
+                // first operator before creating any org): keep them signed in and
+                // let the caller route to /admin, where they manage orgs/packages.
+                // A regular user with no org genuinely has nowhere to go — reject.
+                if (isSuperAdmin) {
+                    const adminUser: AuthenticatedUser = {
+                        id: authData.record.id,
+                        name: authData.record.name,
+                        email: authData.record.email,
+                        primaryOrgSlug: undefined,
+                        isDemo: false,
+                        isBetaTester: false,
+                    }
+                    set({ user: adminUser })
+                    await preloadStores()
+                    return { user: adminUser, error: null }
+                }
                 pb.authStore.clear()
                 return {
                     user: null,

--- a/core/server/coreserver/app_native_export.go
+++ b/core/server/coreserver/app_native_export.go
@@ -269,9 +269,9 @@ func exportNativeBundles(job *installJob, appDir, buildID, runtimeVersion string
 	return out, nil
 }
 
-// envOr returns the environment variable named key, or def when it is unset/empty.
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
+// orDefault returns v when non-empty, else def.
+func orDefault(v, def string) string {
+	if v != "" {
 		return v
 	}
 	return def
@@ -288,25 +288,28 @@ func sentryReleaseFor(runtimeVersion string) string {
 }
 
 // uploadBundleSourcemaps uploads the .hbc + .map under outDir to Sentry via
-// sentry-cli, keyed by (release, dist). No-op (logs) when SENTRY_AUTH_TOKEN is
-// unset — self-hosters without Sentry build normally. Never returns an error:
-// the install succeeds whether or not the upload does.
+// sentry-cli, keyed by (release, dist). No-op (logs) when the Sentry auth token
+// is unset — self-hosters without Sentry build normally. Never returns an error:
+// the install succeeds whether or not the upload does. All Sentry config comes
+// from system settings (the system-wide source of truth), not env vars.
 func uploadBundleSourcemaps(job *installJob, outDir, runtimeVersion, bundleID string) {
-	if os.Getenv("SENTRY_AUTH_TOKEN") == "" {
-		jobLogf(job, "sourcemap upload skipped for %s (SENTRY_AUTH_TOKEN unset)", bundleID)
+	authToken := systemConfig.Get("sentry.auth_token")
+	if authToken == "" {
+		jobLogf(job, "sourcemap upload skipped for %s (sentry.auth_token unset)", bundleID)
 		return
 	}
 	release := sentryReleaseFor(runtimeVersion)
 	// org/project: ios/sentry.properties is prebuild output and is NOT in the
 	// server's build tree, so sentry-cli can't discover them — pass explicitly.
-	// Env-overridable (SENTRY_ORG/SENTRY_PROJECT) but defaulted to the known
-	// argosity/tinycld project so a standard deploy needs only the auth token.
-	org := envOr("SENTRY_ORG", "argosity")
-	project := envOr("SENTRY_PROJECT", "tinycld")
-	// sentry-cli reads SENTRY_AUTH_TOKEN from the env. Point it at the JS output
-	// dir; it pairs each minified file with its sibling .map.
+	// Configurable via system settings but defaulted to the known argosity/tinycld
+	// project so a standard deploy needs only the auth token.
+	org := orDefault(systemConfig.Get("sentry.org"), "argosity")
+	project := orDefault(systemConfig.Get("sentry.project"), "tinycld")
+	// sentry-cli reads the auth token from SENTRY_AUTH_TOKEN in its env. Pass it
+	// via runCmdEnv (NOT a CLI flag) so the secret stays out of the logged args.
 	jsDir := filepath.Join(outDir, "_expo", "static", "js")
-	out, err := runCmd(outDir, "pnpm", "exec", "sentry-cli", "sourcemaps", "upload",
+	out, err := runCmdEnv(outDir, []string{"SENTRY_AUTH_TOKEN=" + authToken},
+		"pnpm", "exec", "sentry-cli", "sourcemaps", "upload",
 		"--org", org, "--project", project,
 		"--release", release, "--dist", bundleID, jsDir)
 	if err != nil {

--- a/core/server/coreserver/app_native_export_test.go
+++ b/core/server/coreserver/app_native_export_test.go
@@ -296,13 +296,11 @@ func TestSentryReleaseFor(t *testing.T) {
 	}
 }
 
-func TestEnvOr(t *testing.T) {
-	t.Setenv("TINYCLD_ENVOR_TEST", "")
-	if got := envOr("TINYCLD_ENVOR_TEST", "fallback"); got != "fallback" {
-		t.Fatalf("empty env should yield fallback, got %q", got)
+func TestOrDefault(t *testing.T) {
+	if got := orDefault("", "fallback"); got != "fallback" {
+		t.Fatalf("empty value should yield fallback, got %q", got)
 	}
-	t.Setenv("TINYCLD_ENVOR_TEST", "set-value")
-	if got := envOr("TINYCLD_ENVOR_TEST", "fallback"); got != "set-value" {
-		t.Fatalf("set env should win, got %q", got)
+	if got := orDefault("set-value", "fallback"); got != "set-value" {
+		t.Fatalf("non-empty value should win, got %q", got)
 	}
 }

--- a/core/server/coreserver/pkg_install.go
+++ b/core/server/coreserver/pkg_install.go
@@ -708,9 +708,20 @@ func getBundledSlugs(app core.App) map[string]bool {
 // shows the full install trace — including the real npm/pnpm/go/expo errors
 // that would otherwise be buried in the SSE stream / DB record only.
 func runCmd(dir string, name string, args ...string) (string, error) {
+	return runCmdEnv(dir, nil, name, args...)
+}
+
+// runCmdEnv is runCmd with extra environment entries ("KEY=VALUE") appended to
+// the inherited env. Use this to pass SECRETS to a subprocess: the extra env is
+// NOT logged (only the command + args are), so a value like a Sentry auth token
+// never lands in the build log — unlike threading it through args.
+func runCmdEnv(dir string, extraEnv []string, name string, args ...string) (string, error) {
 	log.Printf("[pkg_install] $ (cd %s && %s %s)", dir, name, strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	out, err := cmd.CombinedOutput()
 	if s := strings.TrimRight(string(out), "\n"); s != "" {
 		log.Printf("[pkg_install] output of %s:\n%s", name, s)

--- a/core/server/coreserver/rebuild_pipeline.go
+++ b/core/server/coreserver/rebuild_pipeline.go
@@ -265,11 +265,23 @@ func runExportWithProgress(job *installJob, lo, hi int, step, dir string, args .
 			publicEnv = "web"
 		}
 	}
-	exportArgs := append([]string{
+	scopedEnv := []string{
 		"EXPO_PUBLIC_ENV=" + publicEnv,
 		"NODE_ENV=production",
-		"pnpm", "exec", "expo", "export",
-	}, args...)
+	}
+	// Native bundles read the Sentry DSN from EXPO_PUBLIC_SENTRY_DSN inlined at
+	// export time (they have no window to receive the server-injected runtime
+	// config that the WEB bundle uses). Source it from system settings — the
+	// system-wide source of truth — so a native rebuild/OTA picks up the
+	// operator's DSN. The web export deliberately omits it: web resolves the DSN
+	// at runtime from window.__TINYCLD_PUBLIC_CONFIG__, and inlining a snapshot
+	// here would let a stale build-time value shadow the live one.
+	if publicEnv != "web" {
+		if dsn := systemConfig.Get("sentry.dsn"); dsn != "" {
+			scopedEnv = append(scopedEnv, "EXPO_PUBLIC_SENTRY_DSN="+dsn)
+		}
+	}
+	exportArgs := append(append(scopedEnv, "pnpm", "exec", "expo", "export"), args...)
 	return expoStream(
 		func(line string) { reportExpoProgress(job, line, step, lo, hi, throttle) },
 		dir, "env", exportArgs...,

--- a/core/server/coreserver/sentry.go
+++ b/core/server/coreserver/sentry.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -17,28 +16,36 @@ import (
 	"github.com/pocketbase/pocketbase/tools/router"
 )
 
-// RegisterSentry initializes the Sentry client and binds router middleware
-// that captures returned handler errors, panics, and any 5xx response that
-// reaches the client without producing an error value (e.g. handlers that
-// write directly to ResponseWriter, like the go-webdav CalDAV library).
+// RegisterSentry binds the router middleware that captures returned handler
+// errors, panics, and any 5xx response that reaches the client without producing
+// an error value (e.g. handlers that write directly to ResponseWriter, like the
+// go-webdav CalDAV library).
 //
-// Must run before any OnServe handlers register routes — middleware bound
-// after a route is added does not apply to it. Register() calls this first.
+// Must run before any OnServe handlers register routes — middleware bound after a
+// route is added does not apply to it. Register() calls this first.
 //
-// When SENTRY_DSN is empty the SDK still functions but events are dropped,
-// so the middleware is a no-op in dev. The panic recovery still re-panics
-// regardless, so PB's normal 500 response path is unaffected.
+// The Sentry CLIENT itself is initialized later, by RegisterSystemConfig, once
+// the system_settings collection is loaded — the DSN comes from there, not an env
+// var. Until then (and whenever the DSN is empty) the SDK is a no-op: events drop,
+// the middleware still runs, and panic recovery still re-panics so PB's normal 500
+// path is unaffected. initSentryFromConfig performs the actual Init and is reused
+// for live re-init when the DSN changes.
 func RegisterSentry(app *pocketbase.PocketBase) {
+	registerSentryMiddlewareCore(app)
+}
+
+// initSentryFromConfig (re)initializes the global Sentry client from the current
+// system settings. Safe to call repeatedly: sentry.Init swaps the active client,
+// so a DSN change applied here takes effect immediately for subsequent captures.
+func initSentryFromConfig(cfg *SystemConfig) {
 	if err := sentry.Init(sentry.ClientOptions{
-		Dsn:              os.Getenv("SENTRY_DSN"),
+		Dsn:              cfg.Get("sentry.dsn"),
 		Environment:      GetEnvironment(),
 		TracesSampleRate: 0.2,
 		AttachStacktrace: true,
 	}); err != nil {
 		log.Printf("Sentry initialization failed: %v", err)
 	}
-
-	registerSentryMiddlewareCore(app)
 }
 
 // registerSentryMiddlewareCore binds the per-request capture logic. Split

--- a/core/server/coreserver/sentry_test.go
+++ b/core/server/coreserver/sentry_test.go
@@ -264,7 +264,7 @@ func TestInitSentryFromConfig(t *testing.T) {
 	cfg := &SystemConfig{values: map[string]string{}}
 	initSentryFromConfig(cfg) // empty DSN — no-op, no panic
 
-	cfg.set("sentry.dsn", "https://abc@o1.ingest.sentry.io/1")
+	cfg.set("sentry.dsn", "https://abc@o1.ingest.sentry.io/1", false)
 	initSentryFromConfig(cfg) // valid-shaped DSN — swaps the client, no panic
 }
 
@@ -281,14 +281,14 @@ func TestSentryReinitOnlyForSentryKeys(t *testing.T) {
 		}
 	})
 
-	cfg.set("vapid.subject", "mailto:a@b.c")
-	cfg.set("mail.postmark_server_token", "tok")
+	cfg.set("vapid.subject", "mailto:a@b.c", false)
+	cfg.set("mail.postmark_server_token", "tok", true)
 	if reinits != 0 {
 		t.Errorf("non-sentry keys must not trigger reinit, got %d", reinits)
 	}
 
-	cfg.set("sentry.dsn", "https://x@o1.ingest.sentry.io/2")
-	cfg.set("sentry.org", "myorg")
+	cfg.set("sentry.dsn", "https://x@o1.ingest.sentry.io/2", false)
+	cfg.set("sentry.org", "myorg", false)
 	if reinits != 2 {
 		t.Errorf("each sentry.* change should reinit once, got %d", reinits)
 	}

--- a/core/server/coreserver/sentry_test.go
+++ b/core/server/coreserver/sentry_test.go
@@ -254,3 +254,42 @@ func TestSentryMiddlewareCapturesDirectWriteServerError(t *testing.T) {
 		t.Errorf("expected captured body to contain the http.Error message, got %q", body)
 	}
 }
+
+// initSentryFromConfig is safe to call with an empty or a set DSN — empty leaves
+// the SDK a no-op, a value swaps the active client. It must never panic; the boot
+// path and the on-change re-init both call it unconditionally.
+func TestInitSentryFromConfig(t *testing.T) {
+	t.Cleanup(func() { _ = sentry.Init(sentry.ClientOptions{}) }) // reset global client
+
+	cfg := &SystemConfig{values: map[string]string{}}
+	initSentryFromConfig(cfg) // empty DSN — no-op, no panic
+
+	cfg.set("sentry.dsn", "https://abc@o1.ingest.sentry.io/1")
+	initSentryFromConfig(cfg) // valid-shaped DSN — swaps the client, no panic
+}
+
+// The re-init wiring fires ONLY for sentry.* keys: a sentry.dsn change re-inits,
+// an unrelated key (e.g. vapid.subject) does not. This mirrors the prefix filter
+// RegisterSystemConfig installs; push/mail read per-use and must not trigger a
+// Sentry re-init.
+func TestSentryReinitOnlyForSentryKeys(t *testing.T) {
+	cfg := &SystemConfig{values: map[string]string{}}
+	var reinits int
+	cfg.OnChange(func(key, _ string) {
+		if strings.HasPrefix(key, "sentry.") {
+			reinits++
+		}
+	})
+
+	cfg.set("vapid.subject", "mailto:a@b.c")
+	cfg.set("mail.postmark_server_token", "tok")
+	if reinits != 0 {
+		t.Errorf("non-sentry keys must not trigger reinit, got %d", reinits)
+	}
+
+	cfg.set("sentry.dsn", "https://x@o1.ingest.sentry.io/2")
+	cfg.set("sentry.org", "myorg")
+	if reinits != 2 {
+		t.Errorf("each sentry.* change should reinit once, got %d", reinits)
+	}
+}

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -101,6 +101,12 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 	// Middleware bound after a route is added does not apply retroactively.
 	RegisterSentry(app)
 
+	// System-wide settings (Sentry/web-push/mail creds). Loads the
+	// system_settings collection into the in-memory SystemConfig once the DB is
+	// ready and keeps it in sync on edits, so subsystems read current values
+	// without env vars and stateful ones (Sentry) re-init on change.
+	RegisterSystemConfig(app)
+
 	jsvm.MustRegister(app, jsvm.Config{
 		MigrationsDir: opts.MigrationsDir,
 		HooksDir:      opts.HooksDir,

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -152,6 +152,7 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 	RegisterPackageInstallEndpoints(app)
 	RegisterSuperAdminEndpoints(app)
 	RegisterOrgAdminEndpoints(app)
+	RegisterVapidAdminEndpoints(app)
 	RegisterAppUpdateEndpoints(app)
 	RegisterSetupBootstrap(app)
 	RegisterAccountDelete(app)

--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -1,6 +1,8 @@
 package coreserver
 
 import (
+	"bytes"
+	"encoding/json"
 	"io/fs"
 	"net/http"
 	"os"
@@ -9,6 +11,58 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 )
+
+// publicConfigScript builds the inline <script> that publishes NON-secret system
+// config to the web client on window.__TINYCLD_PUBLIC_CONFIG__, read at module
+// init by lib/app-config.ts (e.g. the Sentry DSN). Secret values never appear
+// here — PublicValues() already excludes them. Storage keys are mapped to the
+// client config field names so the browser contract is decoupled from the
+// collection's key namespace. Returns "" when there's nothing to publish.
+//
+// The JSON is marshaled (not string-built) so values are safely escaped; we then
+// guard against "</script>" appearing in a value, which would otherwise close the
+// tag early — JSON-encodes "<" as-is, so a malicious DSN could break out.
+func publicConfigScript() string {
+	vals := systemConfig.PublicValues()
+	// Whitelist + rename: only keys the client is meant to consume, under their
+	// client-facing names. Adding a new public client value is a deliberate edit
+	// here, not an automatic passthrough of every non-secret row.
+	out := map[string]string{}
+	if v := vals["sentry.dsn"]; v != "" {
+		out["sentryDsn"] = v
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	payload, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	// Defense-in-depth against early tag termination from a "</script>" substring.
+	safe := bytes.ReplaceAll(payload, []byte("</"), []byte("<\\/"))
+	return "<script>window.__TINYCLD_PUBLIC_CONFIG__=" + string(safe) + "</script>"
+}
+
+// injectPublicConfig inserts the public-config <script> just before </head> in
+// the SPA shell HTML. The script runs before the deferred bundle JS, so the
+// window global is set by the time lib/configure-core reads it at module init.
+// Falls back to returning the HTML unchanged when there's nothing to inject or
+// no </head> is present.
+func injectPublicConfig(html []byte) []byte {
+	script := publicConfigScript()
+	if script == "" {
+		return html
+	}
+	idx := bytes.Index(bytes.ToLower(html), []byte("</head>"))
+	if idx < 0 {
+		return html
+	}
+	out := make([]byte, 0, len(html)+len(script))
+	out = append(out, html[:idx]...)
+	out = append(out, script...)
+	out = append(out, html[idx:]...)
+	return out
+}
 
 // binaryDir returns the directory containing the running executable, or
 // the empty string for `go run` invocations (where os.Args[0] is a temp
@@ -213,16 +267,18 @@ func StaticWithDynamicFallback(publicDir, websiteDir, releasesDir string) func(*
 			if data, err := os.ReadFile(currentApp); err == nil {
 				e.Response.Header().Set("Cache-Control", "no-store")
 				e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
-				_, _ = e.Response.Write(data)
+				_, _ = e.Response.Write(injectPublicConfig(data))
 				return nil
 			}
 		}
 
-		// Dev fallback: publicDir/app.html.
-		if f, err := publicFs.Open("app.html"); err == nil {
-			f.Close()
+		// Dev fallback: publicDir/app.html. Read into memory (rather than
+		// streaming via FileFS) so the same public-config injection applies.
+		if data, err := fs.ReadFile(publicFs, "app.html"); err == nil {
 			e.Response.Header().Set("Cache-Control", "no-store")
-			return e.FileFS(publicFs, "app.html")
+			e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = e.Response.Write(injectPublicConfig(data))
+			return nil
 		}
 
 		return e.NotFoundError("", nil)

--- a/core/server/coreserver/system_config.go
+++ b/core/server/coreserver/system_config.go
@@ -1,0 +1,107 @@
+package coreserver
+
+import (
+	"log"
+	"sync"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// SystemConfig is the single source of truth for system-wide configuration —
+// the "use-your-own-service" values (Sentry, web-push, mail provider creds) that
+// a third-party host owns. Values live in the `system_settings` collection and
+// are configured from the /admin Settings console; this struct holds the current
+// values in memory so consumers read them without a DB hit on every use, and so
+// stateful consumers (Sentry) can be re-initialized the moment a value changes.
+//
+// There is NO os.Getenv anywhere in the read path: the environment is consulted
+// exactly once, by the create_system_settings migration's one-time seed. After
+// that, the collection is authoritative.
+type SystemConfig struct {
+	mu       sync.RWMutex
+	values   map[string]string
+	onChange []func(key, value string)
+}
+
+// systemConfig is the process-wide instance, constructed by RegisterSystemConfig
+// and read by subsystems (sentry.go, push, mail) via SystemSettings().
+var systemConfig = &SystemConfig{values: map[string]string{}}
+
+// SystemSettings returns the process-wide SystemConfig. Always non-nil; before
+// load() runs (i.e. before the DB is ready) every Get returns "".
+func SystemSettings() *SystemConfig { return systemConfig }
+
+// Get returns the current value for key, or "" if unset. Pure in-memory read.
+func (c *SystemConfig) Get(key string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.values[key]
+}
+
+// OnChange registers a callback fired whenever a key's value changes (via the
+// system_settings record hooks). Used by stateful consumers that must re-init —
+// e.g. Sentry re-runs sentry.Init on a sentry.* change. Consumers that read
+// per-use (push reads VAPID per send; mail builds its provider per call) don't
+// need this; they just call Get at use time.
+func (c *SystemConfig) OnChange(fn func(key, value string)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onChange = append(c.onChange, fn)
+}
+
+// load replaces the in-memory map with every row currently in system_settings.
+// Run once after the DB is ready (an OnServe hook, post-migration).
+func (c *SystemConfig) load(app core.App) {
+	recs, err := app.FindRecordsByFilter("system_settings", "id != ''", "", 0, 0)
+	if err != nil {
+		// The collection may not exist yet on a brand-new DB whose migrations
+		// haven't run; treat as empty rather than failing the boot.
+		log.Printf("system_config: load skipped: %v", err)
+		return
+	}
+	next := make(map[string]string, len(recs))
+	for _, r := range recs {
+		next[r.GetString("key")] = r.GetString("value")
+	}
+	c.mu.Lock()
+	c.values = next
+	c.mu.Unlock()
+}
+
+// set updates a single key in the map and fires change callbacks. Called by the
+// record hooks; the callbacks run OUTSIDE the lock so a reinit handler can call
+// Get without deadlocking.
+func (c *SystemConfig) set(key, value string) {
+	c.mu.Lock()
+	if c.values == nil {
+		c.values = map[string]string{}
+	}
+	c.values[key] = value
+	cbs := make([]func(string, string), len(c.onChange))
+	copy(cbs, c.onChange)
+	c.mu.Unlock()
+	for _, fn := range cbs {
+		fn(key, value)
+	}
+}
+
+// RegisterSystemConfig constructs the system config lifecycle: load all values
+// once the server starts, and keep the in-memory map in sync as rows are created
+// or updated. Edits take effect without a restart — re-init handlers registered
+// via OnChange run on each change.
+func RegisterSystemConfig(app *pocketbase.PocketBase) {
+	// Load after bootstrap/migrations, before the server begins handling
+	// requests. OnServe fires once per boot at that point.
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		systemConfig.load(app)
+		return e.Next()
+	})
+
+	syncRow := func(e *core.RecordEvent) error {
+		systemConfig.set(e.Record.GetString("key"), e.Record.GetString("value"))
+		return e.Next()
+	}
+	app.OnRecordAfterCreateSuccess("system_settings").BindFunc(syncRow)
+	app.OnRecordAfterUpdateSuccess("system_settings").BindFunc(syncRow)
+}

--- a/core/server/coreserver/system_config.go
+++ b/core/server/coreserver/system_config.go
@@ -22,12 +22,13 @@ import (
 type SystemConfig struct {
 	mu       sync.RWMutex
 	values   map[string]string
+	secret   map[string]bool // key → is_secret; gates what may be exposed to clients
 	onChange []func(key, value string)
 }
 
 // systemConfig is the process-wide instance, constructed by RegisterSystemConfig
 // and read by subsystems (sentry.go, push, mail) via SystemSettings().
-var systemConfig = &SystemConfig{values: map[string]string{}}
+var systemConfig = &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
 
 // SystemSettings returns the process-wide SystemConfig. Always non-nil; before
 // load() runs (i.e. before the DB is ready) every Get returns "".
@@ -38,6 +39,22 @@ func (c *SystemConfig) Get(key string) string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.values[key]
+}
+
+// PublicValues returns a copy of every NON-secret key→value pair. This is the
+// only set of values allowed to leave the server toward a client (injected into
+// the web HTML). Secret values (tokens, the VAPID private key, IMAP password)
+// are never included — they're read server-side only.
+func (c *SystemConfig) PublicValues() map[string]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make(map[string]string)
+	for k, v := range c.values {
+		if !c.secret[k] {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // OnChange registers a callback fired whenever a key's value changes (via the
@@ -62,23 +79,31 @@ func (c *SystemConfig) load(app core.App) {
 		return
 	}
 	next := make(map[string]string, len(recs))
+	nextSecret := make(map[string]bool, len(recs))
 	for _, r := range recs {
-		next[r.GetString("key")] = r.GetString("value")
+		key := r.GetString("key")
+		next[key] = r.GetString("value")
+		nextSecret[key] = r.GetBool("is_secret")
 	}
 	c.mu.Lock()
 	c.values = next
+	c.secret = nextSecret
 	c.mu.Unlock()
 }
 
-// set updates a single key in the map and fires change callbacks. Called by the
-// record hooks; the callbacks run OUTSIDE the lock so a reinit handler can call
-// Get without deadlocking.
-func (c *SystemConfig) set(key, value string) {
+// set updates a single key (value + secret flag) and fires change callbacks.
+// Called by the record hooks; the callbacks run OUTSIDE the lock so a reinit
+// handler can call Get without deadlocking.
+func (c *SystemConfig) set(key, value string, isSecret bool) {
 	c.mu.Lock()
 	if c.values == nil {
 		c.values = map[string]string{}
 	}
+	if c.secret == nil {
+		c.secret = map[string]bool{}
+	}
 	c.values[key] = value
+	c.secret[key] = isSecret
 	cbs := make([]func(string, string), len(c.onChange))
 	copy(cbs, c.onChange)
 	c.mu.Unlock()
@@ -113,7 +138,11 @@ func RegisterSystemConfig(app *pocketbase.PocketBase) {
 	})
 
 	syncRow := func(e *core.RecordEvent) error {
-		systemConfig.set(e.Record.GetString("key"), e.Record.GetString("value"))
+		systemConfig.set(
+			e.Record.GetString("key"),
+			e.Record.GetString("value"),
+			e.Record.GetBool("is_secret"),
+		)
 		return e.Next()
 	}
 	app.OnRecordAfterCreateSuccess("system_settings").BindFunc(syncRow)

--- a/core/server/coreserver/system_config.go
+++ b/core/server/coreserver/system_config.go
@@ -2,6 +2,7 @@ package coreserver
 
 import (
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/pocketbase/pocketbase"
@@ -87,14 +88,27 @@ func (c *SystemConfig) set(key, value string) {
 }
 
 // RegisterSystemConfig constructs the system config lifecycle: load all values
-// once the server starts, and keep the in-memory map in sync as rows are created
-// or updated. Edits take effect without a restart — re-init handlers registered
-// via OnChange run on each change.
+// once the server starts, init the consumers that depend on them, and keep the
+// in-memory map in sync as rows are created or updated. Edits take effect without
+// a restart — re-init handlers registered via OnChange run on each change.
 func RegisterSystemConfig(app *pocketbase.PocketBase) {
+	// Re-init Sentry whenever a sentry.* value changes. Registered before the
+	// initial load so no early change is missed. Sentry is the only stateful
+	// consumer; push reads VAPID per-send and mail builds its provider per-call,
+	// so both pick up changes via Get without a re-init handler.
+	systemConfig.OnChange(func(key, _ string) {
+		if strings.HasPrefix(key, "sentry.") {
+			initSentryFromConfig(systemConfig)
+		}
+	})
+
 	// Load after bootstrap/migrations, before the server begins handling
-	// requests. OnServe fires once per boot at that point.
+	// requests, then perform the initial Sentry init from the loaded values.
+	// OnServe fires once per boot at that point. The Sentry middleware is already
+	// bound (RegisterSentry); this supplies the client the middleware reports to.
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
 		systemConfig.load(app)
+		initSentryFromConfig(systemConfig)
 		return e.Next()
 	})
 

--- a/core/server/coreserver/system_config_test.go
+++ b/core/server/coreserver/system_config_test.go
@@ -1,6 +1,7 @@
 package coreserver
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -81,7 +82,7 @@ func TestSystemConfigSetFiresOnChange(t *testing.T) {
 		gotKey, gotVal, fireCnt = key, value, fireCnt+1
 	})
 
-	cfg.set("sentry.dsn", "https://new.dsn")
+	cfg.set("sentry.dsn", "https://new.dsn", false)
 
 	if got := cfg.Get("sentry.dsn"); got != "https://new.dsn" {
 		t.Errorf("set did not update value, got %q", got)
@@ -101,7 +102,7 @@ func TestSystemConfigOnChangeCanRead(t *testing.T) {
 	cfg.OnChange(func(key, _ string) {
 		observed = cfg.Get(key) // must not deadlock
 	})
-	cfg.set("sentry.dsn", "https://read.dsn")
+	cfg.set("sentry.dsn", "https://read.dsn", false)
 	if observed != "https://read.dsn" {
 		t.Errorf("OnChange could not read updated value, got %q", observed)
 	}
@@ -123,7 +124,11 @@ func TestSystemConfigRecordHooksSync(t *testing.T) {
 	systemConfig = &SystemConfig{values: map[string]string{}}
 
 	syncRow := func(e *core.RecordEvent) error {
-		systemConfig.set(e.Record.GetString("key"), e.Record.GetString("value"))
+		systemConfig.set(
+			e.Record.GetString("key"),
+			e.Record.GetString("value"),
+			e.Record.GetBool("is_secret"),
+		)
 		return e.Next()
 	}
 	app.OnRecordAfterCreateSuccess("system_settings").BindFunc(syncRow)
@@ -140,5 +145,77 @@ func TestSystemConfigRecordHooksSync(t *testing.T) {
 	}
 	if got := systemConfig.Get("vapid.subject"); got != "mailto:ops@example.com" {
 		t.Errorf("after update hook: got %q", got)
+	}
+}
+
+// PublicValues exposes non-secret keys and withholds secret ones — the gate that
+// keeps tokens/private keys out of anything sent to a client.
+func TestSystemConfigPublicValues(t *testing.T) {
+	cfg := &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	cfg.set("sentry.dsn", "https://public.dsn", false)
+	cfg.set("sentry.auth_token", "secret-token", true)
+
+	pub := cfg.PublicValues()
+	if pub["sentry.dsn"] != "https://public.dsn" {
+		t.Errorf("non-secret value missing from PublicValues: %v", pub)
+	}
+	if _, present := pub["sentry.auth_token"]; present {
+		t.Error("secret value must NOT appear in PublicValues")
+	}
+}
+
+// injectPublicConfig publishes only non-secret values into the HTML, before
+// </head>, and never leaks a secret. Drives the package-global systemConfig.
+func TestInjectPublicConfig(t *testing.T) {
+	prev := systemConfig
+	t.Cleanup(func() { systemConfig = prev })
+	systemConfig = &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	systemConfig.set("sentry.dsn", "https://abc@o1.ingest.sentry.io/1", false)
+	systemConfig.set("sentry.auth_token", "super-secret", true)
+
+	html := []byte("<html><head><title>x</title></head><body></body></html>")
+	out := string(injectPublicConfig(html))
+
+	if !strings.Contains(out, "window.__TINYCLD_PUBLIC_CONFIG__=") {
+		t.Fatalf("injection missing: %s", out)
+	}
+	if !strings.Contains(out, "https://abc@o1.ingest.sentry.io/1") {
+		t.Error("non-secret DSN should be injected")
+	}
+	if !strings.Contains(out, `"sentryDsn"`) {
+		t.Error("DSN should be published under the client field name sentryDsn")
+	}
+	if strings.Contains(out, "super-secret") || strings.Contains(out, "auth_token") {
+		t.Error("secret value/key must NEVER be injected into the HTML")
+	}
+	// Injected before </head> so it runs before the deferred bundle.
+	if strings.Index(out, "window.__TINYCLD_PUBLIC_CONFIG__") > strings.Index(out, "</head>") {
+		t.Error("script must be injected before </head>")
+	}
+}
+
+// A value containing "</script>" must not terminate the tag early.
+func TestInjectPublicConfigEscapesScriptClose(t *testing.T) {
+	prev := systemConfig
+	t.Cleanup(func() { systemConfig = prev })
+	systemConfig = &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	systemConfig.set("sentry.dsn", "https://x/</script><script>alert(1)</script>", false)
+
+	out := string(injectPublicConfig([]byte("<head></head>")))
+	if strings.Contains(out, "</script><script>alert(1)") {
+		t.Errorf("unescaped </script> breakout in injected config: %s", out)
+	}
+}
+
+// Nothing to publish (no non-secret values) → HTML unchanged.
+func TestInjectPublicConfigNoop(t *testing.T) {
+	prev := systemConfig
+	t.Cleanup(func() { systemConfig = prev })
+	systemConfig = &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	systemConfig.set("sentry.auth_token", "only-a-secret", true)
+
+	html := []byte("<head></head>")
+	if got := string(injectPublicConfig(html)); got != string(html) {
+		t.Errorf("expected HTML unchanged when nothing public, got %q", got)
 	}
 }

--- a/core/server/coreserver/system_config_test.go
+++ b/core/server/coreserver/system_config_test.go
@@ -1,0 +1,144 @@
+package coreserver
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// createSystemSettingsCollection mirrors the runtime shape of
+// pb_migrations/1910000010_create_system_settings.js for unit tests (the JS
+// migration's env-seed path is exercised end-to-end by the export-types replay).
+func createSystemSettingsCollection(t *testing.T, app core.App) {
+	t.Helper()
+	c := core.NewBaseCollection("system_settings")
+	c.Id = "pbc_system_settings"
+	c.Fields.Add(&core.TextField{Name: "key", Required: true, Max: 100})
+	c.Fields.Add(&core.TextField{Name: "value", Max: 5000})
+	c.Fields.Add(&core.BoolField{Name: "is_secret"})
+	c.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	c.Fields.Add(&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true})
+	c.AddIndex("idx_system_settings_key", true, "key", "")
+	if err := app.Save(c); err != nil {
+		t.Fatalf("save system_settings collection: %v", err)
+	}
+}
+
+func saveSetting(t *testing.T, app core.App, key, value string) *core.Record {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("system_settings")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("key", key)
+	rec.Set("value", value)
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("save setting %q: %v", key, err)
+	}
+	return rec
+}
+
+// Get returns "" before anything is loaded, and the stored value after load().
+func TestSystemConfigLoadAndGet(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+	createSystemSettingsCollection(t, app)
+	saveSetting(t, app, "sentry.dsn", "https://example.dsn")
+
+	cfg := &SystemConfig{values: map[string]string{}}
+	if got := cfg.Get("sentry.dsn"); got != "" {
+		t.Errorf("before load: want empty, got %q", got)
+	}
+	cfg.load(app)
+	if got := cfg.Get("sentry.dsn"); got != "https://example.dsn" {
+		t.Errorf("after load: want stored value, got %q", got)
+	}
+	if got := cfg.Get("missing.key"); got != "" {
+		t.Errorf("unset key: want empty, got %q", got)
+	}
+}
+
+// set updates the value live and fires OnChange callbacks (so a stateful consumer
+// like Sentry can re-init without a restart).
+func TestSystemConfigSetFiresOnChange(t *testing.T) {
+	cfg := &SystemConfig{values: map[string]string{}}
+
+	var (
+		mu      sync.Mutex
+		gotKey  string
+		gotVal  string
+		fireCnt int
+	)
+	cfg.OnChange(func(key, value string) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotKey, gotVal, fireCnt = key, value, fireCnt+1
+	})
+
+	cfg.set("sentry.dsn", "https://new.dsn")
+
+	if got := cfg.Get("sentry.dsn"); got != "https://new.dsn" {
+		t.Errorf("set did not update value, got %q", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if fireCnt != 1 || gotKey != "sentry.dsn" || gotVal != "https://new.dsn" {
+		t.Errorf("OnChange fired wrong: cnt=%d key=%q val=%q", fireCnt, gotKey, gotVal)
+	}
+}
+
+// An OnChange handler may call Get without deadlocking (callbacks run outside the
+// lock) — this is exactly what reinitSentry will do.
+func TestSystemConfigOnChangeCanRead(t *testing.T) {
+	cfg := &SystemConfig{values: map[string]string{}}
+	var observed string
+	cfg.OnChange(func(key, _ string) {
+		observed = cfg.Get(key) // must not deadlock
+	})
+	cfg.set("sentry.dsn", "https://read.dsn")
+	if observed != "https://read.dsn" {
+		t.Errorf("OnChange could not read updated value, got %q", observed)
+	}
+}
+
+// The record hooks wired by RegisterSystemConfig keep the in-memory map in sync
+// when a system_settings row is created or updated.
+func TestSystemConfigRecordHooksSync(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+	createSystemSettingsCollection(t, app)
+
+	// Point the package-global at a fresh instance and wire the hooks to it.
+	prev := systemConfig
+	t.Cleanup(func() { systemConfig = prev })
+	systemConfig = &SystemConfig{values: map[string]string{}}
+
+	syncRow := func(e *core.RecordEvent) error {
+		systemConfig.set(e.Record.GetString("key"), e.Record.GetString("value"))
+		return e.Next()
+	}
+	app.OnRecordAfterCreateSuccess("system_settings").BindFunc(syncRow)
+	app.OnRecordAfterUpdateSuccess("system_settings").BindFunc(syncRow)
+
+	rec := saveSetting(t, app, "vapid.subject", "mailto:admin@example.com")
+	if got := systemConfig.Get("vapid.subject"); got != "mailto:admin@example.com" {
+		t.Errorf("after create hook: got %q", got)
+	}
+
+	rec.Set("value", "mailto:ops@example.com")
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("update setting: %v", err)
+	}
+	if got := systemConfig.Get("vapid.subject"); got != "mailto:ops@example.com" {
+		t.Errorf("after update hook: got %q", got)
+	}
+}

--- a/core/server/coreserver/vapid_admin.go
+++ b/core/server/coreserver/vapid_admin.go
@@ -22,23 +22,30 @@ import (
 func RegisterVapidAdminEndpoints(app *pocketbase.PocketBase) {
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
 		e.Router.POST("/api/admin/vapid/generate", func(re *core.RequestEvent) error {
-			privateKey, publicKey, err := push.GenerateVAPIDKeys()
-			if err != nil {
-				return re.InternalServerError("Failed to generate VAPID keys", err)
-			}
-			if err := upsertSystemSetting(app, "vapid.public_key", publicKey, false); err != nil {
-				return re.InternalServerError("Failed to save VAPID public key", err)
-			}
-			if err := upsertSystemSetting(app, "vapid.private_key", privateKey, true); err != nil {
-				return re.InternalServerError("Failed to save VAPID private key", err)
-			}
-			// Return only the public key — the private key stays server-side.
-			return re.JSON(http.StatusOK, map[string]string{"publicKey": publicKey})
+			return handleGenerateVapid(app, re)
 		}).BindFunc(func(re *core.RequestEvent) error {
 			return requireAdmin(app, re)
 		})
 		return e.Next()
 	})
+}
+
+// handleGenerateVapid mints a keypair, persists both keys to system_settings, and
+// returns ONLY the public key. Split out so it's unit-testable against a
+// tests.TestApp without standing up the router.
+func handleGenerateVapid(app core.App, re *core.RequestEvent) error {
+	privateKey, publicKey, err := push.GenerateVAPIDKeys()
+	if err != nil {
+		return re.InternalServerError("Failed to generate VAPID keys", err)
+	}
+	if err := upsertSystemSetting(app, "vapid.public_key", publicKey, false); err != nil {
+		return re.InternalServerError("Failed to save VAPID public key", err)
+	}
+	if err := upsertSystemSetting(app, "vapid.private_key", privateKey, true); err != nil {
+		return re.InternalServerError("Failed to save VAPID private key", err)
+	}
+	// Return only the public key — the private key stays server-side.
+	return re.JSON(http.StatusOK, map[string]string{"publicKey": publicKey})
 }
 
 // upsertSystemSetting writes a single key into the system_settings collection,

--- a/core/server/coreserver/vapid_admin.go
+++ b/core/server/coreserver/vapid_admin.go
@@ -1,0 +1,64 @@
+package coreserver
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/push"
+)
+
+// RegisterVapidAdminEndpoints exposes "generate a VAPID keypair" for the /admin
+// Settings console. Generation AND persistence happen server-side: the operator
+// never needs to read the keys (the server signs with the private key; the
+// browser receives the public key through the normal push-subscribe flow), so
+// the secret private key never travels to the client at all. The endpoint mints
+// the pair, writes both into system_settings, and returns only the public key
+// for display. Bring-your-own keys are still possible via the normal
+// system_settings write (the panel's "use existing keys" path). AuthZ:
+// requireAdmin, same as the other /api/admin endpoints.
+func RegisterVapidAdminEndpoints(app *pocketbase.PocketBase) {
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		e.Router.POST("/api/admin/vapid/generate", func(re *core.RequestEvent) error {
+			privateKey, publicKey, err := push.GenerateVAPIDKeys()
+			if err != nil {
+				return re.InternalServerError("Failed to generate VAPID keys", err)
+			}
+			if err := upsertSystemSetting(app, "vapid.public_key", publicKey, false); err != nil {
+				return re.InternalServerError("Failed to save VAPID public key", err)
+			}
+			if err := upsertSystemSetting(app, "vapid.private_key", privateKey, true); err != nil {
+				return re.InternalServerError("Failed to save VAPID private key", err)
+			}
+			// Return only the public key — the private key stays server-side.
+			return re.JSON(http.StatusOK, map[string]string{"publicKey": publicKey})
+		}).BindFunc(func(re *core.RequestEvent) error {
+			return requireAdmin(app, re)
+		})
+		return e.Next()
+	})
+}
+
+// upsertSystemSetting writes a single key into the system_settings collection,
+// updating the existing row or creating one. Saving fires the
+// OnRecordAfter*Success hooks, so the in-memory SystemConfig refreshes too.
+func upsertSystemSetting(app core.App, key, value string, isSecret bool) error {
+	existing, err := app.FindFirstRecordByFilter(
+		"system_settings", "key = {:key}", map[string]any{"key": key},
+	)
+	if err == nil {
+		existing.Set("value", value)
+		return app.Save(existing)
+	}
+	col, err := app.FindCollectionByNameOrId("system_settings")
+	if err != nil {
+		return fmt.Errorf("find system_settings collection: %w", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("key", key)
+	rec.Set("value", value)
+	rec.Set("is_secret", isSecret)
+	return app.Save(rec)
+}

--- a/core/server/coreserver/vapid_admin_test.go
+++ b/core/server/coreserver/vapid_admin_test.go
@@ -1,0 +1,98 @@
+package coreserver
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// handleGenerateVapid mints a keypair, persists BOTH keys to system_settings, and
+// returns ONLY the public key — the private key must never leave the server.
+func TestHandleGenerateVapid(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+	createSystemSettingsCollection(t, app)
+
+	req := httptest.NewRequest("POST", "/api/admin/vapid/generate", strings.NewReader("{}"))
+	re := &core.RequestEvent{App: app}
+	re.Request = req
+	re.Response = httptest.NewRecorder()
+
+	if err := handleGenerateVapid(app, re); err != nil {
+		t.Fatalf("handleGenerateVapid returned error: %v", err)
+	}
+
+	// Response carries the public key and NOT the private key.
+	body := re.Response.(*httptest.ResponseRecorder).Body.String()
+	var resp map[string]string
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("response not JSON: %v (%s)", err, body)
+	}
+	if resp["publicKey"] == "" {
+		t.Error("response missing publicKey")
+	}
+	if _, leaked := resp["privateKey"]; leaked {
+		t.Error("response must NOT include privateKey")
+	}
+	if strings.Contains(body, "privateKey") {
+		t.Errorf("private key leaked into response body: %s", body)
+	}
+
+	// Both keys are persisted to system_settings; the private one is marked secret.
+	pub, err := app.FindFirstRecordByFilter("system_settings", "key = 'vapid.public_key'")
+	if err != nil {
+		t.Fatalf("vapid.public_key not persisted: %v", err)
+	}
+	if pub.GetString("value") != resp["publicKey"] {
+		t.Error("persisted public key does not match the returned one")
+	}
+	if pub.GetBool("is_secret") {
+		t.Error("public key should not be marked secret")
+	}
+
+	priv, err := app.FindFirstRecordByFilter("system_settings", "key = 'vapid.private_key'")
+	if err != nil {
+		t.Fatalf("vapid.private_key not persisted: %v", err)
+	}
+	if priv.GetString("value") == "" {
+		t.Error("private key value should be stored server-side")
+	}
+	if !priv.GetBool("is_secret") {
+		t.Error("private key must be marked is_secret")
+	}
+}
+
+// upsertSystemSetting updates an existing row or inserts a new one.
+func TestUpsertSystemSetting(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+	createSystemSettingsCollection(t, app)
+
+	if err := upsertSystemSetting(app, "sentry.dsn", "https://a/1", false); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := upsertSystemSetting(app, "sentry.dsn", "https://b/2", false); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	recs, err := app.FindRecordsByFilter("system_settings", "key = 'sentry.dsn'", "", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 row after upsert, got %d", len(recs))
+	}
+	if recs[0].GetString("value") != "https://b/2" {
+		t.Errorf("upsert did not update value, got %q", recs[0].GetString("value"))
+	}
+}

--- a/core/server/pb_migrations/1910000007_pkg_admin_super_admin_rules.js
+++ b/core/server/pb_migrations/1910000007_pkg_admin_super_admin_rules.js
@@ -69,7 +69,11 @@ const GRANTS = [
     // owner accounts. They need view/update to see + edit owners, and `manage`
     // so they can set the managed auth fields (verified/email/password) when
     // creating a pre-verified org owner or resetting an owner's credentials.
-    { name: 'users', ops: ['view', 'update', 'manage'] },
+    // `list` (added later in 1910000011) lets the /admin Organizations tab
+    // resolve each org's owner via a cross-org users list/join; without it owners
+    // render as "No owner assigned". Kept here so a fresh DB grants it directly;
+    // 1910000011's idempotent append is a no-op on those.
+    { name: 'users', ops: ['list', 'view', 'update', 'manage'] },
     // mail_domains only exists when the mail package is installed
     { name: 'mail_domains', ops: ['create'], optional: true },
 ]

--- a/core/server/pb_migrations/1910000010_create_system_settings.js
+++ b/core/server/pb_migrations/1910000010_create_system_settings.js
@@ -1,0 +1,128 @@
+/// <reference path="../pb_data/types.d.ts" />
+// system_settings: deployment-wide configuration that applies to the ENTIRE
+// system (not a single org). It holds the "use-your-own-service" values a
+// third-party host must own — Sentry, web-push (VAPID), mail provider creds —
+// so they're configured from the /admin Settings console instead of env vars.
+//
+// This is the SOLE source of truth at runtime: the server reads values through
+// the in-memory SystemConfig (coreserver/system_config.go), which loads this
+// collection — there is no os.Getenv fallback in the read path. Env vars are
+// consulted ONCE, by the seed below, to carry an existing env-configured
+// deployment across to the DB on the boot that runs this migration.
+//
+// Shape: a flat key/value store. `is_secret` marks values that must never be
+// surfaced to clients or injected into the web HTML / JS bundle (tokens, the
+// VAPID private key, IMAP password). `key` is namespaced by area
+// (`sentry.dsn`, `vapid.private_key`, `mail.postmark_server_token`).
+//
+// Rules: all ops require a PB superuser OR a super-admin app user. A null rule
+// is superuser-only and `@collection.super_admins.user ?= @request.auth.id`
+// adds the super-admins (the same clause the admin console relies on
+// everywhere — see 1910000007_pkg_admin_super_admin_rules). Secret rows are
+// additionally never returned to clients by the server's config injection
+// (see system_config.go / the web HTML injector).
+const SA = '@collection.super_admins.user ?= @request.auth.id'
+
+// key → legacy env var. Used ONLY by the one-time seed. Keep `is_secret` in
+// sync with the secrets policy in docs/plans/system-settings.md.
+const SEED = [
+    { key: 'sentry.dsn', env: 'SENTRY_DSN', secret: false },
+    { key: 'sentry.org', env: 'SENTRY_ORG', secret: false },
+    { key: 'sentry.project', env: 'SENTRY_PROJECT', secret: false },
+    { key: 'sentry.auth_token', env: 'SENTRY_AUTH_TOKEN', secret: true },
+    { key: 'vapid.public_key', env: 'VAPID_PUBLIC_KEY', secret: false },
+    { key: 'vapid.private_key', env: 'VAPID_PRIVATE_KEY', secret: true },
+    { key: 'vapid.subject', env: 'VAPID_SUBJECT', secret: false },
+]
+
+migrate(
+    app => {
+        const col = new Collection({
+            id: 'pbc_system_settings',
+            name: 'system_settings',
+            type: 'base',
+            system: false,
+            listRule: SA,
+            viewRule: SA,
+            createRule: SA,
+            updateRule: SA,
+            deleteRule: SA,
+            fields: [
+                {
+                    id: 'ss_key',
+                    name: 'key',
+                    type: 'text',
+                    required: true,
+                    max: 100,
+                },
+                {
+                    id: 'ss_value',
+                    name: 'value',
+                    type: 'text',
+                    max: 5000,
+                },
+                {
+                    id: 'ss_is_secret',
+                    name: 'is_secret',
+                    type: 'bool',
+                },
+                {
+                    id: 'ss_updated_by',
+                    name: 'updated_by',
+                    type: 'relation',
+                    required: false,
+                    collectionId: '_pb_users_auth_',
+                    cascadeDelete: false,
+                    maxSelect: 1,
+                },
+                {
+                    id: 'ss_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                },
+                {
+                    id: 'ss_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                },
+            ],
+            indexes: ['CREATE UNIQUE INDEX `idx_system_settings_key` ON `system_settings` (`key`)'],
+        })
+        app.save(col)
+
+        // One-time seed from legacy env vars. Only writes a row when the env var
+        // is non-empty AND no row for that key exists yet — so re-running on a
+        // deployment that already configured a value via /admin is a no-op, and a
+        // deployment with no env vars simply starts empty.
+        for (const s of SEED) {
+            // PocketBase's JSVM exposes env via $os.getenv (NOT Node's process.env,
+            // which is undefined here). This is the only env read in the system —
+            // the runtime path reads system_settings, never the environment.
+            const val = $os.getenv(s.env)
+            if (!val) continue
+            try {
+                app.findFirstRecordByFilter('system_settings', 'key = {:key}', { key: s.key })
+                continue // already present
+            } catch (e) {
+                // not found → seed it
+            }
+            const rec = new Record(col)
+            rec.set('key', s.key)
+            rec.set('value', val)
+            rec.set('is_secret', s.secret)
+            app.save(rec)
+        }
+    },
+    app => {
+        try {
+            const c = app.findCollectionByNameOrId('system_settings')
+            app.delete(c)
+        } catch (e) {
+            // may not exist
+        }
+    }
+)

--- a/core/server/pb_migrations/1910000011_super_admin_users_list.js
+++ b/core/server/pb_migrations/1910000011_super_admin_users_list.js
@@ -1,0 +1,52 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Grant super-admins LIST access to `users`.
+//
+// 1910000007_pkg_admin_super_admin_rules granted super-admins view/update/manage
+// on `users` but NOT list — so a super-admin could fetch a specific user by id,
+// but a LIST query (filtered or not) silently returned only rows the org-scoped
+// rule already allowed (their own). The /admin Organizations tab resolves each
+// org's owner with a LIST/join over the local `users` store, so cross-org owners
+// came back unreadable and rendered as "No owner assigned" even though the
+// user_org owner row exists. Listing users is consistent with the super-admin's
+// existing cross-org reach (it already lists orgs + user_org).
+//
+// This appends the same super_admins clause to users.listRule that viewRule
+// already carries. Idempotent: skip if the clause is already present.
+const SA = '@collection.super_admins.user ?= @request.auth.id'
+
+function ruleStr(rule) {
+    if (rule === null || rule === undefined) return null
+    const s = String(rule)
+    return s === '' || s === 'null' ? null : s
+}
+
+migrate(
+    app => {
+        const users = app.findCollectionByNameOrId('users')
+        const current = ruleStr(users.listRule)
+        // null (superuser-only) → just the clause; otherwise OR it in. Skip when
+        // the clause is already present so a re-run is a no-op.
+        if (current === null) {
+            users.listRule = SA
+        } else if (!current.includes(SA)) {
+            users.listRule = `(${current}) || ${SA}`
+        }
+        app.save(users)
+    },
+    app => {
+        const users = app.findCollectionByNameOrId('users')
+        const s = ruleStr(users.listRule)
+        if (s === null) return
+        if (s === SA) {
+            users.listRule = null
+        } else {
+            const suffix = ` || ${SA}`
+            if (s.endsWith(suffix)) {
+                const inner = s.slice(0, -suffix.length)
+                users.listRule =
+                    inner.startsWith('(') && inner.endsWith(')') ? inner.slice(1, -1) : inner
+            }
+        }
+        app.save(users)
+    }
+)

--- a/core/server/push/push.go
+++ b/core/server/push/push.go
@@ -4,11 +4,22 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"os"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/pocketbase/pocketbase/core"
 )
+
+// systemSetting reads a value from the system_settings collection — the
+// system-wide config store (the same one coreserver.SystemConfig loads). push
+// reads it directly from the app (not via coreserver) to avoid an import cycle;
+// VAPID keys are needed per-send and rarely, so a direct lookup is fine.
+func systemSetting(app core.App, key string) string {
+	rec, err := app.FindFirstRecordByFilter("system_settings", "key = {:key}", map[string]any{"key": key})
+	if err != nil {
+		return ""
+	}
+	return rec.GetString("value")
+}
 
 // Payload is the JSON structure sent to the browser push service.
 type Payload struct {
@@ -44,9 +55,9 @@ func SendToUser(app core.App, userID string, payload Payload) {
 		return
 	}
 
-	vapidPublicKey := os.Getenv("VAPID_PUBLIC_KEY")
-	vapidPrivateKey := os.Getenv("VAPID_PRIVATE_KEY")
-	vapidSubject := os.Getenv("VAPID_SUBJECT")
+	vapidPublicKey := systemSetting(app, "vapid.public_key")
+	vapidPrivateKey := systemSetting(app, "vapid.private_key")
+	vapidSubject := systemSetting(app, "vapid.subject")
 	if vapidSubject == "" {
 		vapidSubject = "mailto:admin@tinycld.com"
 	}

--- a/core/server/push/push.go
+++ b/core/server/push/push.go
@@ -21,6 +21,14 @@ func systemSetting(app core.App, key string) string {
 	return rec.GetString("value")
 }
 
+// GenerateVAPIDKeys mints a fresh VAPID keypair (ECDSA P-256, base64url). The
+// public key derives from the private, so they must be generated together — this
+// wraps webpush so coreserver's admin endpoint can offer a "generate" action
+// without importing the webpush library directly.
+func GenerateVAPIDKeys() (privateKey, publicKey string, err error) {
+	return webpush.GenerateVAPIDKeys()
+}
+
 // Payload is the JSON structure sent to the browser push service.
 type Payload struct {
 	Title string `json:"title"`

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -1,0 +1,216 @@
+# Plan: System Settings (move "use-your-own-service" env vars into /admin)
+
+## Goal
+
+Let an operator configure **system-wide** service credentials/config from the
+`/admin` console instead of environment variables — so a third-party host doesn't
+ship our Sentry project, our web-push identity, or our mail provider.
+
+"System settings" = settings that apply to the **entire system**, not a single org
+(contrast the existing **org settings** under `/a/[orgSlug]/settings`).
+
+Motivating case: **Sentry DSN**. The same mechanism covers **VAPID** (web-push
+keypair, core) and **mail** credentials (Postmark/SMTP/IMAP, the `mail` package).
+
+**Env var support is REMOVED entirely** — `system_settings` is the sole source of
+truth (no `os.Getenv` fallback). A live in-memory `SystemConfig` struct holds the
+current values and re-initializes stateful consumers (Sentry today) when a value
+changes, so edits take effect without a restart.
+
+The /admin Settings section is **package-extensible** — built with the exact same
+manifest + lazy-component pattern that org `settings` use, so `mail` contributes its
+own system-settings panel instead of core hard-coding it.
+
+## Scope of vars (triaged from a full env sweep)
+
+**In scope — system-specific service config a host must own:**
+- Sentry: `SENTRY_DSN` (client+server), `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` *(secret)* — core
+- VAPID web-push: `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` *(secret)*, `VAPID_SUBJECT` — core
+- Mail: `MAIL_PROVIDER`, `POSTMARK_SERVER_TOKEN` *(secret)*, `POSTMARK_ACCOUNT_TOKEN` *(secret)*,
+  `MAIL_FROM_ADDRESS`, `SMTP_IMAP_USERNAME`, `SMTP_IMAP_PASSWORD` *(secret)*, `SMTP_DKIM_SELECTOR`, `SMTP_DOMAIN` — **mail package**
+
+**Out of scope (stay env) — infra/topology/build/test:** listen addresses + ports +
+enable flags (`SMTP_ADDR`, `IMAP_ADDR`, `SMTP_ENABLED`, `SMTP_INBOUND_MODE`, ...),
+`TINYCLD_PUBLIC_URL`, `TINYCLD_STATE_DIR`, TLS/domain vars, `ENVIRONMENT`,
+`EXPO_PUBLIC_ENV`, all `PW_*`/`TEST_*`/`SEED_*`/`RUN_*`, demo/dev toggles. These are
+set by the host's process manager and often differ per replica; they're not credentials.
+
+**Migration of existing deployments:** since env support is removed, the
+`system_settings` migration performs a **one-time seed**: for each in-scope key, if
+the row is absent, read the legacy env var and write it in. After that the env var is
+never read again. This carries running deployments across without manual re-entry.
+(A deployment that relied purely on env keeps working; the values just move into the DB.)
+
+## Key facts the design rests on (verified)
+
+- Client Sentry DSN is currently **hardcoded** in `lib/app-config.ts`, read
+  synchronously at module-init (`configure-core` → `initSentry`), NOT at runtime.
+- Web `app.html` is **read from disk and written per-request** by the Go server
+  (`static.go:211-218`) → we can inject a `<script>` into `<head>` at serve time;
+  a `window.__` global set there is available before the deferred bundle JS runs
+  (precedent: `window.location.origin`, `globalThis.__TINYCLD_*`).
+- Native has no `window`/HTML and inits Sentry before connecting to a server →
+  native uses the **build-time** path (`EXPO_PUBLIC_SENTRY_DSN` injected by the
+  rebuild) with the current hardcoded value as the floor.
+- `app.Settings().Meta` is a fixed PB struct → use a **dedicated collection**.
+- Rebuild injects per-platform env at `runExportWithProgress` (`rebuild_pipeline.go:268`).
+- Server Sentry inits once at startup (`sentry.go`); a DSN change needs a restart to
+  affect the SERVER's own capture (the web client picks it up on next load).
+
+## Package extensibility — mirror org `settings` exactly
+
+Org settings flow: manifest `settings: [{slug,component,label}]` → `describe-packages.ts`
+maps it → `gen-config.ts` emits `Component: lazy(() => import('<pkg>/<component>'))`
+→ `derive-components.ts` `deriveSettings()` groups by package → the settings hub
+maps `packageSettings` and a `[...section]` route renders the lazy component.
+Component strings resolve via each package's `exports` map (`"./settings/*"`).
+
+We replicate this for system settings with a new manifest field:
+
+```ts
+systemSettings?: { slug: string; component: string; label: string }[]
+```
+
+- Core itself contributes the **Sentry** (and later VAPID) panel via the synthetic
+  `admin`/core entry (or a small core-owned registration mirroring `builtin-admin.ts`).
+- `mail` contributes its mail-provider panel: `systemSettings: [{ slug:'provider',
+  label:'Mail Provider', component:'system-settings/provider' }]` + an exports entry
+  `"./system-settings/*": "./tinycld/mail/system-settings/*.tsx"`.
+- New runtime export `packageSystemSettings = deriveSystemSettings(tinycldConfig)`.
+- No slot/target validation needed (flat list, like org settings — not the
+  `slots`/`sidebarContributions` cross-package mechanism).
+
+## Data model
+
+Core collection `system_settings` (core migration):
+- `key` (text, unique) — `sentry.dsn`, `vapid.private_key`, `mail.postmark_server_token`, ...
+- `value` (text), `is_secret` (bool), `updated_by` (rel users, optional), autodate created/updated
+- Rules: super-admin OR superuser for all ops (reuse `@collection.super_admins...`
+  clause from `1910000007_*super_admin_rules`). Secret rows never surface to clients
+  (see API). Registered as a pbtsdb store in `core/lib/pocketbase.ts`.
+- **Migration seeds from legacy env once** (see "Migration of existing deployments"):
+  for each known key with no row, write `os.Getenv(<legacy var>)` if non-empty. This is
+  the ONLY place env vars are ever read; the runtime path never reads env.
+
+## Server: SystemConfig struct (single source of truth + re-init on change)
+
+`core/server/coreserver/system_config.go`:
+
+```go
+type SystemConfig struct {
+    mu     sync.RWMutex
+    app    core.App
+    values map[string]string // key → value, loaded from system_settings
+}
+
+func (c *SystemConfig) Get(key string) string          // RLock; pure read of current value
+func (c *SystemConfig) load()                           // (re)read all rows from the DB into values
+func (c *SystemConfig) onChanged(key, value string)     // update map + fire reinit hooks
+```
+
+- One instance constructed in `Register()` (server.go), held on the app (or a package
+  var like other coreserver singletons). `load()` runs once at boot, AFTER migrations.
+- **No `os.Getenv`** anywhere in the read path — `Get` returns only the stored value.
+- A PB hook re-syncs on edit: `OnRecordAfterCreateSuccess("system_settings")` +
+  `OnRecordAfterUpdateSuccess("system_settings")` (precedent: `invite_lifecycle.go:32`)
+  → `onChanged(key, value)`.
+
+**Re-init policy by consumer (driven by how each currently reads its config):**
+- **Sentry** — holds a stateful global client `sentry.Init`'d once at boot. `onChanged`
+  for any `sentry.*` key calls a new `reinitSentry(cfg)` that re-runs `sentry.Init`
+  with the new DSN/environment. (This is the only true re-init.)
+- **Push** — `push.SendToUser` reads VAPID **per send** (push.go:47-49), so it just
+  reads `cfg.Get("vapid.*")` at send time and picks up changes with no re-init.
+- **Mail** — the provider is built **per call** (`providerForOrg` / `newProviderFromEnv`,
+  register.go:127), so it reads `cfg.Get("mail.*")` when constructing and needs no re-init.
+
+So `SystemConfig` notifies exactly one stateful consumer today (Sentry); push/mail are
+naturally live because they read per-use. The struct still centralizes all reads.
+
+## Read-site changes (remove env)
+
+- `sentry.go`: `Dsn: cfg.Get("sentry.dsn")` (was `os.Getenv("SENTRY_DSN")`); add
+  `reinitSentry`. Sourcemap upload reads `sentry.org/project/auth_token` from `cfg`.
+- `push/push.go`: VAPID trio via `cfg.Get` (drop the three `os.Getenv`).
+- `mail` package `register.go`: replace the env fallbacks in `providerForOrg` /
+  `newProviderFromEnv` / `smtpConfigFromEnv` with `cfg.Get("mail.*")`. **Layering note:**
+  mail already reads **org** settings first, then env. New order: org settings →
+  **system settings** (was env). The mail package reads the shared `system_settings`
+  collection (it's a sibling repo; it reads via PB/core, not a core Go import).
+
+## Secrets handling
+
+Per-key `is_secret`:
+- **Non-secret** (Sentry DSN — already public/in-bundle; `VAPID_PUBLIC_KEY`;
+  `MAIL_FROM_ADDRESS`; `SENTRY_ORG`/`PROJECT`): stored plain, may be injected into web HTML / build env.
+- **Secret** (`SENTRY_AUTH_TOKEN`, `VAPID_PRIVATE_KEY`, `POSTMARK_*`,
+  `SMTP_IMAP_PASSWORD`): **write-only** in the UI (shows set/not-set + replace field),
+  never returned to non-admins, never injected client-side; server reads from DB.
+- Encryption-at-rest deferred (PB DB is the existing trust boundary); noted as future hardening.
+
+## Web client: runtime DSN via window global
+
+1. Server injects into `app.html` `<head>` a `<script>` setting
+   `window.__TINYCLD_PUBLIC_CONFIG__ = { sentryDsn: <non-secret value> }`, built from
+   **non-secret** system settings only.
+2. `lib/app-config.ts` `sentryDsn` =
+   `globalThis.__TINYCLD_PUBLIC_CONFIG__?.sentryDsn` (web, runtime-injected)
+   ?? `process.env.EXPO_PUBLIC_SENTRY_DSN` (native; inlined at build from the stored
+   value — see "Native client"). No hardcoded DSN remains in the source.
+   Declared in a `declare global` block.
+3. Changing the DSN in /admin takes effect on the next web page load — no rebuild.
+
+Note: `EXPO_PUBLIC_SENTRY_DSN` here is a *build input* (read at `expo export`, inlined),
+not a runtime env read — consistent with "no runtime env." Native reflects a change
+only after the next rebuild/OTA.
+
+## Native client: build-time inject
+
+`rebuild_pipeline.go::runExportWithProgress`: for native platforms add
+`EXPO_PUBLIC_SENTRY_DSN=<SettingValue(app,'sentry.dsn')>` to the scoped export env.
+Picked up on the next package rebuild / OTA. Web export doesn't need it.
+
+## /admin Settings section
+
+- `SetupDashboard.tsx`: add `'settings'` to the `SetupTab` union, a NAV entry
+  `{ tab:'settings', label:'Settings', crumb:'settings', Icon: Settings }`, and render
+  `<SettingsTab isVisible={activeTab==='settings'} pb={pb} />`.
+- `core/components/setup/SettingsTab.tsx`: lists `packageSystemSettings` groups (core's
+  Sentry/VAPID + mail's panel) and renders the selected lazy panel — same discovery
+  pattern as the org settings hub, but system-scoped (no org filter). Panels read/write
+  the `system_settings` store via `useStore` + `useMutation` (console runs as a
+  super-admin app user, so writes are authorized).
+
+## Phases
+
+1. **Storage + SystemConfig** — `system_settings` collection + migration (incl. one-time
+   seed-from-env) + super-admin rules; register pbtsdb store; `SystemConfig` struct with
+   `load()` at boot + the `OnRecordAfter{Create,Update}Success("system_settings")` →
+   `onChanged` hook. Go unit tests (Get reads current value; onChanged updates it).
+2. **Package mechanism** — manifest `systemSettings` field; `describe-packages.ts` +
+   `gen-config.ts` emission; `deriveSystemSettings` + `packageSystemSettings` export;
+   generator/derive unit tests.
+3. **Server read site (Sentry) + re-init** — `sentry.go` reads `cfg.Get("sentry.dsn")`;
+   add `reinitSentry`; wire it into `onChanged` for `sentry.*` keys. Remove `os.Getenv`.
+4. **Web window injection** — inject non-secret config into `app.html`; `app-config.ts` reads it.
+5. **Native build inject** — feed `cfg.Get("sentry.dsn")` as `EXPO_PUBLIC_SENTRY_DSN` to the native export.
+6. **/admin Settings UI** — NAV + `SettingsTab`; core contributes the Sentry panel.
+7. **Follow-ups** — VAPID panel + read site (core; per-send, no re-init) and mail panel +
+   read sites (mail package; per-call, no re-init), reusing 1–6. Remove their `os.Getenv`.
+
+## Tests
+
+- Go: `SystemConfig.Get` returns the stored value; `onChanged` updates it live;
+  `reinitSentry` runs on a `sentry.dsn` change; migration seeds from env once; collection
+  rules (super-admin write, anon denied).
+- Generator/derive: a manifest with `systemSettings` produces the grouped registry.
+- E2E (extend first-boot install spec): set a Sentry DSN in /admin Settings → reload web →
+  assert injected `window.__TINYCLD_PUBLIC_CONFIG__.sentryDsn` matches AND secret keys absent from HTML.
+- Unit: `app-config.ts` DSN resolution order (window > native-build env input).
+
+## Resolved decisions
+
+- **No env fallback at runtime** — `system_settings` is the sole source; env is read
+  only by the one-time migration seed.
+- **Live re-init on change** via `SystemConfig.onChanged` — Sentry re-inits; push/mail
+  read per-use so they're already live. No restart required.

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -168,6 +168,14 @@ Note: `EXPO_PUBLIC_SENTRY_DSN` here is a *build input* (read at `expo export`, i
 not a runtime env read — consistent with "no runtime env." Native reflects a change
 only after the next rebuild/OTA.
 
+**Done (phase 4):** server injection + `injectPublicConfig` (non-secret only, before
+`</head>`, `</script>`-escaped); `app-config.ts` resolves `window → EXPO_PUBLIC_SENTRY_DSN
+→ ''` with **no hardcoded DSN**. Because the official EAS native build previously
+depended on that hardcode, `eas.json`'s production profile now sets
+`EXPO_PUBLIC_SENTRY_DSN` so the official app keeps reporting; a third-party native
+build is silent until they set their own. **Release-note this** (behavior change for
+self-hosters relying on the env var / on our DSN).
+
 ## Native client: build-time inject
 
 `rebuild_pipeline.go::runExportWithProgress`: for native platforms add

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -201,6 +201,15 @@ remains anywhere in coreserver.
   the `system_settings` store via `useStore` + `useMutation` (console runs as a
   super-admin app user, so writes are authorized).
 
+**Done (phase 6):** `SetupDashboard` has a Settings nav entry + `SettingsTab`.
+`SettingsTab` renders a core-owned **Sentry** panel (DSN field; upserts `sentry.dsn`
+into the `system_settings` store via `useStore`+`useMutation`, keyed by row, using
+RHF `values:` for reactive seeding — no `useEffect`) plus any package-contributed
+`packageSystemSettings` panels (lazy, in Suspense). The panel is non-secret; secret
+fields get the write-only treatment when VAPID/mail land in phase 7. End-to-end
+visual verification (UI → store → server load → web injection) still wants a fresh
+image build — deferred.
+
 ## Phases
 
 1. **Storage + SystemConfig** — `system_settings` collection + migration (incl. one-time

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -264,3 +264,16 @@ image build — deferred.
   only by the one-time migration seed.
 - **Live re-init on change** via `SystemConfig.onChanged` — Sentry re-inits; push/mail
   read per-use so they're already live. No restart required.
+
+## End-to-end verification (done)
+
+`tests/install/run-first-boot-admin.sh` (new smoketest runner — boots a fresh-DB
+image, scrapes the setup token, runs `setup-and-packages.spec.ts`) passes all 5
+specs on an image built from this branch **after rebasing onto main (post-#82)**:
+bootstrap → lists bundled packages → create org → grant super-admin → **configure
+system settings** (save Sentry DSN → reload → `window.__TINYCLD_PUBLIC_CONFIG__.
+sentryDsn` injection confirmed → Generate VAPID → "Configured ✓").
+
+Dependency note: this branch required PR #82's `appPb`-auth fix (the console now
+runs authenticated) — before the rebase, the package list and the Settings-panel
+store reads came back empty because `appPb` was anonymous. #82 merged; rebased in.

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -182,6 +182,14 @@ self-hosters relying on the env var / on our DSN).
 `EXPO_PUBLIC_SENTRY_DSN=<SettingValue(app,'sentry.dsn')>` to the scoped export env.
 Picked up on the next package rebuild / OTA. Web export doesn't need it.
 
+**Done (phase 5):** native export injects `EXPO_PUBLIC_SENTRY_DSN` from
+`systemConfig.Get("sentry.dsn")` (web omitted — runtime-injected). The sourcemap
+upload (`uploadBundleSourcemaps`) now reads `sentry.auth_token`/`org`/`project`
+from `systemConfig` and passes the token to the `sentry-cli` subprocess via a new
+`runCmdEnv` (env, not a logged arg — keeps the secret out of build logs). The old
+`envOr` env helper is gone (replaced by the pure `orDefault`). No `os.Getenv("SENTRY_*")`
+remains anywhere in coreserver.
+
 ## /admin Settings section
 
 - `SetupDashboard.tsx`: add `'settings'` to the `SetupTab` union, a NAV entry

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -227,6 +227,27 @@ image build — deferred.
 7. **Follow-ups** — VAPID panel + read site (core; per-send, no re-init) and mail panel +
    read sites (mail package; per-call, no re-init), reusing 1–6. Remove their `os.Getenv`.
 
+**Done (phase 7):**
+- **VAPID (core):** `push/push.go` reads `vapid.*` from `system_settings` directly off
+  `app` (no coreserver import → no cycle), per-send. `SettingsTab` gained a VAPID panel
+  with a reusable write-only `SecretField` (private key never seeded back into the form;
+  blank submit = unchanged). Shared `useSystemSettings` hook (`system-settings-store.ts`)
+  backs both core panels.
+- **Mail (sibling repo):** `register.go` provider/SMTP/IMAP-credential reads now layer
+  org `settings` → `system_settings` (`mail.*`) → default; the env fallback is gone
+  (`smtpConfigFromEnv`→`smtpConfigFromSystem(app)`, `newProviderFromEnv`→
+  `newProviderFromSystem(app)`, threaded `app` through `smtpConfigFromSettings`/imap
+  fetcher). Mail contributes a `system-settings/provider` panel (provider + write-only
+  Postmark tokens) via its manifest + a `./system-settings/*` exports entry.
+- **Out of scope (stay env, confirmed):** mail's listen-address/port/enable-flag vars
+  (`SMTP_ADDR`, `IMAP_ENABLED`, `SMTP_DOMAIN`, `SMTP_INBOUND_ADDR`, …) — host topology.
+- **Two repos:** core (`tinycld`) and `mail` are separate git repos → two commits,
+  coordinated release. No migrated `os.Getenv("MAIL_*"/"POSTMARK_*"/"SMTP_IMAP_*")`,
+  `VAPID_*`, or `SENTRY_*` reads remain.
+- **Secrets:** front-end obfuscation only (write-only fields); the value still reaches
+  the super-admin client over the wire (existing trust model). NOT injected into public
+  web HTML. (Server-side redaction was considered and declined.)
+
 ## Tests
 
 - Go: `SystemConfig.Get` returns the stored value; `onChanged` updates it live;

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -129,8 +129,12 @@ naturally live because they read per-use. The struct still centralizes all reads
 
 ## Read-site changes (remove env)
 
-- `sentry.go`: `Dsn: cfg.Get("sentry.dsn")` (was `os.Getenv("SENTRY_DSN")`); add
-  `reinitSentry`. Sourcemap upload reads `sentry.org/project/auth_token` from `cfg`.
+- `sentry.go`: `Dsn: cfg.Get("sentry.dsn")` (was `os.Getenv("SENTRY_DSN")`); done in
+  phase 3 via `initSentryFromConfig`, re-run on any `sentry.*` change. **Done.**
+- Sourcemap upload (`app_native_export.go`: `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/
+  `SENTRY_PROJECT`) — these feed the `sentry-cli` SUBPROCESS env, not just a Go read,
+  so they move in **phase 5** (build-env injection) alongside the native build vars,
+  not phase 3.
 - `push/push.go`: VAPID trio via `cfg.Get` (drop the three `os.Getenv`).
 - `mail` package `register.go`: replace the env fallbacks in `providerForOrg` /
   `newProviderFromEnv` / `smtpConfigFromEnv` with `cfg.Get("mail.*")`. **Layering note:**

--- a/eas.json
+++ b/eas.json
@@ -21,7 +21,8 @@
             "autoIncrement": true,
             "env": {
                 "EXPO_PUBLIC_ENV": "production",
-                "NODE_OPTIONS": "--max-old-space-size=8192"
+                "NODE_OPTIONS": "--max-old-space-size=8192",
+                "EXPO_PUBLIC_SENTRY_DSN": "https://bfba682150acd66a9b75f51ddbced312@o4510361420431360.ingest.us.sentry.io/4511261359013888"
             },
             "android": {
                 "buildType": "app-bundle"

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -26,6 +26,30 @@ function devDefaultServer(): string {
     return 'https://localhost:7100'
 }
 
+// Public (non-secret) system config the server injects into the web HTML before
+// the bundle loads — see coreserver/static.go::publicConfigScript. Web only;
+// native has no window/HTML and uses the build-time path below.
+declare global {
+    // eslint-disable-next-line no-var
+    var __TINYCLD_PUBLIC_CONFIG__: { sentryDsn?: string } | undefined
+}
+
+// Resolve the Sentry DSN at startup. Order:
+//   1. window.__TINYCLD_PUBLIC_CONFIG__ — web, injected by the app server at
+//      serve time, so changing it in /admin Settings takes effect on next load
+//      with no rebuild.
+//   2. process.env.EXPO_PUBLIC_SENTRY_DSN — native, inlined at `expo export`
+//      from the stored value by the rebuild pipeline (build input, not a runtime
+//      env read).
+//   3. '' — no DSN configured; Sentry init no-ops (see core/lib/sentry.ts).
+// No hardcoded production DSN: a third-party host must supply its own.
+function resolveSentryDsn(): string {
+    if (typeof globalThis !== 'undefined' && globalThis.__TINYCLD_PUBLIC_CONFIG__?.sentryDsn) {
+        return globalThis.__TINYCLD_PUBLIC_CONFIG__.sentryDsn
+    }
+    return process.env.EXPO_PUBLIC_SENTRY_DSN ?? ''
+}
+
 // App config handed to @tinycld/core at startup. Web resolves the PB address
 // from the page origin (the dev proxy / app server routes /api to PocketBase
 // same-origin); native uses defaultServer on the connect screen.
@@ -34,9 +58,10 @@ function devDefaultServer(): string {
 // app.json alone. The fallback covers the rare case Constants.expoConfig is
 // unavailable (e.g. some unit-test environments).
 //
-// Sentry DSN is hardcoded (matches the EXPO_PUBLIC_SENTRY_DSN value EAS injects
-// from its production environment) so it ships in every build without depending
-// on build-time env plumbing.
+// Sentry DSN is resolved at startup (resolveSentryDsn): web reads the
+// server-injected window global; native uses EXPO_PUBLIC_SENTRY_DSN inlined at
+// build time. There is NO hardcoded production DSN — a host (incl. ours, via EAS
+// env) must supply its own, so a third-party deployment never reports to us.
 export const appConfig: CoreConfig = {
     brandName: Constants.expoConfig?.name ?? 'TinyCld',
     serverShortcuts: {},
@@ -50,8 +75,7 @@ export const appConfig: CoreConfig = {
     webShortcut: () =>
         Platform.OS === 'web' && typeof window !== 'undefined' ? window.location.origin : null,
     defaultServer: __DEV__ ? devDefaultServer() : 'https://tinycld.org',
-    sentryDsn:
-        'https://bfba682150acd66a9b75f51ddbced312@o4510361420431360.ingest.us.sentry.io/4511261359013888',
+    sentryDsn: resolveSentryDsn(),
     privacyUrl: 'https://tinycld.org/privacy',
     sourceUrl: 'https://github.com/tinycld/tinycld',
 }

--- a/scripts/__tests__/describe-packages.test.ts
+++ b/scripts/__tests__/describe-packages.test.ts
@@ -39,12 +39,28 @@ describe('manifestToConfigPkg', () => {
             version: '0.1.0',
             description: 'd',
             settings: [{ slug: 'g', component: 'settings/takeout', label: 'Import' }],
+            systemSettings: [
+                { slug: 'mail', component: 'system-settings/provider', label: 'Mail Provider' },
+            ],
         })
         expect(cp.hasRegister).toBe(false)
         expect(cp.schemaType).toBe('')
         expect(cp.settings).toEqual([{ slug: 'g', component: 'settings/takeout', label: 'Import' }])
+        expect(cp.systemSettings).toEqual([
+            { slug: 'mail', component: 'system-settings/provider', label: 'Mail Provider' },
+        ])
         expect(cp.slots).toEqual([])
         expect(cp.sidebarContributions).toEqual([])
+    })
+
+    it('defaults systemSettings to [] when the manifest omits it', () => {
+        const cp = manifestToConfigPkg('@tinycld/contacts', {
+            name: 'Contacts',
+            slug: 'contacts',
+            version: '0.1.0',
+            description: 'd',
+        })
+        expect(cp.systemSettings).toEqual([])
     })
 
     it('passes through slots and sidebarContributions, defaulting order to 0', () => {

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -10,6 +10,7 @@ const contacts: ConfigPkg = {
     hasProvider: false,
     hasSeed: true,
     settings: [],
+    systemSettings: [],
     slots: [],
     sidebarContributions: [],
     manifest: { name: 'Contacts', slug: 'contacts', version: '0.1.0', description: 'd' },
@@ -23,6 +24,7 @@ const takeout: ConfigPkg = {
     hasProvider: false,
     hasSeed: false,
     settings: [{ slug: 'google-takeout', label: 'Import', component: 'settings/takeout' }],
+    systemSettings: [],
     slots: [],
     sidebarContributions: [],
     manifest: {
@@ -59,6 +61,21 @@ describe('buildConfigSource', () => {
         expect(src).toContain('export type MergedPackageSchema = Record<string, never>')
     })
 
+    it('emits systemSettings as a lazy-loaded array (system-scoped panels)', () => {
+        const withSystem: ConfigPkg = {
+            ...takeout,
+            systemSettings: [
+                { slug: 'provider', label: 'Mail Provider', component: 'system-settings/provider' },
+            ],
+        }
+        const src = buildConfigSource([withSystem])
+        expect(src).toContain('systemSettings: [')
+        expect(src).toContain('label: "Mail Provider"')
+        expect(src).toContain(
+            "lazy(() => import('@tinycld/google-takeout-import/system-settings/provider'))"
+        )
+    })
+
     it('camelCases slugs for identifiers', () => {
         const src = buildConfigSource([
             {
@@ -85,6 +102,7 @@ describe('buildConfigSource', () => {
             hasProvider: true,
             hasSeed: false,
             settings: [],
+            systemSettings: [],
             slots: [],
             sidebarContributions: [],
             manifest: { name: 'Drive', slug: 'drive', version: '0.1.0', description: 'd' },
@@ -105,6 +123,7 @@ describe('buildConfigSource', () => {
             hasProvider: false,
             hasSeed: false,
             settings: [],
+            systemSettings: [],
             slots: [],
             sidebarContributions: [],
             manifest: { name: 'Mail', slug: 'mail', version: '0.1.0', description: 'd' },

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -31,6 +31,11 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
             label: s.label,
             component: s.component,
         })),
+        systemSettings: (manifest.systemSettings ?? []).map(s => ({
+            slug: s.slug,
+            label: s.label,
+            component: s.component,
+        })),
         slots,
         sidebarContributions: (manifest.sidebarContributions ?? []).map(c => ({
             target: c.target,

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -4,6 +4,12 @@ export interface ConfigSettingsPanel {
     component: string // subpath e.g. 'settings/provider'
 }
 
+export interface ConfigSystemSettingsPanel {
+    slug: string
+    label: string
+    component: string // subpath e.g. 'system-settings/provider'
+}
+
 export interface ConfigSidebarContribution {
     target: string
     slot: string
@@ -20,6 +26,7 @@ export interface ConfigPkg {
     hasProvider: boolean
     hasSeed: boolean
     settings: ConfigSettingsPanel[]
+    systemSettings: ConfigSystemSettingsPanel[]
     slots: string[]
     sidebarContributions: ConfigSidebarContribution[]
     manifest: { name: string; slug: string; version: string; description: string } & Record<
@@ -52,6 +59,7 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
             p.hasSidebar ||
             p.hasProvider ||
             p.settings.length > 0 ||
+            p.systemSettings.length > 0 ||
             p.sidebarContributions.length > 0
     )
     if (needsLazy) lines.push("import { lazy } from 'react'")
@@ -83,6 +91,15 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
         if (p.settings.length > 0) {
             lines.push('        settings: [')
             for (const s of p.settings) {
+                lines.push(
+                    `            { slug: ${jsonLiteral(s.slug)}, label: ${jsonLiteral(s.label)}, Component: lazy(() => import('${p.packageName}/${s.component}')) },`
+                )
+            }
+            lines.push('        ],')
+        }
+        if (p.systemSettings.length > 0) {
+            lines.push('        systemSettings: [')
+            for (const s of p.systemSettings) {
                 lines.push(
                     `            { slug: ${jsonLiteral(s.slug)}, label: ${jsonLiteral(s.label)}, Component: lazy(() => import('${p.packageName}/${s.component}')) },`
                 )

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -16,6 +16,7 @@ export interface PackageManifest {
     sidebar?: { component: string }
     provider?: { component: string }
     settings?: { slug: string; component: string; label: string }[]
+    systemSettings?: { slug: string; component: string; label: string }[]
     slots?: string[]
     sidebarContributions?: {
         target: string

--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -30,6 +30,7 @@
  *   --help                 Show this help message
  */
 
+import { deriveUsername } from '@tinycld/core/lib/derive-username'
 import { loadEnv } from '@tinycld/core/lib/load-env'
 import { deriveSeeds } from '@tinycld/core/lib/packages/derive-seeds'
 import PocketBase from 'pocketbase'
@@ -673,6 +674,49 @@ export async function seedForUser(pb: PocketBase, config: SeedConfig): Promise<S
     return login
 }
 
+// Make the admin a REAL app user, not just a PocketBase _superusers record.
+// `reset-dev-db.ts` creates the admin via `superuser upsert`, which only writes
+// _superusers — so without this the admin can sign into the /admin console (PB
+// superuser path) but has no `users` row, no app-shell login, and no membership.
+// This mirrors what the first-boot wizard now does (handleSetupInit): create a
+// `users` record for the admin email + a super_admins grant, so admin@ is a
+// usable super-admin app user. Idempotent: skips creation when the row exists.
+async function ensureAdminAppUser(pb: PocketBase, config: SeedConfig): Promise<void> {
+    let existing: { id: string } | null = null
+    try {
+        existing = await pb.collection('users').getFirstListItem(`email = "${config.adminEmail}"`)
+    } catch (err) {
+        if (!isNotFoundError(err)) throw err
+    }
+
+    let adminUser: { id: string }
+    if (existing) {
+        adminUser = existing
+        log('Found existing admin app user:', config.adminEmail)
+    } else {
+        log('Creating admin app user:', config.adminEmail)
+        adminUser = await pb.collection('users').create({
+            username: deriveUsername(config.adminEmail),
+            email: config.adminEmail,
+            password: config.adminPassword,
+            passwordConfirm: config.adminPassword,
+            name: config.adminEmail.split('@')[0],
+            emailVisibility: true,
+            verified: true,
+        })
+    }
+
+    if (await hasCollection(pb, 'super_admins')) {
+        try {
+            await pb.collection('super_admins').getFirstListItem(`user = "${adminUser.id}"`)
+            log('Found existing super_admins grant for admin')
+        } catch {
+            log('Granting super_admins to admin', config.adminEmail)
+            await pb.collection('super_admins').create({ user: adminUser.id })
+        }
+    }
+}
+
 export async function authSuperuser(config: {
     url: string
     adminEmail: string
@@ -709,7 +753,8 @@ function printLoginSummary(config: SeedConfig, login: SeedLoginResult): void {
         `  user:     ${login.userEmail}`,
         `  password: ${appPassword}`,
         '',
-        'Superuser  (PocketBase /_/ dashboard, and /admin to manage orgs & packages)',
+        'Admin  (super-admin app user — signs into the app AND /admin to manage',
+        'orgs & packages; also a PocketBase superuser for the /_/ dashboard)',
         `  ${url}/admin`,
         `  user:     ${config.adminEmail}`,
         `  password: ${config.adminPassword}`,
@@ -722,6 +767,7 @@ async function main() {
     const config = parseArgs()
     log(`Mode: ${config.mode} (user=${config.userEmail}, org=${config.orgSlug})`)
     const pb = await authSuperuser(config)
+    await ensureAdminAppUser(pb, config)
     const login = await seedForUser(pb, config)
     log('Seeding complete!')
     printLoginSummary(config, login)

--- a/tests/install/run-first-boot-admin.sh
+++ b/tests/install/run-first-boot-admin.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Smoke test for the first-boot /admin console: builds (or reuses) a TinyCld
+# image, boots it on a FRESH blank DB so the first-run setup token is printed,
+# scrapes that token, and runs setup-and-packages.spec.ts against the live
+# container — the bootstrap wizard, the package list, org creation, super-admin
+# grant, and the system-settings panels (Sentry DSN injection + VAPID generate).
+#
+# This is the runner setup-and-packages.spec.ts always needed (run-todo-install.sh
+# only drives the heavy todo-install spec). Always boots a clean DB so the run is
+# deterministic and self-isolating — no hand-running against a reused container.
+#
+# Env knobs (mirror run-todo-install.sh):
+#   IMAGE=<tag>   Skip the build and test an existing local image tag.
+#   PULL=1        Pull from a registry before running (skips the build).
+#   KEEP=1        Leave the container running afterward (manual debugging).
+#   PW_BASE_URL   Override the base URL (default http://localhost:7090).
+set -euo pipefail
+
+DEFAULT_PULL_IMAGE="ghcr.io/tinycld/tinycld:latest"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WS_ROOT="$(cd "${APP_DIR}/.." && pwd)"
+
+CONTAINER=tinycld-first-boot-test
+BASE_URL="${PW_BASE_URL:-http://localhost:7090}"
+LOG_DIR="${SCRIPT_DIR}/first-boot-logs"
+LIVE_LOG="${LOG_DIR}/container.live.log"
+TAIL_PID=""
+
+# Image source: PULL=1 → pull; IMAGE=<tag> → reuse a local tag; neither → build
+# from the current working tree.
+BUILD_IMAGE=1
+PULL_IMAGE=0
+if [ "${PULL:-}" = "1" ]; then
+    BUILD_IMAGE=0
+    PULL_IMAGE=1
+    IMAGE="${IMAGE:-${DEFAULT_PULL_IMAGE}}"
+elif [ -n "${IMAGE:-}" ]; then
+    BUILD_IMAGE=0
+else
+    IMAGE=tinycld-first-boot-test
+fi
+
+cleanup() {
+    if [ -n "${TAIL_PID}" ]; then kill "${TAIL_PID}" >/dev/null 2>&1 || true; fi
+    if [ "${KEEP:-}" = "1" ]; then
+        echo "[runner] KEEP=1 — leaving container ${CONTAINER} up (live log: ${LIVE_LOG})"
+        return
+    fi
+    docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+    [ -n "${MOUNT_ROOT:-}" ] && echo "[runner] bind-mounts at ${MOUNT_ROOT}"
+}
+trap cleanup EXIT
+
+dump_logs() {
+    mkdir -p "${LOG_DIR}"
+    docker logs "${CONTAINER}" > "${LOG_DIR}/container.log" 2>&1 || true
+    echo "[runner] --- last 40 lines of container log ---"
+    tail -40 "${LOG_DIR}/container.log" || true
+}
+
+wait_healthy() {
+    local timeout="${1:-300}"
+    for i in $(seq 1 "${timeout}"); do
+        if curl -sf "${BASE_URL}/api/health" >/dev/null 2>&1; then
+            echo "[runner] healthy after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "[runner] ERROR: container never became healthy (waited ${timeout}s)" >&2
+    dump_logs
+    return 1
+}
+
+# 1. Obtain the image.
+if [ "${PULL_IMAGE}" = "1" ]; then
+    echo "[runner] pulling ${IMAGE}"
+    docker pull "${IMAGE}"
+elif [ "${BUILD_IMAGE}" = "1" ]; then
+    echo "[runner] building ${IMAGE} from ${WS_ROOT}"
+    docker build -f "${APP_DIR}/Dockerfile" -t "${IMAGE}" "${WS_ROOT}"
+else
+    echo "[runner] using existing local image ${IMAGE}"
+fi
+
+# 2. Boot on a FRESH blank DB. The setup token is only printed when pb_data has no
+#    superusers, so a clean mount guarantees it — and makes every run isolated.
+MOUNT_ROOT="$(mktemp -d -t tinycld-first-boot.XXXXXX)"
+mkdir -p "${MOUNT_ROOT}/pb_data" "${MOUNT_ROOT}/builds" "${MOUNT_ROOT}/releases"
+docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+docker run -d --name "${CONTAINER}" -p 7090:7090 \
+    -v "${MOUNT_ROOT}/pb_data:/workspace/pb_data" \
+    -v "${MOUNT_ROOT}/builds:/workspace/builds" \
+    -v "${MOUNT_ROOT}/releases:/workspace/releases" \
+    "${IMAGE}" >/dev/null
+
+mkdir -p "${LOG_DIR}"
+: > "${LIVE_LOG}"
+docker logs -f "${CONTAINER}" >> "${LIVE_LOG}" 2>&1 &
+TAIL_PID=$!
+
+# 3. Wait for first-boot health (cold boot does schema-gen + seeding).
+wait_healthy 300
+
+# 4. Scrape the first-run token. It's printed near the end of boot (after health
+#    answers), so poll the logs for up to 30s.
+TOKEN=""
+for i in $(seq 1 30); do
+    TOKEN=$(docker logs "${CONTAINER}" 2>&1 | grep -oE 'token=[a-f0-9]+' | head -1 | cut -d= -f2 || true)
+    [ -n "${TOKEN}" ] && break
+    sleep 1
+done
+if [ -z "${TOKEN}" ]; then
+    echo "[runner] ERROR: no bootstrap token printed in logs after 30s" >&2
+    dump_logs
+    exit 1
+fi
+echo "[runner] scraped bootstrap token (${#TOKEN} chars)"
+
+# 5. Ensure chromium is present (no-op once cached), then run the spec in place
+#    against the live container.
+echo "[runner] ensuring chromium is installed for playwright"
+(cd "${APP_DIR}" && pnpm exec playwright install chromium >/dev/null)
+
+echo "[runner] running setup-and-packages.spec.ts"
+(
+    cd "${SCRIPT_DIR}"
+    PW_BASE_URL="${BASE_URL}" \
+    PW_SETUP_TOKEN="${TOKEN}" \
+    CI=true FORCE_COLOR=0 \
+    pnpm exec playwright test setup-and-packages.spec.ts --reporter=line,list
+) || { echo "[runner] spec failed"; dump_logs; exit 1; }
+
+echo "[runner] ✅ first-boot /admin smoke test passed"

--- a/tests/install/setup-and-packages.spec.ts
+++ b/tests/install/setup-and-packages.spec.ts
@@ -163,6 +163,11 @@ test.describe('first-run install', () => {
             await ownerPage.getByTestId('login-password').fill(TEST_ORG_OWNER_PASSWORD)
             await ownerPage.getByTestId('login-submit').click()
             await ownerPage.waitForURL(/\/a\//, { timeout: 30_000 })
+            // Landing on /a/ isn't enough — assert the authenticated org app shell
+            // actually rendered. nav-home is the rail's org-home button, present
+            // only inside the signed-in workspace (not on the login screen or an
+            // error shell), so this proves the owner is genuinely authenticated.
+            await expect(ownerPage.getByTestId('nav-home')).toBeVisible({ timeout: 30_000 })
         } finally {
             await ownerPage.close()
         }

--- a/tests/install/setup-and-packages.spec.ts
+++ b/tests/install/setup-and-packages.spec.ts
@@ -207,12 +207,24 @@ test.describe('first-run install', () => {
         await loginAsSuperuser(page)
         await page.getByText('Settings', { exact: true }).first().click()
 
-        // Sentry DSN: fill, save.
+        // Sentry DSN: fill, save. On a fresh deployment the field starts empty, so
+        // filling it makes the form dirty and enables Save. After a successful save
+        // the form is no longer dirty and the button re-disables — wait for that so
+        // the value is persisted before we reload. (The smoketest runner always
+        // boots a clean DB, so the field is reliably empty here.)
         await page.getByRole('textbox', { name: 'Sentry DSN', exact: true }).fill(TEST_DSN)
         await page.getByTestId('sentry-dsn-save').click()
+        await expect(page.getByTestId('sentry-dsn-save')).toBeDisabled()
 
-        // Reload so the server re-serves app.html with the freshly-stored value
-        // injected. (login goto('/admin') is the one allowed full load.)
+        // VAPID: generate a keypair server-side; the panel flips to "Configured".
+        await page.getByTestId('vapid-generate').click()
+        await expect(page.getByText('Configured ✓')).toBeVisible()
+
+        // Reload so the server re-serves app.html with the stored DSN injected as
+        // window.__TINYCLD_PUBLIC_CONFIG__ — the value the web client reads at
+        // startup. This is the public-config injection chain, end to end. The
+        // global is set by an inline <script> regardless of auth, so we can read
+        // it on the (logged-out) shell without signing back in.
         await page.goto('/admin')
         const injected = await page.evaluate(
             () =>
@@ -220,10 +232,5 @@ test.describe('first-run install', () => {
                     .__TINYCLD_PUBLIC_CONFIG__?.sentryDsn
         )
         expect(injected).toBe(TEST_DSN)
-
-        // VAPID: generate a keypair server-side; the panel flips to "Configured".
-        await page.getByText('Settings', { exact: true }).first().click()
-        await page.getByTestId('vapid-generate').click()
-        await expect(page.getByText('Configured ✓')).toBeVisible()
     })
 })

--- a/tests/install/setup-and-packages.spec.ts
+++ b/tests/install/setup-and-packages.spec.ts
@@ -195,4 +195,35 @@ test.describe('first-run install', () => {
         // owner's row (not just "not empty") makes the regression signal precise.
         await expect(page.getByText(TEST_ORG_OWNER_EMAIL, { exact: true })).toBeVisible()
     })
+
+    // Exercises the full system-settings chain end-to-end: save a value in the
+    // /admin Settings UI → server stores it → the app server injects the
+    // non-secret public config into app.html → the next page load exposes it on
+    // window.__TINYCLD_PUBLIC_CONFIG__ (which lib/app-config.ts reads for the
+    // Sentry DSN). Also drives the VAPID generate button.
+    test('superuser can configure system settings (Sentry DSN + VAPID)', async ({ page }) => {
+        const TEST_DSN = 'https://e2ekey@o1.ingest.sentry.io/42'
+
+        await loginAsSuperuser(page)
+        await page.getByText('Settings', { exact: true }).first().click()
+
+        // Sentry DSN: fill, save.
+        await page.getByRole('textbox', { name: 'Sentry DSN', exact: true }).fill(TEST_DSN)
+        await page.getByTestId('sentry-dsn-save').click()
+
+        // Reload so the server re-serves app.html with the freshly-stored value
+        // injected. (login goto('/admin') is the one allowed full load.)
+        await page.goto('/admin')
+        const injected = await page.evaluate(
+            () =>
+                (window as unknown as { __TINYCLD_PUBLIC_CONFIG__?: { sentryDsn?: string } })
+                    .__TINYCLD_PUBLIC_CONFIG__?.sentryDsn
+        )
+        expect(injected).toBe(TEST_DSN)
+
+        // VAPID: generate a keypair server-side; the panel flips to "Configured".
+        await page.getByText('Settings', { exact: true }).first().click()
+        await page.getByTestId('vapid-generate').click()
+        await expect(page.getByText('Configured ✓')).toBeVisible()
+    })
 })


### PR DESCRIPTION
Lets an operator configure system-wide service config from the **/admin → Settings** console instead of env vars, so a third-party host uses its own Sentry / web-push / mail provider rather than ours. `system_settings` is the sole runtime source (a one-time migration seeds it from the legacy env vars); a live `SystemConfig` re-inits Sentry on change with no restart.

## What's in it
- **Storage + `SystemConfig`**: `system_settings` collection (super-admin-gated, `is_secret` per key) + an in-memory config that loads at boot and re-syncs via record hooks.
- **Package-extensible**: a manifest `systemSettings` field (mirrors org `settings`), so packages contribute panels. Mail contributes a provider panel (separate repo — its PR follows).
- **Sentry**: server reads `sentry.dsn` from `SystemConfig` (live re-init); web client gets it at runtime via a server-injected `window.__TINYCLD_PUBLIC_CONFIG__` (no rebuild); native inlines it at build. **No hardcoded DSN** — `eas.json` now supplies the official one.
- **VAPID**: push reads keys from `system_settings`; the panel has a one-click **Generate** (mints + persists server-side, private key never sent to the client) plus a paste path for migration.
- **Secrets**: write-only fields in the UI; never injected into public web HTML.

## Also (admin/seed fixes found while dogfooding `db:reset`)
Independent of the feature, but needed for a working admin locally:
- seed: the `db:reset` admin is now a real app user (`users` + `super_admins`), not just a PB superuser.
- auth: an org-less super-admin can sign in and lands on `/admin`.
- rules: super-admins get `list` on `users` so the Organizations tab resolves owners.

## Tests
- Go: `SystemConfig` (load/get/onChange/hooks), Sentry re-init, public-config redaction + `</script>` escaping, migration env-seed, VAPID generate endpoint, auth login branches.
- Unit: generator/derive for `systemSettings`, settings-field logic, `app-config` DSN resolution.
- E2E: new `run-first-boot-admin.sh` smoketest — boots a fresh-DB image and runs the first-boot spec (bootstrap → packages → org create + owner login → grant → **save Sentry DSN, reload, assert window injection → Generate VAPID**). All 5 pass on a built image.

Depends on #82 (already merged). Removing env support is a behavior change for self-hosters — release-note it.