### PR TITLE
fix: clear stores and query cache on logout to stop cross-user session bleed

### DIFF
--- a/core/lib/pocketbase.ts
+++ b/core/lib/pocketbase.ts
@@ -108,7 +108,8 @@ export function usePocketBase() {
 // auto-reconnects on EventSource error, and reconnect reads PB_SERVER_ADDR
 // — clearing the address before disconnecting realtime trips the "address
 // not resolved" guard. The auth-store's logout already does the realtime
-// teardown + auth clear; we just need to add the address clear.
+// teardown + auth clear + resetSessionState (stores + query cache); we
+// just need to add the address clear.
 export async function disconnectServer() {
     const { useAuthStore } = await import('./stores/auth-store')
     useAuthStore.getState().logout()
@@ -351,8 +352,26 @@ export async function fetchAndSeedUserOrg() {
 
 export async function clearStores() {
     for (const s of Object.values(stores)) {
+        // cleanup() on an already cleaned-up collection throws an invalid
+        // status-transition error, and repeated teardowns are a legal path
+        // (sign out, then "change server" runs logout() a second time).
+        if (s.status === 'cleaned-up') continue
         await s.cleanup()
     }
+}
+
+// Single teardown point for everything cached per-session in memory. On web
+// the SPA survives logout → next login in the same tab (no reload), so
+// anything left behind leaks across users on the same device: the pbtsdb
+// stores still hold the previous user's rows, and the React Query cache still
+// holds their file token (['pb-files-token'] in use-authed-file-url.ts) —
+// which authorizes file reads as that user. Runs from the auth-store's
+// logout(), which disconnectServer() also routes through.
+// TODO: web-push subscription teardown (review §4.12) belongs here once
+// implemented — unsubscribe the device before the session is dropped.
+export async function resetSessionState() {
+    await clearStores()
+    queryClient.clear()
 }
 
 export { PBTSDBProvider, queryClient, stores, useStore }

--- a/core/lib/stores/auth-store.ts
+++ b/core/lib/stores/auth-store.ts
@@ -7,6 +7,7 @@ import {
     PB_SERVER_ADDR,
     pb,
     preloadStores,
+    resetSessionState,
     seedUserOrg,
 } from '@tinycld/core/lib/pocketbase'
 import { create } from '@tinycld/core/lib/store'
@@ -200,6 +201,12 @@ export const useAuthStore = create<AuthStoreState>()((set, get) => ({
         // the same device doesn't inherit the previous user's last-opened
         // file references.
         useWorkspaceStore.setState({ lastPackageHref: {} })
+        // Drop per-session in-memory caches (pbtsdb stores + React Query,
+        // incl. the pb file token) so the next user signing in on this SPA
+        // instance can't read the previous user's rows or reuse their token.
+        resetSessionState().catch(err =>
+            captureException('auth-store.logout resetSessionState', err)
+        )
         set({ user: null })
     },
 

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -42,5 +42,11 @@
     "typeAcquisition": {
         "enable": true
     },
-    "include": ["**/*.ts", "**/*.tsx", "expo-env.d.ts", "../uniwind-types.d.ts"]
+    "include": [
+        "**/*.ts",
+        "**/*.tsx",
+        "expo-env.d.ts",
+        "../uniwind-types.d.ts",
+        "../lucide-icons.d.ts"
+    ]
 }


### PR DESCRIPTION
`logout()` never called `clearStores()` (defined but unused) nor cleared the React Query cache. On web the SPA survives logout → next login in the same tab, so the previous user's org rows stayed in the pbtsdb stores and their cached file token (`['pb-files-token']`, 55-min stale/gc) remained reusable — the next user could read files as them.

- New `resetSessionState()` in `pocketbase.ts`: `await clearStores()` then `queryClient.clear()` (the same instance `Providers.tsx` hands to `QueryClientProvider`, so it covers `useFileToken`). Called from `logout()`; `disconnectServer()` routes through `logout()` and inherits it.
- `clearStores()` now skips already-cleaned-up collections — a repeat teardown (sign out, then "change server") would otherwise throw TanStack DB's invalid status-transition error. Cleaned-up collections restart automatically on next use, so the following login re-preloads normally.
- Push-subscription teardown (review §4.12, MEDIUM) is intentionally left as a TODO on this pipeline rather than half-implemented.
- `core/tsconfig.json` gains `../lucide-icons.d.ts` in `include` so the member's standalone typecheck resolves the generated per-icon deep imports — same hunk as #96, merges cleanly in either order.