### PR TITLE
fix: robustly detect generator mutationFns (avoid silent no-persist)

### DIFF
--- a/core/lib/__tests__/mutations.test.tsx
+++ b/core/lib/__tests__/mutations.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+// Guards the generator-vs-async detection in useMutation. The detection must
+// key off the RETURNED iterator, not mutationFn.constructor.name — otherwise a
+// wrapped generator (a decorator, a wrapping closure, or Babel's regenerator
+// transpile that turns a generator into a plain fn returning a runtime iterator)
+// is misclassified as an async fn, its raw generator is returned unconsumed,
+// and NO transaction is ever awaited (a mutation that "succeeds" without
+// persisting).
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { useMutation } from '../mutations'
+
+function wrapper() {
+    const client = new QueryClient({
+        defaultOptions: { mutations: { retry: false } },
+    })
+    return ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+}
+
+// A stand-in for a pbtsdb Transaction: performMutations awaits `isPersisted.promise`.
+function fakeTransaction() {
+    let resolvePersist!: () => void
+    const promise = new Promise<void>(resolve => {
+        resolvePersist = resolve
+    })
+    return { tx: { isPersisted: { promise } }, resolvePersist }
+}
+
+describe('useMutation generator detection', () => {
+    it('awaits yielded transactions for a plain generator mutationFn', async () => {
+        const { tx, resolvePersist } = fakeTransaction()
+        const afterYield = vi.fn()
+
+        const { result } = renderHook(
+            () =>
+                useMutation({
+                    mutationFn: function* () {
+                        // @ts-expect-error test transaction stub
+                        yield tx
+                        afterYield()
+                        return 'done'
+                    },
+                }),
+            { wrapper: wrapper() }
+        )
+
+        result.current.mutate()
+
+        // The generator must be SUSPENDED at the yield until the transaction persists.
+        await Promise.resolve()
+        expect(afterYield).not.toHaveBeenCalled()
+
+        resolvePersist()
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(afterYield).toHaveBeenCalledTimes(1)
+        expect(result.current.data).toBe('done')
+    })
+
+    it('still awaits transactions when the mutationFn is a plain fn returning an iterator (transpiled/wrapped)', async () => {
+        const { tx, resolvePersist } = fakeTransaction()
+        const afterYield = vi.fn()
+
+        function* gen() {
+            // @ts-expect-error test transaction stub
+            yield tx
+            afterYield()
+            return 'wrapped-done'
+        }
+
+        // The real-world failure mode (Babel regenerator transpile, a decorator,
+        // or a wrapping closure): mutationFn is a PLAIN function — its
+        // constructor.name is 'Function', not 'GeneratorFunction', so the old
+        // check misclassified it as async — but calling it returns an iterator.
+        // The robust detection must key off that returned iterator.
+        const wrappedGen = (...args: []) => gen(...args)
+        expect(wrappedGen.constructor.name).toBe('Function')
+
+        const { result } = renderHook(() => useMutation({ mutationFn: wrappedGen }), {
+            wrapper: wrapper(),
+        })
+
+        result.current.mutate()
+
+        await Promise.resolve()
+        expect(afterYield).not.toHaveBeenCalled()
+
+        resolvePersist()
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        // If the wrapped generator were misclassified as async, the raw
+        // generator object would be returned unconsumed: afterYield would never
+        // run and data would be the iterator, not its return value.
+        expect(afterYield).toHaveBeenCalledTimes(1)
+        expect(result.current.data).toBe('wrapped-done')
+    })
+
+    it('awaits a plain async mutationFn without treating it as a generator', async () => {
+        const asyncFn = vi.fn(async () => 'async-done')
+
+        const { result } = renderHook(() => useMutation({ mutationFn: asyncFn }), {
+            wrapper: wrapper(),
+        })
+
+        result.current.mutate()
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(asyncFn).toHaveBeenCalledTimes(1)
+        expect(result.current.data).toBe('async-done')
+    })
+})

--- a/core/lib/__tests__/mutations.test.tsx
+++ b/core/lib/__tests__/mutations.test.tsx
@@ -8,6 +8,7 @@
 // and NO transaction is ever awaited (a mutation that "succeeds" without
 // persisting).
 
+import type { Transaction } from '@tanstack/react-db'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
@@ -23,13 +24,18 @@ function wrapper() {
     )
 }
 
