### PR TITLE
feat(auth): self-service password reset

### DIFF
--- a/app/reset-password/[token].tsx
+++ b/app/reset-password/[token].tsx
@@ -1,0 +1,157 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
+import { confirmPasswordReset } from '@tinycld/core/lib/account-password'
+import { captureException } from '@tinycld/core/lib/errors'
+import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { CheckCircle2, KeyRound } from 'lucide-react-native'
+import { useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
+
+const resetSchema = z
+    .object({
+        password: z.string().min(8, 'Min 8 characters'),
+        confirmPassword: z.string(),
+    })
+    .refine(v => v.password === v.confirmPassword, {
+        message: 'Passwords must match',
+        path: ['confirmPassword'],
+    })
+
+export default function ResetPassword() {
+    const { token } = useLocalSearchParams<{ token: string }>()
+
+    return (
+        <View className="flex-1 items-center justify-center p-5 bg-background">
+            <DocumentTitle title="Reset password" includeOrg={false} />
+            {token ? <ResetForm token={token} /> : <InvalidCard />}
+        </View>
+    )
+}
+
+function InvalidCard() {
+    const router = useRouter()
+
+    return (
+        <View
+            className="gap-4 p-6 rounded-xl border border-border items-center bg-surface-secondary"
+            style={{ maxWidth: 400, width: '100%' }}
+        >
+            <Text className="text-lg font-semibold text-foreground">Reset link invalid</Text>
+            <Text className="text-center text-sm text-muted-foreground">
+                This password reset link is missing or malformed. Request a new one from the sign-in
+                screen.
+            </Text>
+            <Pressable
+                onPress={() => router.replace('/')}
+                className="px-4 py-2 rounded-lg bg-primary"
+            >
+                <Text className="font-semibold text-primary-foreground">Go to sign in</Text>
+            </Pressable>
+        </View>
+    )
+}
+
+function ResetForm({ token }: { token: string }) {
+    const router = useRouter()
+    const fgColor = useThemeColor('foreground')
+    const primaryBg = useThemeColor('primary')
+
+    const [submitError, setSubmitError] = useState<string | null>(null)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [isSuccess, setIsSuccess] = useState(false)
+
+    const {
+        control,
+        handleSubmit,
+        formState: { errors, isSubmitted },
+    } = useForm({
+        resolver: zodResolver(resetSchema),
+        defaultValues: { password: '', confirmPassword: '' },
+        mode: 'onChange',
+    })
+
+    const onSubmit = handleSubmit(async data => {
+        setSubmitError(null)
+        setIsSubmitting(true)
+        try {
+            await confirmPasswordReset(token, data.password, data.confirmPassword)
+            setIsSuccess(true)
+            router.replace('/')
+        } catch (err) {
+            captureException('account.confirmPasswordReset', err)
+            setSubmitError(
+                'This reset link is invalid or has expired. Request a new one from the sign-in screen.'
+            )
+        } finally {
+            setIsSubmitting(false)
+        }
+    })
+
+    return (
+        <View
+            className="gap-4 p-6 rounded-xl border border-border bg-surface-secondary"
+            style={{ maxWidth: 440, width: '100%' }}
+        >
+            <View className="gap-2 items-center">
+                <View className="size-10 rounded-lg items-center justify-center bg-surface">
+                    {isSuccess ? (
+                        <CheckCircle2 size={20} color={primaryBg} />
+                    ) : (
+                        <KeyRound size={18} color={fgColor} />
+                    )}
+                </View>
+                <Text className="text-xl font-semibold text-foreground text-center">
+                    Choose a new password
+                </Text>
+                <Text
+                    className="text-center text-[13px] text-muted-foreground"
+                    style={{ lineHeight: 18 }}
+                >
+                    Enter a new password for your account.
+                </Text>
+            </View>
+
+            <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
+
+            {submitError && (
+                <View className="rounded-lg p-2 bg-danger-soft" testID="reset-error">
+                    <Text className="text-xs text-danger">{submitError}</Text>
+                </View>
+            )}
+
+            <TextInput
+                control={control}
+                name="password"
+                label="New password"
+                placeholder="At least 8 characters"
+                secureTextEntry
+                autoCapitalize="none"
+            />
+
+            <TextInput
+                control={control}
+                name="confirmPassword"
+                label="Confirm password"
+                placeholder="Re-enter password"
+                secureTextEntry
+                autoCapitalize="none"
+            />
+
+            <Pressable
+                testID="reset-confirm-submit"
+                onPress={onSubmit}
+                disabled={isSubmitting || isSuccess}
+                className={`px-4 py-3 rounded-lg items-center bg-primary ${isSubmitting || isSuccess ? 'opacity-60' : 'opacity-100'}`}
+            >
+                <Text className="font-semibold text-primary-foreground">
+                    {isSuccess
+                        ? 'Password reset, redirecting...'
+                        : isSubmitting
+                          ? 'Resetting...'
+                          : 'Reset password'}
+                </Text>
+            </Pressable>
+        </View>
+    )
+}

--- a/core/components/workspace/LoginModal.tsx
+++ b/core/components/workspace/LoginModal.tsx
@@ -1,5 +1,6 @@
 import { ChangeServerLink } from '@tinycld/core/components/ChangeServerLink'
 import { ReviewModeHints } from '@tinycld/core/components/connect/ReviewModeHints'
+import { requestPasswordReset } from '@tinycld/core/lib/account-password'
 import { useAuth } from '@tinycld/core/lib/auth'
 import { navigateToOrg } from '@tinycld/core/lib/org-url'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
@@ -15,10 +16,49 @@ import {
     View,
 } from 'react-native'
 
+type Mode = 'login' | 'reset'
+
 export function LoginModal() {
+    const backdropColor = useThemeColor('overlay-backdrop')
+    const [mode, setMode] = useState<Mode>('login')
+
+    return (
+        <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            className="absolute top-0 left-0 right-0 bottom-0 justify-center items-center"
+            style={{
+                zIndex: 200,
+                backgroundColor: backdropColor,
+            }}
+        >
+            <View
+                className="rounded-2xl border border-border p-8 bg-background"
+                style={{
+                    width: 400,
+                    maxWidth: '90%',
+                    shadowColor: '#000',
+                    shadowOffset: { width: 0, height: 8 },
+                    shadowOpacity: 0.15,
+                    shadowRadius: 24,
+                    elevation: 8,
+                }}
+            >
+                <LoginForm isVisible={mode === 'login'} onForgotPassword={() => setMode('reset')} />
+                <ResetForm isVisible={mode === 'reset'} onBack={() => setMode('login')} />
+            </View>
+        </KeyboardAvoidingView>
+    )
+}
+
+function LoginForm({
+    isVisible,
+    onForgotPassword,
+}: {
+    isVisible: boolean
+    onForgotPassword: () => void
+}) {
     const mutedColor = useThemeColor('muted-foreground')
     const primaryFg = useThemeColor('primary-foreground')
-    const backdropColor = useThemeColor('overlay-backdrop')
     const { login } = useAuth({ throwIfAnon: false })
     const [identifier, setIdentifier] = useState('')
     const [password, setPassword] = useState('')
@@ -44,74 +84,149 @@ export function LoginModal() {
         }
     }
 
+    if (!isVisible) return null
+
     return (
-        <KeyboardAvoidingView
-            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-            className="absolute top-0 left-0 right-0 bottom-0 justify-center items-center"
-            style={{
-                zIndex: 200,
-                backgroundColor: backdropColor,
-            }}
-        >
-            <View
-                className="rounded-2xl border border-border p-8 bg-background"
-                style={{
-                    width: 400,
-                    maxWidth: '90%',
-                    shadowColor: '#000',
-                    shadowOffset: { width: 0, height: 8 },
-                    shadowOpacity: 0.15,
-                    shadowRadius: 24,
-                    elevation: 8,
-                }}
-            >
-                <Text className="text-[22px] font-bold mb-1 text-foreground">Sign in</Text>
-                <Text className="text-sm mb-6 text-muted-foreground">
-                    Sign in to your account to continue
+        <>
+            <Text className="text-[22px] font-bold mb-1 text-foreground">Sign in</Text>
+            <Text className="text-sm mb-6 text-muted-foreground">
+                Sign in to your account to continue
+            </Text>
+
+            {error && (
+                <View className="rounded-lg p-3 mb-4 bg-danger-soft">
+                    <Text className="text-sm text-danger">{error}</Text>
+                </View>
+            )}
+
+            <View className="mb-4">
+                <Text className="mb-1.5 text-sm font-semibold text-foreground">
+                    Username or email
                 </Text>
+                <TextInput
+                    className="border border-border rounded-lg p-3 text-base text-foreground bg-surface-secondary"
+                    testID="identifier"
+                    value={identifier}
+                    onChangeText={setIdentifier}
+                    placeholder="alice or alice@company.com"
+                    placeholderTextColor={mutedColor}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    autoComplete="username"
+                    editable={!isSubmitting}
+                />
+            </View>
 
-                {error && (
-                    <View className="rounded-lg p-3 mb-4 bg-danger-soft">
-                        <Text className="text-sm text-danger">{error}</Text>
-                    </View>
+            <View className="mb-2">
+                <Text className="mb-1.5 text-sm font-semibold text-foreground">Password</Text>
+                <TextInput
+                    className="border border-border rounded-lg p-3 text-base text-foreground bg-surface-secondary"
+                    testID="login-password"
+                    value={password}
+                    onChangeText={setPassword}
+                    placeholder="Password"
+                    placeholderTextColor={mutedColor}
+                    secureTextEntry
+                    autoComplete="current-password"
+                    editable={!isSubmitting}
+                    onSubmitEditing={handleSubmit}
+                />
+            </View>
+
+            <Pressable
+                testID="forgot-password-link"
+                accessibilityRole="link"
+                onPress={onForgotPassword}
+                className="mb-2 self-end"
+            >
+                <Text className="text-xs text-muted-foreground underline">Forgot password?</Text>
+            </Pressable>
+
+            <Pressable
+                testID="login-submit"
+                className={`rounded-lg items-center mt-2 p-3.5 bg-primary ${canSubmit ? 'opacity-100' : 'opacity-50'}`}
+                onPress={handleSubmit}
+                disabled={!canSubmit}
+            >
+                {isSubmitting ? (
+                    <ActivityIndicator color={primaryFg} size="small" />
+                ) : (
+                    <Text className="text-base font-semibold text-primary-foreground">Sign in</Text>
                 )}
+            </Pressable>
 
-                <View className="mb-4">
-                    <Text className="mb-1.5 text-sm font-semibold text-foreground">
-                        Username or email
+            <ReviewModeHints
+                onPrefill={(id, password) => {
+                    setIdentifier(id)
+                    setPassword(password)
+                }}
+            />
+
+            <View className="mt-4 items-center">
+                <ChangeServerLink />
+            </View>
+        </>
+    )
+}
+
+function ResetForm({ isVisible, onBack }: { isVisible: boolean; onBack: () => void }) {
+    const mutedColor = useThemeColor('muted-foreground')
+    const primaryFg = useThemeColor('primary-foreground')
+    const [email, setEmail] = useState('')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [isSent, setIsSent] = useState(false)
+
+    const canSubmit = email.trim().length > 0 && !isSubmitting
+
+    const handleSubmit = async () => {
+        if (!canSubmit) return
+        setIsSubmitting(true)
+        // requestPasswordReset never throws and never reveals whether the email
+        // exists — we always land on the same confirmation.
+        await requestPasswordReset(email.trim())
+        setIsSubmitting(false)
+        setIsSent(true)
+    }
+
+    if (!isVisible) return null
+
+    return (
+        <>
+            <Text className="text-[22px] font-bold mb-1 text-foreground">Reset password</Text>
+            <Text className="text-sm mb-6 text-muted-foreground">
+                Enter your email and we'll send you a reset link
+            </Text>
+
+            {isSent ? (
+                <View className="rounded-lg p-3 mb-4 bg-surface-secondary" testID="reset-sent">
+                    <Text className="text-sm text-foreground">
+                        If an account exists for that email, we've sent a reset link. Check your
+                        inbox.
                     </Text>
+                </View>
+            ) : (
+                <View className="mb-2">
+                    <Text className="mb-1.5 text-sm font-semibold text-foreground">Email</Text>
                     <TextInput
                         className="border border-border rounded-lg p-3 text-base text-foreground bg-surface-secondary"
-                        testID="identifier"
-                        value={identifier}
-                        onChangeText={setIdentifier}
-                        placeholder="alice or alice@company.com"
+                        testID="reset-email"
+                        value={email}
+                        onChangeText={setEmail}
+                        placeholder="alice@company.com"
                         placeholderTextColor={mutedColor}
                         autoCapitalize="none"
                         autoCorrect={false}
-                        autoComplete="username"
-                        editable={!isSubmitting}
-                    />
-                </View>
-
-                <View className="mb-4">
-                    <Text className="mb-1.5 text-sm font-semibold text-foreground">Password</Text>
-                    <TextInput
-                        className="border border-border rounded-lg p-3 text-base text-foreground bg-surface-secondary"
-                        testID="login-password"
-                        value={password}
-                        onChangeText={setPassword}
-                        placeholder="Password"
-                        placeholderTextColor={mutedColor}
-                        secureTextEntry
-                        autoComplete="current-password"
+                        keyboardType="email-address"
+                        autoComplete="email"
                         editable={!isSubmitting}
                         onSubmitEditing={handleSubmit}
                     />
                 </View>
+            )}
 
+            {!isSent && (
                 <Pressable
-                    testID="login-submit"
+                    testID="reset-submit"
                     className={`rounded-lg items-center mt-2 p-3.5 bg-primary ${canSubmit ? 'opacity-100' : 'opacity-50'}`}
                     onPress={handleSubmit}
                     disabled={!canSubmit}
@@ -120,22 +235,20 @@ export function LoginModal() {
                         <ActivityIndicator color={primaryFg} size="small" />
                     ) : (
                         <Text className="text-base font-semibold text-primary-foreground">
-                            Sign in
+                            Send reset link
                         </Text>
                     )}
                 </Pressable>
+            )}
 
-                <ReviewModeHints
-                    onPrefill={(id, password) => {
-                        setIdentifier(id)
-                        setPassword(password)
-                    }}
-                />
-
-                <View className="mt-4 items-center">
-                    <ChangeServerLink />
-                </View>
-            </View>
-        </KeyboardAvoidingView>
+            <Pressable
+                testID="reset-back"
+                accessibilityRole="link"
+                onPress={onBack}
+                className="mt-4 items-center"
+            >
+                <Text className="text-xs text-muted-foreground underline">Back to sign in</Text>
+            </Pressable>
+        </>
     )
 }

--- a/core/lib/account-password.ts
+++ b/core/lib/account-password.ts
@@ -35,3 +35,34 @@ export async function changeMyPassword(args: ChangePasswordArgs): Promise<void> 
         throw err
     }
 }
