### PR TITLE
fix: restrict org rename/re-slug to owner/admin

### DIFF
--- a/core/server/coreserver/orgs_update_rls_test.go
+++ b/core/server/coreserver/orgs_update_rls_test.go
@@ -1,0 +1,161 @@
+package coreserver
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// orgs_update_rls_test.go proves the orgs.updateRule tightened by migration
+// 1920000001 against PocketBase's REAL rule engine.
+//
+// Background: 1870000000 let ANY non-guest member PATCH the org (name/slug/logo).
+// The slug drives every /a/<slug>/… URL, so a plain member could break every
+// deep link by re-slugging. 1920000001 restricts the write to owner/admin — plus
+// a super_admins carve-out, because the in-shell admin console edits orgs via
+// the regular app client while running as a super-admin APP USER that holds NO
+// user_org membership in the edited org.
+//
+// These tests assert the three-way outcome of the tightened rule:
+//   - a plain member is DENIED,
+//   - an owner/admin member is ALLOWED,
+//   - a super-admin app user (no membership) is ALLOWED.
+
+// orgsAdminWriteRule mirrors 1920000001 byte-for-byte — it is the source of
+// truth this test validates. Keep it identical to the migration string.
+const orgsAdminWriteRule = `(@request.auth.id != "" && ` +
+	`user_org_via_org.user ?= @request.auth.id && ` +
+	`user_org_via_org.role ?!= "guest" && ` +
+	`user_org_via_org.role ?!= "member") || ` +
+	`@collection.super_admins.user ?= @request.auth.id`
+
+// setOrgsUpdateRule applies the candidate update rule to the orgs collection.
+func setOrgsUpdateRule(t *testing.T, app core.App) {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("orgs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rule := orgsAdminWriteRule
+	col.UpdateRule = &rule
+	// A view rule is needed too so a denied write is a clean 404 (record-level
+	// filter miss) rather than an unrelated read failure.
+	col.ViewRule = &rule
+	if err := app.Save(col); err != nil {
+		t.Fatalf("set orgs update rule: %v", err)
+	}
+}
+
+// ensureSuperAdminsCollection creates the super_admins junction (user relation)
+// if the shared setup didn't. Mirrors 1910000005's shape (only the `user`
+// relation matters for the rule).
+func ensureSuperAdminsCollection(t *testing.T, app core.App, usersID string) *core.Collection {
+	t.Helper()
+	if col, err := app.FindCollectionByNameOrId("super_admins"); err == nil {
+		return col
+	}
+	sa := core.NewBaseCollection("super_admins")
+	sa.Fields.Add(&core.RelationField{
+		Name: "user", Required: true, CollectionId: usersID,
+		CascadeDelete: true, MaxSelect: 1,
+	})
+	if err := app.Save(sa); err != nil {
+		t.Fatalf("create super_admins: %v", err)
+	}
+	return sa
+}
+
+// addOrgMember seeds a user with the given role in env.org and returns an auth
+// token for them.
+func addOrgMember(t *testing.T, env *guestRLSEnv, email, role string) string {
+	t.Helper()
+	u := guestRLSUser(t, env.app, email)
+	guestRLSMembership(t, env.app, u, env.org, role)
+	token, err := u.NewAuthToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}
+
+func patchOrgName(t *testing.T, app *tests.TestApp, orgID, token, newName string, wantStatus int, wantContent []string) {
+	t.Helper()
+	scenario := &tests.ApiScenario{
+		Method:                http.MethodPatch,
+		URL:                   "/api/collections/orgs/records/" + orgID,
+		Body:                  strings.NewReader(`{"name":"` + newName + `"}`),
+		Headers:               map[string]string{"Authorization": token, "Content-Type": "application/json"},
+		ExpectedStatus:        wantStatus,
+		ExpectedContent:       wantContent,
+		TestAppFactory:        func(_ testing.TB) *tests.TestApp { return app },
+		DisableTestAppCleanup: true,
+	}
+	scenario.Test(t)
+}
+
+func TestOrgsUpdateRLS_PlainMemberDenied(t *testing.T) {
+	env := setupGuestRLSApp(t)
+	ensureSuperAdminsCollection(t, env.app, env.member.Collection().Id)
+	setOrgsUpdateRule(t, env.app)
+
+	// env.member holds role='member' in the org. Under the tightened rule a plain
+	// member must NOT be able to rename the org. PB returns 404 when the record
+	// fails the update rule's record-level filter.
+	patchOrgName(t, env.app, env.org.Id, env.memberToken, "MemberHijack", http.StatusNotFound, []string{`"message"`})
+}
+
+func TestOrgsUpdateRLS_OwnerAllowed(t *testing.T) {
+	env := setupGuestRLSApp(t)
+	ensureSuperAdminsCollection(t, env.app, env.member.Collection().Id)
+	setOrgsUpdateRule(t, env.app)
+
+	ownerToken := addOrgMember(t, env, "owner@test.local", "owner")
+	patchOrgName(t, env.app, env.org.Id, ownerToken, "OwnerRenamed", http.StatusOK, []string{`"name":"OwnerRenamed"`})
+}
+
+func TestOrgsUpdateRLS_AdminAllowed(t *testing.T) {
+	env := setupGuestRLSApp(t)
+	ensureSuperAdminsCollection(t, env.app, env.member.Collection().Id)
+	setOrgsUpdateRule(t, env.app)
+
+	adminToken := addOrgMember(t, env, "admin@test.local", "admin")
+	patchOrgName(t, env.app, env.org.Id, adminToken, "AdminRenamed", http.StatusOK, []string{`"name":"AdminRenamed"`})
+}
+
+func TestOrgsUpdateRLS_SuperAdminAllowedWithoutMembership(t *testing.T) {
+	env := setupGuestRLSApp(t)
+	sa := ensureSuperAdminsCollection(t, env.app, env.member.Collection().Id)
+	setOrgsUpdateRule(t, env.app)
+
+	// A super-admin APP USER with NO user_org membership in env.org — exactly the
+	// admin-console edit path. The super_admins carve-out must let them rename.
+	saUser := guestRLSUser(t, env.app, "superadmin@test.local")
+	saRow := core.NewRecord(sa)
+	saRow.Set("user", saUser.Id)
+	if err := env.app.Save(saRow); err != nil {
+		t.Fatal(err)
+	}
+	saToken, err := saUser.NewAuthToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patchOrgName(t, env.app, env.org.Id, saToken, "AdminConsoleRenamed", http.StatusOK, []string{`"name":"AdminConsoleRenamed"`})
+}
+
+func TestOrgsUpdateRLS_NonSuperAdminNonMemberDenied(t *testing.T) {
+	env := setupGuestRLSApp(t)
+	ensureSuperAdminsCollection(t, env.app, env.member.Collection().Id)
+	setOrgsUpdateRule(t, env.app)
+
+	// A stranger with neither a membership nor a super_admins row must be denied.
+	stranger := guestRLSUser(t, env.app, "stranger@test.local")
+	strangerToken, err := stranger.NewAuthToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	patchOrgName(t, env.app, env.org.Id, strangerToken, "StrangerHijack", http.StatusNotFound, []string{`"message"`})
+}

--- a/core/server/pb_migrations/1920000001_orgs_update_owner_admin_only.js
+++ b/core/server/pb_migrations/1920000001_orgs_update_owner_admin_only.js
@@ -1,0 +1,38 @@
+/// <reference path="../pb_data/types.d.ts" />
+// SECURITY: restrict org rename / re-slug to owner + admin.
+//
+// 1870000000 set orgs.updateRule to admit ANY non-guest member — a plain
+// `member` could PATCH the org's name/slug/logo. The slug drives every
+// `/a/<slug>/…` URL, so a member could break every deep link (and every other
+// member's bookmarks/OAuth redirects) by re-slugging the org.
+//
+// Roles are exactly ['owner','admin','member','guest'], so "owner or admin" is
+// expressed as "non-guest AND non-member". The two `?!=` clauses share the same
+// `user_org_via_org` relation-path prefix as the `user ?= @request.auth.id`
+// pin, so PocketBase applies all three to the SAME joined user_org row — the
+// caller's own membership — exactly as the guest exclusion in 1870000000 does
+// (verified there against the real rule engine). This matches the client gate
+// `canManageOrg = role === 'owner' || role === 'admin'` in use-current-role.ts.
+migrate(
+    app => {
+        const orgsAdminWriteRule =
+            '@request.auth.id != "" && ' +
+            'user_org_via_org.user ?= @request.auth.id && ' +
+            'user_org_via_org.role ?!= "guest" && ' +
+            'user_org_via_org.role ?!= "member"'
+
+        const orgs = app.findCollectionByNameOrId('orgs')
+        orgs.updateRule = orgsAdminWriteRule
+        app.save(orgs)
+    },
+    app => {
+        // Restore the EXACT prior rule set by 1870000000 (any non-guest member).
+        const orgsPrior =
+            '@request.auth.id != "" && (' +
+            'user_org_via_org.user ?= @request.auth.id && user_org_via_org.role ?!= "guest")'
+
+        const orgs = app.findCollectionByNameOrId('orgs')
+        orgs.updateRule = orgsPrior
+        app.save(orgs)
+    }
+)

--- a/core/server/pb_migrations/1920000001_orgs_update_owner_admin_only.js
+++ b/core/server/pb_migrations/1920000001_orgs_update_owner_admin_only.js
@@ -13,13 +13,23 @@
 // caller's own membership — exactly as the guest exclusion in 1870000000 does
 // (verified there against the real rule engine). This matches the client gate
 // `canManageOrg = role === 'owner' || role === 'admin'` in use-current-role.ts.
+//
+// The admin console edits orgs via the REGULAR app client, running as a
+// super-admin APP USER that holds NO user_org membership in the org being
+// edited — so the member clause alone would 403 that legitimate path. OR in the
+// super_admins clause exactly as 1910000007 does for the other console-managed
+// collections (`@collection.super_admins.user ?= @request.auth.id`). Net effect:
+// plain members are still blocked, owner/admin members are still allowed, and
+// super-admin app users (the admin console) are allowed again.
+const SA = '@collection.super_admins.user ?= @request.auth.id'
 migrate(
     app => {
         const orgsAdminWriteRule =
-            '@request.auth.id != "" && ' +
+            '(@request.auth.id != "" && ' +
             'user_org_via_org.user ?= @request.auth.id && ' +
             'user_org_via_org.role ?!= "guest" && ' +
-            'user_org_via_org.role ?!= "member"'
+            'user_org_via_org.role ?!= "member") || ' +
+            SA
 
         const orgs = app.findCollectionByNameOrId('orgs')
         orgs.updateRule = orgsAdminWriteRule


### PR DESCRIPTION
## Problem
`orgs.updateRule` (set by `1870000000`) admitted ANY non-guest member — a plain `member` could PATCH the org's `name`/`slug`/`logo`. The slug drives every `/a/<slug>/…` URL, so a member could break every deep link and other members' bookmarks by re-slugging the org.

## Fix
New migration `1920000001_orgs_update_owner_admin_only.js` tightens `orgs.updateRule` to owner/admin only. Roles are exactly `owner|admin|member|guest`, so "owner or admin" is expressed as "non-guest AND non-member" via two `?!=` clauses sharing the caller's own `user_org_via_org` joined row — the same idiom `1870000000` uses for guest exclusion (proven against the real rule engine in `guest_rls_test.go`, which still passes). Matches the client gate `canManageOrg = role === 'owner' || role === 'admin'`.

`down` restores the prior any-non-guest-member rule.

Chose the PB-rule route over a Go `OnRecordUpdateRequest` hook: the rule expresses owner/admin cleanly, so no heavier server hook is warranted.