### PR TITLE
fix: scrub credential keys and ?token= values in Sentry

### DIFF
--- a/core/lib/sentry-scrub.test.ts
+++ b/core/lib/sentry-scrub.test.ts
@@ -50,4 +50,52 @@ describe('scrubPII', () => {
         expect(PII_KEY_PATTERN.test('USER_EMAIL')).toBe(true)
         expect(PII_KEY_PATTERN.test('orgId')).toBe(false)
     })
+
+    it('scrubs credential keys', () => {
+        const input = {
+            token: 'abc',
+            password: 'p',
+            secret: 's',
+            authorization: 'Bearer x',
+            apiKey: 'k',
+            api_key: 'k2',
+            s3_key: 'k3',
+            ok: 'keep',
+        }
+        const out = scrubPII(input) as Record<string, unknown>
+        expect(out.ok).toBe('keep')
+        for (const k of [
+            'token',
+            'password',
+            'secret',
+            'authorization',
+            'apiKey',
+            'api_key',
+            's3_key',
+        ]) {
+            expect(out[k]).toBe('[Filtered]')
+        }
+    })
+
+    it('does not over-scrub benign identifier keys', () => {
+        const input = { orgId: '1', monkey: 'ook', keyboard: 'qwerty', id: 'x' }
+        expect(scrubPII(input)).toEqual(input)
+    })
+
+    it('redacts the token in a [share-session, token] queryKey array', () => {
+        expect(scrubPII(['share-session', 'super-secret-token'])).toEqual([
+            'share-session',
+            '[Filtered]',
+        ])
+    })
+
+    it('redacts credential query params in URL string values', () => {
+        const input = { url: 'https://api.example.com/x?token=abc123&keep=1' }
+        const out = scrubPII(input) as Record<string, unknown>
+        expect(out.url).toBe('https://api.example.com/x?token=[Filtered]&keep=1')
+    })
+
+    it('redacts a bare ?token= URL passed as a top-level string', () => {
+        expect(scrubPII('/api/session?token=deadbeef')).toBe('/api/session?token=[Filtered]')
+    })
 })

--- a/core/lib/sentry-scrub.ts
+++ b/core/lib/sentry-scrub.ts
@@ -1,10 +1,48 @@
-export const PII_KEY_PATTERN = /email|body|subject|name|phone|address|content|filename|title/i
+// Keys whose *value* is PII or a credential. The credential group
+// (token/password/secret/authorization/auth/apikey) was added because query
+// errors and fetch breadcrumbs carry secrets — e.g. a `['share-session', token]`
+// queryKey or a `?token=...` URL — that were previously shipped to Sentry raw.
+// `key` is anchored (word-boundary-ish) so it scrubs `apiKey`/`api_key`/`s3_key`
+// without swallowing benign identifiers like `orgId` or `monkey`.
+export const PII_KEY_PATTERN =
+    /email|body|subject|name|phone|address|content|filename|title|token|password|passwd|secret|authorization|auth|apikey|api_key|(?:^|[_-])key(?:$|[_-])|^key$/i
+
+// Credential query-param names whose value must be redacted inside a URL/string,
+// e.g. `https://x/y?token=abc&sig=zzz` -> `?token=[Filtered]&sig=[Filtered]`.
+const CREDENTIAL_PARAM_PATTERN =
+    /([?&#](?:token|access_token|refresh_token|password|passwd|secret|authorization|auth|api[_-]?key|key|sig|signature|code|session)=)([^&#\s]+)/gi
+
+// queryKey arrays put the secret in a positional slot next to a marker string,
+// e.g. `['share-session', '<token>']`. Redact the element(s) following such a
+// marker rather than relying on a key name (there is none in an array).
+const CREDENTIAL_MARKER_PATTERN =
+    /(?:^|[_-])(?:session|token|secret|password|auth|apikey|api_key)(?:$|[_-])/i
 
 const FILTERED = '[Filtered]'
 const CIRCULAR = '[Circular]'
 
+function scrubCredentialsInString(value: string): string {
+    return value.replace(
+        CREDENTIAL_PARAM_PATTERN,
+        (_match, prefix: string) => `${prefix}${FILTERED}`
+    )
+}
+
+function scrubArray(value: unknown[], seen: WeakSet<object>): unknown[] {
+    let redactNext = false
+    return value.map(item => {
+        if (redactNext && typeof item === 'string') {
+            redactNext = false
+            return FILTERED
+        }
+        redactNext = typeof item === 'string' && CREDENTIAL_MARKER_PATTERN.test(item)
+        return scrubPII(item, seen)
+    })
+}
+
 export function scrubPII<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
     if (value === null || value === undefined) return value
+    if (typeof value === 'string') return scrubCredentialsInString(value) as unknown as T
     if (typeof value !== 'object') return value
 
     const obj = value as unknown as object
@@ -14,7 +52,7 @@ export function scrubPII<T>(value: T, seen: WeakSet<object> = new WeakSet()): T 
     seen.add(obj)
 
     if (Array.isArray(value)) {
-        return value.map(item => scrubPII(item, seen)) as unknown as T
+        return scrubArray(value, seen) as unknown as T
     }
 
     const out: Record<string, unknown> = {}


### PR DESCRIPTION
## Problem
`sentry-scrub`'s `PII_KEY_PATTERN` only matched PII key names (`email|name|body|…`) and never touched string *values*. Secrets leaked to Sentry via:
- the `query.error` handler shipping `queryKey` — including `['share-session', <token>]`, where the token sits in a positional array slot behind no key name; and
- fetch/xhr breadcrumbs whose URL string carries `?token=…`.

## Fix
- Extended `PII_KEY_PATTERN` with `token|password|passwd|secret|authorization|auth|apikey|api_key` and an anchored `key` (matches `apiKey`/`api_key`/`s3_key`, not `orgId`/`monkey`).
- `scrubPII` now also scrubs string values: credential query params (`?token=abc` → `?token=[Filtered]`).
- Array scrubbing redacts the element after a credential marker, so `['share-session', token]` → `['share-session', '[Filtered]']`.
- Added unit tests for all of the above (11 tests, was 6).