### PR TITLE
fix: default-deny package access until access data loads

### DIFF
--- a/app/a/[orgSlug]/index.tsx
+++ b/app/a/[orgSlug]/index.tsx
@@ -1,10 +1,10 @@
 import { trace } from '@tinycld/core/lib/debug-trace'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
-import { useSortedPackages } from '@tinycld/core/lib/use-sorted-packages'
+import { useSortedPackagesResult } from '@tinycld/core/lib/use-sorted-packages'
 import { Redirect } from 'expo-router'
 
 export default function OrgIndex() {
-    const sorted = useSortedPackages()
+    const { packages: sorted, isReady } = useSortedPackagesResult()
     const orgHref = useOrgHref()
     const first = sorted[0]
 
@@ -12,7 +12,14 @@ export default function OrgIndex() {
         sortedCount: sorted.length,
         slugs: sorted.map(p => p.slug),
         firstSlug: first?.slug ?? null,
+        isReady,
     })
+
+    // Access data now default-denies while loading, so an empty list can mean
+    // "still loading" rather than "genuinely nothing". Wait for isReady before
+    // deciding where to land — redirecting to settings prematurely would flash
+    // then bounce to the real package once the registry/overrides arrive.
+    if (!isReady) return null
 
     if (first) {
         const href = orgHref(first.slug as never)
@@ -23,10 +30,9 @@ export default function OrgIndex() {
     // No nav package to land on — a package-less shell, or an org whose only
     // contributors are settings-only (no nav entry). Redirect to settings rather
     // than rendering a dead-end skeleton forever, which left the org root with no
-    // valid child and surfaced as "Unmatched Route" after login. On a build with
-    // packages compiled in, useAccessiblePackages falls back to all of them while
-    // the registry loads, so `sorted` is empty here only when there genuinely is
-    // nothing to show — making the settings redirect safe (no transient flash).
+    // valid child and surfaced as "Unmatched Route" after login. isReady above
+    // guarantees `sorted` is empty here only when there genuinely is nothing to
+    // show — making the settings redirect safe (no transient flash).
     const settingsHref = orgHref('settings' as never)
     trace('OrgIndex redirect to settings (no packages)', { href: JSON.stringify(settingsHref) })
     return <Redirect href={settingsHref} />

--- a/core/lib/use-accessible-packages.ts
+++ b/core/lib/use-accessible-packages.ts
@@ -5,7 +5,18 @@ import { useStore } from '@tinycld/core/lib/pocketbase'
 import { useCurrentRole } from '@tinycld/core/lib/use-current-role'
 import { useOrgLiveQuery } from '@tinycld/core/lib/use-org-live-query'
 
-export function useAccessiblePackages() {
+type AccessiblePackage = ReturnType<typeof usePackages>[number]
+
+export interface AccessiblePackagesResult {
+    packages: AccessiblePackage[]
+    // False until the registry + per-user override queries have all loaded.
+    // Callers that must decide "there is genuinely nothing to show" (e.g. the
+    // org-index settings redirect) should wait for this rather than acting on
+    // the transient empty list during the default-deny load window.
+    isReady: boolean
+}
+
+export function useAccessiblePackagesResult(): AccessiblePackagesResult {
     const packages = usePackages()
     const { role, userOrgId } = useCurrentRole()
     const [orgPkgAccessCollection] = useStore('org_pkg_access')
@@ -13,7 +24,7 @@ export function useAccessiblePackages() {
     const [orgPkgEnabledCollection] = useStore('org_pkg_enabled')
 
     // Global registry: which packages are active (bundled or installed)
-    const { data: registryRecords } = useLiveQuery(
+    const { data: registryRecords, isReady: registryReady } = useLiveQuery(
         query =>
             query
                 .from({ pkg_registry: pkgRegistryCollection })
@@ -22,7 +33,7 @@ export function useAccessiblePackages() {
     )
 
     // Also include 'installed' status packages
-    const { data: installedRecords } = useLiveQuery(
+    const { data: installedRecords, isReady: installedReady } = useLiveQuery(
         query =>
             query
                 .from({ pkg_registry: pkgRegistryCollection })
@@ -40,7 +51,7 @@ export function useAccessiblePackages() {
     )
 
     // User-level access overrides
-    const { data: overrides } = useOrgLiveQuery(
+    const { data: overrides, isReady: overridesReady } = useOrgLiveQuery(
         query =>
             query
                 .from({ org_pkg_access: orgPkgAccessCollection })
@@ -55,24 +66,48 @@ export function useAccessiblePackages() {
     // Build map of org-level disabled packages
     const orgDisabledSlugs = new Set((orgToggles ?? []).filter(t => !t.enabled).map(t => t.pkg))
 
-    // Start with packages that are both compiled-in and active in registry
-    // If the registry has no records yet (first load), fall back to all packages
+    // Start with packages that are both compiled-in and active in registry.
+    // Only fall back to "all compiled-in packages" once the registry queries
+    // have actually LOADED and are legitimately empty — NOT while they're still
+    // loading (empty-on-first-load), which would flash every package before the
+    // registry arrives. Distinguish loaded-and-empty from not-yet-loaded via
+    // isReady rather than the record count.
+    const registryLoaded = registryReady && installedReady
     const hasRegistry = allActiveRecords.length > 0
-    let filtered = hasRegistry ? packages.filter(pkg => activeSlugs.has(pkg.slug)) : packages
+    let filtered =
+        registryLoaded && !hasRegistry
+            ? packages
+            : packages.filter(pkg => activeSlugs.has(pkg.slug))
 
     // Remove org-level disabled packages
     filtered = filtered.filter(pkg => !orgDisabledSlugs.has(pkg.slug))
 
-    // Apply user-level access for non-admins
-    if (role === 'owner' || role === 'admin') return filtered
+    // Admins/owners see everything active; they have no per-user overrides to
+    // wait on, so they're ready as soon as the registry has loaded.
+    if (role === 'owner' || role === 'admin') {
+        return { packages: filtered, isReady: registryLoaded }
+    }
+
+    // Non-admins are gated on BOTH the registry AND their per-user overrides.
+    // Default-DENY until overrides load: an empty overrideMap during the load
+    // window would read as "no restrictions" and flash forbidden packages for a
+    // restricted member/guest, so show nothing until overrides are ready.
+    const isReady = registryLoaded && overridesReady
+    if (!isReady) return { packages: [], isReady: false }
 
     const overrideMap = new Map(
         (overrides ?? []).map(o => [o.pkg, o.access as 'full' | 'readonly' | 'none'])
     )
 
-    return filtered.filter(pkg => {
+    const accessible = filtered.filter(pkg => {
         const access = overrideMap.get(pkg.slug)
         if (role === 'guest') return access === 'full' || access === 'readonly'
         return access !== 'none'
     })
+    return { packages: accessible, isReady: true }
+}
+
+// Backward-compatible array accessor: the accessible package list only.
+export function useAccessiblePackages(): AccessiblePackage[] {
+    return useAccessiblePackagesResult().packages
 }

--- a/core/lib/use-pkg-access.ts
+++ b/core/lib/use-pkg-access.ts
@@ -9,7 +9,7 @@ export function usePkgAccess(pkgSlug: string): PackageAccessLevel {
     const { role, userOrgId } = useCurrentRole()
     const [orgPkgAccessCollection] = useStore('org_pkg_access')
 
-    const { data: overrides } = useLiveQuery(
+    const { data: overrides, isReady } = useLiveQuery(
         query =>
             query
                 .from({ org_pkg_access: orgPkgAccessCollection })
@@ -19,7 +19,15 @@ export function usePkgAccess(pkgSlug: string): PackageAccessLevel {
         [userOrgId, pkgSlug]
     )
 
+    // Owners/admins always have full access — no override row to wait for.
     if (role === 'owner' || role === 'admin') return 'full'
+
+    // Default-DENY until the override query has loaded: a member with a
+    // readonly/none override otherwise reads 'full' during the load window and
+    // flashes forbidden UI. Once loaded we apply the real default (member: full
+    // unless overridden; guest: none unless overridden). The 'none' floor here
+    // is transient — it resolves as soon as the org_pkg_access query is ready.
+    if (!isReady) return 'none'
 
     const override = overrides?.[0]
 

--- a/core/lib/use-sorted-packages.ts
+++ b/core/lib/use-sorted-packages.ts
@@ -1,12 +1,15 @@
-import { useAccessiblePackages } from '@tinycld/core/lib/use-accessible-packages'
+import { useAccessiblePackagesResult } from '@tinycld/core/lib/use-accessible-packages'
 import { useUserPreference } from '@tinycld/core/lib/use-user-preference'
 import { useMemo } from 'react'
 
-export function useSortedPackages() {
-    const packages = useAccessiblePackages()
+// Returns the nav packages in display order PLUS whether the underlying access
+// data has settled. Callers that redirect on an empty list (org-index) must
+// wait for isReady so they don't act on the transient default-deny empty state.
+export function useSortedPackagesResult() {
+    const { packages, isReady } = useAccessiblePackagesResult()
     const [pkgOrder] = useUserPreference('core', 'pkg_order', [] as string[])
 
-    return useMemo(() => {
+    const sorted = useMemo(() => {
         // Packages without a nav entry (e.g. settings-only contributors like
         // google-takeout-import) must not appear in the rail.
         const navPackages = packages.filter(p => p.nav)
@@ -20,4 +23,10 @@ export function useSortedPackages() {
             return aIdx - bIdx
         })
     }, [packages, pkgOrder])
+
+    return { packages: sorted, isReady }
+}
+
+export function useSortedPackages() {
+    return useSortedPackagesResult().packages
 }


### PR DESCRIPTION
Restricted users saw a flash of forbidden packages/UI before access data loaded (server rules still protected the data — this is a UI leak):
- `usePkgAccess` returned `'full'` for a member until the `org_pkg_access` row arrived (no readiness gate).
- `useAccessiblePackages` fell back to ALL packages when the registry query was empty on first load (couldn't tell loading from loaded-and-empty), and its empty override map read as "no restrictions" during load.

Now both gate on `useLiveQuery` `isReady` and default-DENY until loaded: `usePkgAccess` returns `'none'` until ready; `useAccessiblePackages` filters to the registry (empty while loading) and only falls back to all packages when the registry is loaded-and-legitimately-empty, and shows nothing for non-admins until their overrides load. To avoid a premature org-index → settings redirect during the now-empty load window, `useAccessiblePackages`/`useSortedPackages` grew `*Result()` variants exposing `isReady`; `OrgIndex` waits for it. Array accessors stay backward-compatible; legitimately-full users are unaffected once loaded.