+
+/**
+ * Request a password-reset email for the given address. Uses PocketBase's
+ * built-in flow (PB mints the token and owns its lifecycle); the outbound email
+ * is overridden server-side to send via the core mailer with a link to the
+ * app's own /reset-password/<token> screen.
+ *
+ * Failures are reported but NOT rethrown: the login UI always shows the same
+ * "if an account exists, we've sent a link" confirmation so the response can't
+ * be used to discover whether an email is registered.
+ */
+export async function requestPasswordReset(email: string): Promise<void> {
+    try {
+        await pb.collection('users').requestPasswordReset(email)
+    } catch (err) {
+        captureException('account.requestPasswordReset', err)
+    }
+}
+
+/**
+ * Complete a password reset using the token from the emailed link. Errors here
+ * (invalid/expired token, weak password) ARE surfaced so the confirm screen can
+ * show them to the user.
+ */
+export async function confirmPasswordReset(
+    token: string,
+    password: string,
+    passwordConfirm: string
+): Promise<void> {
+    await pb.collection('users').confirmPasswordReset(token, password, passwordConfirm)
+}

--- a/core/server/coreserver/invite_lifecycle.go
+++ b/core/server/coreserver/invite_lifecycle.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	htmltpl "html"
 	"strings"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 const (
 	inviteTokenTTL  = 7 * 24 * time.Hour
 	inviteTokenSize = 32 // bytes; hex-encoded to 64 chars
-	brandColor      = "#0d9488"
 )
 
 // RegisterInviteLifecycle wires a hook that emails invited users after
