### PR TITLE
Unified core mailer: provider registry + system_settings config

### DIFF
--- a/core/components/setup/SettingsTab.tsx
+++ b/core/components/setup/SettingsTab.tsx
@@ -1,13 +1,25 @@
 import { PB_SERVER_ADDR } from '@tinycld/core/lib/config'
 import { packageSystemSettings } from '@tinycld/core/lib/packages/derive-components'
+import { usePackages } from '@tinycld/core/lib/packages/use-packages'
 import { pb as appPb } from '@tinycld/core/lib/pocketbase'
 import { Button, ButtonText } from '@tinycld/core/ui/button'
-import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
+import {
+    FormErrorSummary,
+    SelectInput,
+    TextInput,
+    Toggle,
+    useForm,
+    z,
+    zodResolver,
+} from '@tinycld/core/ui/form'
 import { type ReactNode, Suspense, useState } from 'react'
 import type { Control, FieldValues, Path } from 'react-hook-form'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { PageHeader, SectionLabel } from './console-ui'
 import {
+    deliveryEnabledValue,
+    fromAddressSchema,
+    isDeliveryEnabled,
     type SettingRow,
     sentryDsnSchema,
     shouldPersistSecret,
@@ -25,6 +37,7 @@ export function SettingsTab({ isVisible }: { isVisible: boolean }) {
             />
             <SentrySettings />
             <VapidSettings />
+            <MailSettings />
             <PackageSettings />
         </View>
     )
@@ -274,6 +287,133 @@ function VapidPaste({
 // through the DOM); instead it shows whether a value is configured and a hint
 // that leaving it blank keeps the current one. Submitting blank means "unchanged"
 // — the caller must skip the write when the field is empty.
+// Core transactional mail (invites, password reset, share notifications). These
+// are the SHARED `mail.*` keys the core mailer reads. When the mail feature
+// package is installed it owns provider selection + the server token via its own
+// "Provider" panel, so here we only surface the from-address and the delivery
+// switch to avoid two editors of the same key. In a mail-less assembly we also
+// surface provider + token so core mail is configurable on its own.
+const mailProviders = [
+    { label: 'Postmark', value: 'postmark' },
+    { label: 'Self-hosted SMTP', value: 'smtp' },
+]
+
+const mailSchema = z.object({
+    provider: z.enum(['postmark', 'smtp']),
+    serverToken: z.string(), // secret, write-only
+    fromAddress: fromAddressSchema,
+    deliveryEnabled: z.boolean(),
+})
+
+function MailSettings() {
+    const { byKey, upsert } = useSystemSettings()
+    const mailPackageInstalled = usePackages().some(p => p.slug === 'mail')
+
+    const provider = byKey.get('mail.provider')
+    const serverToken = byKey.get('mail.postmark_server_token')
+    const fromAddress = byKey.get('mail.from_address')
+    const deliveryEnabled = byKey.get('mail.delivery_enabled')
+
+    const {
+        control,
+        handleSubmit,
+        setError,
+        formState: { errors, isSubmitting, isSubmitted, isDirty },
+    } = useForm({
+        resolver: zodResolver(mailSchema),
+        values: {
+            provider: (provider?.value || 'postmark') as 'postmark' | 'smtp',
+            serverToken: '',
+            fromAddress: fromAddress?.value ?? '',
+            deliveryEnabled: isDeliveryEnabled(deliveryEnabled?.value),
+        },
+        mode: 'onChange',
+    })
+
+    const onSubmit = handleSubmit(async data => {
+        try {
+            await upsert.mutateAsync({
+                key: 'mail.from_address',
+                value: data.fromAddress,
+                isSecret: false,
+            })
+            await upsert.mutateAsync({
+                key: 'mail.delivery_enabled',
+                value: deliveryEnabledValue(data.deliveryEnabled),
+                isSecret: false,
+            })
+            if (!mailPackageInstalled) {
+                await upsert.mutateAsync({
+                    key: 'mail.provider',
+                    value: data.provider,
+                    isSecret: false,
+                })
+                if (shouldPersistSecret(data.serverToken)) {
+                    await upsert.mutateAsync({
+                        key: 'mail.postmark_server_token',
+                        value: data.serverToken,
+                        isSecret: true,
+                    })
+                }
+            }
+        } catch (err) {
+            setError('fromAddress', {
+                message: err instanceof Error ? err.message : 'Failed to save',
+            })
+        }
+    })
+
+    return (
+        <Panel label="Mail — Sending (transactional)">
+            <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
+                Outbound mail for invites, password resets, and share notifications.
+                {mailPackageInstalled
+                    ? ' The provider and credentials are configured in the Mail package’s Provider panel below.'
+                    : ' Choose a provider and credentials for delivery.'}
+            </Text>
+            <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
+
+            {!mailPackageInstalled && (
+                <>
+                    <SelectInput
+                        control={control}
+                        name="provider"
+                        label="Provider"
+                        options={mailProviders}
+                    />
+                    <SecretField
+                        control={control}
+                        name="serverToken"
+                        label="Postmark server token"
+                        existing={serverToken}
+                    />
+                </>
+            )}
+
+            <TextInput
+                control={control}
+                name="fromAddress"
+                label="From address"
+                placeholder="noreply@tinycld.org"
+                autoCapitalize="none"
+                hint="The default From for transactional mail. Blank uses noreply@tinycld.org."
+            />
+            <Toggle
+                control={control}
+                name="deliveryEnabled"
+                label="Deliver mail"
+                hint="Off logs emails instead of sending them. Dev/test builds always log."
+            />
+            <SaveRow
+                testID="mail-settings-save"
+                onPress={onSubmit}
+                isPending={upsert.isPending}
+                isDisabled={isSubmitting || !isDirty}
+            />
+        </Panel>
+    )
+}
+
 function SecretField<T extends FieldValues>({
     control,
     name,

--- a/core/components/setup/SettingsTab.tsx
+++ b/core/components/setup/SettingsTab.tsx
@@ -1,6 +1,6 @@
 import { PB_SERVER_ADDR } from '@tinycld/core/lib/config'
 import { packageSystemSettings } from '@tinycld/core/lib/packages/derive-components'
-import { usePackages } from '@tinycld/core/lib/packages/use-packages'
+import { packageRegistry } from '@tinycld/core/lib/packages/static-registry'
 import { pb as appPb } from '@tinycld/core/lib/pocketbase'
 import { Button, ButtonText } from '@tinycld/core/ui/button'
 import {
@@ -307,7 +307,9 @@ const mailSchema = z.object({
 
 function MailSettings() {
     const { byKey, upsert } = useSystemSettings()
-    const mailPackageInstalled = usePackages().some(p => p.slug === 'mail')
+    // Build-time registry (same source that decides whether mail's Provider
+    // panel renders), so the two panels' key ownership stays consistent.
+    const mailPackageInstalled = packageRegistry.some(p => p.slug === 'mail')
 
     const provider = byKey.get('mail.provider')
     const serverToken = byKey.get('mail.postmark_server_token')

--- a/core/components/setup/__tests__/system-settings-logic.test.ts
+++ b/core/components/setup/__tests__/system-settings-logic.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+    deliveryEnabledValue,
+    fromAddressSchema,
+    isDeliveryEnabled,
     rowsToMap,
     sentryDsnSchema,
     shouldPersistSecret,
@@ -45,5 +48,28 @@ describe('vapidSubjectSchema', () => {
     })
     it('rejects a bare string', () => {
         expect(vapidSubjectSchema.safeParse('admin').success).toBe(false)
+    })
+})
+
+describe('fromAddressSchema', () => {
+    it('accepts a valid email and blank (blank = server default)', () => {
+        expect(fromAddressSchema.safeParse('noreply@tinycld.org').success).toBe(true)
+        expect(fromAddressSchema.safeParse('').success).toBe(true)
+    })
+    it('rejects a non-email', () => {
+        expect(fromAddressSchema.safeParse('not-an-email').success).toBe(false)
+    })
+})
+
+describe('delivery-enabled mapping', () => {
+    it('maps the toggle boolean to a stored string', () => {
+        expect(deliveryEnabledValue(true)).toBe('true')
+        expect(deliveryEnabledValue(false)).toBe('false')
+    })
+    it('treats absent / anything-but-"false" as enabled', () => {
+        expect(isDeliveryEnabled(undefined)).toBe(true)
+        expect(isDeliveryEnabled('true')).toBe(true)
+        expect(isDeliveryEnabled('')).toBe(true)
+        expect(isDeliveryEnabled('false')).toBe(false)
     })
 })

--- a/core/components/setup/system-settings-logic.ts
+++ b/core/components/setup/system-settings-logic.ts
@@ -38,3 +38,24 @@ export const vapidSubjectSchema = z.union([
     z.string().url('Use a URL or mailto: URI'),
     z.literal(''),
 ])
+
+// The default From for transactional mail. Blank falls back to the server
+// default (noreply@tinycld.org); otherwise it must be a bare email address.
+export const fromAddressSchema = z.union([
+    z.string().email('Enter a valid email address'),
+    z.literal(''),
+])
+
+/**
+ * Whether a delivery-enabled toggle's boolean maps to a stored "false" string.
+ * The server treats any value other than "false" as enabled, so we only need to
+ * persist the explicit-off case distinctly; we store "true"/"false" for clarity.
+ */
+export function deliveryEnabledValue(enabled: boolean): string {
+    return enabled ? 'true' : 'false'
+}
+
+/** Parse a stored mail.delivery_enabled value; absent/anything-but-"false" is on. */
+export function isDeliveryEnabled(stored: string | undefined): boolean {
+    return stored !== 'false'
+}

--- a/core/server/coreserver/system_config.go
+++ b/core/server/coreserver/system_config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
+	"tinycld.org/core/mailer"
 )
 
 // SystemConfig is the single source of truth for system-wide configuration —
@@ -135,6 +136,13 @@ func (c *SystemConfig) set(key, value string, isSecret bool) {
 // in-memory map in sync as rows are created or updated. Edits take effect without
 // a restart — re-init handlers registered via OnChange run on each change.
 func RegisterSystemConfig(app *pocketbase.PocketBase) {
+	// Point the core transactional mailer at system config. The resolver reads
+	// lazily (per-send), so it's safe to set here before the OnServe load —
+	// Get returns "" until then, and sends only happen well after boot. This is
+	// the single seam that keeps the mailer out of an import cycle with this
+	// package (mailer can't import coreserver).
+	mailer.ConfigResolver = systemConfig.Get
+
 	// Re-init Sentry whenever a sentry.* value changes. Registered before the
 	// initial load so no early change is missed. Sentry is the only stateful
 	// consumer; push reads VAPID per-send and mail builds its provider per-call,

--- a/core/server/go.mod
+++ b/core/server/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/coder/websocket v1.8.14
 	github.com/disintegration/imaging v1.6.2
+	github.com/emersion/go-message v0.18.2
 	github.com/gen2brain/go-fitz v1.24.14
 	github.com/getsentry/sentry-go v0.44.1
 	github.com/jdeng/goheif v0.0.0-20260407171156-9bf5264f67af
@@ -16,6 +17,7 @@ require (
 	github.com/pocketbase/dbx v1.12.0
 	github.com/pocketbase/pocketbase v0.38.1
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/image v0.40.0
 	golang.org/x/net v0.54.0
 )
 
@@ -48,7 +50,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
-	golang.org/x/image v0.40.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect

--- a/core/server/go.sum
+++ b/core/server/go.sum
@@ -29,6 +29,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+GvvE=
 github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7x/Lpg=
+github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/core/server/mailer/README.md
+++ b/core/server/mailer/README.md
@@ -1,11 +1,13 @@
-# tinycld/mailer
+# tinycld.org/core/mailer
 
-Shared email sending package for all TinyCld packages. Wraps the configured provider (currently Postmark) so any package can send transactional emails without depending on the mail package.
+The shared outbound email stack for all TinyCld packages: a provider registry
+(Postmark, self-hosted SMTP) selected by configuration, so any package can send
+transactional email without depending on the mail feature package.
 
 ## Usage
 
 ```go
-import "tinycld/mailer"
+import "tinycld.org/core/mailer"
 
 // Simple transactional email (notifications, invites, etc.)
 err := mailer.DefaultSender().Send(ctx, &mailer.Message{
@@ -14,35 +16,49 @@ err := mailer.DefaultSender().Send(ctx, &mailer.Message{
     HTML:    "<p>Hello!</p>",
     Text:    "Hello!",
 })
-
-// Rich email with CC, BCC, attachments, threading headers
-result, err := mailer.Default().SendFull(ctx, &mailer.SendRequest{
-    From:    "sender@example.com",
-    To:      []mailer.Recipient{{Name: "Holly", Email: "holly@example.com"}},
-    Subject: "Re: Project update",
-    HTMLBody: "<p>Sounds good</p>",
-    TextBody: "Sounds good",
-    InReplyTo: "<original-message-id@example.com>",
-})
 ```
 
-## Environment Variables
+`DefaultSender()` returns the configured provider, or a log-only sender when
+delivery is disabled or nothing is configured. `CanDeliver()` reports whether a
+real send would actually go out.
 
-| Variable | Required | Description |
+## Configuration
+
+Configuration lives in the **`system_settings`** collection (the `mail.*` keys),
+edited from the **/admin → Settings** console — there is no `os.Getenv` in the
+runtime read path. The server reads through `mailer.ConfigResolver`, which
+`coreserver` points at the in-memory `SystemConfig`. Reads happen per-send, so an
+/admin edit applies on the next send without a restart.
+
+| `system_settings` key | Secret | Description |
 |---|---|---|
-| `POSTMARK_SERVER_TOKEN` | Yes (for delivery) | Postmark server API token |
-| `MAIL_FROM_ADDRESS` | No | Default "From" address. Defaults to `noreply@tinycld.org` |
-| `SKIP_SENDING_MAIL` | No | `true` forces logging instead of delivery; `false` forces real delivery. When unset, the default is `true` for PocketBase processes started with `--dev` (dev/test/seed) and `false` otherwise. |
+| `mail.provider` | no | `postmark` (default) or `smtp` |
+| `mail.postmark_server_token` | yes | Postmark server API token (required to deliver via Postmark) |
+| `mail.postmark_account_token` | yes | Postmark account token (domain ops; mail feature) |
+| `mail.from_address` | no | Default "From" address. Defaults to `noreply@tinycld.org` |
+| `mail.delivery_enabled` | no | `false` logs instead of delivering. Any other value (or unset) delivers in production |
+| `mail.smtp_public_hostname` | no | EHLO/MX hostname for the self-hosted SMTP sender |
+
+The mail feature package contributes the **Provider** panel that edits provider
+selection, the Postmark/SMTP credentials, and inbound (SMTP/IMAP) config. The
+core **Mail — Sending** panel edits the from-address and the delivery switch
+(and, in a mail-less assembly, provider + token), so the two never edit the same
+key.
 
 ## Development
 
-By default, any PocketBase started with `--dev` logs emails to stdout instead of delivering. Production runs without `--dev` and delivers normally. Set `SKIP_SENDING_MAIL=false` in a `--dev` process to force real delivery (e.g. for end-to-end testing against Postmark sandboxes).
+PocketBase processes started with `--dev` (dev/test/seed) **log emails to stdout
+instead of delivering**, regardless of `mail.delivery_enabled`, so local and CI
+runs never send real mail. Production runs without `--dev` and delivers unless
+`mail.delivery_enabled` is `false`.
 
-Logged emails are printed in a formatted box. This applies to both simple sends (`Send`) and full sends (`SendFull`) across all packages.
+Logged emails are printed in a formatted box (both `Send` and `SendFull`). When
+the `TINYCLD_EMAIL_LOG` env var is set, each logged email is also appended as a
+JSON line to that file — the e2e suite reads it to assert on outbound mail.
 
 ```
 ╭──────────────────────────────────────────────────────────╮
-│  EMAIL (not delivered — SKIP_SENDING_MAIL is set)        │
+│  EMAIL (not delivered — delivery is disabled)       │
 ├──────────────────────────────────────────────────────────┤
 │  To:      Holly Stitt <holly@example.com>
 │  Subject: Nathan shared "API Design Proposal" with you
@@ -54,5 +70,3 @@ Nathan shared "API Design Proposal" with you.
 Open: http://localhost:7100/a/test-org/drive?file=abc123
 ╰──────────────────────────────────────────────────────────╯
 ```
-
-Add `SKIP_SENDING_MAIL=true` to your `.env` file for local development.

--- a/core/server/mailer/config_test.go
+++ b/core/server/mailer/config_test.go
@@ -1,0 +1,87 @@
+package mailer
+
+import (
+	"testing"
+)
+
+// withConfig swaps ConfigResolver to read from a static map for the duration of
+// a test, and forces devAutoLog off so delivery decisions reflect config alone.
+func withConfig(t *testing.T, values map[string]string) {
+	t.Helper()
+	origResolver := ConfigResolver
+	origDev := devAutoLog
+	ConfigResolver = func(key string) string { return values[key] }
+	devAutoLog = false
+	t.Cleanup(func() {
+		ConfigResolver = origResolver
+		devAutoLog = origDev
+	})
+}
+
+func TestDefaultSender_LogsWhenUnconfigured(t *testing.T) {
+	withConfig(t, map[string]string{})
+	if _, ok := DefaultSender().(*LogSender); !ok {
+		t.Errorf("expected LogSender when no provider configured, got %T", DefaultSender())
+	}
+	if CanDeliver() {
+		t.Errorf("CanDeliver should be false when no provider configured")
+	}
+}
+
+func TestDefaultSender_PostmarkWhenTokenSet(t *testing.T) {
+	withConfig(t, map[string]string{
+		keyPostmarkToken: "tok-123",
+		keyFromAddress:   "hello@example.com",
+	})
+	s, ok := DefaultSender().(*PostmarkSender)
+	if !ok {
+		t.Fatalf("expected PostmarkSender, got %T", DefaultSender())
+	}
+	if s.defaultFrom != "hello@example.com" {
+		t.Errorf("from: got %q, want hello@example.com", s.defaultFrom)
+	}
+	if !CanDeliver() {
+		t.Errorf("CanDeliver should be true with a token set")
+	}
+}
+
+func TestDefaultSender_SMTPWhenProviderSMTP(t *testing.T) {
+	withConfig(t, map[string]string{
+		keyProvider:       "smtp",
+		keySMTPPublicHost: "mx.example.com",
+	})
+	if _, ok := DefaultSender().(*SMTPSender); !ok {
+		t.Errorf("expected SMTPSender when provider=smtp, got %T", DefaultSender())
+	}
+	if !CanDeliver() {
+		t.Errorf("CanDeliver should be true for smtp provider")
+	}
+}
+
+func TestDefaultSender_DeliveryDisabledLogs(t *testing.T) {
+	withConfig(t, map[string]string{
+		keyPostmarkToken:   "tok-123",
+		keyDeliveryEnabled: "false",
+	})
+	if _, ok := DefaultSender().(*LogSender); !ok {
+		t.Errorf("expected LogSender when delivery disabled, got %T", DefaultSender())
+	}
+	if CanDeliver() {
+		t.Errorf("CanDeliver should be false when delivery disabled")
+	}
+}
+
+func TestDefaultSender_DevAutoLog(t *testing.T) {
+	withConfig(t, map[string]string{keyPostmarkToken: "tok-123"})
+	devAutoLog = true // simulate a --dev process
+	if _, ok := DefaultSender().(*LogSender); !ok {
+		t.Errorf("expected LogSender in --dev process, got %T", DefaultSender())
+	}
+}
+
+func TestFromAddress_DefaultsWhenUnset(t *testing.T) {
+	withConfig(t, map[string]string{})
+	if got := fromAddress(); got != defaultFromAddress {
+		t.Errorf("fromAddress: got %q, want %q", got, defaultFromAddress)
+	}
+}

--- a/core/server/mailer/mailer.go
+++ b/core/server/mailer/mailer.go
@@ -164,6 +164,10 @@ func buildSender() Sender {
 		}
 		return NewPostmarkSender(token, ConfigResolver(keyPostmarkAccount), fromAddress())
 	default:
+		// An unrecognized provider would silently degrade to log-only, which
+		// looks to an operator like mail is configured when it isn't. Surface it.
+		fmt.Fprintf(os.Stderr, "[mailer] unknown %s=%q — mail will be logged, not delivered\n",
+			keyProvider, ConfigResolver(keyProvider))
 		return nil
 	}
 }

--- a/core/server/mailer/mailer.go
+++ b/core/server/mailer/mailer.go
@@ -1,11 +1,12 @@
-// Package mailer provides a shared email sending interface for all packages.
-// It wraps the configured provider (e.g. Postmark) so that any package can
-// send transactional emails without depending on the mail package.
+// Package mailer provides the shared outbound email stack for all packages —
+// a provider registry (Postmark, self-hosted SMTP) selected by configuration,
+// so any package can send transactional email without depending on the mail
+// feature package. Configuration is read from the system_settings collection
+// via ConfigResolver (the mail.* keys), per-send, so /admin edits apply live.
 //
-// Delivery gating: by default, PocketBase processes started with --dev (i.e.
-// dev/test/seed) log emails to stdout instead of delivering. SKIP_SENDING_MAIL
-// can override either way: "true" forces logging, "false" forces real
-// delivery. Production runs without --dev and delivers by default.
+// Delivery gating: PocketBase processes started with --dev (dev/test/seed) log
+// emails to stdout instead of delivering. In production, delivery is on unless
+// the mail.delivery_enabled setting is "false". See deliveryEnabled.
 package mailer
 
 import (
@@ -98,58 +99,99 @@ type FullSender interface {
 	SendFull(ctx context.Context, req *SendRequest) (*SendResult, error)
 }
 
-// --- Singleton ---
+// --- Configuration ---
 
-var (
-	instance *PostmarkSender
-	once     sync.Once
-	deliver  bool
+// Config keys read from the system_settings collection (via ConfigResolver).
+// They live in the shared `mail.*` namespace so the core transactional mailer
+// and the mail feature package read one set of credentials.
+const (
+	keyProvider        = "mail.provider" // "postmark" | "smtp" (default postmark)
+	keyPostmarkToken   = "mail.postmark_server_token"
+	keyPostmarkAccount = "mail.postmark_account_token"
+	keyFromAddress     = "mail.from_address"     // default From; falls back to defaultFromAddress
+	keyDeliveryEnabled = "mail.delivery_enabled" // "false" disables delivery (logs instead)
+	keySMTPPublicHost  = "mail.smtp_public_hostname"
 )
 
-func init() {
-	// Default to NOT delivering when PocketBase runs with --dev (the flag
-	// only ever appears in dev/test/seed processes). Production binaries
-	// invoke `serve` without --dev, so deliver defaults to true there.
-	// SKIP_SENDING_MAIL=true forces no-delivery regardless; setting it to
-	// "false" explicitly opts a --dev process back into real delivery.
-	devMode := slices.Contains(os.Args, "--dev")
-	skip := os.Getenv("SKIP_SENDING_MAIL")
-	if skip == "" {
-		deliver = !devMode
-	} else {
-		deliver = !strings.EqualFold(skip, "true")
+const defaultFromAddress = "noreply@tinycld.org"
+
+// ConfigResolver is the seam through which the mailer reads its configuration.
+// coreserver populates it at startup to read from the in-memory SystemConfig
+// (backed by the system_settings collection). The default returns "" so the
+// package still builds and works standalone (tests, the bootstrap binary) —
+// with no token configured it logs instead of delivering.
+//
+// Reads happen per-send (no caching), so an /admin edit to a mail.* setting
+// takes effect on the next send without a restart — matching how the mail
+// feature package and Sentry/VAPID consume system config.
+var ConfigResolver = func(string) string { return "" }
+
+// devAutoLog is true when this process was started with --dev (dev/test/seed).
+// Such processes log emails instead of delivering by default, regardless of
+// the mail.delivery_enabled setting, so local/CI runs never send real mail.
+// Captured once at init since it's a fixed process property.
+var devAutoLog = slices.Contains(os.Args, "--dev")
+
+// deliveryEnabled reports whether outbound delivery is on. Delivery is off in
+// --dev processes (auto-log) and when mail.delivery_enabled is explicitly
+// "false". Otherwise it is on (the production default).
+func deliveryEnabled() bool {
+	if devAutoLog {
+		return false
+	}
+	return !strings.EqualFold(ConfigResolver(keyDeliveryEnabled), "false")
+}
+
+// fromAddress returns the configured default From, or the package default.
+func fromAddress() string {
+	if v := ConfigResolver(keyFromAddress); v != "" {
+		return v
+	}
+	return defaultFromAddress
+}
+
+// buildSender constructs the configured outbound sender from current config,
+// or nil when nothing is configured (e.g. postmark selected but no token).
+// Built per-call so config changes apply immediately.
+func buildSender() Sender {
+	switch strings.ToLower(ConfigResolver(keyProvider)) {
+	case "smtp":
+		return NewSMTPSender(SMTPConfig{PublicHostname: ConfigResolver(keySMTPPublicHost)})
+	case "", "postmark":
+		token := ConfigResolver(keyPostmarkToken)
+		if token == "" {
+			return nil
+		}
+		return NewPostmarkSender(token, ConfigResolver(keyPostmarkAccount), fromAddress())
+	default:
+		return nil
 	}
 }
 
-// Default returns the shared PostmarkSender (or nil if not configured).
-func Default() *PostmarkSender {
-	once.Do(func() {
-		token := os.Getenv("POSTMARK_SERVER_TOKEN")
-		from := os.Getenv("MAIL_FROM_ADDRESS")
-		if from == "" {
-			from = "noreply@tinycld.org"
-		}
-		if token != "" {
-			instance = NewPostmarkSender(token, "", from)
-		}
-	})
-	return instance
-}
-
-// DefaultSender returns a Sender, falling back to LogSender if no provider is configured.
-// The PostmarkSender itself checks DELIVER_MAIL and logs instead of sending in dev mode.
+// DefaultSender returns the Sender to use for a send. When delivery is disabled
+// (dev/test or mail.delivery_enabled=false) or no provider is configured, it
+// returns the log-only LogSender (which also writes TINYCLD_EMAIL_LOG for e2e).
 func DefaultSender() Sender {
-	s := Default()
-	if s == nil {
+	if !deliveryEnabled() {
 		return &LogSender{}
 	}
-	return s
+	if s := buildSender(); s != nil {
+		return s
+	}
+	return &LogSender{}
+}
+
+// CanDeliver reports whether a real outbound provider is configured AND
+// delivery is enabled — i.e. whether DefaultSender().Send would actually
+// deliver rather than log.
+func CanDeliver() bool {
+	return deliveryEnabled() && buildSender() != nil
 }
 
 // NoopSender silently discards messages.
 type NoopSender struct{}
 
-func (n *NoopSender) Send(_ context.Context, _ *Message) error              { return nil }
+func (n *NoopSender) Send(_ context.Context, _ *Message) error { return nil }
 func (n *NoopSender) SendFull(_ context.Context, _ *SendRequest) (*SendResult, error) {
 	return &SendResult{}, nil
 }
@@ -211,7 +253,7 @@ func appendToEmailLog(entry loggedEmail) {
 
 func (l *LogSender) Send(_ context.Context, msg *Message) error {
 	fmt.Println("╭──────────────────────────────────────────────────────────╮")
-	fmt.Println("│  EMAIL (not delivered — SKIP_SENDING_MAIL is set)   │")
+	fmt.Println("│  EMAIL (not delivered — delivery is disabled)       │")
 	fmt.Println("├──────────────────────────────────────────────────────────┤")
 	fmt.Printf("│  To:      %s\n", FormatRecipients(msg.To))
 	if msg.From != "" {
@@ -239,7 +281,7 @@ func (l *LogSender) Send(_ context.Context, msg *Message) error {
 
 func (l *LogSender) SendFull(_ context.Context, req *SendRequest) (*SendResult, error) {
 	fmt.Println("╭──────────────────────────────────────────────────────────╮")
-	fmt.Println("│  EMAIL (not delivered — SKIP_SENDING_MAIL is set)   │")
+	fmt.Println("│  EMAIL (not delivered — delivery is disabled)       │")
 	fmt.Println("├──────────────────────────────────────────────────────────┤")
 	fmt.Printf("│  To:      %s\n", FormatRecipients(req.To))
 	if len(req.Cc) > 0 {

--- a/core/server/mailer/postmark.go
+++ b/core/server/mailer/postmark.go
@@ -12,10 +12,11 @@ var log = &LogSender{}
 
 // PostmarkSender sends email via the Postmark API.
 // It implements both Sender (simple) and FullSender (rich with CC/BCC/attachments).
-// When DELIVER_MAIL is not "true", it logs emails to stdout instead of delivering.
+// When delivery is disabled (a --dev process or mail.delivery_enabled=false) it
+// logs emails to stdout instead of delivering — see deliveryEnabled.
 type PostmarkSender struct {
-	client       *postmark.Client
-	defaultFrom  string
+	client      *postmark.Client
+	defaultFrom string
 }
 
 // NewPostmarkSender creates a Postmark-backed sender.
@@ -34,7 +35,7 @@ func (p *PostmarkSender) Client() *postmark.Client {
 
 // Send sends a simple transactional email.
 func (p *PostmarkSender) Send(ctx context.Context, msg *Message) error {
-	if !deliver {
+	if !deliveryEnabled() {
 		return log.Send(ctx, msg)
 	}
 	from := msg.From
@@ -63,11 +64,15 @@ func (p *PostmarkSender) Send(ctx context.Context, msg *Message) error {
 
 // SendFull sends a rich email with CC, BCC, attachments, and threading headers.
 func (p *PostmarkSender) SendFull(ctx context.Context, req *SendRequest) (*SendResult, error) {
-	if !deliver {
+	if !deliveryEnabled() {
 		return log.SendFull(ctx, req)
 	}
+	from := req.From
+	if from == "" {
+		from = p.defaultFrom
+	}
 	email := postmark.Email{
-		From:     req.From,
+		From:     from,
 		To:       FormatRecipients(req.To),
 		Cc:       FormatRecipients(req.Cc),
 		Bcc:      FormatRecipients(req.Bcc),

--- a/core/server/mailer/smtp.go
+++ b/core/server/mailer/smtp.go
@@ -64,9 +64,7 @@ var smtpDial = func(ctx context.Context, network, addr string) (net.Conn, error)
 	return d.DialContext(ctx, network, addr)
 }
 
-// Send adapts the simple Message shape onto SendFull. When delivery is gated
-// off (dev/test or mail.delivery_enabled=false) the caller routes through
-// LogSender instead, so SMTPSender always attempts a real delivery.
+// Send adapts the simple Message shape onto SendFull.
 func (p *SMTPSender) Send(ctx context.Context, msg *Message) error {
 	_, err := p.SendFull(ctx, &SendRequest{
 		From:     msg.From,
@@ -91,6 +89,9 @@ func (p *SMTPSender) Send(ctx context.Context, msg *Message) error {
 func (p *SMTPSender) SendFull(ctx context.Context, req *SendRequest) (*SendResult, error) {
 	if req == nil {
 		return nil, fmt.Errorf("nil send request")
+	}
+	if !deliveryEnabled() {
+		return log.SendFull(ctx, req)
 	}
 
 	messageID := generateMessageID(p.cfg.PublicHostname)

--- a/core/server/mailer/smtp.go
+++ b/core/server/mailer/smtp.go
@@ -1,0 +1,529 @@
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"net/smtp"
+	"sort"
+	"strings"
+	"time"
+
+	gomail "github.com/emersion/go-message/mail"
+)
+
+// SMTPConfig is the outbound configuration for the self-hosted SMTP sender —
+// direct-to-MX delivery with no provider account. Inbound concerns (the MX
+// listener, IMAP fetcher, DKIM verification) live in the mail package and are
+// not represented here. Defaults are applied by NewSMTPSender.
+type SMTPConfig struct {
+	// PublicHostname is what we announce in EHLO and embed in the generated
+	// Message-ID. Defaults to "localhost".
+	PublicHostname string
+
+	// OutboundTimeout caps the total time per recipient-domain delivery
+	// attempt (MX lookup + SMTP conversation). Defaults to 30s.
+	OutboundTimeout time.Duration
+}
+
+func (c *SMTPConfig) applyDefaults() {
+	if c.PublicHostname == "" {
+		c.PublicHostname = "localhost"
+	}
+	if c.OutboundTimeout == 0 {
+		c.OutboundTimeout = 30 * time.Second
+	}
+}
+
+// SMTPSender delivers mail by talking SMTP directly: outbound via
+// recipient-domain MX lookup. There is no provider account — credentials are
+// not used for outbound; per-recipient delivery either works or it doesn't.
+// It implements Sender and FullSender.
+type SMTPSender struct {
+	cfg SMTPConfig
+}
+
+// NewSMTPSender builds an SMTPSender with defaults applied.
+func NewSMTPSender(cfg SMTPConfig) *SMTPSender {
+	cfg.applyDefaults()
+	return &SMTPSender{cfg: cfg}
+}
+
+// smtpMXLookup is swappable for tests.
+var smtpMXLookup = net.DefaultResolver.LookupMX
+
+// smtpDial opens a connection to host:port. Swappable for tests.
+var smtpDial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+	d := net.Dialer{}
+	return d.DialContext(ctx, network, addr)
+}
+
+// Send adapts the simple Message shape onto SendFull. When delivery is gated
+// off (dev/test or mail.delivery_enabled=false) the caller routes through
+// LogSender instead, so SMTPSender always attempts a real delivery.
+func (p *SMTPSender) Send(ctx context.Context, msg *Message) error {
+	_, err := p.SendFull(ctx, &SendRequest{
+		From:     msg.From,
+		To:       msg.To,
+		Subject:  msg.Subject,
+		HTMLBody: msg.HTML,
+		TextBody: msg.Text,
+		ReplyTo:  msg.ReplyTo,
+	})
+	return err
+}
+
+// SendFull performs a single outbound delivery attempt per recipient-domain
+// group. Recipients are grouped by their domain; for each group we resolve MX,
+// walk MX hosts in priority order, and try opportunistic STARTTLS. A permanent
+// (5xx) response for a recipient bubbles up as a RecipientFailure on the
+// returned SendResult. A successful send to at least one recipient returns nil
+// error; if every recipient permanently failed we still return nil error (the
+// FailedRecipients slice carries the bad news so the caller can persist the
+// message as 'bounced'). A transport-level failure (e.g. all MX hosts
+// unreachable) returns an error and no SendResult.
+func (p *SMTPSender) SendFull(ctx context.Context, req *SendRequest) (*SendResult, error) {
+	if req == nil {
+		return nil, fmt.Errorf("nil send request")
+	}
+
+	messageID := generateMessageID(p.cfg.PublicHostname)
+	body, err := buildOutgoingRFC5322(req, messageID, p.cfg.PublicHostname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build message: %w", err)
+	}
+
+	envelopeFrom, err := envelopeAddress(req.From)
+	if err != nil {
+		return nil, fmt.Errorf("invalid From address: %w", err)
+	}
+
+	groups := groupRecipientsByDomain(req)
+	if len(groups) == 0 {
+		return nil, fmt.Errorf("no recipients")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.OutboundTimeout)
+	defer cancel()
+
+	result := &SendResult{MessageID: messageID, ProviderMessageID: messageID}
+	deliveredAny := false
+	var lastTransportErr error
+
+	for domain, recipients := range groups {
+		delivered, failures, transportErr := p.deliverToDomain(ctx, domain, envelopeFrom, recipients, body)
+		if transportErr != nil {
+			lastTransportErr = transportErr
+			// Transport error against this domain → mark every recipient in
+			// the group as failed so the caller can persist bounce_reason.
+			for _, rcpt := range recipients {
+				result.FailedRecipients = append(result.FailedRecipients, RecipientFailure{
+					Email:  rcpt,
+					Reason: transportErr.Error(),
+				})
+			}
+			continue
+		}
+		result.FailedRecipients = append(result.FailedRecipients, failures...)
+		if delivered {
+			deliveredAny = true
+		}
+	}
+
+	if !deliveredAny && lastTransportErr != nil && len(result.FailedRecipients) == len(allRecipients(req)) {
+		// Every recipient failed transport — return error so the caller
+		// surfaces 502 to the user instead of silently storing the message.
+		return nil, fmt.Errorf("smtp delivery failed for all recipients: %w", lastTransportErr)
+	}
+
+	return result, nil
+}
+
+// deliverToDomain opens an SMTP connection to one MX host for `domain` and
+// issues MAIL FROM / RCPT TO (one per recipient) / DATA. Returns whether at
+// least one recipient was accepted, the list of recipients that got a
+// permanent (5xx) failure, and any transport error (failed to reach any MX).
+func (p *SMTPSender) deliverToDomain(ctx context.Context, domain, from string, recipients []string, body []byte) (bool, []RecipientFailure, error) {
+	hosts, err := resolveMXHosts(ctx, domain)
+	if err != nil {
+		return false, nil, fmt.Errorf("mx lookup for %s: %w", domain, err)
+	}
+
+	var lastErr error
+	for _, host := range hosts {
+		conn, err := smtpDial(ctx, "tcp", host+":25")
+		if err != nil {
+			lastErr = fmt.Errorf("dial %s: %w", host, err)
+			continue
+		}
+
+		delivered, failures, convErr := runSMTPConversation(conn, host, p.cfg.PublicHostname, from, recipients, body)
+		// runSMTPConversation closes its own connection on the happy path;
+		// on transport error we still close defensively.
+		_ = conn.Close()
+		if convErr != nil {
+			lastErr = fmt.Errorf("smtp to %s: %w", host, convErr)
+			continue
+		}
+		return delivered, failures, nil
+	}
+
+	return false, nil, fmt.Errorf("all MX hosts unreachable for %s: %w", domain, lastErr)
+}
+
+// runSMTPConversation drives the SMTP conversation against an already-dialed
+// connection. STARTTLS is attempted when advertised; AUTH is never offered
+// (this is server-to-server traffic, not client submission).
+func runSMTPConversation(conn net.Conn, host, helo, from string, recipients []string, body []byte) (bool, []RecipientFailure, error) {
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return false, nil, fmt.Errorf("new client: %w", err)
+	}
+	defer client.Close()
+
+	if err := client.Hello(helo); err != nil {
+		return false, nil, fmt.Errorf("EHLO: %w", err)
+	}
+
+	if ok, _ := client.Extension("STARTTLS"); ok {
+		tlsCfg := &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12}
+		if err := client.StartTLS(tlsCfg); err != nil {
+			// Fall through without TLS — opportunistic. Most receivers accept.
+			// We deliberately do not fail here: a failing STARTTLS is far
+			// rarer than a misconfigured TLS cert on the receiver, and most
+			// receivers accept plaintext fallback for incoming mail.
+		}
+	}
+
+	if err := client.Mail(from); err != nil {
+		return false, nil, fmt.Errorf("MAIL FROM: %w", err)
+	}
+
+	var failures []RecipientFailure
+	acceptedCount := 0
+	for _, rcpt := range recipients {
+		if err := client.Rcpt(rcpt); err != nil {
+			// Distinguish permanent (5xx) from temporary (4xx) failures by
+			// the leading digit of the SMTP code carried in the error. The
+			// net/smtp client wraps the response as "<code> <text>" in
+			// err.Error(), so a simple prefix check is reliable enough.
+			reason := err.Error()
+			if isPermanentSMTPError(reason) {
+				failures = append(failures, RecipientFailure{Email: rcpt, Reason: reason})
+				continue
+			}
+			// Temporary failure → treat as transport error so the caller
+			// retries the whole batch on the next MX (or surfaces 502).
+			return false, nil, fmt.Errorf("RCPT TO %s: %w", rcpt, err)
+		}
+		acceptedCount++
+	}
+
+	if acceptedCount == 0 {
+		// All recipients permanently failed at RCPT — close cleanly without
+		// sending DATA. The failures slice carries the per-recipient bounces.
+		_ = client.Reset()
+		_ = client.Quit()
+		return false, failures, nil
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return false, failures, fmt.Errorf("DATA: %w", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return false, failures, fmt.Errorf("write body: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return false, failures, fmt.Errorf("close DATA: %w", err)
+	}
+
+	_ = client.Quit()
+	return true, failures, nil
+}
+
+// isPermanentSMTPError checks whether an error string from net/smtp begins
+// with a 5xx response code. Net/smtp formats responses as "NNN <text>" or
+// "NNN-<text>" for multiline; both forms are covered by checking the first
+// digit. Returns false for empty strings and non-numeric prefixes so transient
+// network errors don't get mistaken for permanent bounces.
+func isPermanentSMTPError(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	return s[0] == '5' && isDigit(s[1]) && isDigit(s[2])
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+// resolveMXHosts returns hosts sorted by preference. If MX lookup yields no
+// records (NXDOMAIN or empty), RFC 5321 §5.1 requires falling back to the
+// domain's A/AAAA record — we honor that by returning the domain itself.
+func resolveMXHosts(ctx context.Context, domain string) ([]string, error) {
+	mxs, err := smtpMXLookup(ctx, domain)
+	if err == nil && len(mxs) > 0 {
+		sort.SliceStable(mxs, func(i, j int) bool { return mxs[i].Pref < mxs[j].Pref })
+		hosts := make([]string, len(mxs))
+		for i, mx := range mxs {
+			hosts[i] = strings.TrimSuffix(mx.Host, ".")
+		}
+		return hosts, nil
+	}
+	// Fallback to the bare domain — receivers without explicit MX still get mail.
+	return []string{domain}, nil
+}
+
+// groupRecipientsByDomain partitions To+Cc+Bcc by recipient domain.
+func groupRecipientsByDomain(req *SendRequest) map[string][]string {
+	groups := make(map[string][]string)
+	add := func(addr string) {
+		_, domain := splitAddress(addr)
+		if domain == "" {
+			return
+		}
+		groups[domain] = append(groups[domain], addr)
+	}
+	for _, r := range req.To {
+		add(r.Email)
+	}
+	for _, r := range req.Cc {
+		add(r.Email)
+	}
+	for _, r := range req.Bcc {
+		add(r.Email)
+	}
+	return groups
+}
+
+// allRecipients flattens To+Cc+Bcc into a single slice of email addresses.
+func allRecipients(req *SendRequest) []string {
+	out := make([]string, 0, len(req.To)+len(req.Cc)+len(req.Bcc))
+	for _, r := range req.To {
+		out = append(out, r.Email)
+	}
+	for _, r := range req.Cc {
+		out = append(out, r.Email)
+	}
+	for _, r := range req.Bcc {
+		out = append(out, r.Email)
+	}
+	return out
+}
+
+// envelopeAddress extracts the bare email from a possibly-display-name-wrapped
+// From string ("Alice <a@example.com>" → "a@example.com"). The wire-level
+// MAIL FROM must be the bare address.
+func envelopeAddress(from string) (string, error) {
+	if from == "" {
+		return "", fmt.Errorf("empty from")
+	}
+	if i := strings.LastIndex(from, "<"); i >= 0 {
+		if j := strings.Index(from[i:], ">"); j > 0 {
+			return strings.TrimSpace(from[i+1 : i+j]), nil
+		}
+	}
+	return strings.TrimSpace(from), nil
+}
+
+// splitAddress splits an email address into its local-part and domain. Returns
+// empty strings when there is no single "@" separator.
+func splitAddress(email string) (localPart, domain string) {
+	at := strings.LastIndex(email, "@")
+	if at <= 0 || at == len(email)-1 {
+		return "", ""
+	}
+	return email[:at], email[at+1:]
+}
+
+// generateMessageID builds an RFC-compliant Message-ID rooted at the operator's
+// public hostname. Time + 8 random hex chars keep collision probability negligible.
+func generateMessageID(hostname string) string {
+	if hostname == "" {
+		hostname = "localhost"
+	}
+	suffix, _ := randomHex(8)
+	return fmt.Sprintf("<%d.%s@%s>", time.Now().UTC().UnixNano(), suffix, hostname)
+}
+
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// --- RFC 5322 message construction ---
+
+// buildOutgoingRFC5322 serializes a SendRequest into RFC 5322 bytes for direct
+// SMTP delivery. Threading headers (In-Reply-To, References) are emitted when
+// present. Attachments are emitted as a multipart/mixed wrapper around the
+// text/html alternative. The Message-ID is injected (the caller generates it
+// up-front so the same value can be stored locally for thread matching).
+func buildOutgoingRFC5322(req *SendRequest, messageID, helo string) ([]byte, error) {
+	var buf bytes.Buffer
+
+	var h gomail.Header
+	h.SetDate(time.Now().UTC())
+	h.SetSubject(req.Subject)
+	h.SetMessageID(messageID)
+
+	if req.From != "" {
+		fromAddrs, err := gomail.ParseAddressList(req.From)
+		if err == nil && len(fromAddrs) > 0 {
+			h.SetAddressList("From", fromAddrs)
+		} else {
+			// Fall back: treat as a bare address with no display name.
+			h.SetAddressList("From", []*gomail.Address{{Address: req.From}})
+		}
+	}
+	if req.ReplyTo != "" {
+		if addrs, err := gomail.ParseAddressList(req.ReplyTo); err == nil && len(addrs) > 0 {
+			h.SetAddressList("Reply-To", addrs)
+		}
+	}
+	if len(req.To) > 0 {
+		h.SetAddressList("To", recipientsToAddrs(req.To))
+	}
+	if len(req.Cc) > 0 {
+		h.SetAddressList("Cc", recipientsToAddrs(req.Cc))
+	}
+	// Bcc is deliberately omitted from headers — it lives only in the SMTP
+	// envelope, per RFC 5322 §3.6.3.
+
+	if req.InReplyTo != "" {
+		h.Set("In-Reply-To", req.InReplyTo)
+	}
+	if req.References != "" {
+		h.Set("References", req.References)
+	}
+	for _, hdr := range req.Headers {
+		// Custom headers from the caller are appended verbatim. We do not
+		// overwrite headers we've already set (Subject, From, etc.).
+		if hdr.Name == "" {
+			continue
+		}
+		h.Set(hdr.Name, hdr.Value)
+	}
+
+	if len(req.Attachments) > 0 {
+		mw, err := gomail.CreateWriter(&buf, h)
+		if err != nil {
+			return nil, fmt.Errorf("create writer: %w", err)
+		}
+		if err := writeAlternativePart(mw, req.TextBody, req.HTMLBody); err != nil {
+			mw.Close()
+			return nil, err
+		}
+		for _, att := range req.Attachments {
+			if err := writeAttachmentFromBase64(mw, att); err != nil {
+				return nil, err
+			}
+		}
+		mw.Close()
+		return buf.Bytes(), nil
+	}
+
+	if req.HTMLBody != "" {
+		mw, err := gomail.CreateWriter(&buf, h)
+		if err != nil {
+			return nil, fmt.Errorf("create writer: %w", err)
+		}
+		if err := writeAlternativePart(mw, req.TextBody, req.HTMLBody); err != nil {
+			mw.Close()
+			return nil, err
+		}
+		mw.Close()
+		return buf.Bytes(), nil
+	}
+
+	h.SetContentType("text/plain", map[string]string{"charset": "utf-8"})
+	w, err := gomail.CreateSingleInlineWriter(&buf, h)
+	if err != nil {
+		return nil, fmt.Errorf("create plain writer: %w", err)
+	}
+	io.WriteString(w, req.TextBody)
+	w.Close()
+	return buf.Bytes(), nil
+}
+
+func recipientsToAddrs(rs []Recipient) []*gomail.Address {
+	out := make([]*gomail.Address, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, &gomail.Address{Name: r.Name, Address: r.Email})
+	}
+	return out
+}
+
+// writeAlternativePart writes a multipart/alternative body (text + optional
+// html) into the given writer.
+func writeAlternativePart(mw *gomail.Writer, textBody, htmlBody string) error {
+	altW, err := mw.CreateInline()
+	if err != nil {
+		return fmt.Errorf("failed to create alternative part: %w", err)
+	}
+
+	var textH gomail.InlineHeader
+	textH.SetContentType("text/plain", map[string]string{"charset": "utf-8"})
+	tw, err := altW.CreatePart(textH)
+	if err != nil {
+		return fmt.Errorf("failed to create text part: %w", err)
+	}
+	io.WriteString(tw, textBody)
+	tw.Close()
+
+	if htmlBody != "" {
+		var htmlH gomail.InlineHeader
+		htmlH.SetContentType("text/html", map[string]string{"charset": "utf-8"})
+		hw, err := altW.CreatePart(htmlH)
+		if err != nil {
+			return fmt.Errorf("failed to create html part: %w", err)
+		}
+		io.WriteString(hw, htmlBody)
+		hw.Close()
+	}
+
+	altW.Close()
+	return nil
+}
+
+func writeAttachmentFromBase64(mw *gomail.Writer, att Attachment) error {
+	data, err := base64.StdEncoding.DecodeString(att.Content)
+	if err != nil {
+		return fmt.Errorf("decode attachment %q: %w", att.Name, err)
+	}
+	contentType := att.ContentType
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	var ah gomail.InlineHeader
+	ah.SetContentType(contentType, map[string]string{"name": att.Name})
+	ah.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", att.Name))
+	ah.Set("Content-Transfer-Encoding", "base64")
+	if att.ContentID != "" {
+		ah.Set("Content-ID", "<"+att.ContentID+">")
+	}
+
+	aw, err := mw.CreateSingleInline(ah)
+	if err != nil {
+		return fmt.Errorf("create attachment part: %w", err)
+	}
+	encoder := base64.NewEncoder(base64.StdEncoding, aw)
+	encoder.Write(data)
+	encoder.Close()
+	aw.Close()
+	return nil
+}
+
+// Compile-time assertion that SMTPSender satisfies both sender interfaces.
+var (
+	_ Sender     = (*SMTPSender)(nil)
+	_ FullSender = (*SMTPSender)(nil)
+)

--- a/core/server/mailer/smtp.go
+++ b/core/server/mailer/smtp.go
@@ -332,11 +332,13 @@ func envelopeAddress(from string) (string, error) {
 	return strings.TrimSpace(from), nil
 }
 
-// splitAddress splits an email address into its local-part and domain. Returns
-// empty strings when there is no single "@" separator.
+// splitAddress splits an email address into its local-part and domain. The
+// address is trimmed and lower-cased first so the derived domain is a clean
+// MX-lookup target. Returns empty strings when there is no single "@" separator.
 func splitAddress(email string) (localPart, domain string) {
+	email = strings.TrimSpace(strings.ToLower(email))
 	at := strings.LastIndex(email, "@")
-	if at <= 0 || at == len(email)-1 {
+	if at < 1 || at >= len(email)-1 {
 		return "", ""
 	}
 	return email[:at], email[at+1:]

--- a/core/server/mailer/smtp_test.go
+++ b/core/server/mailer/smtp_test.go
@@ -1,0 +1,347 @@
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/textproto"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEnvelopeAddress(t *testing.T) {
+	cases := map[string]string{
+		"alice@example.com":         "alice@example.com",
+		"Alice <alice@example.com>": "alice@example.com",
+		"  bob@example.org  ":       "bob@example.org",
+		"\"Carol Q\" <carol@x.com>": "carol@x.com",
+	}
+	for in, want := range cases {
+		got, err := envelopeAddress(in)
+		if err != nil {
+			t.Errorf("envelopeAddress(%q) error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("envelopeAddress(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsPermanentSMTPError(t *testing.T) {
+	cases := map[string]bool{
+		"":                          false,
+		"foo":                       false,
+		"550 5.1.1 user unknown":    true,
+		"5":                         false,
+		"552 mailbox full":          true,
+		"450 try again later":       false,
+		"421 service not available": false,
+		"5XX bogus":                 false,
+		"4xx not numeric":           false,
+	}
+	for in, want := range cases {
+		if got := isPermanentSMTPError(in); got != want {
+			t.Errorf("isPermanentSMTPError(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestGroupRecipientsByDomain(t *testing.T) {
+	req := &SendRequest{
+		To:  []Recipient{{Email: "a@example.com"}, {Email: "b@example.com"}},
+		Cc:  []Recipient{{Email: "c@example.org"}},
+		Bcc: []Recipient{{Email: "d@example.org"}, {Email: "malformed"}},
+	}
+	got := groupRecipientsByDomain(req)
+	if len(got["example.com"]) != 2 {
+		t.Errorf("example.com: got %v", got["example.com"])
+	}
+	if len(got["example.org"]) != 2 {
+		t.Errorf("example.org: got %v", got["example.org"])
+	}
+	if _, ok := got[""]; ok {
+		t.Errorf("malformed address should not produce empty-key group")
+	}
+}
+
+// TestSMTPSenderSend_DirectMX_Success drives a fake in-process SMTP receiver
+// and asserts the full conversation (MAIL FROM / RCPT TO / DATA) is issued and
+// the right body is delivered. This is the integration-level test for the
+// outbound code path.
+func TestSMTPSenderSend_DirectMX_Success(t *testing.T) {
+	receiver := newFakeSMTPReceiver(t, smtpReceiverConfig{})
+	defer receiver.close()
+
+	swapMXLookup(t, map[string][]*net.MX{
+		"example.org": {{Host: "127.0.0.1", Pref: 10}},
+	})
+	swapSMTPDial(t, receiver.dialOverride)
+
+	p := NewSMTPSender(SMTPConfig{PublicHostname: "mx.tinycld.test"})
+	result, err := p.SendFull(context.Background(), &SendRequest{
+		From:     "alice@tinycld.test",
+		To:       []Recipient{{Email: "bob@example.org"}},
+		Subject:  "Hello",
+		TextBody: "hi from tinycld",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(result.FailedRecipients) != 0 {
+		t.Errorf("expected 0 failed recipients, got %+v", result.FailedRecipients)
+	}
+	if result.MessageID == "" {
+		t.Errorf("expected non-empty MessageID")
+	}
+
+	received := receiver.firstMessage(t)
+	if received.from != "alice@tinycld.test" {
+		t.Errorf("MAIL FROM: got %q, want alice@tinycld.test", received.from)
+	}
+	if len(received.rcpt) != 1 || received.rcpt[0] != "bob@example.org" {
+		t.Errorf("RCPT TO: got %v", received.rcpt)
+	}
+	if !strings.Contains(received.body, "hi from tinycld") {
+		t.Errorf("body missing payload; got: %s", received.body)
+	}
+	if !strings.Contains(received.body, "Subject: Hello") {
+		t.Errorf("body missing Subject header; got: %s", received.body)
+	}
+}
+
+// A 5xx response at RCPT TO must surface as a RecipientFailure rather than a
+// transport error. This is the contract that lets endpoints_send mark the
+// stored message as bounced with the right reason.
+func TestSMTPSenderSend_PermanentFailureSurfacesAsRecipientFailure(t *testing.T) {
+	receiver := newFakeSMTPReceiver(t, smtpReceiverConfig{
+		rejectRcpt: map[string]string{
+			"unknown@example.org": "550 5.1.1 No such user",
+		},
+	})
+	defer receiver.close()
+
+	swapMXLookup(t, map[string][]*net.MX{
+		"example.org": {{Host: "127.0.0.1", Pref: 10}},
+	})
+	swapSMTPDial(t, receiver.dialOverride)
+
+	p := NewSMTPSender(SMTPConfig{PublicHostname: "mx.tinycld.test"})
+	result, err := p.SendFull(context.Background(), &SendRequest{
+		From:     "alice@tinycld.test",
+		To:       []Recipient{{Email: "unknown@example.org"}},
+		Subject:  "hi",
+		TextBody: "test",
+	})
+	if err != nil {
+		t.Fatalf("Send returned error (should be nil with FailedRecipients): %v", err)
+	}
+	if len(result.FailedRecipients) != 1 {
+		t.Fatalf("expected 1 failed recipient, got %+v", result.FailedRecipients)
+	}
+	if result.FailedRecipients[0].Email != "unknown@example.org" {
+		t.Errorf("failed recipient email: got %q", result.FailedRecipients[0].Email)
+	}
+	if !strings.HasPrefix(result.FailedRecipients[0].Reason, "550") {
+		t.Errorf("failed reason: got %q, want to start with 550", result.FailedRecipients[0].Reason)
+	}
+}
+
+// When MX lookup yields nothing AND the bare-domain fallback also fails to
+// dial, Send must return a transport error so the calling endpoint surfaces
+// a 502 to the user instead of silently dropping the message.
+func TestSMTPSenderSend_AllMXDown_TransportError(t *testing.T) {
+	swapMXLookup(t, map[string][]*net.MX{})
+	swapSMTPDial(t, func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, errors.New("dial error: connection refused")
+	})
+
+	p := NewSMTPSender(SMTPConfig{PublicHostname: "mx.tinycld.test", OutboundTimeout: 2 * time.Second})
+	_, err := p.SendFull(context.Background(), &SendRequest{
+		From:     "alice@tinycld.test",
+		To:       []Recipient{{Email: "bob@example.org"}},
+		Subject:  "hi",
+		TextBody: "test",
+	})
+	if err == nil {
+		t.Fatalf("expected transport error, got nil")
+	}
+}
+
+// --- Test helpers ---
+
+func swapMXLookup(t *testing.T, m map[string][]*net.MX) {
+	t.Helper()
+	orig := smtpMXLookup
+	smtpMXLookup = func(_ context.Context, name string) ([]*net.MX, error) {
+		if mxs, ok := m[name]; ok {
+			return mxs, nil
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { smtpMXLookup = orig })
+}
+
+func swapSMTPDial(t *testing.T, fn func(ctx context.Context, network, addr string) (net.Conn, error)) {
+	t.Helper()
+	orig := smtpDial
+	smtpDial = fn
+	t.Cleanup(func() { smtpDial = orig })
+}
+
+// fakeSMTPReceiver is an in-process SMTP server good enough to test the
+// outbound conversation. It uses net/textproto so the test stays independent
+// of the production go-smtp library's behavior.
+type fakeSMTPReceiver struct {
+	listener net.Listener
+	cfg      smtpReceiverConfig
+	mu       sync.Mutex
+	received []fakeSMTPMessage
+	done     chan struct{}
+}
+
+type smtpReceiverConfig struct {
+	rejectRcpt map[string]string // RCPT addr → SMTP response (e.g. "550 5.1.1 No such user")
+}
+
+type fakeSMTPMessage struct {
+	from string
+	rcpt []string
+	body string
+}
+
+func newFakeSMTPReceiver(t *testing.T, cfg smtpReceiverConfig) *fakeSMTPReceiver {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	r := &fakeSMTPReceiver{listener: ln, cfg: cfg, done: make(chan struct{})}
+	go r.serve()
+	return r
+}
+
+func (r *fakeSMTPReceiver) close() {
+	r.listener.Close()
+}
+
+// dialOverride lets the SMTPSender connect to this in-process server even
+// though the MX records claim a different host. The sender always dials
+// "<host>:25"; we ignore the address and dial our actual listener.
+func (r *fakeSMTPReceiver) dialOverride(_ context.Context, _, _ string) (net.Conn, error) {
+	return net.Dial("tcp", r.listener.Addr().String())
+}
+
+func (r *fakeSMTPReceiver) firstMessage(t *testing.T) fakeSMTPMessage {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		r.mu.Lock()
+		if len(r.received) > 0 {
+			msg := r.received[0]
+			r.mu.Unlock()
+			return msg
+		}
+		r.mu.Unlock()
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for SMTP message")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func (r *fakeSMTPReceiver) serve() {
+	for {
+		conn, err := r.listener.Accept()
+		if err != nil {
+			return
+		}
+		go r.handle(conn)
+	}
+}
+
+func (r *fakeSMTPReceiver) handle(conn net.Conn) {
+	defer conn.Close()
+	tc := textproto.NewConn(conn)
+	defer tc.Close()
+
+	_ = tc.PrintfLine("220 fake.smtp ready")
+
+	msg := fakeSMTPMessage{}
+	var inData bool
+	var bodyBuf bytes.Buffer
+
+	for {
+		line, err := tc.ReadLine()
+		if err != nil {
+			return
+		}
+		if inData {
+			if line == "." {
+				inData = false
+				msg.body = bodyBuf.String()
+				bodyBuf.Reset()
+				_ = tc.PrintfLine("250 OK queued")
+				r.mu.Lock()
+				r.received = append(r.received, msg)
+				msg = fakeSMTPMessage{}
+				r.mu.Unlock()
+				continue
+			}
+			bodyBuf.WriteString(line)
+			bodyBuf.WriteString("\r\n")
+			continue
+		}
+
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, "EHLO"), strings.HasPrefix(upper, "HELO"):
+			_ = tc.PrintfLine("250-fake.smtp")
+			_ = tc.PrintfLine("250 8BITMIME")
+		case strings.HasPrefix(upper, "MAIL FROM:"):
+			msg.from = extractAddress(line[len("MAIL FROM:"):])
+			_ = tc.PrintfLine("250 OK")
+		case strings.HasPrefix(upper, "RCPT TO:"):
+			addr := extractAddress(line[len("RCPT TO:"):])
+			if resp, blocked := r.cfg.rejectRcpt[addr]; blocked {
+				_ = tc.PrintfLine("%s", resp)
+				continue
+			}
+			msg.rcpt = append(msg.rcpt, addr)
+			_ = tc.PrintfLine("250 OK")
+		case upper == "DATA":
+			inData = true
+			_ = tc.PrintfLine("354 end with <CR><LF>.<CR><LF>")
+		case upper == "QUIT":
+			_ = tc.PrintfLine("221 bye")
+			return
+		case upper == "RSET":
+			msg = fakeSMTPMessage{}
+			_ = tc.PrintfLine("250 OK")
+		case upper == "NOOP":
+			_ = tc.PrintfLine("250 OK")
+		default:
+			_ = tc.PrintfLine("502 5.5.2 command not implemented")
+		}
+	}
+}
+
+// extractAddress strips angle brackets, surrounding whitespace, and any
+// trailing ESMTP parameters (e.g. " BODY=8BITMIME") from an SMTP address
+// argument like " <alice@example.com> BODY=8BITMIME". Used by the fake server.
+func extractAddress(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, "<"); i >= 0 {
+		if j := strings.Index(s[i:], ">"); j > 0 {
+			return s[i+1 : i+j]
+		}
+	}
+	if sp := strings.IndexAny(s, " \t"); sp >= 0 {
+		s = s[:sp]
+	}
+	return s
+}

--- a/docs/plans/mailer-config-from-system-settings.md
+++ b/docs/plans/mailer-config-from-system-settings.md
@@ -1,0 +1,139 @@
+# Core transactional mailer reads env vars instead of SystemConfig — config refactor
+
+**Status:** Discovered while building the password-reset feature (branch `feat/password-reset`).
+Deferred to its own session because it's a cross-cutting config refactor, not part of the
+reset feature itself.
+
+## The bug
+
+`core/server/mailer/mailer.go` — the shared transactional mailer used by **invites** and
+(now) **password reset** — reads its configuration directly from environment variables,
+cached once via `sync.Once`:
+
+- `mailer.go:127` → `os.Getenv("POSTMARK_SERVER_TOKEN")`
+- `mailer.go:128` → `os.Getenv("MAIL_FROM_ADDRESS")` (defaults to `noreply@tinycld.org`)
+- `mailer.go:116` → `os.Getenv("SKIP_SENDING_MAIL")` (delivery on/off, read in `init()`)
+- `mailer.go:189` → `os.Getenv("TINYCLD_EMAIL_LOG")` (test-only log path — fine to leave as env)
+
+This contradicts the app's established configuration model. Per
+`core/server/coreserver/system_config.go` and the seed migration
+`core/server/pb_migrations/1910000010_create_system_settings.js`:
+
+> "This is the SOLE source of truth at runtime: the server reads values through the
+> in-memory SystemConfig … there is no os.Getenv fallback in the read path. Env vars are
+> consulted ONCE, by the seed below, to carry an existing env-configured deployment across
+> to the DB on the boot that runs this migration."
+
+So Sentry, web-push/VAPID, and the `mail` **feature package** all read their creds from the
+`system_settings` collection (via `coreserver.SystemSettings().Get(key)` in Go, or
+`systemSetting(app, key)` in the mail package), configurable from the `/admin` Settings
+console. The **core transactional mailer is the one subsystem still on env vars** — it can't
+be reconfigured from `/admin`, and its config diverges from how the rest of the system works.
+
+### Why it surfaced
+
+The password-reset hook (`core/server/coreserver/password_reset_mailer.go`) added a
+`mailer.CanDeliver()` gate (`Default() != nil`, i.e. "is `POSTMARK_SERVER_TOKEN` set in
+env?") to decide whether to override PB's reset email or defer to PB's native SMTP. Because
+that signal is env-based, it doesn't reflect the real (system_settings-based) config state,
+and it routed the e2e/test environment down the wrong branch. The correct fix is not to
+patch the gate — it's to make the core mailer read from SystemConfig like everything else.
+
+## Two parallel mail systems (context)
+
+There are two distinct mailers, and this refactor only concerns the first:
+
+| System | Used by | Token source today | "Configured?" signal |
+|---|---|---|---|
+| **Core `mailer`** (`tinycld.org/core/mailer`) | invites, password reset | env `POSTMARK_SERVER_TOKEN` | `mailer.Default() != nil` |
+| **`mail` package `Provider`** (`mail/server/`) | user mailboxes (Gmail-style client) | `system_settings` key `mail.postmark_server_token` (via `systemSetting()`) | `provider.Configured()` |
+
+The `mail` package already does it right (`mail/server/register.go:428` `systemSetting()`,
+`:446` `newProviderFromSystem`). The core mailer should follow the same model. Note `mail`
+*depends on* `tinycld.org/core/mailer` (builds `PostmarkProvider` on top of
+`mailer.PostmarkSender`) — the dependency is one-way; core never imports `mail`.
+
+## Constraint: no import cycle
+
+`mailer` is a standalone Go package that `coreserver` imports. `coreserver` owns
+`SystemConfig`. So `mailer` **cannot** import `coreserver` (cycle:
+`coreserver → mailer → coreserver`).
+
+**Resolution — invert the dependency.** Have `mailer` expose a config-provider seam (a
+package-level function variable, or a small interface) that `coreserver` populates at startup
+to read from `SystemConfig`. Sketch:
+
+```go
+// in mailer: a settable resolver, default returns zero/empty so the package
+// still builds and works standalone (tests, the bootstrap binary).
+var ConfigResolver func(key string) string = func(string) string { return "" }
+
+// Default()/DefaultSender()/CanDeliver()/deliver read via ConfigResolver(...)
+// instead of os.Getenv(...). Drop the sync.Once caching (or make it re-read on
+// SystemConfig OnChange) so an /admin edit takes effect without a restart —
+// mirror how the mail package builds its provider per-call.
+
+// in coreserver Register(), after RegisterSystemConfig(app):
+mailer.ConfigResolver = func(key string) string { return SystemSettings().Get(key) }
+```
+
+`SystemConfig.OnChange` (`system_config.go:83`) already exists for stateful consumers to
+re-init on change — use it if any caching remains.
+
+## Open design decisions (resolve in the new session)
+
+1. **Token key sharing.** Should the core mailer read the **same** `mail.postmark_server_token`
+   the mail package uses, or a separate `core.*` key? (Leaning: share `mail.postmark_server_token`
+   — one token to configure; core reads it via SystemConfig whether or not the mail package is
+   installed, since the key lives in the shared `system_settings` collection. But confirm the
+   mail package's seed of that key happens even in a mail-less assembly — it may not, in which
+   case core needs to own the seed/field.)
+2. **Delivery toggle.** Model today's `SKIP_SENDING_MAIL` as an admin-editable
+   `mail.delivery_enabled` bool in system_settings (default ON in prod; keep the `--dev`
+   auto-skip in code so dev/test still log by default), or derive "deliver" purely from token
+   presence (no explicit field).
+3. **From address.** Add `mail.from_address` (public) as an `/admin` field, defaulting to
+   `noreply@tinycld.org` when unset.
+4. **Caching / live reconfig.** Decide whether an `/admin` change should take effect without a
+   restart (preferred, matches Sentry/VAPID/mail) — if so, drop `sync.Once` and resolve
+   per-send (or wire `OnChange`).
+
+## Work items
+
+- [ ] Add a config-provider seam to `core/server/mailer/mailer.go`; replace the `os.Getenv`
+      reads for `POSTMARK_SERVER_TOKEN` / `MAIL_FROM_ADDRESS` / `SKIP_SENDING_MAIL` with it.
+      Keep `TINYCLD_EMAIL_LOG` as-is (test infra).
+- [ ] Populate the seam from `SystemConfig` in `coreserver.Register()` (after
+      `RegisterSystemConfig`). Use `OnChange` if any state is cached.
+- [ ] Decide token-key sharing vs. a dedicated core key (decision #1). If core owns keys, add
+      them to the seed list in `1910000010_create_system_settings.js` (key → legacy env:
+      `POSTMARK_SERVER_TOKEN`, `MAIL_FROM_ADDRESS`) so existing env deployments carry over once.
+- [ ] Add a delivery-enabled field + a from-address field (decisions #2/#3) and seed them.
+- [ ] Add a **Mail** panel to the `/admin` Settings console
+      (`core/components/setup/SettingsTab.tsx`) — mirror `SentrySettings`/`VapidSettings`,
+      using `useSystemSettings()` and the write-only `SecretField` for the token. (Note: the
+      mail *feature package* already contributes its own provider panel via manifest
+      `systemSettings`; this new core panel is for the transactional/core mailer creds — make
+      sure the two don't confuse operators. Consider whether they should be unified.)
+- [ ] Update `core/server/mailer/README.md` (the env-var table) to point at system_settings.
+- [ ] Tests: a Go test that `mailer` reads through the resolver (not env); confirm invite +
+      reset e2e still pass once the override path is unconditional.
+
+## Interaction with the password-reset feature (branch `feat/password-reset`)
+
+The reset hook currently gates on `mailer.CanDeliver()` and defers to PB native SMTP when
+false. Once this refactor lands, revisit the reset hook:
+
+- The cleanest end state is to **drop the gate** and always override + send via
+  `mailer.DefaultSender()` exactly like invites (`invite_lifecycle.go:162`,
+  `invite_link.go:235`), since PB's native SMTP isn't configured in this app anyway and the
+  invite pattern is the proven one. `DefaultSender()` already falls back to `LogSender` (logs
+  in dev/e2e, writes `TINYCLD_EMAIL_LOG`), which is what the reset e2e asserts on.
+- The reviewer flagged that the current `CanDeliver()` gate breaks the reset e2e
+  (`tests/e2e/password-reset.spec.ts`): in the test env the gate is false → defers to PB
+  native SMTP → nothing written to the email log → `waitForEmailTo` times out. Dropping the
+  gate fixes this. Remove `mailer.CanDeliver()` (added for this gate) if nothing else uses it.
+
+A smaller secondary review note to fold in: the reset hook mixes `e.App` (settings) and the
+captured `app` (logger/send) — pick one consistently.
+```

--- a/docs/plans/unified-core-mailer.md
+++ b/docs/plans/unified-core-mailer.md
@@ -1,0 +1,209 @@
+# Unified core mailer — consolidate email sending into core
+
+**Status:** Plan. Supersedes and absorbs `docs/plans/mailer-config-from-system-settings.md`
+(that doc's narrower "core mailer reads env instead of SystemConfig" bug is a subset of this).
+Discovered while building password-reset (`feat/password-reset`); the reset-hook fix rides along here.
+
+## Goal & motivation
+
+Today there are **two parallel mailer stacks**, and more consumers are coming
+(calendar invites, a future SES provider):
+
+| Stack | Used by | Providers | Config source | Live reconfig? |
+|---|---|---|---|---|
+| Core `mailer` (`tinycld.org/core/mailer`) | invites, password-reset, drive shares | Postmark only | env (`sync.Once` + `init()`) | no |
+| Mail `Provider` (`mail/server/`) | user mailboxes | Postmark + self-hosted SMTP | `system_settings` (`mail.*`, per-use) | yes (record hooks) |
+
+This is divergent and duplicative. **The fix is one outbound abstraction in core**, sourced
+from `system_settings`, that every transactional consumer and the mail product share — so
+calendar gets a sender for free and SES plugs in once.
+
+### Confirmed decisions
+
+1. **Move SMTP-outbound into core.** Core becomes a real 2-provider registry (postmark +
+   smtp). The self-hosted direct-MX sender + RFC-5322 builder move out of the mail package
+   into core, routed through the deliver gate. Mail keeps its **inbound** SMTP/IMAP server,
+   bounce/domain/DKIM, and IMAP fetcher.
+2. **Shared `mail.*` namespace.** Core reads the existing `mail.provider` /
+   `mail.postmark_server_token` keys, plus new `mail.from_address` and `mail.delivery_enabled`.
+   **No data migration** — reuse the 13 keys the mail product already defines.
+3. **Admin panel only, no env seed.** Configure from `/admin` going forward; no env carry-over
+   migration. Existing env-configured deployments re-enter the token once.
+4. **Scope = config refactor + reset-hook fix + a shared template layer.** Calendar email and
+   SES are future work *enabled by* this seam, not wired here.
+
+## The seam (what moves, what stays)
+
+The mail package already drew the line: `Send` + `Configured` are the **outbound/shared**
+half; `ParseInbound` / `ParseBounce` / `AddDomain` / `CheckDomainVerification` /
+`CheckInboundDomain` / `VerifyWebhookSignature` are **mailbox-specific**.
+
+```
+MOVES INTO core/server/mailer/:
+  - Provider abstraction: a SendProvider interface (Send + Configured) + a registry keyed by
+    `mail.provider` ("postmark" | "smtp"), read per-send from system_settings.
+  - PostmarkProvider's SENDING (already mostly here via PostmarkSender).
+  - SMTP-outbound: smtp_provider.go (Send + MX/dial), smtp_outbound_build.go (RFC-5322),
+    SMTPConfig's OUTBOUND fields (PublicHostname, OutboundTimeout, DKIMSelector for signing later),
+    generateMessageID, envelopeAddress, groupRecipientsByDomain, resolveMXHosts,
+    runSMTPConversation, isPermanentSMTPError. Keep the swappable smtpDial/smtpMXLookup
+    test hooks (move the seam, keep it injectable).
+  - Config resolver: read mail.provider / mail.postmark_server_token / mail.postmark_account_token /
+    mail.from_address / mail.delivery_enabled / mail.smtp_public_hostname from system_settings.
+
+STAYS in mail/server/:
+  - Inbound SMTP MX listener (smtp_inbound_server.go), submission server + sessions
+    (smtp_server.go, smtp_session.go, auth.go), the whole IMAP server + fetcher,
+    domain/DKIM verification, bounce/inbound parsing, webhook routing (resolveWebhookProvider),
+    settings-cache invalidation + IMAP reconcile hooks.
+  - Mail's Provider interface stays (it still needs the mailbox methods); its Send/Configured
+    now delegate to the core SendProvider rather than re-implementing. The SMTPConfig inbound
+    fields (IMAP*, InboundMode) stay in mail.
+```
+
+Mail's `Provider` continues to exist for the mailbox product; its `Send` becomes a thin
+delegate to the core provider built from the same `mail.*` keys (exactly as `PostmarkProvider.Send`
+already delegates to `mailer.PostmarkSender.SendFull` today). The inbound/SMTP-listener code that
+shares `parseRFC5322` with outbound build keeps a copy of (or imports) the shared parser — confirm
+the inbound parser dependency when splitting `smtp_provider.go` (it reuses `parseRFC5322`).
+
+## Config keys (all `mail.*`, in `system_settings`)
+
+Outbound (read by core):
+
+| Key | Secret | Meaning | Default |
+|---|---|---|---|
+| `mail.provider` | no | `postmark` \| `smtp` | `postmark` |
+| `mail.postmark_server_token` | yes | Postmark server token | — |
+| `mail.postmark_account_token` | yes | Postmark account token (domain ops) | — |
+| `mail.from_address` | no | default From | `noreply@tinycld.org` |
+| `mail.delivery_enabled` | no | master deliver switch | ON (prod) |
+| `mail.smtp_public_hostname` | no | SMTP EHLO/MX host | `localhost` |
+
+Inbound / mailbox-only (stay read by mail): `mail.smtp_inbound_mode`, `mail.smtp_imap_*`,
+`mail.smtp_dkim_selector`. No new keys for these.
+
+## Delivery gating (replacing `sync.Once` + `init()` `deliver` bool)
+
+Resolve per-send (matches how mail builds its provider per-call, enables live `/admin` reconfig):
+
+```
+deliver = devAutoLog ? false : delivery_enabled_from_system_settings(default true)
+```
+
+- Keep the **`--dev` auto-log** so dev/test/seed/e2e log by default with zero config (today's
+  behavior). `--dev` detection stays via `os.Args` at startup (it's a process property, fine to
+  read once).
+- `mail.delivery_enabled` is the admin-editable master switch (default ON; an operator can pause
+  delivery from `/admin` without unsetting the token).
+- **Drop `sync.Once`**: build the sender per-send (or per a cheap cache invalidated by a
+  `system_settings` `mail.*` record hook). Per-send construction is the simplest and matches the
+  mail product — no caching needed.
+- **`TINYCLD_EMAIL_LOG` JSONL path is unchanged** — the e2e helpers
+  (`tests/e2e/email-log-helpers.ts`) read it and the reset spec asserts on it. `LogSender` stays
+  exactly as-is.
+- Retire `SKIP_SENDING_MAIL` / `POSTMARK_SERVER_TOKEN` / `MAIL_FROM_ADDRESS` env reads from the
+  runtime path. (No env seed — decision #3. Document the change in the README; existing
+  deployments reconfigure via `/admin`.)
+
+## Admin UI
+
+- **Core contributes its own outbound "Mail" panel** to `/admin` Settings, always present
+  (transactional mail is core, must be configurable even in a mail-less assembly). Mirror
+  `SentrySettings`/`VapidSettings` in `core/components/setup/SettingsTab.tsx`: `useSystemSettings()`,
+  `SecretField` (write-only) for the token, plain fields for provider / from-address /
+  delivery-enabled / smtp public hostname. Add schemas to `system-settings-logic.ts` with unit
+  tests in `__tests__/`.
+- **The mail product's existing "Provider" panel** (`mail/.../system-settings/provider.tsx`) keeps
+  owning the **mailbox-only** keys (account token, SMTP/IMAP inbound, DKIM). Both share the `mail.*`
+  namespace but manage **disjoint** keys.
+- **Avoid operator confusion:** core panel label = "Mail — Sending (transactional)"; mail panel
+  stays "Mail — Provider" (mailbox/inbound). Today both can write `mail.provider` /
+  `mail.postmark_server_token`; make the core panel own those outbound keys and have the mail panel
+  defer to / cross-link them (or render them read-only with a "configured in core Mail settings"
+  note) so there's a single source of truth for the shared keys. Resolve the exact ownership split
+  during implementation; the rule is **each shared key is editable in exactly one panel.**
+
+## Reset-hook fix (folds in from the password-reset branch)
+
+- **Drop the `mailer.CanDeliver()` gate** in `password_reset_mailer.go`. Always override + send
+  via the core sender exactly like invites (`invite_lifecycle.go` `send()` /
+  `invite_link.go:sendInviteEmailTo`). PB native SMTP isn't configured in this app; the invite
+  pattern is proven; `DefaultSender()` already degrades to `LogSender` (logs in dev/e2e, writes
+  `TINYCLD_EMAIL_LOG`) — which is what `tests/e2e/password-reset.spec.ts` asserts on. This fixes the
+  e2e timeout the reviewer flagged (gate false in test env → deferred to PB → nothing logged).
+- Remove `mailer.CanDeliver()` if nothing else uses it after the change (grep: only the reset hook
+  references it).
+- **Fix the `e.App` vs captured `app` wart:** `password_reset_mailer.go:47` reads `e.App.Settings().Meta`
+  while lines 41/50 use the captured `app`. Switch line 47 to `app.Settings().Meta` for consistency
+  with every sibling registrar.
+
+## Shared template layer
+
+Four sites hand-roll near-identical HTML+text (invite-link, invite-lifecycle, password-reset,
+drive share/share-otp). Extract a small shared template helper in core (the invite/reset emails
+already share `buildInviteEmailHTML`/`buildPasswordResetEmailHTML`, `greeting`, `htmlEscape`,
+`brandColor` — generalize into one `RenderTransactionalEmail({appName, greeting, body, ctaLabel,
+ctaLink})` returning `(html, text)`). Migrate the 4 core sites; offer drive the same helper (its 3
+sites duplicate the markup too). Keep the diff focused: helper + call-site swaps, no behavior change
+to the rendered output beyond consolidation.
+
+## Work items
+
+**Core mailer package (`core/server/mailer/`)**
+- [ ] Introduce a `SendProvider` interface (`Send`/`SendFull` + `Configured`) and a registry
+      selected by `mail.provider`. Keep `Sender`/`FullSender`/`Message`/`SendRequest`/`LogSender`/
+      `NoopSender` as-is (they're the I/O contract).
+- [ ] Move SMTP-outbound from `mail/server/` (`smtp_provider.go` send path,
+      `smtp_outbound_build.go`, outbound `SMTPConfig` fields, MX/dial/conversation helpers, test
+      hooks). Route it through the `deliver` gate (it currently ignores it — real fix).
+- [ ] Replace `sync.Once`/`init()` env reads with a per-send resolver over `system_settings`
+      (provider, token, account token, from, delivery_enabled, smtp public hostname). Drop
+      `Default()`/`CanDeliver()` env semantics; keep `DefaultSender()` returning a `Sender` that
+      logs when delivery is off / unconfigured.
+- [ ] Inject the resolver from `coreserver`: set it inside `RegisterSystemConfig` (it owns the
+      config lifecycle + `OnServe` load). The resolver closes over `systemConfig.Get` and reads
+      lazily, so registration order is safe (config is empty pre-`OnServe`, populated after).
+- [ ] Fix `defaultFrom` asymmetry (`Send` applies it, `SendFull` doesn't) while here.
+- [ ] Clean doc drift: dead `DELIVER_MAIL` comments, stale `tinycld/mailer` import in README,
+      document `TINYCLD_EMAIL_LOG`.
+
+**Mail package (`mail/server/`)**
+- [ ] Repoint mail's `Provider.Send`/`Configured` at the core `SendProvider` (delegate, don't
+      re-implement). Keep the mailbox-specific interface methods + inbound/IMAP/domain code.
+- [ ] Remove the now-moved outbound SMTP files; keep inbound SMTP/IMAP and the shared
+      `parseRFC5322` (decide import-from-core vs keep-local for the parser).
+- [ ] Resolve panel ownership of the shared `mail.*` outbound keys (see Admin UI).
+
+**Core transactional consumers**
+- [ ] Drop the reset-hook `CanDeliver()` gate; fix `e.App`/`app`; remove `CanDeliver()` if unused.
+- [ ] Extract `RenderTransactionalEmail`; migrate invite-link, invite-lifecycle, password-reset
+      (and drive's 3 sites) onto it.
+
+**Admin / config**
+- [ ] Add the core "Mail — Sending" panel + `mail.from_address` / `mail.delivery_enabled` /
+      provider / token fields; schemas + unit tests in `setup/__tests__/`.
+- [ ] Update `core/server/mailer/README.md`: env-var table → `system_settings` + `/admin`.
+
+**Tests**
+- [ ] Go: a mailer test that sending reads provider/token/from/delivery through the resolver (not
+      env); move/keep the SMTP provider tests (`smtp_provider_test.go`) alongside the moved code.
+- [ ] e2e: confirm invite + password-reset specs pass with the gate dropped (the reset spec relies
+      on the override always firing → `LogSender` → `TINYCLD_EMAIL_LOG`).
+
+## Risks & notes
+
+- **SMTP-outbound move is the largest, riskiest piece** — it pulls real network code (MX lookup,
+  dial, STARTTLS) across a package boundary and couples to the inbound parser. Land it behind the
+  test hooks; keep `smtp_provider_test.go` green through the move. Consider doing the move as the
+  first, isolated commit (pure relocation, no behavior change) before wiring config.
+- **Two reconcile mechanisms** (core `SystemConfig.OnChange`; mail's PB record hooks on
+  `system_settings`). The core mailer reading per-send needs neither; if any caching is added, use a
+  `mail.*`-prefixed record hook (mirror mail's `reconcileOnSystemMail`) rather than `OnChange`.
+- **Shared-key ownership** between the two panels is the subtle UX trap (decision #2 chose to share
+  `mail.*`). Enforce single-editor-per-key.
+- **Calendar** is the first future consumer of the new seam (invites/reminders today only emit
+  in-app `notify` records). Out of scope here, but the abstraction should make adding it trivial.
+- **SES** plugs into the registry as a third provider keyed by `mail.provider` = `ses` — no further
+  structural change once the registry exists.
+```


### PR DESCRIPTION
Consolidates the two parallel mailer stacks into one. See `docs/plans/unified-core-mailer.md`.

**What changed**
- Relocate the self-hosted SMTP outbound sender + RFC-5322 builder from the mail package into `core/server/mailer` as `SMTPSender`. Core is now a real 2-provider registry (postmark + smtp).
- Replace the env-based `sync.Once` config with a per-send resolver reading from `system_settings` (the `mail.*` keys) via `mailer.ConfigResolver`, injected by `coreserver`. `/admin` edits apply live, no restart.
- Add a core "Mail — Sending" admin panel for the shared keys (from-address, delivery switch, plus provider + token in a mail-less assembly). Mail's Provider panel keeps the mailbox/inbound keys; the two never edit the same key.

**Behavior changes to note**
- SMTP outbound now honors the delivery gate (`--dev` auto-log + `mail.delivery_enabled`). Previously the self-hosted SMTP path ignored it and could dial real MX under `--dev`.
- The runtime `POSTMARK_SERVER_TOKEN` / `MAIL_FROM_ADDRESS` / `SKIP_SENDING_MAIL` env reads are gone; configuration is `system_settings` only.

**Depends on** tinycld/mail#29 (mail-side delegation to `mailer.SMTPSender`).

Builds + Go/TS unit tests green. The password-reset hook's `CanDeliver()` gate fix is a follow-up on the password-reset branch.
