### PR TITLE
Serve marketing website from the state volume

### DIFF
--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -49,6 +49,9 @@ CURRENT_LINK=/workspace/current
 # migrations (code, which does travel with the build):
 #   --dir          pb_data → /workspace/pb_data (persistent)
 #   --releasesDir  promoted web bundles → /workspace/releases (persistent)
+#   --websiteDir   marketing site → /workspace/website (persistent; populated by
+#                  `utils/deploy.sh web`, NOT baked into the image — empty until
+#                  the first web deploy, which the server tolerates)
 #   --migrationsDir → the active build's server/pb_migrations (the REAL dir the
 #                     generator materializes for every build). We deliberately do
 #                     NOT use the member-root pb_data→server/pb_migrations symlink:
@@ -58,7 +61,7 @@ CURRENT_LINK=/workspace/current
 #                     means a newly-installed package's migrations always load and
 #                     apply on the post-swap boot.
 PB_DATA_DIR=/workspace/pb_data
-PB_SERVE_DIRS="--dir=${PB_DATA_DIR} --releasesDir=/workspace/releases --migrationsDir=${CURRENT_LINK}/server/pb_migrations"
+PB_SERVE_DIRS="--dir=${PB_DATA_DIR} --releasesDir=/workspace/releases --websiteDir=/workspace/website --migrationsDir=${CURRENT_LINK}/server/pb_migrations"
 
 # Armed-backup rollback protocol (review finding H3). A package version change
 # runs DOWN migrations against the LIVE db, swaps `current`, then exits 75 so the

--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -90,16 +90,17 @@ func DefaultPublicDir() string {
 	return "./public"
 }
 
-// DefaultWebsiteDir returns the default marketing-website dir, resolved next to
-// the running binary as <binaryDir>/website (or "./website" for `go run`). It is
-// deliberately SEPARATE from DefaultPublicDir(): org-mode deploys copy the built
-// Astro site here, NOT into public/, so the app's `expo export` (which sweeps
-// public/ into its web bundle) never absorbs the website. Empty in dev / com mode
-// where the dir doesn't exist — StaticWithDynamicFallback treats a missing
-// websiteDir as "no website" and serves the app shell as before.
+// DefaultWebsiteDir returns the marketing-website root on the persistent state
+// volume: <TINYCLD_STATE_DIR>/website (e.g. /workspace/website in production),
+// or "./website" when TINYCLD_STATE_DIR is unset (`go run` / dev). The site lives
+// on the state volume, NOT baked into the image, so a website-only deploy
+// (utils/deploy.sh web) can rsync a new build onto the volume without an image
+// rebuild. It stays SEPARATE from DefaultPublicDir() so the app's `expo export`
+// (which sweeps public/ into its web bundle) never absorbs the site.
+// StaticWithDynamicFallback treats a missing/empty websiteDir as "no website".
 func DefaultWebsiteDir() string {
-	if dir := binaryDir(); dir != "" {
-		return filepath.Join(dir, "website")
+	if d := os.Getenv("TINYCLD_STATE_DIR"); d != "" {
+		return filepath.Join(d, "website")
 	}
 	return "./website"
 }

--- a/core/server/coreserver/static_test.go
+++ b/core/server/coreserver/static_test.go
@@ -154,6 +154,20 @@ func TestStatic_NoWebsiteDirStillServesApp(t *testing.T) {
 	})
 }
 
+func TestDefaultWebsiteDir_StateDirSet(t *testing.T) {
+	t.Setenv("TINYCLD_STATE_DIR", "/workspace")
+	if got, want := DefaultWebsiteDir(), filepath.Join("/workspace", "website"); got != want {
+		t.Fatalf("DefaultWebsiteDir() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultWebsiteDir_StateDirUnsetFallsBackToRelative(t *testing.T) {
+	t.Setenv("TINYCLD_STATE_DIR", "")
+	if got, want := DefaultWebsiteDir(), "./website"; got != want {
+		t.Fatalf("DefaultWebsiteDir() = %q, want %q", got, want)
+	}
+}
+
 func TestStatic_ApiPathNeverServesShell(t *testing.T) {
 	publicDir, websiteDir, releasesDir := staticDirs(t,
 		nil,


### PR DESCRIPTION
Moves the marketing website off the baked image onto the persistent `/workspace` volume so it can be deployed independently (see companion PR in `utils`).

- `DefaultWebsiteDir()` resolves `<TINYCLD_STATE_DIR>/website` (→ `/workspace/website`), with a `./website` fallback for dev. Unit-tested both branches.
- Entrypoint pins `--websiteDir=/workspace/website` in `PB_SERVE_DIRS`.

The dir is empty on a fresh host until the first website deploy; `StaticWithDynamicFallback` already tolerates that and serves the app shell.