### PR TITLE
fix: hide change-server link on web

### DIFF
--- a/core/components/ChangeServerLink.tsx
+++ b/core/components/ChangeServerLink.tsx
@@ -1,8 +1,11 @@
 import { disconnectServer } from '@tinycld/core/lib/pocketbase'
 import { router } from 'expo-router'
-import { Pressable, Text } from 'react-native'
+import { Platform, Pressable, Text } from 'react-native'
 
 export function ChangeServerLink() {
+    // Web always talks to its own origin — there's no other server to switch to.
+    if (Platform.OS === 'web') return null
+
     async function onPress() {
         await disconnectServer()
         router.replace('/connect?backTo=/')


### PR DESCRIPTION
On web the app always talks to its own origin, so there is no other server to switch to. `ChangeServerLink` now returns `null` when `Platform.OS === 'web'`, hiding it on both the login and superuser-setup screens. Native still shows it.