### PR TITLE
core/blankfile: attach a blank file on drive_items create

### DIFF
--- a/core/server/blankfile/blankfile.go
+++ b/core/server/blankfile/blankfile.go
@@ -1,0 +1,89 @@
+// Package blankfile lets a document package (text, calc, …) auto-attach a
+// minimal valid backing file to a freshly-created drive_items row that was
+// created with no file.
+//
+// Why this exists: creating a blank document used to require the *client* to
+// materialize a valid empty office file (a Blob or a temp file) and upload it as
+// multipart form data. That is brittle — React Native's Android FormData
+// polyfill can't upload an in-memory Blob at all (the request commits server-side
+// but the response read fails with "Network request failed"), so every client
+// platform had to re-implement a temp-file workaround per format. Moving the
+// blank-file synthesis to the server removes that whole class of client bugs: the
+// client just inserts a drive_items row with no file, and the owning package's
+// registration here attaches the skeleton.
+//
+// The skeleton is a static, embedded artifact supplied by the caller (via
+// go:embed) — identical bytes to what the client used to upload. No runtime
+// document generation is involved.
+//
+// Blank files are quota-exempt: this hook sets `size` for the Drive UI but does
+// not run the storage-quota check (drive's own OnRecordCreate ran that against
+// the incoming size, which is 0 for a no-file create).
+package blankfile
+
+import (
+	"fmt"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
+)
+
+// driveItemsCollection is the collection blank documents live in. Matches the
+// const each package server already uses (calc/server/persist.go etc.).
+const driveItemsCollection = "drive_items"
+
+// Register binds an OnRecordCreate("drive_items") hook that attaches `skeleton`
+// (a valid empty file of the given mimeType) to any create whose mime_type
+// matches and that carries no file yet.
+//
+//   - mimeType:  the drive_items.mime_type this package owns (e.g. the docx or
+//     xlsx MIME). The hook is a no-op for any other value.
+//   - filename:  the on-disk name given to the attached file. PocketBase renames
+//     the blob to a content hash on save; this only seeds mime/extension.
+//   - skeleton:  the embedded blank-file bytes (via go:embed). Must be non-empty.
+//
+// Idempotent and upload-safe: a create that already has a file set (a real
+// upload) is left untouched, so this never overwrites user content. Multiple
+// packages may each Register for their own mimeType against the same collection;
+// each hook only fires for its match.
+//
+// The file is set on e.Record BEFORE e.Next(), so it persists in the same INSERT
+// — no second save, and it composes with drive's own OnRecordCreate hook
+// (quota/dedup/owner-share), which only touches `name`/`size`.
+func Register(app core.App, mimeType, filename string, skeleton []byte) {
+	if len(skeleton) == 0 {
+		// A caller wiring up an empty skeleton is a build-time mistake (bad
+		// embed path); fail loud at startup rather than silently attaching
+		// zero bytes — a zero-byte file is exactly the corrupt-download bug
+		// this package exists to prevent.
+		panic(fmt.Sprintf("blankfile.Register(%q): skeleton is empty", mimeType))
+	}
+
+	app.OnRecordCreate(driveItemsCollection).BindFunc(func(e *core.RecordEvent) error {
+		if e.Record.GetString("mime_type") != mimeType {
+			return e.Next()
+		}
+		// Leave any create that already carries a file. Two forms to check:
+		//   - GetString("file") — a filename already persisted (e.g. an update,
+		//     or a record hydrated from an existing file).
+		//   - GetUnsavedFiles("file") — a pending upload on THIS create. On a
+		//     create hook the uploaded blob isn't a filename yet, so GetString
+		//     returns "" while the file is very much present; without this check
+		//     the hook would clobber a real upload's bytes with the skeleton.
+		if e.Record.GetString("file") != "" || len(e.Record.GetUnsavedFiles("file")) > 0 {
+			return e.Next()
+		}
+
+		f, err := filesystem.NewFileFromBytes(skeleton, filename)
+		if err != nil {
+			return fmt.Errorf("blankfile: build skeleton file (%s): %w", mimeType, err)
+		}
+		e.Record.Set("file", f)
+		// Set size for the Drive UI column. Quota-exempt by design: drive's
+		// OnRecordCreate already checked quota against the incoming size (0),
+		// and we deliberately don't re-check for the fixed skeleton cost.
+		e.Record.Set("size", len(skeleton))
+
+		return e.Next()
+	})
+}

