### PR TITLE
fix: watchman excludes the current generated server dir

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -413,12 +413,14 @@ function startPbWatcher(opts: {
                     'allof',
                     ['type', 'f'],
                     ['suffix', 'go'],
-                    // Any package-owned server source: core/server/**.go and
-                    // <sibling>/server/**.go. Exclude app/server/** because
-                    // those .go files (package_extensions.go, go.work) are
-                    // generator output — rebuilding on them would loop.
+                    // Any package-owned server source: tinycld/core/server/**.go
+                    // and <sibling>/server/**.go. Exclude tinycld/server/**
+                    // because those .go files (package_extensions.go, go.work)
+                    // are generator output — rebuilding on them would loop.
+                    // (Globs are wholename, relative to the watched workspace
+                    // root one level up from the tinycld/ member dir.)
                     ['match', '**/server/**', 'wholename'],
-                    ['not', ['match', 'app/server/**', 'wholename']],
+                    ['not', ['match', 'tinycld/server/**', 'wholename']],
                 ],
                 fields: ['name', 'exists'],
                 ...(resp.relative_path ? { relative_root: resp.relative_path } : {}),


### PR DESCRIPTION
The PB-rebuild watchman subscription in `scripts/dev.ts` excluded `app/server/**` (`wholename`) so the generator's own Go output (`package_extensions.go`, `go.work`) wouldn't trigger a rebuild loop. Post-merge the generated app server lives at `tinycld/server/*.go` (`SERVER_DIR = APP_DIR/server`), not `app/server/`, so the stale exclusion never matched — running `packages:generate` while `pnpm dev` was watching triggered a spurious PB rebuild/restart.

The subscription watches the workspace root (one level up from the `tinycld/` member), and globs are `wholename` relative to it, so the correct exclusion is `tinycld/server/**`. `tinycld/core/server/**` and `<sibling>/server/**` (real source) are unaffected. Comment updated to match.