### PR TITLE
fix: dev server regenerates PB types into the live core dir

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -434,7 +434,7 @@ function spawnPbBinary(pbPort: number, publicUrl: string, dataDir: string | null
     const onPbErr = withPrefix('pb', '\x1b[31m') // red
     const args = ['--dev', '--http', `127.0.0.1:${pbPort}`]
     if (dataDir) args.push('--dir', dataDir)
-    args.push('--typesDir', path.join(ROOT, '..', 'core', 'types'), 'serve')
+    args.push('--typesDir', path.join(ROOT, 'core', 'types'), 'serve')
     // The mail package's IMAP server defaults to :1143 in dev. The Playwright
     // IMAP suite (app/tests/e2e/imap-helpers.ts) connects on :1193 — a port
     // distinct from the normal dev one so an e2e run never collides with a


### PR DESCRIPTION
`dev.ts` still passed the pre-merge `--typesDir` path (`ROOT/../core/types`), so the dev server wrote regenerated `pbSchema.ts`/`pbZodSchema.ts` into an orphan `~/code/tinycld/core/types/` outside the repo — the app kept compiling against stale types while the live schema moved. Point it at the nested core (`ROOT/core/types`), matching the `--typesDir` the sibling `e2e-serve.ts` already uses.