### PR TITLE
Restore iOS accessibility for swipeable rows + fix false offline overlay

### DIFF
--- a/core/components/SwipeableRow.tsx
+++ b/core/components/SwipeableRow.tsx
@@ -113,6 +113,7 @@ function NativeSwipeableRow({
             overshootRight={false}
             enabled={enabled}
             containerStyle={swipeContainerStyle}
+            accessible={false}
         >
             {children}
         </ReanimatedSwipeable>

--- a/core/lib/use-connectivity-detector.native.ts
+++ b/core/lib/use-connectivity-detector.native.ts
@@ -1,37 +1,69 @@
 import NetInfo from '@react-native-community/netinfo'
+import { getResolvedAddress, probe } from '@tinycld/core/lib/server-address'
 import { useConnectivityStore } from '@tinycld/core/lib/stores/connectivity-store'
 import { useEffect } from 'react'
 
 const OFFLINE_DEBOUNCE_MS = 1500
+const SERVER_CONFIRM_TIMEOUT_MS = 3000
 
 export function useConnectivityDetector(): void {
     useEffect(() => {
         const { setOnline } = useConnectivityStore.getState()
         let offlineTimer: ReturnType<typeof setTimeout> | null = null
+        let cancelled = false
+
+        const clearOfflineTimer = () => {
+            if (offlineTimer) {
+                clearTimeout(offlineTimer)
+                offlineTimer = null
+            }
+        }
+
+        // NetInfo's isInternetReachable is a probe to a public host, which
+        // returns false on networks that can't reach it even when OUR server
+        // can — a captive/filtered LAN, or the iOS simulator (whose reachability
+        // probe is unreliable and routinely reports offline while localhost:7100
+        // answers fine). Treating that as offline pops the full-screen blocking
+        // OfflineOverlay over a perfectly usable app. So before flipping offline,
+        // confirm against the server we actually depend on: if /api/health still
+        // answers, we're online regardless of what NetInfo thinks of the wider
+        // internet. Only when the server probe ALSO fails do we go offline.
+        const confirmOfflineAgainstServer = async () => {
+            const address = getResolvedAddress()
+            if (!address) {
+                if (!cancelled) setOnline(false)
+                return
+            }
+            try {
+                await probe(address, SERVER_CONFIRM_TIMEOUT_MS)
+                // Server reachable — NetInfo's "offline" is a false negative.
+                if (!cancelled) setOnline(true)
+            } catch {
+                if (!cancelled) setOnline(false)
+            }
+        }
 
         const unsubscribe = NetInfo.addEventListener(state => {
             const reachable = state.isInternetReachable !== false
             const online = Boolean(state.isConnected) && reachable
 
             if (online) {
-                if (offlineTimer) {
-                    clearTimeout(offlineTimer)
-                    offlineTimer = null
-                }
+                clearOfflineTimer()
                 setOnline(true)
                 return
             }
 
             if (offlineTimer) return
             offlineTimer = setTimeout(() => {
-                setOnline(false)
                 offlineTimer = null
+                void confirmOfflineAgainstServer()
             }, OFFLINE_DEBOUNCE_MS)
         })
 
         return () => {
+            cancelled = true
             unsubscribe()
-            if (offlineTimer) clearTimeout(offlineTimer)
+            clearOfflineTimer()
         }
     }, [])
 }


### PR DESCRIPTION
Two iOS-specific fixes found while bringing up App Store screenshot capture on the simulator.

## SwipeableRow accessibility
`react-native-gesture-handler`'s `ReanimatedSwipeable` collapses its children into a single opaque accessibility element on iOS, so **contact-list and mail-inbox rows exposed nothing to VoiceOver** (their names, star/menu buttons were unreachable). Android renders the same code fine. Adding `accessible={false}` to the `ReanimatedSwipeable` tells iOS to descend into the children — restoring per-row/per-control accessibility.

## False offline overlay
`useConnectivityDetector` flipped the app offline purely on NetInfo's `isInternetReachable`, which probes a **public** host. On captive/filtered networks — and consistently on the iOS simulator — that reports `false` while our own server (`localhost:7100`) answers HTTP 200. The result is the full-screen `zIndex:10001` `pointerEvents:auto` `OfflineOverlay` blocking a perfectly usable app (and, mid-login, swallowing field taps so the password lands in the username field). Now, before going offline, we confirm against the resolved server via `probe(address)` → `/api/health`; we only surface offline when the server probe **also** fails. Real-user-correct too, not just for the sim.