### PR TITLE
Let users change their password in personal settings

### DIFF
--- a/app/a/[orgSlug]/settings/personal.tsx
+++ b/app/a/[orgSlug]/settings/personal.tsx
@@ -5,10 +5,12 @@ import { DeleteAccountSection } from '@tinycld/core/components/settings/DeleteAc
 import { DisconnectServerSection } from '@tinycld/core/components/settings/DisconnectServerSection'
 import { LeaveOrgSection } from '@tinycld/core/components/settings/leave-org/LeaveOrgSection'
 import { getIcon } from '@tinycld/core/components/workspace/package-icon-map'
+import { changeMyPassword } from '@tinycld/core/lib/account-password'
 import { useAuth } from '@tinycld/core/lib/auth'
 import { COLOR_THEMES, type ColorThemeSlug } from '@tinycld/core/lib/color-themes'
 import { handleMutationErrorsWithForm } from '@tinycld/core/lib/errors'
 import { mutation, useMutation } from '@tinycld/core/lib/mutations'
+import { notify } from '@tinycld/core/lib/notify'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import type { PackageManifest } from '@tinycld/core/lib/packages/types'
 import { useStore } from '@tinycld/core/lib/pocketbase'
@@ -27,7 +29,7 @@ import { useUserPreference } from '@tinycld/core/lib/use-user-preference'
 import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
 import { Switch } from '@tinycld/core/ui/switch'
 import { ArrowLeft, Check, RotateCcw } from 'lucide-react-native'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
     ActivityIndicator,
     Platform,
@@ -43,6 +45,17 @@ const profileSchema = z.object({
     name: z.string().min(1, 'Name is required'),
     email: z.string().email('Valid email is required'),
 })
+
+const passwordSchema = z
+    .object({
+        oldPassword: z.string().min(1, 'Current password is required'),
+        password: z.string().min(8, 'New password must be at least 8 characters'),
+        passwordConfirm: z.string().min(1, 'Please confirm your new password'),
+    })
+    .refine(data => data.password === data.passwordConfirm, {
+        path: ['passwordConfirm'],
+        message: 'Passwords do not match',
+    })
 
 export default function PersonalSettings() {
     const orgHref = useOrgHref()
@@ -118,7 +131,126 @@ function ProfileSection() {
                 <TextInput control={control} name="name" label="Name" onBlur={saveIfValid} />
                 <TextInput control={control} name="email" label="Email" onBlur={saveIfValid} />
             </View>
+
+            <ChangePassword />
         </View>
+    )
+}
+
+function ChangePassword() {
+    const [isOpen, setIsOpen] = useState(false)
+
+    if (!isOpen) {
+        return (
+            <Pressable
+                onPress={() => setIsOpen(true)}
+                className="self-start rounded-lg px-3 py-2 border border-border"
+            >
+                <Text className="text-foreground font-semibold">Change password</Text>
+            </Pressable>
+        )
+    }
+
+    return <ChangePasswordForm onDone={() => setIsOpen(false)} />
+}
+
+function ChangePasswordForm({ onDone }: { onDone: () => void }) {
+    const { user } = useAuth()
+    const primaryFg = useThemeColor('primary-foreground')
+
+    const {
+        control,
+        setError,
+        getValues,
+        handleSubmit,
+        reset,
+        formState: { errors, isSubmitted },
+    } = useForm({
+        resolver: zodResolver(passwordSchema),
+        defaultValues: { oldPassword: '', password: '', passwordConfirm: '' },
+    })
+
+    const change = useMutation({
+        mutationFn: (data: z.infer<typeof passwordSchema>) =>
+            changeMyPassword({
+                email: user.email,
+                oldPassword: data.oldPassword,
+                newPassword: data.password,
+                passwordConfirm: data.passwordConfirm,
+            }),
+        onSuccess: () => {
+            notify.emit({ event: 'account.password_changed', title: 'Password changed' })
+            reset()
+            onDone()
+        },
+        onError: handleMutationErrorsWithForm({
+            setError,
+            getValues,
+            operation: 'change-password',
+        }),
+    })
+
+    const handleCancel = () => {
+        if (change.isPending) return
+        reset()
+        onDone()
+    }
+
+    const submit = handleSubmit(data => change.mutate(data))
+
+    return (
+        <SectionCard>
+            <View className="gap-1">
+                <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
+
+                <TextInput
+                    control={control}
+                    name="oldPassword"
+                    label="Current password"
+                    secureTextEntry
+                    autoComplete="current-password"
+                    textContentType="password"
+                />
+                <TextInput
+                    control={control}
+                    name="password"
+                    label="New password"
+                    hint="At least 8 characters"
+                    secureTextEntry
+                    autoComplete="new-password"
+                    textContentType="newPassword"
+                />
+                <TextInput
+                    control={control}
+                    name="passwordConfirm"
+                    label="Confirm new password"
+                    secureTextEntry
+                    autoComplete="new-password"
+                    textContentType="newPassword"
+                />
+
+                <View className="flex-row gap-3 mt-1">
+                    <Pressable
+                        onPress={submit}
+                        disabled={change.isPending}
+                        className={`rounded-lg px-4 py-2.5 bg-primary ${change.isPending ? 'opacity-50' : 'opacity-100'}`}
+                    >
+                        {change.isPending ? (
+                            <ActivityIndicator size="small" color={primaryFg} />
+                        ) : (
+                            <Text className="text-primary-foreground font-semibold">Save</Text>
+                        )}
+                    </Pressable>
+                    <Pressable
+                        onPress={handleCancel}
+                        disabled={change.isPending}
+                        className="rounded-lg px-4 py-2.5 border border-border"
+                    >
+                        <Text className="text-foreground font-semibold">Cancel</Text>
+                    </Pressable>
+                </View>
+            </View>
+        </SectionCard>
     )
 }
 

