### PR TITLE
fix(core): dock package sidebar on tablet instead of a blocking overlay

### DIFF
--- a/core/components/workspace/WorkspaceLayout.tsx
+++ b/core/components/workspace/WorkspaceLayout.tsx
@@ -3,7 +3,7 @@ import { NotificationDrawer } from '@tinycld/core/components/NotificationDrawer'
 import { usePackage } from '@tinycld/core/lib/packages/use-packages'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
-import { Platform, Pressable, View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { FrozenStack } from './FrozenStack'
 import { MobileLayout } from './MobileLayout'
@@ -12,25 +12,29 @@ import { PackageRail } from './PackageRail'
 import { PackageSidebar } from './PackageSidebar'
 import { useBreakpoint } from './useBreakpoint'
 
-const SIDEBAR_WIDTH = 260
-const RAIL_WIDTH = 64
-const TRANSITION = 'all 0.25s cubic-bezier(0.4, 0, 0.2, 1)'
+// Docked sidebar width. The tablet breakpoint (768–1023dp) is narrow enough that
+// the full desktop width would crowd the workspace and push toolbars (e.g. the
+// drive List/Grid toggle) off-screen, so it gets a slimmer panel there.
+const SIDEBAR_WIDTH_DESKTOP = 260
+const SIDEBAR_WIDTH_TABLET = 175
 
 export function WorkspaceLayout({ isReady = true }: { isReady?: boolean }) {
     const bgColor = useThemeColor('background')
-    const overlayColor = useThemeColor('overlay-backdrop')
     const breakpoint = useBreakpoint()
-    const isSidebarOpen = useWorkspaceStore(s => s.isSidebarOpen)
-    const setSidebarOpen = useWorkspaceStore(s => s.setSidebarOpen)
     const activePkgSlug = useWorkspaceStore(s => s.activePkgSlug)
     const activePkg = usePackage(activePkgSlug ?? '')
     const insets = useSafeAreaInsets()
 
     if (breakpoint === 'mobile') return <MobileLayout isReady={isReady} />
 
-    const isTablet = breakpoint === 'tablet'
+    // Tablet + desktop both dock the package sidebar as a persistent panel next
+    // to the rail. (Mobile uses MobileDrawer instead.) An earlier tablet-only
+    // variant rendered the sidebar as a full-screen modal overlay, but it
+    // defaulted open with no UI to toggle it — so it just covered the workspace
+    // with a touch-capturing dim layer and blocked all interaction. The docked
+    // panel matches the intended "contextual sidebar to the right of the rail".
     const hasSidebar = activePkg?.sidebar != null
-    const showSidebarOverlay = isTablet && isSidebarOpen && hasSidebar
+    const sidebarWidth = breakpoint === 'tablet' ? SIDEBAR_WIDTH_TABLET : SIDEBAR_WIDTH_DESKTOP
 
     return (
         <View
@@ -52,17 +56,7 @@ export function WorkspaceLayout({ isReady = true }: { isReady?: boolean }) {
                 {isReady && <NotificationDrawer />}
 
                 <PackageProviderWrapper>
-                    {isReady &&
-                        hasSidebar &&
-                        (isTablet ? (
-                            <SidebarOverlay
-                                isVisible={showSidebarOverlay}
-                                overlayColor={overlayColor}
-                                onDismiss={() => setSidebarOpen(false)}
-                            />
-                        ) : (
-                            <PackageSidebar width={SIDEBAR_WIDTH} />
-                        ))}
+                    {isReady && hasSidebar && <PackageSidebar width={sidebarWidth} />}
 
                     <View
                         className="flex-1"
@@ -74,52 +68,6 @@ export function WorkspaceLayout({ isReady = true }: { isReady?: boolean }) {
                         <FrozenStack />
                     </View>
                 </PackageProviderWrapper>
-            </View>
-        </View>
-    )
-}
-
-function SidebarOverlay({
-    isVisible,
-    overlayColor,
-    onDismiss,
-}: {
-    isVisible: boolean
-    overlayColor: string
-    onDismiss: () => void
-}) {
-    return (
-        <View
-            className="absolute top-0 left-0 right-0 bottom-0 flex-row"
-            style={{
-                zIndex: 100,
-            }}
-            pointerEvents={isVisible ? 'auto' : 'none'}
-        >
-            <Pressable
-                className="absolute top-0 right-0 bottom-0"
-                style={
-                    {
-                        left: RAIL_WIDTH,
-                        backgroundColor: overlayColor,
-                        opacity: isVisible ? 1 : 0,
-                        transition: TRANSITION,
-                    } as object
-                }
-                onPress={onDismiss}
-            />
-            <View
-                style={[
-                    { marginLeft: RAIL_WIDTH, zIndex: 101, alignSelf: 'stretch' as const },
-                    Platform.OS === 'web'
-                        ? ({
-                              transform: `translateX(${isVisible ? 0 : -SIDEBAR_WIDTH}px)`,
-                              transition: TRANSITION,
-                          } as object)
-                        : undefined,
-                ]}
-            >
-                <PackageSidebar width={SIDEBAR_WIDTH} />
             </View>
         </View>
     )


### PR DESCRIPTION
## Problem

On the **tablet breakpoint (768–1023 dp)**, the package sidebar rendered as a full-screen `pointerEvents: 'auto'` dimming **overlay that defaults open** (`isSidebarOpen: true`) with no UI to toggle it. It covered the whole workspace and swallowed all touch/click input — including nav-rail taps — so navigation silently did nothing.

Nothing in the app ever calls `toggleSidebar`/`setSidebarOpen(true)`; the only control is the overlay's own backdrop-dismiss. So the default-open overlay was purely a blocker with no way to (re)open it — clearly unintended.

Repros on **web too** at a 768–1023 px window (the overlay div intercepts pointer events). Phones (mobile breakpoint → `MobileLayout`, no overlay) and desktop-width windows (docked panel) were unaffected — which is why it looked native-tablet-specific.

## Fix

- Render the package sidebar as a **docked panel** on tablet, same as desktop (mobile keeps `MobileDrawer`).
- Size it **responsively**: **175 px on tablet** vs 260 px on desktop, so the narrower tablet width doesn't crowd the workspace or push toolbars off-screen (e.g. the drive List/Grid toggle was getting clipped past the screen edge).
- Delete the now-dead `SidebarOverlay` component.

## Testing

Verified on 800 dp Android tablet emulators (7"/10") and via headless web at 800 px: navigation works with no blocking overlay, the docked folder-tree / calendar sidebars render, and toolbars are no longer clipped. Desktop and mobile layouts are unchanged.