### PR TITLE
fix: tear down push subscription on logout

### DIFF
--- a/core/lib/expo-push.ts
+++ b/core/lib/expo-push.ts
@@ -38,3 +38,35 @@ export async function registerExpoPushToken(userId: string): Promise<boolean> {
         return false
     }
 }
+
+// Tear down this device's Expo push registration on logout: delete the
+// server push_subscriptions row(s) for this user's Expo token so the backend
+// stops pushing to a device the user has signed out of. A no-op on web (no
+// Expo token) and best-effort — a teardown failure must never block logout.
+//
+// `authToken` is passed explicitly (rather than read from pb.authStore) so the
+// caller can run teardown as part of logout without racing pb.authStore.clear():
+// we send it as the Authorization header so the delete is authorized even once
+// the store has been cleared.
+export async function unregisterExpoPushToken(userId: string, authToken?: string): Promise<void> {
+    if (Platform.OS === 'web') return
+
+    const authOptions = authToken ? { headers: { Authorization: authToken } } : {}
+    try {
+        const Notifications = await import('expo-notifications')
+        const tokenData = await Notifications.getExpoPushTokenAsync()
+        const token = tokenData.data
+
+        // biome-ignore lint/plugin/pbtsdb-no-raw-pb-access: imperative push-teardown util (not a React hook); pairs with registerExpoPushToken above.
+        const records = await pb.collection('push_subscriptions').getFullList({
+            ...authOptions,
+            filter: `user = "${userId}" && platform = "expo" && expo_token = "${token}"`,
+        })
+        for (const record of records) {
+            // biome-ignore lint/plugin/pbtsdb-no-raw-pb-access: imperative push-teardown util (not a React hook); pairs with registerExpoPushToken above.
+            await pb.collection('push_subscriptions').delete(record.id, authOptions)
+        }
+    } catch {
+        // Best-effort: a failed teardown must never block logout.
+    }
+}

