### PR TITLE
fix: prune-releases targets /workspace/releases (was a permanent no-op)

### DIFF
--- a/bin/prune-releases.sh
+++ b/bin/prune-releases.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Delete release directories under /app/releases/ older than 7 days,
-# never deleting the one /app/releases/current points at. Scheduled by the
+# Delete release directories under /workspace/releases/ older than 7 days,
+# never deleting the one /workspace/releases/current points at. Scheduled by the
 # deploy platform (e.g. a host cron invoking this inside the app container);
 # the image itself carries no scheduler config.
 #
@@ -16,7 +16,7 @@
 # tracks the build, not the promote.
 set -eu
 
-RELEASES_DIR=/app/releases
+RELEASES_DIR=/workspace/releases
 CURRENT=$(readlink "$RELEASES_DIR/current" 2>/dev/null || true)
 RELEASE_ID_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}-[a-f0-9]+$'
 


### PR DESCRIPTION
`bin/prune-releases.sh` set `RELEASES_DIR=/app/releases`, but the runtime release dir is `/workspace/releases` (see `config/entrypoint.sh`: `--releasesDir=/workspace/releases` and `promote_release`). The scheduled cron always hit the `[ ! -d "$RELEASES_DIR" ]` guard and exited 0, so old release dirs never got pruned and accumulated forever.

Point `RELEASES_DIR` at `/workspace/releases` (and update the header comment to match). No other changes — the rest of the script already references the variable.