### PR TITLE
fix: core small bugs (formatBytes, download URL, org-slug dep, logger, impersonation)

### DIFF
--- a/core/components/setup/OrganizationsTab.tsx
+++ b/core/components/setup/OrganizationsTab.tsx
@@ -1,7 +1,7 @@
 import { eq } from '@tanstack/db'
 import { useLiveQuery } from '@tanstack/react-db'
 import { deriveUsername } from '@tinycld/core/lib/derive-username'
-import { captureException } from '@tinycld/core/lib/errors'
+import { captureException, handleMutationErrorsWithForm } from '@tinycld/core/lib/errors'
 import { mutation, useMutation } from '@tinycld/core/lib/mutations'
 import { navigateToOrg } from '@tinycld/core/lib/org-url'
 import { packageRegistry } from '@tinycld/core/lib/packages/static-registry'
@@ -248,7 +248,18 @@ function OrgRow({
                 token: string
                 owner: { id: string; name: string; email: string }
             }>(`/api/admin/orgs/${org.id}/impersonate`, { method: 'POST' })
-            appPb.authStore.save(token, { id: owner.id, email: owner.email } as never)
+            // Save the full owner identity — getUserFromAuthStore derives the
+            // signed-in user (incl. the name shown in the user menu) from the
+            // saved auth record, so dropping `name` left the menu blank. The
+            // collectionId/Name fields make this a valid PB auth record without
+            // an `as never` cast (mirrors SetupWizard's post-setup save).
+            appPb.authStore.save(token, {
+                id: owner.id,
+                name: owner.name,
+                email: owner.email,
+                collectionId: '_pb_users_auth_',
+                collectionName: 'users',
+            })
             // Navigate via the router (web AND native) — a raw window.location.href
             // assignment no-ops on native (RN has no window.location), so impersonate
             // silently went nowhere on device. navigateToOrg uses expo-router and
@@ -307,12 +318,13 @@ function OrgRow({
 }
 
 function OrgExpandedDetails({ isVisible, org }: { isVisible: boolean; org: OrgEntry }) {
-    const [saveError, setSaveError] = useState<string | null>(null)
     const [orgsCollection, usersCollection] = useStore('orgs', 'users')
 
     const {
         control,
         handleSubmit,
+        setError,
+        getValues,
         formState: { errors, isSubmitted, isDirty },
     } = useForm({
         resolver: zodResolver(editOrgSchema),
@@ -345,11 +357,13 @@ function OrgExpandedDetails({ isVisible, org }: { isVisible: boolean; org: OrgEn
                 })
             }
         }),
-        onError: err => setSaveError(err instanceof Error ? err.message : 'Failed to update'),
+        // Map PB validation errors back onto the form fields (falling back to a
+        // toast for non-field errors) instead of dropping them into a single
+        // string — a duplicate email/name now flags the offending field.
+        onError: handleMutationErrorsWithForm({ setError, getValues, operation: 'editOrg' }),
     })
 
     const onSave = handleSubmit(data => {
-        setSaveError(null)
         save.mutate(data)
     })
 
@@ -370,12 +384,6 @@ function OrgExpandedDetails({ isVisible, org }: { isVisible: boolean; org: OrgEn
             <Divider />
 
             <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
-
-            {saveError && (
-                <View className="rounded-lg p-2 bg-danger-soft">
-                    <Text className="text-xs text-danger">{saveError}</Text>
-                </View>
-            )}
 
             <View className="gap-3">
                 <SectionLabel>Organization</SectionLabel>
@@ -460,7 +468,6 @@ function OrgExpandedDetails({ isVisible, org }: { isVisible: boolean; org: OrgEn
 }
 
 function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCreated: () => void }) {
-    const [submitError, setSubmitError] = useState<string | null>(null)
     const [orgsCollection, usersCollection, userOrgCollection, orgProvisioningCollection] =
         useStore('orgs', 'users', 'user_org', 'org_provisioning')
 
@@ -468,6 +475,8 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
         control,
         handleSubmit,
         setValue,
+        setError,
+        getValues,
         watch,
         reset,
         formState: { errors, isSubmitted },
@@ -552,11 +561,13 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
             reset()
             onCreated()
         },
-        onError: err => setSubmitError(err instanceof Error ? err.message : 'Failed to create org'),
+        // A username/slug collision comes back as a PB field error — route it to
+        // the matching input (toast fallback for anything unmapped) rather than a
+        // single opaque string.
+        onError: handleMutationErrorsWithForm({ setError, getValues, operation: 'createOrg' }),
     })
 
     const onSubmit = handleSubmit(data => {
-        setSubmitError(null)
         create.mutate(data)
     })
 