-// A stand-in for a pbtsdb Transaction: performMutations awaits `isPersisted.promise`.
+type FakeTransaction = Transaction<Record<string, unknown>>
+
+// A stand-in for a pbtsdb Transaction: the mutation machinery only touches
+// `isPersisted.promise`, so we stub that and cast to Transaction to satisfy the
+// GeneratorMutationFn yield type (the generators below must typecheck).
 function fakeTransaction() {
     let resolvePersist!: () => void
     const promise = new Promise<void>(resolve => {
         resolvePersist = resolve
     })
-    return { tx: { isPersisted: { promise } }, resolvePersist }
+    const tx = { isPersisted: { promise } } as unknown as FakeTransaction
+    return { tx, resolvePersist }
 }
 
 describe('useMutation generator detection', () => {
@@ -41,7 +47,6 @@ describe('useMutation generator detection', () => {
             () =>
                 useMutation({
                     mutationFn: function* () {
-                        // @ts-expect-error test transaction stub
                         yield tx
                         afterYield()
                         return 'done'
@@ -67,7 +72,6 @@ describe('useMutation generator detection', () => {
         const afterYield = vi.fn()
 
         function* gen() {
-            // @ts-expect-error test transaction stub
             yield tx
             afterYield()
             return 'wrapped-done'

--- a/core/lib/mutations.ts
+++ b/core/lib/mutations.ts
@@ -16,15 +16,18 @@ import {
  * })
  * ```
  */
-export async function performMutations<TResult = void>(
-    fn: () => Generator<
-        Transaction<Record<string, unknown>> | Transaction<Record<string, unknown>>[],
-        TResult,
-        void
-    >
-): Promise<TResult> {
-    const gen = fn()
+type TransactionYield =
+    | Transaction<Record<string, unknown>>
+    | Transaction<Record<string, unknown>>[]
 
+// Drive a Transaction-yielding generator to completion, awaiting each yielded
+// Transaction (or array, in parallel) before resuming. Takes an already-created
+// iterator so callers that must invoke the generator fn exactly once (to detect
+// whether it IS a generator by inspecting its return value) can hand the result
+// straight in without re-invoking.
+async function drainTransactions<TResult>(
+    gen: Generator<TransactionYield, TResult, void>
+): Promise<TResult> {
     let result = gen.next()
     while (!result.done) {
         const value = result.value
@@ -37,6 +40,34 @@ export async function performMutations<TResult = void>(
     }
 
     return result.value
+}
+
+export async function performMutations<TResult = void>(
+    fn: () => Generator<
+        Transaction<Record<string, unknown>> | Transaction<Record<string, unknown>>[],
+        TResult,
+        void
+    >
+): Promise<TResult> {
+    return drainTransactions(fn())
+}
+
+// A generator's return value is an iterator: it has both `.next()` and is
+// iterable via Symbol.iterator. Duck-typing on the RETURNED object is robust
+// where `mutationFn.constructor.name === 'GeneratorFunction'` is not — a
+// decorator, a wrapping closure, or Babel's regenerator transpile (which turns
+// a generator into a plain function whose call returns a runtime iterator) all
+// leave a fn whose constructor.name is 'Function', which the old check treated
+// as async — returning the raw generator unconsumed so NO transaction was ever
+// awaited (a mutation that "succeeds" without persisting).
+function isTransactionGenerator(
+    value: unknown
+): value is Generator<TransactionYield, unknown, void> {
+    return (
+        value != null &&
+        typeof (value as Iterator<unknown>).next === 'function' &&
+        typeof (value as Iterable<unknown>)[Symbol.iterator] === 'function'
+    )
 }
 
 type GeneratorMutationFn<TData, TVariables> = (
@@ -116,17 +147,28 @@ export function useMutation<TData = unknown, TError = Error, TVariables = void>(
 ): UseMutationResult<TData, TError, TVariables> {
     const { mutationFn, ...restOptions } = options
 
-    const isGeneratorFn = mutationFn && mutationFn.constructor.name === 'GeneratorFunction'
-
-    const wrappedOptions = isGeneratorFn
-        ? {
-              ...restOptions,
-              mutationFn: (variables: TVariables) =>
-                  performMutations(() =>
-                      (mutationFn as GeneratorMutationFn<TData, TVariables>)(variables)
-                  ),
+    // A single wrapper that decides generator-vs-async by INVOKING the fn once
+    // and inspecting what it returns — not by the fragile constructor.name of
+    // the fn itself. The fn is called exactly once per mutation run (no
+    // double-invocation of a non-idempotent async fn): a generator's call is
+    // side-effect free until driven, so calling it here to test the result is
+    // safe, and an async fn's returned promise is awaited directly.
+    const wrappedMutationFn = mutationFn
+        ? async (variables: TVariables): Promise<TData> => {
+              const result = (
+                  mutationFn as (
+                      v: TVariables
+                  ) => ReturnType<GeneratorMutationFn<TData, TVariables>>
+              )(variables)
+              if (isTransactionGenerator(result)) {
+                  return drainTransactions(result) as Promise<TData>
+              }
+              return result as unknown as Promise<TData>
           }
-        : (options as AsyncMutationOptions<TData, TError, TVariables>)
+        : undefined
 
-    return useTanStackMutation(wrappedOptions)
+    return useTanStackMutation({
+        ...restOptions,
+        mutationFn: wrappedMutationFn,
+    } as UseMutationOptions<TData, TError, TVariables>)
 }


### PR DESCRIPTION
`useMutation` decided generator-vs-async via `mutationFn.constructor.name === 'GeneratorFunction'`. Any wrapping — a decorator, a wrapping closure, or Babel's regenerator transpile (which turns a generator into a plain function returning a runtime iterator) — leaves a fn whose `constructor.name` is `'Function'`, so it was misclassified as async: the raw generator was returned unconsumed and NO transaction was ever awaited (a mutation that "succeeds" without persisting).

Now a single wrapper invokes the fn exactly once and duck-types on the RETURNED value (`typeof result.next === 'function'` && iterable). A returned iterator is driven to completion (`drainTransactions`); anything else (a promise) is awaited directly. No double-invocation of a non-idempotent async fn. Adds a regression test: a plain fn returning a generator iterator still has its yielded transactions awaited and persisted (fails against the old check).