### PR TITLE
fix: throw AuthRequiredError instead of fabricating an anon user

### DIFF
--- a/core/lib/auth.tsx
+++ b/core/lib/auth.tsx
@@ -78,12 +78,13 @@ export function useAuth(options?: {
         : { login, logout, user: null, isLoggedIn: false, isInitializing: !hasHydrated }
 
     if (throwIfAnon) {
+        // The throwIfAnon contract is "the caller requires an authenticated
+        // user". When there is none we throw AuthRequiredError so the nearest
+        // error boundary handles it, rather than fabricating a blank-id user
+        // that downstream hooks would run queries against (user.id === '').
+        // Anon-allowed callers pass throwIfAnon: false and are unaffected.
         if (!context.user) {
-            return {
-                ...context,
-                isLoggedIn: false,
-                user: { id: '', name: '', email: '', isDemo: false },
-            } as unknown as AuthenticatedContext
+            throw new AuthRequiredError()
         }
         return context as AuthenticatedContext
     }

--- a/core/lib/use-user-preference.ts
+++ b/core/lib/use-user-preference.ts
@@ -11,7 +11,13 @@ export function useUserPreference<T>(
     key: string,
     defaultValue: T
 ): readonly [T, (newValue: T) => void] {
-    const { user } = useAuth()
+    // Anon-tolerant: this hook runs in the theme/color path (useColorTheme →
+    // useUserPreference), which mounts on every screen INCLUDING the pre-auth
+    // login screen. Passing throwIfAnon: false keeps it from throwing before
+    // anyone is authed; when anon we skip the user-scoped query and return the
+    // caller's default. Mirrors use-theme-preference.ts.
+    const { user, isLoggedIn } = useAuth({ throwIfAnon: false })
+    const userId = user?.id ?? ''
     const [userPreferencesCollection] = useStore('user_preferences')
 
     const { data: rows } = useLiveQuery(
@@ -22,13 +28,13 @@ export function useUserPreference<T>(
                     and(
                         eq(user_preferences.app, app),
                         eq(user_preferences.key, key),
-                        eq(user_preferences.user, user.id)
+                        eq(user_preferences.user, userId)
                     )
                 ),
-        [app, key, user.id]
+        [app, key, userId]
     )
 
-    const existing = rows?.[0]
+    const existing = isLoggedIn ? rows?.[0] : undefined
     const value = existing ? (existing.value as T) : defaultValue
 
     // Re-resolve the row at mutation time rather than capturing the render-time
@@ -39,6 +45,7 @@ export function useUserPreference<T>(
     // back, manifesting as the UI flipping to the new value and snapping back.
     const upsert = useMutation({
         mutationFn: mutation(function* (newValue: T) {
+            if (!user) return
             const current = userPreferencesCollection.toArray.find(
                 r => r.app === app && r.key === key && r.user === user.id
             )
@@ -60,9 +67,11 @@ export function useUserPreference<T>(
 
     const setValue = useCallback(
         (newValue: T) => {
+            // No-op when anon: there's no user to scope the preference to.
+            if (!isLoggedIn) return
             upsert.mutate(newValue)
         },
-        [upsert]
+        [isLoggedIn, upsert]
     )
 
     return [value, setValue] as const

--- a/core/lib/use-user-preferences.ts
+++ b/core/lib/use-user-preferences.ts
@@ -4,7 +4,11 @@ import { useAuth } from '@tinycld/core/lib/auth'
 import { useStore } from '@tinycld/core/lib/pocketbase'
 
 export function useUserPreferences(app: string) {
-    const { user } = useAuth()
+    // Anon-tolerant to match useUserPreference: user-scoped preference hooks may
+    // mount before login (the theme/color path renders on the pre-auth screen),
+    // so we must not throw when anon — skip the query and return no rows.
+    const { user, isLoggedIn } = useAuth({ throwIfAnon: false })
+    const userId = user?.id ?? ''
     const [userPreferencesCollection] = useStore('user_preferences')
 
     const { data: preferences } = useLiveQuery(
@@ -12,10 +16,10 @@ export function useUserPreferences(app: string) {
             query
                 .from({ user_preferences: userPreferencesCollection })
                 .where(({ user_preferences }) =>
-                    and(eq(user_preferences.app, app), eq(user_preferences.user, user.id))
+                    and(eq(user_preferences.app, app), eq(user_preferences.user, userId))
                 ),
-        [app, user.id]
+        [app, userId]
     )
 
-    return preferences ?? []
+    return isLoggedIn ? (preferences ?? []) : []
 }


### PR DESCRIPTION
`useAuth({ throwIfAnon: true })` (the default overload) fabricated a `{ id: '', name: '', email: '' }` user via `as unknown as AuthenticatedContext` when anon, so the exported `AuthRequiredError` was never thrown and downstream hooks ran queries against `user.id === ''`.

Now it throws `AuthRequiredError` when anon, letting the nearest error boundary (root `AppErrorBoundary`, wired via Expo Router's per-route `ErrorBoundary`) handle it. The `throwIfAnon: true` overload is the "must be authed" contract; anon-allowed callers use `throwIfAnon: false` and are unaffected. Authed paths are unchanged. All org-scoped default-`useAuth()` callers render only inside the authed org gate, and public/share routes use `throwIfAnon: false`.