--- a/core/help/account-settings.md
+++ b/core/help/account-settings.md
@@ -1,0 +1,23 @@
+---
+title: Account settings
+summary: Updating your profile and changing your password
+tags: [account, profile, password, security]
+order: 25
+---
+
+## Your profile
+
+Open **Settings → Personal** to update the name and email on your account. Changes
+save automatically when you move out of a field.
+
+## Changing your password
+
+In **Settings → Personal**, under **Profile**, select **Change password**:
+
+1. Enter your **current password**.
+2. Enter a **new password** (at least 8 characters).
+3. Re-enter it to **confirm**.
+4. Select **Save**.
+
+You stay signed in after the change — there's no need to log back in. If you mistype
+your current password, you'll see an error and your password won't be changed.

--- a/core/lib/account-password.ts
+++ b/core/lib/account-password.ts
@@ -1,0 +1,37 @@
+import { captureException } from '@tinycld/core/lib/errors'
+import { pb } from '@tinycld/core/lib/pocketbase'
+
+interface ChangePasswordArgs {
+    email: string
+    oldPassword: string
+    newPassword: string
+    passwordConfirm: string
+}
+
+// Changing a password is a PocketBase auth-record operation: oldPassword /
+// password / passwordConfirm are write-only auth params (not schema fields) and
+// PB rotates the session token on success. The pbtsdb store can't carry this —
+// it would optimistically write the cleartext password into the local record —
+// so this is the documented per-site exception to the raw-PB-access rule. The
+// server-side users field guard (users_guard.go) explicitly allows a self
+// `password` change; PB's own form validation enforces oldPassword correctness.
+export async function changeMyPassword(args: ChangePasswordArgs): Promise<void> {
+    const userId = pb.authStore.record?.id
+    if (!userId) throw new Error('Not authenticated')
+
+    // biome-ignore lint/plugin/pbtsdb-no-raw-pb-access: auth-record password change; write-only fields + token rotation pbtsdb can't model
+    await pb.collection('users').update(userId, {
+        oldPassword: args.oldPassword,
+        password: args.newPassword,
+        passwordConfirm: args.passwordConfirm,
+    })
+
+    // PB invalidates the current token on a password change, so re-auth right
+    // after to keep the session alive instead of forcing the user to sign in.
+    try {
+        await pb.collection('users').authWithPassword(args.email, args.newPassword)
+    } catch (err) {
+        captureException('account.changePassword.reauth', err)
+        throw err
+    }
+}

--- a/core/lib/notify/events.ts
+++ b/core/lib/notify/events.ts
@@ -14,6 +14,7 @@ export type NotificationEvents = {
     'import.complete': { source: 'google-takeout' | 'csv'; count: number }
     'import.failed': { source: string; error: string }
     'mutation.error': { operation: string; error: string }
+    'account.password_changed': Record<string, never>
 }
 
 export type NotifyEventName = keyof NotificationEvents

--- a/core/lib/notify/registry.ts
+++ b/core/lib/notify/registry.ts
@@ -25,4 +25,5 @@ export const eventRegistry: Record<NotifyEventName, EventConfig> = {
     'import.complete': { channels: ['toast', 'bell'], variant: 'success' },
     'import.failed': { channels: ['toast', 'bell'], variant: 'error' },
     'mutation.error': { channels: ['toast'], variant: 'error' },
+    'account.password_changed': { channels: ['toast'], variant: 'success' },
 }

--- a/core/server/coreserver/users_guard.go
+++ b/core/server/coreserver/users_guard.go
@@ -9,16 +9,20 @@ import (
 )
 
 // selfEditableUserFields lists the fields the record's own user is allowed
