### PR TITLE
fix: stop debug-trace from beaconing in release builds

### DIFF
--- a/core/lib/debug-trace.ts
+++ b/core/lib/debug-trace.ts
@@ -12,14 +12,17 @@ import { Platform } from 'react-native'
 //
 // Fire-and-forget; never throws, never blocks render. REMOVE once the routing
 // bug is found — this is a debug aid, not a shipping feature.
+//
+// Both the console line AND the network beacon are __DEV__-gated: a release
+// build must NEVER beacon (it would POST to /api/app/boot on every trace call,
+// including every navigateToOrg, for all users).
 export function trace(message: string, extra?: Record<string, unknown>): void {
+    if (!__DEV__) return
+
     const serverUrl = getResolvedAddress()
     const line = extra ? `TRACE: ${message} ${JSON.stringify(extra)}` : `TRACE: ${message}`
-    // Always emit to console too (works in dev / on the Metro side).
-    if (__DEV__) {
-        // biome-ignore lint/suspicious/noConsole: temporary debug tracer
-        console.log(`[trace] ${line}`)
-    }
+    // biome-ignore lint/suspicious/noConsole: temporary debug tracer
+    console.log(`[trace] ${line}`)
     if (!serverUrl) return
     void fetch(`${serverUrl}/api/app/boot`, {
         method: 'POST',


### PR DESCRIPTION
The temporary `trace()` tracer only `__DEV__`-gated its console line — the network POST to `/api/app/boot` fired on EVERY call in release builds too (it's wired into every `navigateToOrg` and several route renders), so every user beaconed on every trace.

Gate the whole function on `__DEV__` with an early return, so no beacon fires in a release build (console + fetch are both dev-only now). Kept the module in place rather than removing it: `trace` still has 11 call sites across 6 files that the routing-bug investigation relies on; the file's own note says to remove it once that's found, and that removal is out of scope for this security fix.