### PR TITLE
fix: constrain createRule user on push_subscriptions + user_preferences

### DIFF
--- a/core/server/pb_migrations/1920000000_pin_createrule_user.js
+++ b/core/server/pb_migrations/1920000000_pin_createrule_user.js
@@ -1,0 +1,32 @@
+/// <reference path="../pb_data/types.d.ts" />
+// push_subscriptions and user_preferences originally shipped with a createRule
+// of just `@request.auth.id != ""`, which let any authed user create a row
+// owned by *another* user (the `user` relation was never pinned to the caller).
+// For push_subscriptions that enabled a cross-user push hijack: an attacker
+// could POST a subscription row with `user = <victim>` and an attacker-owned
+// endpoint, and push.SendToUser would then deliver the victim's content to the
+// attacker. Pin both createRules so the row's `user` must equal the authed id.
+migrate(
+    app => {
+        const pinnedRule = '@request.auth.id != "" && user = @request.auth.id'
+
+        const pushSubs = app.findCollectionByNameOrId('push_subscriptions')
+        pushSubs.createRule = pinnedRule
+        app.save(pushSubs)
+
+        const userPrefs = app.findCollectionByNameOrId('user_preferences')
+        userPrefs.createRule = pinnedRule
+        app.save(userPrefs)
+    },
+    app => {
+        const originalRule = '@request.auth.id != ""'
+
+        const pushSubs = app.findCollectionByNameOrId('push_subscriptions')
+        pushSubs.createRule = originalRule
+        app.save(pushSubs)
+
+        const userPrefs = app.findCollectionByNameOrId('user_preferences')
+        userPrefs.createRule = originalRule
+        app.save(userPrefs)
+    }
+)


### PR DESCRIPTION
## Problem
`push_subscriptions` and `user_preferences` shipped with `createRule: '@request.auth.id != ""'` — no pin on the `user` relation. Any authed user could create a row owned by *another* user. For `push_subscriptions` this enables a cross-user push hijack: an attacker POSTs a subscription with `user=<victim>` and an attacker-owned endpoint, and `push.SendToUser` then delivers the victim's content to the attacker.

## Fix
New migration `1920000000_pin_createrule_user.js` tightens both createRules to `@request.auth.id != "" && user = @request.auth.id`. The historical `1700000000_*` migration is left untouched (already ran on live DBs). `down` restores the original rule.