--- a/core/server/blankfile/blankfile_test.go
+++ b/core/server/blankfile/blankfile_test.go
@@ -1,0 +1,128 @@
+package blankfile
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
+)
+
+const testMime = "application/test-blank"
+
+// a couple of non-empty, arbitrary skeleton bytes — content is irrelevant to
+// the hook, only that it's attached.
+var testSkeleton = []byte("SKELETON-BYTES-1234")
+
+// newAppWithDriveItems builds a test app with a drive_items collection carrying
+// the fields the hook reads/writes, and registers the blankfile hook for
+// testMime.
+func newAppWithDriveItems(t *testing.T) *tests.TestApp {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("tests.NewTestApp: %v", err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+
+	items := core.NewBaseCollection(driveItemsCollection)
+	items.Fields.Add(&core.TextField{Name: "name"})
+	items.Fields.Add(&core.TextField{Name: "org"})
+	items.Fields.Add(&core.TextField{Name: "mime_type"})
+	items.Fields.Add(&core.NumberField{Name: "size"})
+	items.Fields.Add(&core.FileField{Name: "file", MaxSelect: 1, MaxSize: 104857600})
+	if err := app.Save(items); err != nil {
+		t.Fatalf("save drive_items collection: %v", err)
+	}
+
+	// Register takes core.App (the OnRecordCreate hook surface), which
+	// *tests.TestApp implements — so pass it directly.
+	Register(app, testMime, "blank.bin", testSkeleton)
+	return app
+}
+
+func newDriveItem(t *testing.T, app *tests.TestApp) *core.Record {
+	t.Helper()
+	c, err := app.FindCollectionByNameOrId(driveItemsCollection)
+	if err != nil {
+		t.Fatalf("find drive_items: %v", err)
+	}
+	return core.NewRecord(c)
+}
+
+// A blank create (matching mime, no file) gets the skeleton + size attached.
+func TestAttachesSkeletonToBlankCreate(t *testing.T) {
+	app := newAppWithDriveItems(t)
+	rec := newDriveItem(t, app)
+	rec.Set("name", "Untitled.bin")
+	rec.Set("mime_type", testMime)
+	rec.Set("size", 0)
+
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("save blank create: %v", err)
+	}
+
+	reloaded, err := app.FindRecordById(driveItemsCollection, rec.Id)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.GetString("file") == "" {
+		t.Fatal("expected file to be attached, got empty")
+	}
+	if got := reloaded.GetInt("size"); got != len(testSkeleton) {
+		t.Fatalf("expected size %d, got %d", len(testSkeleton), got)
+	}
+}
+
+// A create that already carries a file (a real upload) is left untouched — the
+// hook must never overwrite user content.
+func TestLeavesExistingFileUntouched(t *testing.T) {
+	app := newAppWithDriveItems(t)
+	rec := newDriveItem(t, app)
+	rec.Set("name", "real-upload.bin")
+	rec.Set("mime_type", testMime)
+
+	userBytes := []byte("USER-UPLOADED-CONTENT-that-differs-from-skeleton")
+	f, err := filesystem.NewFileFromBytes(userBytes, "real.bin")
+	if err != nil {
+		t.Fatalf("build user file: %v", err)
+	}
+	rec.Set("file", f)
+	rec.Set("size", len(userBytes))
+
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("save real upload: %v", err)
+	}
+
+	reloaded, err := app.FindRecordById(driveItemsCollection, rec.Id)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	// Size must reflect the user's upload, not the skeleton — proving the hook
+	// no-op'd on an already-filed record.
+	if got := reloaded.GetInt("size"); got != len(userBytes) {
+		t.Fatalf("expected user size %d preserved, got %d (skeleton is %d)",
+			len(userBytes), got, len(testSkeleton))
+	}
+}
+
+// A create with a different mime is ignored entirely (no file attached).
+func TestIgnoresOtherMime(t *testing.T) {
+	app := newAppWithDriveItems(t)
+	rec := newDriveItem(t, app)
+	rec.Set("name", "photo.png")
+	rec.Set("mime_type", "image/png")
+	rec.Set("size", 0)
+
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("save other-mime create: %v", err)
+	}
+
+	reloaded, err := app.FindRecordById(driveItemsCollection, rec.Id)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.GetString("file") != "" {
+		t.Fatal("expected no file attached for non-owned mime, got one")
+	}
+}


### PR DESCRIPTION
Adds `core/server/blankfile`: `Register(app, mime, filename, skeleton)` binds an `OnRecordCreate("drive_items")` hook that attaches an embedded blank file (supplied by the caller via `go:embed`) to a create matching the mime and carrying **no file**.

- A create that already has a file — **including a pending upload**, detected via `GetUnsavedFiles("file")` — is left untouched, so real uploads are never clobbered.
- Blank files are quota-exempt (`size` is set for the Drive UI; no quota check).
- Format-agnostic: the mime, filename, and skeleton bytes are all caller-supplied. Multiple packages register for their own mime against the same collection.

This lets document packages (text, calc) create a blank doc with a bare no-file insert instead of uploading a client-materialized skeleton — which RN Android can't send as multipart form data.

Includes unit tests (attach-on-blank, leave-existing-upload, ignore-other-mime). Dependency for the text/calc server PRs.