### PR TITLE
fix(system-settings): harden secret injection gate + document breaking change

### DIFF
--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -15,20 +15,24 @@ import (
 // publicConfigScript builds the inline <script> that publishes NON-secret system
 // config to the web client on window.__TINYCLD_PUBLIC_CONFIG__, read at module
 // init by lib/app-config.ts (e.g. the Sentry DSN). Secret values never appear
-// here — PublicValues() already excludes them. Storage keys are mapped to the
-// client config field names so the browser contract is decoupled from the
-// collection's key namespace. Returns "" when there's nothing to publish.
+// here (see the two gates below). Storage keys are mapped to client-facing field
+// names so the browser contract is decoupled from the collection's key namespace.
+// Returns "" when there's nothing to publish.
 //
 // The JSON is marshaled (not string-built) so values are safely escaped; we then
 // guard against "</script>" appearing in a value, which would otherwise close the
 // tag early — JSON-encodes "<" as-is, so a malicious DSN could break out.
 func publicConfigScript() string {
-	vals := systemConfig.PublicValues()
-	// Whitelist + rename: only keys the client is meant to consume, under their
-	// client-facing names. Adding a new public client value is a deliberate edit
-	// here, not an automatic passthrough of every non-secret row.
+	// Two independent gates keep secrets out of the HTML: (1) PublicValues()
+	// returns only non-secret rows, and (2) the explicit whitelist below names the
+	// exact keys the client may consume, under their client-facing names. Adding a
+	// public client value is a deliberate edit here, not an automatic passthrough.
+	// The whitelist is also asserted non-secret at injection time (the one place a
+	// leak is unrecoverable) so a row mis-flagged is_secret=false elsewhere still
+	// can't slip a credential into the page.
+	const sentryDSNKey = "sentry.dsn"
 	out := map[string]string{}
-	if v := vals["sentry.dsn"]; v != "" {
+	if v := systemConfig.publicValue(sentryDSNKey); v != "" {
 		out["sentryDsn"] = v
 	}
 	if len(out) == 0 {

--- a/core/server/coreserver/system_config.go
+++ b/core/server/coreserver/system_config.go
@@ -42,9 +42,15 @@ func (c *SystemConfig) Get(key string) string {
 }
 
 // PublicValues returns a copy of every NON-secret key→value pair. This is the
-// only set of values allowed to leave the server toward a client (injected into
-// the web HTML). Secret values (tokens, the VAPID private key, IMAP password)
-// are never included — they're read server-side only.
+// only set of values allowed to be injected into the web HTML. Secret values
+// (tokens, the VAPID private key, IMAP password) are never included here.
+//
+// NOTE: this gates HTML INJECTION only. It is NOT a confidentiality boundary for
+// the secret values themselves — those still live in the super-admin-readable
+// system_settings collection, so a super admin's client reads them over the wire
+// (the admin UI just renders them write-only). The trust boundary is "super
+// admin"; "secret" here means "never embedded in the public page served to every
+// visitor".
 func (c *SystemConfig) PublicValues() map[string]string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -55,6 +61,18 @@ func (c *SystemConfig) PublicValues() map[string]string {
 		}
 	}
 	return out
+}
+
+// publicValue returns the value for key ONLY if it is non-secret; a secret (or
+// unset) key returns "". Per-key gate for the HTML injector so a single
+// whitelisted key can't leak even if a row were mis-flagged.
+func (c *SystemConfig) publicValue(key string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.secret[key] {
+		return ""
+	}
+	return c.values[key]
 }
 
 // OnChange registers a callback fired whenever a key's value changes (via the

--- a/core/server/coreserver/system_config_test.go
+++ b/core/server/coreserver/system_config_test.go
@@ -219,3 +219,36 @@ func TestInjectPublicConfigNoop(t *testing.T) {
 		t.Errorf("expected HTML unchanged when nothing public, got %q", got)
 	}
 }
+
+// publicValue (the per-key injection gate) returns a non-secret value but BLANKS
+// a secret one — so even a whitelisted key can't leak a credential into the HTML
+// if it were mis-flagged secret.
+func TestSystemConfigPublicValue(t *testing.T) {
+	cfg := &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	cfg.set("sentry.dsn", "https://public.dsn", false)
+	if got := cfg.publicValue("sentry.dsn"); got != "https://public.dsn" {
+		t.Errorf("non-secret publicValue = %q, want the value", got)
+	}
+	// Flip the same key to secret → must blank.
+	cfg.set("sentry.dsn", "https://now.secret", true)
+	if got := cfg.publicValue("sentry.dsn"); got != "" {
+		t.Errorf("secret publicValue must be blank, got %q", got)
+	}
+	if got := cfg.publicValue("missing"); got != "" {
+		t.Errorf("unset publicValue must be blank, got %q", got)
+	}
+}
+
+// The injector relies on publicValue: a sentry.dsn mis-flagged secret must NOT
+// appear in the injected HTML.
+func TestInjectPublicConfigSkipsSecretSentryDsn(t *testing.T) {
+	prev := systemConfig
+	t.Cleanup(func() { systemConfig = prev })
+	systemConfig = &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	systemConfig.set("sentry.dsn", "https://leak.dsn", true) // mis-flagged secret
+
+	out := string(injectPublicConfig([]byte("<head></head>")))
+	if out != "<head></head>" {
+		t.Errorf("a secret-flagged sentry.dsn must not be injected, got %q", out)
+	}
+}

--- a/docs/plans/system-settings.md
+++ b/docs/plans/system-settings.md
@@ -277,3 +277,27 @@ sentryDsn` injection confirmed → Generate VAPID → "Configured ✓").
 Dependency note: this branch required PR #82's `appPb`-auth fix (the console now
 runs authenticated) — before the rebase, the package list and the Settings-panel
 store reads came back empty because `appPb` was anonymous. #82 merged; rebased in.
+
+## Upgrade notes — BREAKING for self-hosters
+
+Service config is no longer read from environment variables at runtime; it lives in
+**/admin → Settings** (the `system_settings` collection). The collection migration
+performs a **one-time seed from the legacy env vars** on the first boot that runs
+it, so an existing env-configured deployment carries over automatically. After
+that, env changes have no effect — edit the values in /admin.
+
+Things that change on upgrade:
+- **Sentry** (`SENTRY_DSN` etc.): server + web read it from settings; the hardcoded
+  client DSN is gone. The official EAS build supplies it via `eas.json`. A
+  **third-party native rebuild reports nowhere until they set their own DSN** in
+  /admin (web picks up a change on next load; native on next rebuild/OTA).
+- **VAPID** (`VAPID_*`): web-push keys come from settings — use the "Generate
+  keypair" button or paste an existing pair. An unconfigured deployment sends no push.
+- **Mail** (`MAIL_PROVIDER`/`POSTMARK_*`/`SMTP_IMAP_*`): provider + credentials are
+  now **system-wide** (Settings → Mail), not per-org. Org mail settings keep only
+  domain management. The seed migrates env values; otherwise configure in /admin.
+- **NOT changed** (still env): listen addresses/ports/enable-flags (`SMTP_ADDR`,
+  `IMAP_ENABLED`, `SMTP_DOMAIN`, …), `TINYCLD_PUBLIC_URL`, TLS/domain vars — host
+  topology, set by the process manager.
+
+For the release: tag the system-settings commits as a breaking change in the notes.


### PR DESCRIPTION
Review follow-ups for the system-settings feature (#83, merged).

- **Per-key injection gate**: add `SystemConfig.publicValue(key)` — returns a value only if non-secret, `''` for a secret/unset key. The web-HTML injector reads through it, so a whitelisted key can't leak a credential into the page even if a row were mis-flagged `is_secret=false`. Second gate at the one unrecoverable point.
- **Honest comments**: reworded the "write-only secret" wording — `PublicValues` gates HTML injection only; it is NOT a confidentiality boundary for the values themselves (secrets still reach a super-admin client over the wire; the UI renders them write-only). Trust boundary is "super admin".
- **Breaking-change docs**: operator-facing "Upgrade notes — BREAKING" section covering the env→settings removal (Sentry/VAPID/mail), the one-time migration seed, and what stays env.

Tests: `publicValue` (non-secret/secret/unset) + a secret-flagged `sentry.dsn` is not injected.

Carries a `BREAKING CHANGE:` trailer for the release notes.