### PR TITLE
fix: e2e helpers drift — isPackageLinked sibling scan + seed/helper password default

### DIFF
--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -86,6 +86,13 @@ interface SeedLoginResult {
     passwordGenerated: boolean
 }
 
+// The password the e2e login helper uses when TEST_USER_PW is unset. It MUST
+// match TEST_USER_PASSWORD in tests/e2e/helpers.ts: playwright.config.ts never
+// loads .env, so on a clean checkout without TEST_USER_PW the seed and the
+// helper have to agree on a shared literal or every login() fails. An explicit
+// TEST_USER_PW (e.g. from CI) still overrides this for both sides.
+const TEST_USER_DEFAULT_PASSWORD = 'TestUser1234!'
+
 const TEST_DEFAULTS = {
     userEmail: process.env.TEST_USER_LOGIN || 'user@tinycld.org',
     userUsername: process.env.TEST_USER_USERNAME || 'tester',
@@ -199,11 +206,15 @@ function parseArgs(): SeedConfig {
 
     // An explicit password comes from --user-pw, or from the mode's env var
     // (TEST_USER_PW in test mode — set by CI — or REVIEW_DEMO_PASSWORD in demo
-    // mode for App Review). When none is set, userPassword is '' and seedForUser
-    // mints a random one on create rather than reusing a shared literal.
+    // mode for App Review). In test mode, fall back to the shared default the
+    // e2e login helper reads (TEST_USER_DEFAULT_PASSWORD) so a clean checkout
+    // without TEST_USER_PW still logs in — the helper and seed MUST agree on
+    // that literal. Demo mode has no shared login helper, so when
+    // REVIEW_DEMO_PASSWORD is unset userPassword stays '' and seedForUser mints
+    // a random one on create rather than reusing a known literal.
     const envPassword =
         mode === 'test'
-            ? (process.env.TEST_USER_PW ?? '')
+            ? (process.env.TEST_USER_PW ?? TEST_USER_DEFAULT_PASSWORD)
             : (process.env.REVIEW_DEMO_PASSWORD ?? '')
     const userPassword = overrides.userPassword ?? envPassword
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -7,17 +7,21 @@ export const TEST_USER_EMAIL = process.env.TEST_USER_LOGIN || 'user@tinycld.org'
 export const TEST_USER_PASSWORD = process.env.TEST_USER_PW || 'TestUser1234!'
 export const TEST_USER_USERNAME = process.env.TEST_USER_USERNAME ?? 'tester'
 
-// isPackageLinked checks whether a given @tinycld/* package is wired into
-// this core checkout. Tests that depend on package-contributed routes or
-// collections should guard with `test.skip(!isPackageLinked('mail'), ...)`
-// so they run when the package is linked (dev/package CI) and are skipped
-// when core runs standalone (core's own CI).
+// isPackageLinked checks whether a given feature package is present in this
+// workspace. Tests that depend on package-contributed routes or collections
+// should guard with `test.skip(!isPackageLinked('mail'), ...)` so they run when
+// the package is present (dev/package CI) and skip when the app shell runs
+// standalone (its own CI).
+//
+// A feature is "present" when its sibling member dir exists at the workspace
+// root and carries a manifest.ts (the marker that makes a dir a member — see
+// tinycld.packages.ts). The old `<checkout>/packages/@tinycld/<slug>` layout is
+// gone: features are now flat sibling dirs under the workspace root, resolved
+// the same way as shortcutStubInstalled() below.
 export function isPackageLinked(slug: string): boolean {
-    const corePackagesDir = path.resolve(import.meta.dirname, '..', '..', 'packages')
-    return (
-        fs.existsSync(path.join(corePackagesDir, '@tinycld', slug)) ||
-        fs.existsSync(path.join(corePackagesDir, slug))
-    )
+    // tinycld/tests/e2e/helpers.ts → tinycld/tests → tinycld → workspace root → <slug>/manifest.ts
+    const manifest = path.resolve(import.meta.dirname, '..', '..', '..', slug, 'manifest.ts')
+    return fs.existsSync(manifest)
 }
 
 // The keyboard-shortcut and offline-overlay specs drive a minimal stub package

--- a/tests/unit/e2e-helpers.test.ts
+++ b/tests/unit/e2e-helpers.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { isPackageLinked } from '../e2e/helpers'
+
+// isPackageLinked resolves "<workspaceRoot>/<slug>/manifest.ts" from helpers.ts's
+// own location. These tests exercise that contract against the real workspace so
+// a future path drift (like the old "packages/@tinycld/<slug>" layout) is caught.
+describe('isPackageLinked', () => {
+    // helpers.ts lives at tinycld/tests/e2e/helpers.ts, so the workspace root is
+    // three levels up from tests/unit/ (this file) as well.
+    const workspaceRoot = path.resolve(import.meta.dirname, '..', '..', '..')
+    const scratchSlug = '__tinycld_test_scratch_pkg__'
+    const scratchDir = path.join(workspaceRoot, scratchSlug)
+
+    afterAll(() => {
+        fs.rmSync(scratchDir, { recursive: true, force: true })
+    })
+
+    it('returns false for a slug with no sibling member dir', () => {
+        expect(isPackageLinked('__definitely_not_a_real_package__')).toBe(false)
+    })
+
+    it('returns false for a sibling dir that lacks a manifest.ts', () => {
+        fs.mkdirSync(scratchDir, { recursive: true })
+        expect(isPackageLinked(scratchSlug)).toBe(false)
+    })
+
+    it('returns true once the sibling dir has a manifest.ts', () => {
+        fs.mkdirSync(scratchDir, { recursive: true })
+        fs.writeFileSync(path.join(scratchDir, 'manifest.ts'), 'export default {}\n')
+        expect(isPackageLinked(scratchSlug)).toBe(true)
+    })
+})


### PR DESCRIPTION
Two e2e-tooling regressions from the post-merge layout change:

**isPackageLinked** (`tests/e2e/helpers.ts`) checked `<checkout>/packages/@tinycld/<slug>` / `<checkout>/packages/<slug>`. That `packages/` dir is gone — features are now flat sibling member dirs under the workspace root — so it was **always false**. `invite-flow.spec.ts`'s mailbox assertion never ran, and any future `test.skip(!isPackageLinked(...))` would skip permanently. Rebuilt it on the current reality: a feature is present when `<workspaceRoot>/<slug>/manifest.ts` exists (same resolution as `shortcutStubInstalled()` right below it). Added a unit test.

**Seed/helper password mismatch:** the helper's `TEST_USER_PASSWORD` defaults to `'TestUser1234!'` when `TEST_USER_PW` is unset, but `seed-db.ts` minted a *random* password in that case — and `playwright.config.ts` never loads `.env` — so a clean checkout without `TEST_USER_PW` failed every `login()`. Made the **test-mode** seed default to the same shared constant (`TEST_USER_DEFAULT_PASSWORD = 'TestUser1234!'`) when `TEST_USER_PW` is unset, so seed and helper agree. An explicit `TEST_USER_PW` still overrides both. Demo mode (App Review) is unchanged — it keeps minting a random password when `REVIEW_DEMO_PASSWORD` is unset.

Verified with `tinycld-pkg check` (566 tests pass, +3 new).