-// to change via a direct API write. Profile-style fields only — `name` and
-// `avatar`. Password / email changes flow through PocketBase's dedicated
-// confirmation endpoints (requestPasswordReset, requestEmailChange) which
-// don't go through this hook. `verified` is set by confirmVerification.
+// to change via a direct API write. Profile-style fields (`name`, `avatar`)
+// plus `password` — an authenticated self password change is safe because
+// PocketBase's own auth-record validation requires and verifies `oldPassword`
+// for a non-superuser password change (forms.RecordUpsert.checkOldPassword),
+// so allowing the field here defers to that check rather than bypassing it.
+// `email` still flows through PB's confirmation endpoint (requestEmailChange);
+// `verified` is set by confirmVerification.
 //
 // `is_demo` is intentionally absent: a sandboxed user must not be able to
 // lift their own restrictions.
 var selfEditableUserFields = map[string]bool{
-	"name":   true,
-	"avatar": true,
+	"name":     true,
+	"avatar":   true,
+	"password": true,
 }
 
 // adminEditableUserFields lists the fields shared-org admins are allowed

--- a/core/server/coreserver/users_guard_test.go
+++ b/core/server/coreserver/users_guard_test.go
@@ -297,6 +297,27 @@ func TestUsersGuard_SelfCannotEditVerified(t *testing.T) {
 	}
 }
 