@@ -134,20 +132,15 @@ func sendExistingMemberEmail(app core.App, user *core.Record, org *core.Record, 
 	}
 
 	subject := fmt.Sprintf("You've been added to %s", orgName)
-	htmlBody := buildInviteEmailHTML(inviteEmailData{
-		Greeting:   greeting(userName),
-		OrgName:    orgName,
-		Role:       role,
-		CTALabel:   fmt.Sprintf("Open %s", orgName),
-		CTALink:    link,
-		Intro:      fmt.Sprintf("You've been added to <strong>%s</strong> as a <strong>%s</strong>. Sign in with your existing account to get started.", htmlEscape(orgName), htmlEscape(role)),
-		Footer:     "If you didn't expect to join this organization, please contact your admin.",
-		CopyPrompt: "Or copy this link into your browser:",
+	htmlBody, text := mailer.RenderTransactionalEmail(mailer.TransactionalEmail{
+		Eyebrow:  "Invitation to " + orgName,
+		Greeting: mailer.Greeting(userName),
+		BodyHTML: fmt.Sprintf("You've been added to <strong>%s</strong> as a <strong>%s</strong>. Sign in with your existing account to get started.", mailer.EscapeHTML(orgName), mailer.EscapeHTML(role)),
+		BodyText: fmt.Sprintf("You've been added to %s as a %s. Sign in with your existing account to get started.", orgName, role),
+		CTALabel: fmt.Sprintf("Open %s", orgName),
+		CTALink:  link,
+		Footer:   "If you didn't expect to join this organization, please contact your admin.",
 	})
-	text := fmt.Sprintf(
-		"%s,\n\nYou've been added to %s as a %s. Sign in with your existing account to get started.\n\n%s\n",
-		greeting(userName), orgName, role, link,
-	)
 
 	send(app, userName, userEmail, subject, htmlBody, text)
 }
@@ -163,89 +156,4 @@ func send(app core.App, toName, toEmail, subject, htmlBody, textBody string) {
 		app.Logger().Error("invite lifecycle: failed to send email",
 			"to", toEmail, "subject", subject, "error", err)
 	}
-}
-
-func greeting(name string) string {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return "Hi"
-	}
-	return "Hi " + name
-}
-
-func htmlEscape(s string) string {
-	return htmltpl.EscapeString(s)
-}
-
-type inviteEmailData struct {
-	Greeting   string
-	OrgName    string
-	Role       string
-	Intro      string
-	CTALabel   string
-	CTALink    string
-	CopyPrompt string
-	Footer     string
-}
-
-func buildInviteEmailHTML(d inviteEmailData) string {
-	return fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>%s</title>
-</head>
-<body style="margin:0;padding:0;background:#f5f5f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1c1917;">
-  <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" border="0" style="background:#f5f5f4;padding:40px 16px;">
-    <tr>
-      <td align="center">
-        <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%%;background:#ffffff;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.08);overflow:hidden;">
-          <tr>
-            <td style="padding:32px 40px 16px 40px;border-top:4px solid %s;">
-              <p style="margin:0 0 8px 0;font-size:14px;color:#78716c;letter-spacing:0.5px;text-transform:uppercase;font-weight:600;">Invitation to %s</p>
-              <h1 style="margin:0;font-size:24px;line-height:1.3;font-weight:600;color:#1c1917;">%s,</h1>
-            </td>
-          </tr>
-          <tr>
-            <td style="padding:8px 40px 8px 40px;">
-              <p style="margin:0;font-size:16px;line-height:1.6;color:#44403c;">%s</p>
-            </td>
-          </tr>
-          <tr>
-            <td style="padding:24px 40px 8px 40px;">
-              <a href="%s" style="display:inline-block;padding:12px 24px;background:%s;color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;font-size:15px;">%s</a>
-            </td>
-          </tr>
-          <tr>
-            <td style="padding:8px 40px 32px 40px;">
-              <p style="margin:16px 0 4px 0;font-size:13px;color:#78716c;">%s</p>
-              <p style="margin:0;font-size:13px;color:#44403c;word-break:break-all;"><a href="%s" style="color:%s;text-decoration:none;">%s</a></p>
-            </td>
-          </tr>
-          <tr>
-            <td style="padding:20px 40px;border-top:1px solid #e7e5e4;background:#fafaf9;">
-              <p style="margin:0;font-size:12px;line-height:1.6;color:#78716c;">%s</p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>`,
-		htmlEscape(d.OrgName),
-		brandColor,
-		htmlEscape(d.OrgName),
-		htmlEscape(d.Greeting),
-		d.Intro,
-		htmlEscape(d.CTALink),
-		brandColor,
-		htmlEscape(d.CTALabel),
-		htmlEscape(d.CopyPrompt),
-		htmlEscape(d.CTALink),
-		brandColor,
-		htmlEscape(d.CTALink),
-		htmlEscape(d.Footer),
-	)
 }

--- a/core/server/coreserver/invite_link.go
+++ b/core/server/coreserver/invite_link.go
@@ -211,20 +211,15 @@ func sendInviteEmailTo(app core.App, toEmail string, user *core.Record, org *cor
 	}
 
 	subject := fmt.Sprintf("You've been invited to %s", orgName)
-	htmlBody := buildInviteEmailHTML(inviteEmailData{
-		Greeting:   greeting(userName),
-		OrgName:    orgName,
-		Role:       role,
-		CTALabel:   "Set your password",
-		CTALink:    link,
-		Intro:      fmt.Sprintf("You've been invited to join <strong>%s</strong> as a <strong>%s</strong>. To get started, set a password for your account.", htmlEscape(orgName), htmlEscape(role)),
-		Footer:     "If you weren't expecting this invitation, you can safely ignore this email. The link expires in 7 days.",
-		CopyPrompt: "Or copy this link into your browser:",
+	htmlBody, text := mailer.RenderTransactionalEmail(mailer.TransactionalEmail{
+		Eyebrow:  "Invitation to " + orgName,
+		Greeting: mailer.Greeting(userName),
+		BodyHTML: fmt.Sprintf("You've been invited to join <strong>%s</strong> as a <strong>%s</strong>. To get started, set a password for your account.", mailer.EscapeHTML(orgName), mailer.EscapeHTML(role)),
+		BodyText: fmt.Sprintf("You've been invited to join %s as a %s. To get started, set a password for your account. The link expires in 7 days.", orgName, role),
+		CTALabel: "Set your password",
+		CTALink:  link,
+		Footer:   "If you weren't expecting this invitation, you can safely ignore this email. The link expires in 7 days.",
 	})
-	text := fmt.Sprintf(
-		"%s,\n\nYou've been invited to join %s as a %s.\n\nSet your password: %s\n\nThe link expires in 7 days.\n",
-		greeting(userName), orgName, role, link,
-	)
 
 	msg := &mailer.Message{
 		To:      []mailer.Recipient{{Name: userName, Email: toEmail}},

--- a/core/server/coreserver/password_reset_mailer.go
+++ b/core/server/coreserver/password_reset_mailer.go
@@ -1,0 +1,78 @@
+package coreserver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+	"tinycld.org/core/mailer"
+)
+
+// RegisterPasswordResetMailer overrides PocketBase's built-in password-reset
+// email for the app's `users` collection so the link points at the app's own
+// reset screen and the message is delivered through the shared core mailer
+// (the same path invites use) rather than PocketBase's native SMTP.
+//
+// PocketBase still owns the reset token lifecycle (mint, expiry, single-use) —
+// we only replace the email. The token is available on the event as
+// e.Meta["token"]; we build a link to /reset-password/<token>, which the client
+// route app/reset-password/[token].tsx consumes via confirmPasswordReset.
+//
+// The send always goes through mailer.DefaultSender() (like invites): it
+// delivers via the configured provider when delivery is enabled, and otherwise
+// logs (dev/test, or no provider configured), so we never depend on PB's
+// native SMTP. We return without calling e.Next() to suppress PB's own send.
+func RegisterPasswordResetMailer(app *pocketbase.PocketBase) {
+	registerPasswordResetMailerCore(app)
+}
+
+func registerPasswordResetMailerCore(app core.App) {
+	// Tagged to "users" so superusers keep PocketBase's default reset path.
+	app.OnMailerRecordPasswordResetSend("users").BindFunc(func(e *core.MailerRecordEvent) error {
+		token, _ := e.Meta["token"].(string)
+		if token == "" {
+			// Without a token we can't build a working link; let PB send its
+			// default email rather than a broken one.
+			app.Logger().Warn("password reset: missing token in mailer event; deferring to PB")
+			return e.Next()
+		}
+
+		toEmail := e.Record.Email()
+		toName := e.Record.GetString("name")
+		settings := app.Settings().Meta
+		subject, htmlBody, text := buildPasswordResetMessage(settings.AppURL, settings.AppName, toName, token)
+
+		send(app, toName, toEmail, subject, htmlBody, text)
+
+		// Suppress PocketBase's native send by returning without calling e.Next().
+		return nil
+	})
+}
+
+// buildPasswordResetMessage assembles the subject, HTML, and text bodies of the
+// reset email via the shared transactional-email template. Pulled out of the
+// hook so it's unit-testable without PocketBase's trigger machinery. toName may
+// be empty (falls back to a generic greeting); the link always points at the
+// app's own reset screen.
+func buildPasswordResetMessage(appURL, appName, toName, token string) (subject, html, text string) {
+	base := strings.TrimRight(appURL, "/")
+	link := fmt.Sprintf("%s/reset-password/%s", base, token)
+
+	eyebrow := "Password reset"
+	if appName != "" {
+		eyebrow = "Password reset · " + appName
+	}
+
+	subject = "Reset your password"
+	html, text = mailer.RenderTransactionalEmail(mailer.TransactionalEmail{
+		Eyebrow:  eyebrow,
+		Greeting: mailer.Greeting(toName),
+		BodyHTML: "We received a request to reset your password. Click the button below to choose a new one. This link will expire soon.",
+		BodyText: "We received a request to reset your password. Open the link below to choose a new one. If you didn't request this, you can safely ignore this email.",
+		CTALabel: "Reset password",
+		CTALink:  link,
+		Footer:   "If you didn't request a password reset, no action is needed — your password stays the same.",
+	})
+	return subject, html, text
+}

--- a/core/server/coreserver/password_reset_mailer_test.go
+++ b/core/server/coreserver/password_reset_mailer_test.go
@@ -1,0 +1,60 @@
+package coreserver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPasswordResetMessage_LinkPointsAtAppResetScreen(t *testing.T) {
+	subject, html, text := buildPasswordResetMessage(
+		"https://app.example.com/",
+		"Example",
+		"Alice",
+		"tok-123",
+	)
+
+	wantLink := "https://app.example.com/reset-password/tok-123"
+
+	if subject != "Reset your password" {
+		t.Errorf("subject = %q, want %q", subject, "Reset your password")
+	}
+	// Trailing slash on AppURL must be trimmed (no double slash before /reset-password).
+	if strings.Contains(html, "//reset-password") {
+		t.Errorf("html link has double slash: %q", html)
+	}
+	if !strings.Contains(html, wantLink) {
+		t.Errorf("html missing reset link %q", wantLink)
+	}
+	if !strings.Contains(text, wantLink) {
+		t.Errorf("text missing reset link %q", wantLink)
+	}
+	// Must NOT link at PocketBase's admin confirm UI.
+	if strings.Contains(html, "/_/#/auth/confirm-password-reset") {
+		t.Errorf("html links at PB admin UI instead of app screen: %q", html)
+	}
+	if !strings.Contains(html, "Hi Alice") {
+		t.Errorf("html missing personalized greeting, got %q", html)
+	}
+	// The eyebrow names the app.
+	if !strings.Contains(html, "Password reset · Example") {
+		t.Errorf("html missing app-named eyebrow, got %q", html)
+	}
+}
+
+func TestBuildPasswordResetMessage_EmptyNameUsesGenericGreeting(t *testing.T) {
+	_, html, _ := buildPasswordResetMessage("https://app.example.com", "Example", "", "tok-9")
+	if !strings.Contains(html, "Hi,") {
+		t.Errorf("expected generic 'Hi,' greeting when name empty, got %q", html)
+	}
+}
+
+func TestBuildPasswordResetMessage_EmptyAppNameDropsSeparator(t *testing.T) {
+	_, html, _ := buildPasswordResetMessage("https://app.example.com", "", "Bob", "tok-1")
+	// With no app name the eyebrow is the bare "Password reset" (no trailing " · ").
+	if strings.Contains(html, "Password reset ·") {
+		t.Errorf("expected bare 'Password reset' eyebrow when AppName empty, got %q", html)
+	}
+	if !strings.Contains(html, "Password reset") {
+		t.Errorf("expected 'Password reset' eyebrow, got %q", html)
+	}
+}

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -147,6 +147,7 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 	RegisterInviteEndpoint(app)
 	RegisterInviteLinkEndpoints(app)
 	RegisterInviteLifecycle(app)
+	RegisterPasswordResetMailer(app)
 	RegisterAuditHooks(app)
 	RegisterOrgPkgEnabledHooks(app)
 	RegisterPackageInstallEndpoints(app)

--- a/core/server/mailer/template.go
+++ b/core/server/mailer/template.go
@@ -1,0 +1,112 @@
+package mailer
+
+import (
+	"fmt"
+	htmltpl "html"
+	"strings"
+)
+
+// BrandColor is the accent color used across transactional emails (CTA button,
+// top border, link color). Kept here so every email rendered through
+// RenderTransactionalEmail shares one source of truth.
+const BrandColor = "#0d9488"
+
+// TransactionalEmail describes a single transactional message in the shared
+// house style: an uppercase eyebrow, a greeting, a body, a primary call-to-action
+// button (with a copy-paste link fallback), and a muted footer note.
+//
+// BodyHTML is inserted verbatim into the HTML body, so callers that interpolate
+// user-controlled values into it MUST escape them first (use EscapeHTML). BodyText
+// is the plain-text equivalent for the text/plain MIME part. Eyebrow, Greeting,
+// CTALabel, and Footer are escaped by the renderer.
+type TransactionalEmail struct {
+	Eyebrow  string // uppercase label above the greeting, e.g. "Password reset · Acme"
+	Greeting string // e.g. "Hi Alice" (no trailing comma — the template adds it)
+	BodyHTML string // HTML body paragraph(s); caller pre-escapes interpolated values
+	BodyText string // plain-text body for the text/plain part
+	CTALabel string // button text, e.g. "Reset password"
+	CTALink  string // button + copy-link target URL
+	Footer   string // muted note at the bottom
+}
+
+// EscapeHTML escapes a string for safe interpolation into an email's BodyHTML.
+func EscapeHTML(s string) string {
+	return htmltpl.EscapeString(s)
+}
+
+// Greeting builds a "Hi <name>" greeting, falling back to a bare "Hi" when the
+// name is empty. Shared so every transactional email greets consistently.
+func Greeting(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "Hi"
+	}
+	return "Hi " + name
+}
+
+// RenderTransactionalEmail renders the shared house-style email and returns the
+// HTML and plain-text bodies. The two share the same CTA link; the text body is
+// the caller-provided BodyText followed by the link.
+func RenderTransactionalEmail(d TransactionalEmail) (html, text string) {
+	html = fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>%s</title>
+</head>
+<body style="margin:0;padding:0;background:#f5f5f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1c1917;">
+  <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" border="0" style="background:#f5f5f4;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%%;background:#ffffff;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.08);overflow:hidden;">
+          <tr>
+            <td style="padding:32px 40px 16px 40px;border-top:4px solid %s;">
+              <p style="margin:0 0 8px 0;font-size:14px;color:#78716c;letter-spacing:0.5px;text-transform:uppercase;font-weight:600;">%s</p>
+              <h1 style="margin:0;font-size:24px;line-height:1.3;font-weight:600;color:#1c1917;">%s,</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:8px 40px 8px 40px;">
+              <p style="margin:0;font-size:16px;line-height:1.6;color:#44403c;">%s</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 40px 8px 40px;">
+              <a href="%s" style="display:inline-block;padding:12px 24px;background:%s;color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;font-size:15px;">%s</a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:8px 40px 32px 40px;">
+              <p style="margin:16px 0 4px 0;font-size:13px;color:#78716c;">Or copy this link into your browser:</p>
+              <p style="margin:0;font-size:13px;color:#44403c;word-break:break-all;"><a href="%s" style="color:%s;text-decoration:none;">%s</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 40px;border-top:1px solid #e7e5e4;background:#fafaf9;">
+              <p style="margin:0;font-size:12px;line-height:1.6;color:#78716c;">%s</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`,
+		htmltpl.EscapeString(d.Eyebrow),
+		BrandColor,
+		htmltpl.EscapeString(d.Eyebrow),
+		htmltpl.EscapeString(d.Greeting),
+		d.BodyHTML,
+		htmltpl.EscapeString(d.CTALink),
+		BrandColor,
+		htmltpl.EscapeString(d.CTALabel),
+		htmltpl.EscapeString(d.CTALink),
+		BrandColor,
+		htmltpl.EscapeString(d.CTALink),
+		htmltpl.EscapeString(d.Footer),
+	)
+
+	text = fmt.Sprintf("%s,\n\n%s\n\n%s\n", d.Greeting, d.BodyText, d.CTALink)
+	return html, text
+}

