### PR TITLE
fix: compare ownership against the real run UID/GID, not literal 1000:1000

### DIFF
--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -243,6 +243,12 @@ seed_baked_build() {
 fix_data_dir_ownership() {
     [ "$(id -u)" = "0" ] || return 0
 
+    # The expected owner is whatever uid:gid $RUN_AS actually resolves to. The
+    # Dockerfile lets an operator build with a non-default uid/gid
+    # (--build-arg TINYCLD_UID/GID), so we must not hardcode 1000:1000 — that
+    # would re-run the full recursive chown on every boot for a non-default uid.
+    want_owner="$(id -u "$RUN_AS"):$(id -g "$RUN_AS")"
+
     for dir in \
         /workspace/pb_data \
         /workspace/builds \
@@ -252,7 +258,7 @@ fix_data_dir_ownership() {
         # already owned correctly — the steady state after first run, so normal
         # restarts pay nothing. A fresh root-owned mount triggers the fix-up.
         owner=$(stat -c '%u:%g' "$dir" 2>/dev/null || echo '')
-        if [ "$owner" != "1000:1000" ]; then
+        if [ "$owner" != "$want_owner" ]; then
             echo "[entrypoint] fixing ownership of $dir (was '$owner') -> $RUN_AS"
             chown -R "$RUN_AS:$RUN_AS" "$dir"
         fi


### PR DESCRIPTION
`fix_data_dir_ownership` skipped its recursive chown when the data dir was already owned `1000:1000`. But the Dockerfile lets an operator build with a non-default uid/gid via `--build-arg TINYCLD_UID/GID`, in which case `$RUN_AS` (`tinycld`) is *not* 1000:1000 — so the literal comparison never matched and the full recursive chown of pb_data/builds/releases ran on **every** boot.

Compute the expected owner from the actual run user once (`$(id -u "$RUN_AS"):$(id -g "$RUN_AS")`) and compare against that. For the default uid this is still 1000:1000, so behavior is unchanged in the common case; for a custom uid the steady-state fast path now works.