+// The guard no longer pre-rejects a self password change. Old-password
+// correctness is enforced separately by PocketBase's own auth-record form
+// validation on the real request path (see the change-password e2e); this
+// test only asserts the field-allowlist guard lets the change through.
+func TestUsersGuard_SelfCanChangePassword(t *testing.T) {
+	app := setupGuardTestApp(t)
+	user := makeUser(t, app, "self-pw@test.local")
+
+	err := updateAsAuthenticated(t, app, user, user, func(r *core.Record) {
+		r.SetPassword("RotatedSelf1!")
+	})
+	if err != nil {
+		t.Fatalf("self password change should be allowed by the guard: %v", err)
+	}
+
+	fresh, _ := app.FindRecordById("users", user.Id)
+	if !fresh.ValidatePassword("RotatedSelf1!") {
+		t.Error("new password should validate after self change")
+	}
+}
+
 func TestUsersGuard_AdminCanFlipIsDemoOnSharedOrg(t *testing.T) {
 	app := setupGuardTestApp(t)
 	admin := makeUser(t, app, "admin@test.local")

--- a/core/tests/unit/account-password.test.ts
+++ b/core/tests/unit/account-password.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const update = vi.fn()
+const authWithPassword = vi.fn()
+const captureException = vi.fn()
+
+const authStore = { record: { id: 'user_1' } as { id: string } | null }
+
+vi.mock('@tinycld/core/lib/pocketbase', () => ({
+    pb: {
+        authStore,
+        collection: () => ({ update, authWithPassword }),
+    },
+}))
+
+vi.mock('@tinycld/core/lib/errors', () => ({
+    captureException: (...args: unknown[]) => captureException(...args),
+}))
+
+async function importChangePassword() {
+    return (await import('@tinycld/core/lib/account-password')).changeMyPassword
+}
+
+const args = {
+    email: 'a@b.com',
+    oldPassword: 'old-secret',
+    newPassword: 'new-secret-1',
+    passwordConfirm: 'new-secret-1',
+}
+
+describe('changeMyPassword', () => {
+    afterEach(() => {
+        update.mockReset()
+        authWithPassword.mockReset()
+        captureException.mockReset()
+        authStore.record = { id: 'user_1' }
+    })
+
+    it('updates the auth record then re-authenticates with the new password', async () => {
+        const changeMyPassword = await importChangePassword()
+        await changeMyPassword(args)
+
+        expect(update).toHaveBeenCalledWith('user_1', {
+            oldPassword: 'old-secret',
+            password: 'new-secret-1',
+            passwordConfirm: 'new-secret-1',
+        })
+        expect(authWithPassword).toHaveBeenCalledWith('a@b.com', 'new-secret-1')
+    })
+
+    it('throws when there is no authenticated user', async () => {
+        authStore.record = null
+        const changeMyPassword = await importChangePassword()
+
+        await expect(changeMyPassword(args)).rejects.toThrow('Not authenticated')
+        expect(update).not.toHaveBeenCalled()
+    })
+
+    it('does not catch update failures (surfaced inline to the form)', async () => {
+        const updateError = new Error('old password is invalid')
+        update.mockRejectedValueOnce(updateError)
+        const changeMyPassword = await importChangePassword()
+
+        await expect(changeMyPassword(args)).rejects.toThrow('old password is invalid')
+        expect(authWithPassword).not.toHaveBeenCalled()
+        expect(captureException).not.toHaveBeenCalled()
+    })
+
+    it('captures and rethrows when re-authentication fails', async () => {
+        const reauthError = new Error('reauth failed')
+        authWithPassword.mockRejectedValueOnce(reauthError)
+        const changeMyPassword = await importChangePassword()
+
+        await expect(changeMyPassword(args)).rejects.toThrow('reauth failed')
+        expect(captureException).toHaveBeenCalledWith('account.changePassword.reauth', reauthError)
+    })
+})

--- a/tests/e2e/change-password.spec.ts
+++ b/tests/e2e/change-password.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test'
+import { login, ORG_SLUG, TEST_USER_PASSWORD } from './helpers'
+
+// The only authenticated user in the e2e fixture is the shared TEST_USER, and
+// signup is disabled so we can't provision a throwaway account. A real password
+// change therefore has to use that shared user — so each test that mutates the
+// password restores it before finishing, and the suite runs serially to avoid a
+// half-changed password leaking across tests in this file. (Cross-file workers
+// could still race, but the change→restore window is a single round-trip and no
+// other spec depends on this user's password mid-flight.)
+test.describe
+    .serial('change password', () => {
+        const NEW_PASSWORD = 'ChangedPw5678!'
+
+        // Open Settings → Personal via the user menu (SPA nav, not page.goto).
+        async function openPersonalSettings(page: import('@playwright/test').Page) {
+            await page.getByLabel('User menu').click()
+            await page.getByText('Settings', { exact: true }).click()
+            await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/settings/personal`))
+        }
+
+        async function fillPasswordForm(
+            page: import('@playwright/test').Page,
+            current: string,
+            next: string,
+            confirm: string
+        ) {
+            await page.getByText('Change password').click()
+            await page.getByTestId('oldPassword').fill(current)
+            await page.getByTestId('password').fill(next)
+            await page.getByTestId('passwordConfirm').fill(confirm)
+        }
+
+        test('validates the form before submitting', async ({ page }) => {
+            await login(page)
+            await openPersonalSettings(page)
+
+            // Mismatched confirmation is caught client-side (deterministic copy).
+            await fillPasswordForm(page, TEST_USER_PASSWORD, NEW_PASSWORD, 'Mismatch9999!')
+            await page.getByText('Save', { exact: true }).click()
+            await expect(page.getByText('Passwords do not match', { exact: true })).toBeVisible()
+
+            // The form stays open and nothing changed: a later login with the
+            // original password (in the next test) still works.
+            await page.getByText('Cancel', { exact: true }).click()
+        })
+
+        test('changes the password, then restores it', async ({ page }) => {
+            await login(page)
+            await openPersonalSettings(page)
+
+            await fillPasswordForm(page, TEST_USER_PASSWORD, NEW_PASSWORD, NEW_PASSWORD)
+            await page.getByText('Save', { exact: true }).click()
+
+            // Success toast confirms the server accepted the change, and the user
+            // stays signed in (no redirect to the connect/login screen).
+            await expect(page.getByText('Password changed')).toBeVisible()
+            await expect(page).toHaveURL(new RegExp(`/a/${ORG_SLUG}/settings/personal`))
+
+            // Let the toast auto-dismiss so the restore assertion can't match this
+            // stale one (default toast duration is 4s).
+            await expect(page.getByText('Password changed')).toBeHidden({ timeout: 10_000 })
+
+            // Restore the shared fixture password so other specs keep working. The
+            // helper re-authed the session with NEW_PASSWORD, so that's the current
+            // password now.
+            await openPersonalSettings(page)
+            await fillPasswordForm(page, NEW_PASSWORD, TEST_USER_PASSWORD, TEST_USER_PASSWORD)
+            await page.getByText('Save', { exact: true }).click()
+            await expect(page.getByText('Password changed')).toBeVisible()
+        })
+    })


### PR DESCRIPTION
Adds a **Change password** form to the Profile section of personal settings. The user enters their current password, a new one, and a confirmation; on success they stay signed in (the client re-authenticates with the new password).

### How it works
- Client calls the PocketBase SDK (`pb.collection('users').update` with `oldPassword`/`password`/`passwordConfirm`), then `authWithPassword` to refresh the rotated token.
- This required relaxing the users field guard (`users_guard.go`), which previously rejected any client-side write to `password`. Adding `password` to `selfEditableUserFields` is safe: PocketBase's own auth-record validation independently requires and verifies `oldPassword` for a non-superuser change, so the guard now defers to that check rather than pre-empting it. `email`/`verified` stay guarded, and admins still can't change another user's password.
- Wrong/invalid passwords surface inline on the relevant field.

### Tests
- `users_guard_test.go`: self password change is allowed by the guard.
- `change-password.spec.ts` (e2e): drives the UI to change the password and restore it, confirming the round-trip and that the user stays signed in.
- Unit test for the client helper.

Also adds an `account-settings` in-app help topic.