--- a/core/server/mailer/template_test.go
+++ b/core/server/mailer/template_test.go
@@ -1,0 +1,56 @@
+package mailer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTransactionalEmail_EscapesAndLinks(t *testing.T) {
+	html, text := RenderTransactionalEmail(TransactionalEmail{
+		Eyebrow:  "Password reset · Acme",
+		Greeting: Greeting("Alice"),
+		BodyHTML: "Reset your <strong>password</strong>.",
+		BodyText: "Reset your password.",
+		CTALabel: "Reset password",
+		CTALink:  "https://app.example.com/reset-password/abc",
+	})
+
+	if !strings.Contains(html, "https://app.example.com/reset-password/abc") {
+		t.Errorf("html missing CTA link: %q", html)
+	}
+	// BodyHTML is inserted verbatim (caller-escaped), so <strong> survives.
+	if !strings.Contains(html, "<strong>password</strong>") {
+		t.Errorf("html should pass BodyHTML through verbatim, got %q", html)
+	}
+	// The eyebrow is escaped by the renderer; the dot separator is plain text.
+	if !strings.Contains(html, "Password reset · Acme") {
+		t.Errorf("html missing eyebrow, got %q", html)
+	}
+	if !strings.Contains(text, "Hi Alice,") {
+		t.Errorf("text missing greeting, got %q", text)
+	}
+	if !strings.Contains(text, "https://app.example.com/reset-password/abc") {
+		t.Errorf("text missing link, got %q", text)
+	}
+}
+
+func TestRenderTransactionalEmail_EscapesEyebrowAndCTALabel(t *testing.T) {
+	html, _ := RenderTransactionalEmail(TransactionalEmail{
+		Eyebrow:  "<x>",
+		Greeting: Greeting(""),
+		CTALabel: "<y>",
+		CTALink:  "https://e/x",
+	})
+	if strings.Contains(html, "<x>") || strings.Contains(html, "<y>") {
+		t.Errorf("eyebrow/CTALabel must be HTML-escaped, got %q", html)
+	}
+}
+
+func TestGreeting(t *testing.T) {
+	if got := Greeting("  Bob  "); got != "Hi Bob" {
+		t.Errorf("Greeting trims and prefixes; got %q", got)
+	}
+	if got := Greeting(""); got != "Hi" {
+		t.Errorf("empty name → bare 'Hi'; got %q", got)
+	}
+}