--- a/core/lib/pocketbase.ts
+++ b/core/lib/pocketbase.ts
@@ -367,8 +367,11 @@ export async function clearStores() {
 // holds their file token (['pb-files-token'] in use-authed-file-url.ts) —
 // which authorizes file reads as that user. Runs from the auth-store's
 // logout(), which disconnectServer() also routes through.
-// TODO: web-push subscription teardown (review §4.12) belongs here once
-// implemented — unsubscribe the device before the session is dropped.
+//
+// Push subscription teardown is NOT done here: it needs the userId and an
+// authorized PB session, both of which are gone by the time resetSessionState
+// runs (logout() clears pb.authStore first). The auth-store's logout() tears
+// down push explicitly, before the auth clear — see teardownPushOnLogout.
 export async function resetSessionState() {
     await clearStores()
     queryClient.clear()

--- a/core/lib/stores/auth-store.ts
+++ b/core/lib/stores/auth-store.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { captureException } from '@tinycld/core/lib/errors'
+import { unregisterExpoPushToken } from '@tinycld/core/lib/expo-push'
 import {
     authStoreReady,
     fetchAndSeedUserOrg,
@@ -13,7 +14,10 @@ import {
 import { create } from '@tinycld/core/lib/store'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import type { UserSession } from '@tinycld/core/lib/types'
+import { resetExpoPushRegistration } from '@tinycld/core/lib/use-expo-push-registration'
+import { isPushSupported, unsubscribeFromPush } from '@tinycld/core/lib/web-push'
 import type { Orgs, UserOrg, Users } from '@tinycld/core/types/pbSchema'
+import { Platform } from 'react-native'
 
 interface UserOrgExpanded extends UserOrg {
     expand?: { org?: Orgs }
@@ -53,6 +57,22 @@ async function clearPrimaryOrgStorage(): Promise<void> {
     } catch {
         // Storage might not be available
     }
+}
+
+// Tear down the device's push subscription on logout: remove the browser/device
+// push registration AND delete the matching server push_subscriptions row, so a
+// signed-out device stops receiving pushes. Resetting resetExpoPushRegistration()
+// clears the module-lifetime guard so a second user signing in on the same
+// running session re-registers their own token (otherwise the guard would
+// suppress it). Best-effort: platform push helpers already swallow their own
+// errors, and any failure here must never block logout.
+async function teardownPushOnLogout(userId: string, authToken: string): Promise<void> {
+    if (Platform.OS === 'web') {
+        if (isPushSupported()) await unsubscribeFromPush(userId, authToken)
+    } else {
+        await unregisterExpoPushToken(userId, authToken)
+    }
+    resetExpoPushRegistration()
 }
 
 type RequestOtpResult = {
@@ -194,7 +214,22 @@ export const useAuthStore = create<AuthStoreState>()((set, get) => ({
     },
 
     logout: () => {
+        // Capture the userId + token while pb.authStore is still authed — push
+        // teardown deletes this user's server subscription row and needs both.
+        // The token is forwarded as an Authorization header inside teardown so
+        // the delete stays authorized after pb.authStore.clear() below (which
+        // runs synchronously, before teardown's async PB requests dispatch).
+        const userId = get().user?.id
+        const authToken = pb.authStore.token
         pb.realtime.unsubscribe()
+        // Fire-and-forget push teardown: unsubscribe the device and delete the
+        // server push_subscriptions row, then reset the module-lifetime
+        // registration guard so a second user on this same session re-registers.
+        if (userId) {
+            teardownPushOnLogout(userId, authToken).catch(err =>
+                captureException('auth-store.logout teardownPush', err)
+            )
+        }
         pb.authStore.clear()
         clearPrimaryOrgStorage()
         // Wipe per-device rail deep-links so a second user signing in on

--- a/core/lib/use-expo-push-registration.ts
+++ b/core/lib/use-expo-push-registration.ts
@@ -1,15 +1,25 @@
 import { useAuth } from '@tinycld/core/lib/auth'
 import { registerExpoPushToken } from '@tinycld/core/lib/expo-push'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { Platform } from 'react-native'
+
+// Module-lifetime guard so we register the device's push token at most once
+// per app session, even as the hook re-mounts across route changes. It's
+// module-scoped (not a component ref) so logout can reset it — otherwise a
+// second user signing in on the same running SPA/app would never get their
+// own registration. resetExpoPushRegistration() clears it from logout.
+let registered = false
+
+export function resetExpoPushRegistration(): void {
+    registered = false
+}
 
 export function useExpoPushRegistration() {
     const { user } = useAuth()
-    const registered = useRef(false)
 
     useEffect(() => {
-        if (Platform.OS === 'web' || registered.current || !user?.id) return
-        registered.current = true
+        if (Platform.OS === 'web' || registered || !user?.id) return
+        registered = true
         registerExpoPushToken(user.id)
     }, [user?.id])
 }

--- a/core/lib/web-push.ts
+++ b/core/lib/web-push.ts
@@ -51,7 +51,12 @@ export async function subscribeToPush(userId: string): Promise<boolean> {
     return true
 }
 
-export async function unsubscribeFromPush(userId: string): Promise<void> {
+// `authToken` is passed explicitly (rather than read from pb.authStore) so the
+// caller can run teardown as part of logout without racing pb.authStore.clear():
+// when provided it's sent as the Authorization header so the delete is
+// authorized even once the store has been cleared. The in-app settings toggle
+// omits it and relies on the live session.
+export async function unsubscribeFromPush(userId: string, authToken?: string): Promise<void> {
     if (!isPushSupported()) return
 
     const registration = await navigator.serviceWorker.ready
@@ -59,14 +64,16 @@ export async function unsubscribeFromPush(userId: string): Promise<void> {
     if (subscription) {
         await subscription.unsubscribe()
 
+        const authOptions = authToken ? { headers: { Authorization: authToken } } : {}
         const { pb } = await import('./pocketbase')
         // biome-ignore lint/plugin/pbtsdb-no-raw-pb-access: imperative ServiceWorker unsubscribe util (not a React hook); pb is lazy-imported to break a require cycle.
         const records = await pb.collection('push_subscriptions').getFullList({
+            ...authOptions,
             filter: `user = "${userId}" && endpoint = "${subscription.endpoint}"`,
         })
         for (const record of records) {
             // biome-ignore lint/plugin/pbtsdb-no-raw-pb-access: imperative ServiceWorker unsubscribe util (not a React hook); pairs with subscribeToPush above.
-            await pb.collection('push_subscriptions').delete(record.id)
+            await pb.collection('push_subscriptions').delete(record.id, authOptions)
         }
     }
 }


### PR DESCRIPTION
Completes the push-teardown TODO left by #97's `resetSessionState()`.

On logout, before `pb.authStore.clear()`, we now:
- delete the server `push_subscriptions` row for the signed-out user (web: by endpoint; native: by Expo token) and unsubscribe the browser/device push registration;
- reset the module-lifetime registration guard in `useExpoPushRegistration` so a second user signing in on the same running session registers their own token.

The auth token is captured before the clear and forwarded as an `Authorization` header so the delete stays authorized despite the synchronous auth clear. Teardown is best-effort and never blocks logout.