### PR TITLE
chore: core API nits (rename dup notify, typecheck tests, stable captureException keys)

### DIFF
--- a/app/accept-invite/[token].tsx
+++ b/app/accept-invite/[token].tsx
@@ -59,7 +59,7 @@ export default function AcceptInvite() {
                 setLoadState({ status: 'ready', info })
             } catch (err) {
                 if (cancelled) return
-                captureException('Failed to load invitation', err)
+                captureException('invite.accept.load', err)
                 setLoadState({
                     status: 'invalid',
                     message: 'Could not reach the server. Try again in a moment.',
@@ -149,7 +149,7 @@ function AcceptForm({ token, info }: { token: string; info: InviteInfo }) {
             router.replace(`/a/${orgSlug}`)
         } catch (err) {
             const message = err instanceof Error ? err.message : 'Failed to accept invitation'
-            captureException('Accept invite failed', err)
+            captureException('invite.accept.submit', err)
             setSubmitError(message)
         } finally {
             setIsSubmitting(false)

--- a/core/components/setup/OrganizationsTab.tsx
+++ b/core/components/setup/OrganizationsTab.tsx
@@ -255,7 +255,7 @@ function OrgRow({
             // preserves the in-org subpath on web.
             navigateToOrg(org.slug)
         } catch (err) {
-            captureException('Failed to impersonate user', err)
+            captureException('setup.org.impersonate', err)
         }
     }
 

--- a/core/lib/__tests__/handle-mutation-errors.test.ts
+++ b/core/lib/__tests__/handle-mutation-errors.test.ts
@@ -8,7 +8,7 @@ vi.mock('@tinycld/core/lib/pocketbase', () => ({
     },
 }))
 vi.mock('@tinycld/core/lib/notifications', () => ({
-    notify: vi.fn(() => Promise.resolve()),
+    showOsNotification: vi.fn(() => Promise.resolve()),
 }))
 
 describe('handleMutationErrorsWithForm', () => {

--- a/core/lib/notifications.ts
+++ b/core/lib/notifications.ts
@@ -60,8 +60,12 @@ export async function requestNotificationPermission(): Promise<boolean> {
 
 /**
  * Show an OS notification immediately.
+ *
+ * Named distinctly from the `notify` event dispatcher in
+ * `@tinycld/core/lib/notify` — this is the low-level OS-notification
+ * primitive; that one is the app-wide toast/bell/OS event bus.
  */
-export async function notify({ title, body, data }: NotifyOptions): Promise<void> {
+export async function showOsNotification({ title, body, data }: NotifyOptions): Promise<void> {
     const allowed = await requestNotificationPermission()
     if (!allowed) return
 
@@ -93,7 +97,7 @@ export async function scheduleNotification({
 
     const secondsUntil = Math.max(0, (triggerAt.getTime() - Date.now()) / 1000)
     if (secondsUntil <= 0) {
-        await notify({ title, body, data })
+        await showOsNotification({ title, body, data })
         return null
     }
 

--- a/core/lib/notify/__tests__/dispatcher.test.ts
+++ b/core/lib/notify/__tests__/dispatcher.test.ts
@@ -10,7 +10,7 @@ vi.mock('@tinycld/core/lib/pocketbase', () => ({
     },
 }))
 vi.mock('@tinycld/core/lib/notifications', () => ({
-    notify: vi.fn(() => Promise.resolve()),
+    showOsNotification: vi.fn(() => Promise.resolve()),
 }))
 vi.mock('@tinycld/core/lib/stores/toast-store', () => ({
     useToastStore: { getState: () => ({ addToast: vi.fn() }) },

--- a/core/lib/notify/__tests__/os.test.ts
+++ b/core/lib/notify/__tests__/os.test.ts
@@ -2,7 +2,7 @@ import { osChannel } from '@tinycld/core/lib/notify/channels/os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@tinycld/core/lib/notifications', () => ({
-    notify: vi.fn(() => Promise.resolve()),
+    showOsNotification: vi.fn(() => Promise.resolve()),
 }))
 
 describe('OsChannel', () => {
@@ -11,7 +11,7 @@ describe('OsChannel', () => {
     })
 
     it('forwards title/body/data to the platform notify helper', async () => {
-        const { notify: osNotify } = await import('@tinycld/core/lib/notifications')
+        const { showOsNotification: osNotify } = await import('@tinycld/core/lib/notifications')
         await osChannel.dispatch({
             event: 'import.complete',
             title: 'Done',
@@ -28,7 +28,7 @@ describe('OsChannel', () => {
     })
 
     it('omits body and data when not provided', async () => {
-        const { notify: osNotify } = await import('@tinycld/core/lib/notifications')
+        const { showOsNotification: osNotify } = await import('@tinycld/core/lib/notifications')
         await osChannel.dispatch({
             event: 'import.complete',
             title: 'Just a title',

--- a/core/lib/notify/__tests__/smoke.test.ts
+++ b/core/lib/notify/__tests__/smoke.test.ts
@@ -12,7 +12,7 @@ vi.mock('@tinycld/core/lib/pocketbase', () => ({
     },
 }))
 vi.mock('@tinycld/core/lib/notifications', () => ({
-    notify: vi.fn(() => Promise.resolve()),
+    showOsNotification: vi.fn(() => Promise.resolve()),
 }))
 
 describe('notify end-to-end (toast path)', () => {

--- a/core/lib/notify/channels/os.ts
+++ b/core/lib/notify/channels/os.ts
@@ -1,10 +1,10 @@
-import { notify as osNotify } from '@tinycld/core/lib/notifications'
+import { showOsNotification } from '@tinycld/core/lib/notifications'
 import type { DispatchInput, NotifyChannel } from '@tinycld/core/lib/notify/channels/types'
 
 export const osChannel: NotifyChannel = {
     name: 'os',
     async dispatch(input: DispatchInput) {
-        await osNotify({
+        await showOsNotification({
             title: input.title,
             body: input.body,
             data: input.data,

--- a/core/lib/realtime/use-realtime-room.ts
+++ b/core/lib/realtime/use-realtime-room.ts
@@ -145,7 +145,7 @@ export function useRealtimeRoom({
                     const parsed = text.length > 0 ? JSON.parse(text) : null
                     setServerHello(parsed)
                 } catch (err) {
-                    captureException('realtime: ServerHello JSON parse failed', err, {
+                    captureException('realtime.serverHello.parse', err, {
                         roomKind,
                         roomID,
                     })
@@ -159,7 +159,7 @@ export function useRealtimeRoom({
                     const parsed = text.length > 0 ? JSON.parse(text) : null
                     setServerSlot(parsed)
                 } catch (err) {
-                    captureException('realtime: ServerSlot JSON parse failed', err, {
+                    captureException('realtime.serverSlot.parse', err, {
                         roomKind,
                         roomID,
                     })
@@ -184,7 +184,7 @@ export function useRealtimeRoom({
                         // renders don't disappear into the void; the
                         // UI still falls through to its own empty
                         // state, but at least we'll see the cause.
-                        captureException('realtime: bootstrap failed', err, {
+                        captureException('realtime.bootstrap', err, {
                             roomKind,
                             roomID,
                         })

--- a/core/lib/stores/auth-store.ts
+++ b/core/lib/stores/auth-store.ts
@@ -128,7 +128,7 @@ export const useAuthStore = create<AuthStoreState>()((set, get) => ({
                     set({ user: currentUser })
                 }
             } catch (err) {
-                captureException('auth-store.initAuth hydration failed', err)
+                captureException('auth-store.initAuth.hydrate', err)
             } finally {
                 set({ hasHydrated: true })
             }
@@ -227,7 +227,7 @@ export const useAuthStore = create<AuthStoreState>()((set, get) => ({
         // registration guard so a second user on this same session re-registers.
         if (userId) {
             teardownPushOnLogout(userId, authToken).catch(err =>
-                captureException('auth-store.logout teardownPush', err)
+                captureException('auth-store.logout.teardownPush', err)
             )
         }
         pb.authStore.clear()
@@ -240,7 +240,7 @@ export const useAuthStore = create<AuthStoreState>()((set, get) => ({
         // incl. the pb file token) so the next user signing in on this SPA
         // instance can't read the previous user's rows or reuse their token.
         resetSessionState().catch(err =>
-            captureException('auth-store.logout resetSessionState', err)
+            captureException('auth-store.logout.resetSessionState', err)
         )
         set({ user: null })
     },

--- a/core/lib/stores/workspace-store.ts
+++ b/core/lib/stores/workspace-store.ts
@@ -50,6 +50,13 @@ export const useWorkspaceStore = create<WorkspaceStoreState>()(
                 }),
         }),
         {
+            // Key kept as 'tinycld_sidebar_open' for historical reasons even
+            // though it now also persists `lastPackageHref` (see partialize).
+            // Renaming to something accurate (e.g. 'tinycld_workspace') would
+            // orphan every existing user's stored sidebar/last-href state on
+            // upgrade — Zustand's version/migrate can't carry state across a
+            // key rename — and this state is trivial enough that the silent
+            // drop isn't worth it. Left as-is intentionally.
             name: 'tinycld_sidebar_open',
             storage: asyncStorage,
             partialize: s => ({

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -30,15 +30,7 @@
         "preserveSymlinks": true,
         "types": ["node", "react"]
     },
-    "exclude": [
-        "node_modules",
-        ".expo",
-        "**/test",
-        "**/dist",
-        "node_modules/**/types",
-        "**/__tests__",
-        "ideas"
-    ],
+    "exclude": ["node_modules", ".expo", "**/dist", "node_modules/**/types", "ideas"],
     "typeAcquisition": {
         "enable": true
     },

--- a/core/ui/hooks/useLabelMutations.ts
+++ b/core/ui/hooks/useLabelMutations.ts
@@ -24,7 +24,7 @@ export function useLabelMutations() {
     )
 
     const onError = (error: unknown) => {
-        captureException('Label action failed', error)
+        captureException('labels.mutation', error)
     }
 
     const createLabel = useMutation({


### PR DESCRIPTION
Small API-design cleanups in core. No behavior change beyond the log-key/name renames.

1. **Disambiguate the two `notify` exports.** `core/lib/notifications.ts` exported `notify` (the OS-notification primitive) alongside the app-wide event dispatcher `notify` in `core/lib/notify`. Renamed the former to `showOsNotification` (it had a single non-test importer — the `os` channel — so this is the smaller blast radius) and updated that importer plus the four test mocks.
2. **Typecheck core's tests.** `core/tsconfig.json` excluded `**/__tests__` and `**/test`, so `tinycld-pkg typecheck` never covered core's unit tests. Removed the test excludes; `tsc` now type-checks them and passes (no hidden errors were being masked).
3. **`workspace-store.ts` persist key.** The key `tinycld_sidebar_open` now also stores `lastPackageHref`, so the name is stale. Chose NOT to rename: a key rename orphans every user's existing persisted state on upgrade (Zustand's version/migrate can't carry state across a key change), and this state is trivial. Added a comment documenting the drift and the decision instead.
4. **Stable `captureException` dot-keys.** Converted prose contexts to `namespace.action` keys matching the existing convention: `labels.mutation`, `setup.org.impersonate`, `auth-store.initAuth.hydrate` / `auth-store.logout.teardownPush` / `auth-store.logout.resetSessionState`, `realtime.serverHello.parse` / `realtime.serverSlot.parse` / `realtime.bootstrap`, `invite.accept.load` / `invite.accept.submit`.

Verified: `pnpm exec tinycld-pkg check` green (biome + tsc-including-tests + 563 unit tests).

Note: item 4's `OrganizationsTab.tsx` change (line ~258) is on a different line than the impersonation fix in the sibling PR "fix: core small bugs" — they touch the same file but should merge cleanly.