@@ -570,12 +581,6 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                 </Text>
 
                 <FormErrorSummary errors={errors} isEnabled={isSubmitted} />
-
-                {submitError && (
-                    <View className="rounded-lg p-2 bg-danger-soft">
-                        <Text className="text-xs text-danger">{submitError}</Text>
-                    </View>
-                )}
 
                 <View className="gap-3">
                     <SectionLabel>Organization</SectionLabel>

--- a/core/file-viewer/file-url.ts
+++ b/core/file-viewer/file-url.ts
@@ -33,9 +33,14 @@ export function downloadFile(source: FilePreviewSource) {
 export function downloadFromUrl(url: string, fileName: string, mimeType: string) {
     if (Platform.OS === 'web') {
         // PocketBase serves files with `?download=1` as Content-Disposition:
-        // attachment. URLs that already encode their own download semantics
-        // (drive's share-link `?inline=0`) are passed through untouched.
-        const href = url.includes('?') ? url : `${url}?download=1`
+        // attachment. A protected file arrives with a `?token=…` query, so we
+        // must join the download param with `&` vs `?` on whether a query
+        // already exists — a bare `url.includes('?')` skip dropped the param on
+        // every authed URL, so protected files opened inline instead of saving.
+        // URLs that already encode their own download semantics (drive's
+        // share-link `?inline=0`/`?download=…`) are passed through untouched.
+        const encodesDisposition = /[?&](download|inline)=/.test(url)
+        const href = encodesDisposition ? url : `${url}${url.includes('?') ? '&' : '?'}download=1`
         const a = document.createElement('a')
         a.href = href
         a.download = fileName

--- a/core/lib/format-utils.ts
+++ b/core/lib/format-utils.ts
@@ -1,9 +1,18 @@
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
+
 export function formatBytes(bytes: number): string {
     if (bytes === 0) return '—'
-    const units = ['B', 'KB', 'MB', 'GB']
-    const i = Math.floor(Math.log(bytes) / Math.log(1024))
-    const value = bytes / 1024 ** i
-    return `${value.toFixed(i > 0 ? 1 : 0)} ${units[i]}`
+    // A non-finite (NaN/Infinity) or negative size is never a real file size;
+    // treat it as nothing rather than emitting "NaN undefined".
+    if (!Number.isFinite(bytes) || bytes < 0) return '0 B'
+    // Bytes below 1 KiB (incl. fractional counts < 1) belong in the 'B' unit;
+    // log-based index math would otherwise produce a negative exponent.
+    if (bytes < 1024) return `${Math.round(bytes)} B`
+    // Clamp the exponent to the last available unit so a petabyte-plus value
+    // still renders in 'PB' instead of indexing past the array into undefined.
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), BYTE_UNITS.length - 1)
+    const value = bytes / 1024 ** exponent
+    return `${value.toFixed(1)} ${BYTE_UNITS[exponent]}`
 }
 
 export function formatDate(isoDate: string): string {
@@ -12,7 +21,9 @@ export function formatDate(isoDate: string): string {
     // (e.g. a drive search row before its record is loaded); our API otherwise
     // always emits well-formed dates.
     if (!isoDate) return ''
-    return new Date(isoDate).toLocaleDateString('en-US', {
+    // Use the device locale (undefined) to match formatRelativeDate — an
+    // absolute date shouldn't render as en-US on a non-US device.
+    return new Date(isoDate).toLocaleDateString(undefined, {
         month: 'short',
         day: 'numeric',
         year: 'numeric',

--- a/core/lib/pocketbase.ts
+++ b/core/lib/pocketbase.ts
@@ -119,22 +119,20 @@ export async function disconnectServer() {
     setResolvedAddress(null)
 }
 
+// Route pbtsdb's internal logs somewhere useful. Errors go to Sentry so a
+// failed subscription/sync is observable in production instead of being
+// silently dropped — the previous empty if/else bodies discarded EVERYTHING,
+// errors included, which is the bug this fixes. The debug/info/warn levels are
+// subscription-lifecycle chatter with no production value, so they're
+// intentionally dropped rather than logged (no unguarded console shipped).
 setLogger({
     debug: () => {},
-    info: (_msg, context) => {
-        if (context) {
-        } else {
-        }
-    },
-    warn: (_msg, context) => {
-        if (context) {
-        } else {
-        }
-    },
-    error: (_msg, context) => {
-        if (context) {
-        } else {
-        }
+    info: () => {},
+    warn: () => {},
+    error: (msg, context) => {
+        // Stable grouping key; the varying message rides in the Error and the
+        // pbtsdb context object rides in `extra`.
+        captureException('pbtsdb.error', new Error(msg), context as Record<string, unknown>)
     },
 })
 

--- a/core/lib/use-org-live-query.ts
+++ b/core/lib/use-org-live-query.ts
@@ -23,6 +23,9 @@ export function useOrgLiveQuery<TContext extends Context>(
             if (!orgId || !userOrgId) return null
             return queryFn(q, scope)
         },
-        [orgId, userOrgId, ...deps]
+        // orgSlug is part of `scope`, so a query that filters on it (e.g.
+        // eq(org.slug, orgSlug)) must re-run when the org is renamed —
+        // otherwise it keeps matching the stale slug.
+        [orgId, userOrgId, orgSlug, ...deps]
     )
 }

--- a/core/tests/unit/format-utils.test.ts
+++ b/core/tests/unit/format-utils.test.ts
@@ -27,4 +27,33 @@ describe('formatBytes', () => {
         expect(formatBytes(1024 * 1024)).toBe('1.0 MB')
         expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB')
     })
+
+    // A negative or non-finite size is never a real file size — it must not
+    // render as "NaN undefined".
+    it('renders a floor value for negative or non-finite input', () => {
+        expect(formatBytes(-1)).toBe('0 B')
+        expect(formatBytes(-1024)).toBe('0 B')
+        expect(formatBytes(Number.NaN)).toBe('0 B')
+        expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('0 B')
+    })
+
+    // Fractional counts below one byte belong in the 'B' unit rather than
+    // producing a negative log exponent.
+    it('rounds sub-1 byte counts into the B unit', () => {
+        expect(formatBytes(0.4)).toBe('0 B')
+        expect(formatBytes(0.9)).toBe('1 B')
+    })
+
+    // TB is a real unit: without the extended units array + index clamp this
+    // returned "1.0 undefined".
+    it('formats terabytes and larger without falling off the unit array', () => {
+        expect(formatBytes(1024 ** 4)).toBe('1.0 TB')
+        expect(formatBytes(1024 ** 5)).toBe('1.0 PB')
+    })
+
+    // A value beyond the largest known unit clamps to PB rather than indexing
+    // past the array end.
+    it('clamps astronomically large sizes to the last unit', () => {
+        expect(formatBytes(1024 ** 8)).toBe(`${(1024 ** 3).toFixed(1)} PB`)
+    })
 })


### PR DESCRIPTION
Fixes five low-severity correctness bugs in core.

- **formatBytes** (`core/lib/format-utils.ts`): guards non-finite/negative input (was `"NaN undefined"`), handles `0<bytes<1` (was a negative log exponent), extends the unit table to TB/PB and clamps the index so ≥1 TB no longer renders `"1.0 undefined"`. Also switches `formatDate` from hardcoded `en-US` to the device locale, matching `formatRelativeDate`. Adds edge-case unit tests.
- **download URL** (`core/file-viewer/file-url.ts`): a bare `url.includes('?')` check skipped appending `?download=1` on any URL that already had a query — including authed `?token=…` URLs — so protected files opened inline instead of saving. Now joins the param with `&`/`?` based on whether a query exists, and only skips when the URL already encodes its own disposition (`download=`/`inline=`).
- **org-slug dep** (`core/lib/use-org-live-query.ts`): `orgSlug` was missing from the liveQuery dep array, so a query filtering on `org.slug` kept the stale slug after a rename. Added it.
- **pbtsdb logger** (`core/lib/pocketbase.ts`): `setLogger` installed empty `if/else` bodies that discarded every log, errors included. Errors now route to `captureException('pbtsdb.error', …)`; the non-error levels are intentionally dropped (no unguarded console shipped).
- **impersonation** (`core/components/setup/OrganizationsTab.tsx`): saved `{id,email}` (missing `name`) → blank identity in the user menu. Now saves the full owner record with `collectionId`/`collectionName` (mirroring SetupWizard) — no `as never`. Both org forms' mutation `onError` now route through `handleMutationErrorsWithForm` so PB field errors land on the right input instead of a single opaque string.

Verified: `pnpm exec tinycld-pkg check` green (biome + tsc + 567 unit tests, incl. 8 formatBytes cases).