### PR TITLE
fix: mount persistent disk at /workspace/pb_data (prevent data loss on redeploy)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,7 +8,7 @@ artifacts behind it.
 ## The one hard requirement
 
 TinyCld writes its embedded SQLite database, file uploads, and server private
-keys to **`/workspace/tinycld/pb_data`** inside the container. That directory
+keys to **`/workspace/pb_data`** inside the container. That directory
 **must** be backed by a persistent volume. Hosts with an ephemeral filesystem
 (Heroku, DigitalOcean App Platform, AWS App Runner, Cloudflare Containers, …)
 silently destroy the database on every restart and are not supported — use a
@@ -68,7 +68,7 @@ file. To (re)create the public template:
 3. Service → **Variables**: add `AUTOCERT_ENABLED=false`, `PUBLIC_SCHEME=https`,
    `HTTP_ADDR=0.0.0.0:7090`, and `TINYCLD_PUBLIC_URL` (the railway.app domain).
 4. Service → **Volumes**: add a volume mounted at
-   `/workspace/tinycld/pb_data`.
+   `/workspace/pb_data`.
 5. Project → **Settings → Create Template** → publish.
 
 Record the resulting button URL here once published:

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -48,7 +48,7 @@ primary_region = "iad"     # pick a region near you: fly platform regions
 # PocketBase data: SQLite DB, file uploads, server private keys.
 [mounts]
     source = "pb_data"
-    destination = "/workspace/tinycld/pb_data"
+    destination = "/workspace/pb_data"
 
 [[vm]]
     size = "shared-cpu-1x"

--- a/deploy/render.yaml
+++ b/deploy/render.yaml
@@ -50,5 +50,5 @@ services:
           name: pb_data
           # PocketBase data: SQLite DB, file uploads, server private keys.
           # This is the one thing that must survive restarts/redeploys.
-          mountPath: /workspace/tinycld/pb_data
+          mountPath: /workspace/pb_data
           sizeGB: 10


### PR DESCRIPTION
The Render and Fly blueprints mounted the persistent volume at `/workspace/tinycld/pb_data`, but the runtime opens the database at `/workspace/pb_data` (`config/entrypoint.sh` sets `PB_DATA_DIR=/workspace/pb_data` and serves with `--dir=${PB_DATA_DIR}`). The SQLite DB therefore lived on the ephemeral container filesystem, and the first redeploy lost all data.

Fix: point the Render `mountPath` and Fly `destination` at `/workspace/pb_data`, and correct the same stale path in `deploy/README.md` (including the manual Railway volume instructions, which would reproduce the identical data loss).