### PR TITLE
chore(expo): hide dev-client tools button

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,6 +30,12 @@
                     "project": "tinycld"
                 }
             ],
+            [
+                "expo-dev-client",
+                {
+                    "toolsButton": false
+                }
+            ],
             "./plugins/with-app-updater.cjs"
         ],
         "icon": "./assets/app-icon.png",


### PR DESCRIPTION
Adds the `expo-dev-client` config plugin with `toolsButton: false` to hide the floating dev-client tools button.