### PR TITLE
fix: stop persisting superuser token on the shared app client

### DIFF
--- a/core/lib/use-superuser-pb.ts
+++ b/core/lib/use-superuser-pb.ts
@@ -1,12 +1,61 @@
 import { PB_SERVER_ADDR } from '@tinycld/core/lib/config'
 import { pb as appPb } from '@tinycld/core/lib/pocketbase'
-import PocketBase from 'pocketbase'
-import { useCallback, useRef, useState } from 'react'
+import PocketBase, { BaseAuthStore } from 'pocketbase'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// The raw-superuser fallback (SetupPage's SuperuserLoginForm) drives the admin
+// console through the pbtsdb stores, which are bound to the shared app client —
+// so those reads/writes only pass PocketBase's collection rules while that
+// client carries the rule-bypassing superuser token. Mirroring the token onto
+// the shared client's persistent auth store (the previous approach) left the
+// WHOLE app running with collection-rule bypass — surviving reloads — until an
+// explicit logout. Instead we temporarily swap the shared client's auth store
+// for an in-memory one holding the superuser token, and swap the original store
+// back when the admin surface unmounts. The superuser token never reaches
+// persisted storage, and leaving the admin surface restores the prior session.
+let elevation: { prior: BaseAuthStore; superuserToken: string } | null = null
+
+function elevateSharedClient(superuserPb: PocketBase) {
+    const token = superuserPb.authStore.token
+    const record = superuserPb.authStore.record
+    if (elevation) {
+        // Re-login while already elevated (e.g. an expired token): refresh the
+        // in-memory store rather than nesting another swap.
+        elevation.superuserToken = token
+        appPb.authStore.save(token, record)
+        return
+    }
+    const memory = new BaseAuthStore()
+    memory.save(token, record)
+    elevation = { prior: appPb.authStore, superuserToken: token }
+    appPb.authStore = memory
+}
+
+function restoreSharedClient() {
+    if (!elevation) return
+    const memory = appPb.authStore
+    const { prior, superuserToken } = elevation
+    elevation = null
+    appPb.authStore = prior
+    if (memory.token && memory.token !== superuserToken) {
+        // Impersonation ("Visit" on an org row) saved the org owner's token
+        // onto the shared client while elevated — carry that ordinary user
+        // auth over to the real (persistent) store instead of discarding it.
+        prior.save(memory.token, memory.record)
+    } else if (!memory.token) {
+        // Something cleared the session while elevated (logout/disconnect) —
+        // propagate the clear so the prior auth doesn't resurrect.
+        prior.clear()
+    }
+}
 
 export function useSuperUserPB() {
     const pbRef = useRef<PocketBase | null>(null)
     if (!pbRef.current) {
-        pbRef.current = new PocketBase(PB_SERVER_ADDR)
+        // Explicit in-memory store: the SDK's default LocalAuthStore persists
+        // to window.localStorage on web, which would leak the superuser token
+        // across sessions.
+        pbRef.current = new PocketBase(PB_SERVER_ADDR, new BaseAuthStore())
     }
     const pb = pbRef.current
 
@@ -20,13 +69,7 @@ export function useSuperUserPB() {
             setIsLoading(true)
             try {
                 await pb.collection('_superusers').authWithPassword(email, password)
-                // Mirror the superuser token onto the shared app pb client so the
-                // pbtsdb stores the console writes through carry it. Without this
-                // the stores stay anonymous and managed-field writes (e.g. setting
-                // `verified` on a new org owner) fail the users manageRule with a
-                // 400. PB superusers bypass that rule, so the mirrored token
-                // authorizes the create.
-                appPb.authStore.save(pb.authStore.token, pb.authStore.record)
+                elevateSharedClient(pb)
                 setIsAuthenticated(true)
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'Authentication failed'
@@ -37,6 +80,10 @@ export function useSuperUserPB() {
         },
         [pb]
     )
+
+    // Tear the elevation down when the admin surface unmounts so nothing keeps
+    // running with superuser auth on the shared client after leaving it.
+    useEffect(() => restoreSharedClient, [])
 
     return {
         pb,

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -42,5 +42,11 @@
     "typeAcquisition": {
         "enable": true
     },
-    "include": ["**/*.ts", "**/*.tsx", "expo-env.d.ts", "../uniwind-types.d.ts"]
+    "include": [
+        "**/*.ts",
+        "**/*.tsx",
+        "expo-env.d.ts",
+        "../uniwind-types.d.ts",
+        "../lucide-icons.d.ts"
+    ]
 }


### PR DESCRIPTION
The /admin raw-superuser login mirrored the rule-bypassing `_superusers` token onto the shared app client's persistent auth store — the whole app then ran with collection-rule bypass, across reloads, until an explicit logout. The dedicated superuser client also persisted its token to `localStorage` on web via the SDK's default `LocalAuthStore`.

- Elevation is now an in-memory auth-store swap scoped to the admin surface: the token never reaches persisted storage, and the original store is restored when the surface unmounts (an impersonation token minted while elevated is carried over to the real store).
- The dedicated superuser client now uses an explicit in-memory `BaseAuthStore`.
- `core/tsconfig.json` now includes `../lucide-icons.d.ts` so the member's standalone typecheck resolves the generated per-icon deep imports (was failing with TS2307).

Full elevation (rather than per-operation) is required because the admin tabs' pbtsdb live reads and writes are bound to the shared client; the swap keeps it session-scoped and unpersisted.