--- a/core/tests/unit/account-password.test.ts
+++ b/core/tests/unit/account-password.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const update = vi.fn()
 const authWithPassword = vi.fn()
+const requestPasswordReset = vi.fn()
+const confirmPasswordReset = vi.fn()
 const captureException = vi.fn()
 
 const authStore = { record: { id: 'user_1' } as { id: string } | null }
@@ -9,7 +12,12 @@ const authStore = { record: { id: 'user_1' } as { id: string } | null }
 vi.mock('@tinycld/core/lib/pocketbase', () => ({
     pb: {
         authStore,
-        collection: () => ({ update, authWithPassword }),
+        collection: () => ({
+            update,
+            authWithPassword,
+            requestPasswordReset,
+            confirmPasswordReset,
+        }),
     },
 }))
 
@@ -73,5 +81,49 @@ describe('changeMyPassword', () => {
 
         await expect(changeMyPassword(args)).rejects.toThrow('reauth failed')
         expect(captureException).toHaveBeenCalledWith('account.changePassword.reauth', reauthError)
+    })
+})
+
+describe('requestPasswordReset', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        authStore.record = { id: 'user_1' }
+    })
+
+    it('calls PocketBase requestPasswordReset with the email', async () => {
+        const { requestPasswordReset: fn } = await import('@tinycld/core/lib/account-password')
+        requestPasswordReset.mockResolvedValueOnce(true)
+        await fn('alice@example.com')
+        expect(requestPasswordReset).toHaveBeenCalledWith('alice@example.com')
+    })
+
+    it('never throws and reports unexpected failures (no account enumeration)', async () => {
+        const { requestPasswordReset: fn } = await import('@tinycld/core/lib/account-password')
+        requestPasswordReset.mockRejectedValueOnce(new Error('boom'))
+        await expect(fn('nobody@example.com')).resolves.toBeUndefined()
+        expect(captureException).toHaveBeenCalledWith(
+            'account.requestPasswordReset',
+            expect.any(Error)
+        )
+    })
+})
+
+describe('confirmPasswordReset', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        authStore.record = { id: 'user_1' }
+    })
+
+    it('forwards token and both passwords to PocketBase', async () => {
+        const { confirmPasswordReset: fn } = await import('@tinycld/core/lib/account-password')
+        confirmPasswordReset.mockResolvedValueOnce(true)
+        await fn('tok-1', 'newpassword', 'newpassword')
+        expect(confirmPasswordReset).toHaveBeenCalledWith('tok-1', 'newpassword', 'newpassword')
+    })
+
+    it('propagates errors so the confirm screen can surface them', async () => {
+        const { confirmPasswordReset: fn } = await import('@tinycld/core/lib/account-password')
+        confirmPasswordReset.mockRejectedValueOnce(new Error('invalid token'))
+        await expect(fn('bad', 'pw12345678', 'pw12345678')).rejects.toThrow('invalid token')
     })
 })

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test'
+import { clearEmailLog, extractFirstLink, waitForEmailTo } from './email-log-helpers'
+import { ORG_SLUG, TEST_USER_EMAIL, TEST_USER_PASSWORD } from './helpers'
+
+// Drives the full self-service password-reset flow from the login modal:
+// request → email (captured via the mailer LogSender) → confirm screen → sign
+// in with the reset password.
+//
+// The new password is set back to TEST_USER_PASSWORD so the shared test account
+// is left exactly as the other specs (which call login()) expect.
+test.describe('password reset', () => {
+    test('request → emailed link → set new password → sign in', async ({ page }) => {
+        clearEmailLog()
+
+        await page.goto('/')
+
+        // Open the inline forgot-password form and request a reset.
+        await page.getByTestId('forgot-password-link').click()
+        await page.getByTestId('reset-email').fill(TEST_USER_EMAIL)
+        await page.getByTestId('reset-submit').click()
+
+        // Generic confirmation is always shown (no account enumeration).
+        await expect(page.getByTestId('reset-sent')).toBeVisible({ timeout: 10_000 })
+
+        // The override hook sends via the mailer LogSender with our own link.
+        const email = await waitForEmailTo(TEST_USER_EMAIL, {
+            subjectMatch: /reset your password/i,
+            timeoutMs: 10_000,
+        })
+        const link = extractFirstLink(email, /https?:\/\/[^\s"'<>]+\/reset-password\/[^\s"'<>]+/)
+        const resetPath = new URL(link, 'http://localhost').pathname
+        expect(resetPath).toMatch(/\/reset-password\/.+/)
+
+        // Visit the emailed link and set a new password (same value, to leave the
+        // shared account unchanged for other specs).
+        await page.goto(resetPath)
+        await expect(page.getByText('Choose a new password', { exact: true })).toBeVisible({
+            timeout: 10_000,
+        })
+        await page.getByPlaceholder('At least 8 characters').fill(TEST_USER_PASSWORD)
+        await page.getByPlaceholder('Re-enter password').fill(TEST_USER_PASSWORD)
+        await page.getByTestId('reset-confirm-submit').click()
+
+        // On success the screen redirects to the login route.
+        await page.waitForURL(/\/$|\/admin|\/a\//, { timeout: 15_000 })
+
+        // Confirm the reset password actually authenticates.
+        await page.goto('/')
+        await page.getByTestId('identifier').fill(TEST_USER_EMAIL)
+        await page.getByPlaceholder('Password').fill(TEST_USER_PASSWORD)
+        await page.getByText('Sign in', { exact: true }).last().click()
+        await page.waitForURL(new RegExp(`/a/${ORG_SLUG}|/a/|/admin`), { timeout: 15_000 })
+    })
+
+    test('garbage token shows an invalid/expired error', async ({ page }) => {
+        await page.goto('/reset-password/not-a-real-token')
+        await page.getByPlaceholder('At least 8 characters').fill('brandnewpassword')
+        await page.getByPlaceholder('Re-enter password').fill('brandnewpassword')
+        await page.getByTestId('reset-confirm-submit').click()
+        await expect(page.getByTestId('reset-error')).toBeVisible({ timeout: 10_000 })
+    })
+})


### PR DESCRIPTION
Adds a 'Forgot password?' flow to the login modal, built on the unified core mailer.

## What
- **Server:** a coreserver hook overrides PocketBase's built-in reset email (PB still owns the token) and sends via the core mailer with a link to the app's own `/reset-password/<token>` screen. Falls back to PB's default send only if the token is missing.
- **Client:** `requestPasswordReset`/`confirmPasswordReset` helpers, an inline reset form in `LoginModal`, and a public reset-confirm screen.
- **Refactor (first commit):** extracts a shared `mailer.RenderTransactionalEmail` template and migrates both invite emails onto it, removing ~110 lines of duplicated HTML. No change to invite subjects/HTML.

## Notes
- The request path never reveals whether an email is registered (no account enumeration).
- Sends via `mailer.DefaultSender()` like invites, so it degrades to the log sender in dev/e2e.

## Tests
Go (reset builder + template helper), client unit (both helpers incl. no-enumeration), and an e2e full-flow spec (request → email → confirm → sign in, plus garbage-token error).