### PR TITLE
fix: quote ROOT_PEM path in generate-ssl (breaks on macOS spaces)

### DIFF
--- a/scripts/generate-ssl.sh
+++ b/scripts/generate-ssl.sh
@@ -11,6 +11,6 @@ else
     mkcert -cert-file "$CERT" -key-file "$KEY" localhost 127.0.0.1 ::1
 fi
 
-echo Installing $ROOT_PEM into booted sim
+echo "Installing $ROOT_PEM into booted sim"
 
-xcrun simctl keychain booted add-root-cert $ROOT_PEM
+xcrun simctl keychain booted add-root-cert "$ROOT_PEM"


### PR DESCRIPTION
On macOS, `mkcert -CAROOT` returns `~/Library/Application Support/mkcert` — a path with a space. `ROOT_PEM` was expanded unquoted in the `echo` and `xcrun simctl keychain booted add-root-cert` lines, so it word-split and the command failed on the exact platform (iOS simulator) it targets.

Quote both expansions. All other variable expansions in the script were already quoted.