### PR TITLE
fix: replace raw hex with semantic theme tokens (tinycld)

### DIFF
--- a/app/a/[orgSlug]/settings/audit-log.tsx
+++ b/app/a/[orgSlug]/settings/audit-log.tsx
@@ -32,11 +32,21 @@ const RESOURCE_TYPE_OPTIONS = [
     { label: 'Packages', value: 'org_pkg_enabled' },
 ] as const
 
-const ACTION_BADGE_COLORS = {
-    created: { bg: 'rgba(34, 197, 94, 0.15)', text: '#22c55e' },
-    updated: { bg: 'rgba(59, 130, 246, 0.15)', text: '#3b82f6' },
-    deleted: { bg: 'rgba(239, 68, 68, 0.15)', text: '#ef4444' },
+// Each audit action maps to a semantic soft-status class pair so the badge
+// tracks the theme (created=success, updated=accent, deleted=danger) instead of
+// a fixed hex that would read the same — and clash — in dark mode.
+const ACTION_BADGE_CLASS = {
+    created: 'bg-success-soft',
+    updated: 'bg-accent',
+    deleted: 'bg-danger-soft',
 } as const
+const ACTION_TEXT_CLASS = {
+    created: 'text-success-soft-foreground',
+    updated: 'text-accent-foreground',
+    deleted: 'text-danger-soft-foreground',
+} as const
+
+type AuditAction = keyof typeof ACTION_BADGE_CLASS
 
 export default function AuditLogSettings() {
     const orgHref = useOrgHref()
@@ -212,7 +222,6 @@ function AuditLogRow({ entry }: { entry: AuditEntry }) {
     const mutedColor = useThemeColor('muted-foreground')
 
     const actorName = entry.expand?.actor?.name || entry.expand?.actor?.email || 'System'
-    const actionColors = ACTION_BADGE_COLORS[entry.action as keyof typeof ACTION_BADGE_COLORS]
     const hasDetails = Boolean(
         (entry.action === 'updated' && entry.changes && Object.keys(entry.changes).length > 0) ||
             (entry.action === 'deleted' && entry.snapshot && Object.keys(entry.snapshot).length > 0)
@@ -229,7 +238,7 @@ function AuditLogRow({ entry }: { entry: AuditEntry }) {
                 <View className="flex-1 gap-1">
                     <View className="flex-row gap-2 items-center flex-wrap">
                         <Text className="text-foreground text-sm font-semibold">{actorName}</Text>
-                        <ActionBadge action={entry.action} colors={actionColors} />
+                        <ActionBadge action={entry.action} />
                         <Text className="text-muted-foreground text-[13px]">{resourceLabel}</Text>
                     </View>
                     <EntryLabel isVisible={!!entry.resource_label} label={entry.resource_label} />
@@ -272,12 +281,11 @@ function ExpandIcon({
     )
 }
 
-function ActionBadge({ action, colors }: { action: string; colors: { bg: string; text: string } }) {
+function ActionBadge({ action }: { action: string }) {
+    const key = (action in ACTION_BADGE_CLASS ? action : 'updated') as AuditAction
     return (
-        <View className="rounded px-1.5 py-0.5" style={{ backgroundColor: colors.bg }}>
-            <Text className="text-[11px] font-semibold" style={{ color: colors.text }}>
-                {action}
-            </Text>
+        <View className={`rounded px-1.5 py-0.5 ${ACTION_BADGE_CLASS[key]}`}>
+            <Text className={`text-[11px] font-semibold ${ACTION_TEXT_CLASS[key]}`}>{action}</Text>
         </View>
     )
 }

--- a/app/a/[orgSlug]/settings/members.tsx
+++ b/app/a/[orgSlug]/settings/members.tsx
@@ -470,11 +470,15 @@ function StatChip({
     const fgColor = useThemeColor('foreground')
     const mutedColor = useThemeColor('muted-foreground')
     const borderColor = useThemeColor('border')
+    const warningColor = useThemeColor('warning')
+    const primaryColor = useThemeColor('primary')
 
+    // warn=warning, owner=primary — theme tokens instead of a fixed light-mode
+    // hex that clashed in dark mode.
     const tones = {
         neutral: { fg: fgColor, accent: mutedColor, ring: borderColor },
-        warn: { fg: '#b45309', accent: '#b45309', ring: 'rgba(180, 83, 9, 0.35)' },
-        owner: { fg: '#7c3aed', accent: '#7c3aed', ring: 'rgba(124, 58, 237, 0.35)' },
+        warn: { fg: warningColor, accent: warningColor, ring: warningColor },
+        owner: { fg: primaryColor, accent: primaryColor, ring: primaryColor },
     }[tone]
 
     return (

--- a/app/a/[orgSlug]/settings/personal.tsx
+++ b/app/a/[orgSlug]/settings/personal.tsx
@@ -318,6 +318,7 @@ function ColorThemePicker({
     isDark: boolean
 }) {
     const borderColor = useThemeColor('border')
+    const onSwatchColor = useThemeColor('primary-foreground')
 
     return (
         <View className="flex-row gap-4 flex-wrap">
@@ -341,7 +342,7 @@ function ColorThemePicker({
                                 borderColor: isActive ? swatchColor : borderColor,
                             }}
                         >
-                            {isActive && <Check size={18} color="#fff" />}
+                            {isActive && <Check size={18} color={onSwatchColor} />}
                         </View>
                         <Text
                             className={`text-[11px] ${isActive ? 'font-semibold text-foreground' : 'font-normal text-muted-foreground'}`}

--- a/app/connect.tsx
+++ b/app/connect.tsx
@@ -43,6 +43,7 @@ export default function Connect() {
 
     const fg = useThemeColor('foreground')
     const muted = useThemeColor('muted-foreground')
+    const backdrop = useThemeColor('overlay-backdrop')
 
     const { control, handleSubmit, reset } = useForm({
         resolver: zodResolver(urlSchema),
@@ -194,7 +195,7 @@ export default function Connect() {
                     <Pressable
                         onPress={closeSheet}
                         className="flex-1"
-                        style={{ backgroundColor: 'rgba(0,0,0,0.45)' }}
+                        style={{ backgroundColor: backdrop }}
                     />
                     <View
                         className="bg-background px-6 pt-3 pb-8"

--- a/app/connect.web.tsx
+++ b/app/connect.web.tsx
@@ -155,10 +155,7 @@ export default function ConnectWeb() {
                         disabled={busy}
                         className={`border-[1.5px] border-foreground bg-foreground rounded-2xl p-[18px] flex-row items-start gap-3.5 ${busy ? 'opacity-60' : 'opacity-100'}`}
                     >
-                        <View
-                            className="w-9 h-9 rounded-[10px] items-center justify-center"
-                            style={{ backgroundColor: 'rgba(255,255,255,0.12)' }}
-                        >
+                        <View className="w-9 h-9 rounded-[10px] items-center justify-center bg-background/10">
                             <Globe size={18} color={bg} />
                         </View>
                         <View className="flex-1">

--- a/core/components/LabelManagerDialog.tsx
+++ b/core/components/LabelManagerDialog.tsx
@@ -185,12 +185,11 @@ function CreateLabelRow({ onCreated }: { onCreated: () => void }) {
             <Pressable onPress={() => setIsCreating(true)}>
                 <View className="flex-row items-center px-3 py-2 gap-2 opacity-60">
                     <View
+                        className="border-[1.5px] border-border/70"
                         style={{
                             width: 14,
                             height: 14,
                             borderRadius: 7,
-                            borderWidth: 1.5,
-                            borderColor: 'rgba(128, 128, 128, 0.4)',
                             borderStyle: 'dashed',
                             alignItems: 'center',
                             justifyContent: 'center',

--- a/core/components/StarIcon.tsx
+++ b/core/components/StarIcon.tsx
@@ -6,16 +6,17 @@ interface StarIconProps {
     size?: number
 }
 
-const STARRED_COLOR = '#facc15'
-
 export function StarIcon({ isStarred, size = 16 }: StarIconProps) {
     const mutedColor = useThemeColor('muted-foreground')
+    // `warning` is the theme's amber/gold token — it renders as a legible gold in
+    // both light and dark, unlike a fixed hex that only suited light mode.
+    const starredColor = useThemeColor('warning')
 
     return (
         <Star
             size={size}
-            color={isStarred ? STARRED_COLOR : mutedColor}
-            fill={isStarred ? STARRED_COLOR : 'transparent'}
+            color={isStarred ? starredColor : mutedColor}
+            fill={isStarred ? starredColor : 'transparent'}
         />
     )
 }

--- a/core/components/help/MarkdownRenderer.tsx
+++ b/core/components/help/MarkdownRenderer.tsx
@@ -102,9 +102,12 @@ class HelpRenderer extends Renderer {
         // paints top + left. That gives a single-pixel grid with no
         // doubled-up lines and works without relying on the library's
         // reanimated-table Cell (which we replaced to fix overflow).
-        // tableStyle.borderColor flows in from the styles map below so
-        // the grid picks up the themed border color.
-        const borderColor = tableStyle?.borderColor ?? '#888'
+        // tableStyle.borderColor always flows in from the themed styles map
+        // below (styles.table.borderColor = useThemeColor('border')), so the
+        // grid picks up the theme's border color. The `transparent` fallback
+        // only guards the never-hit case where the renderer is used without our
+        // styles map — it must not hardcode a raw color that breaks in dark mode.
+        const borderColor = tableStyle?.borderColor ?? 'transparent'
         const rowFlex: ViewStyle = { flexDirection: 'row', ...rowStyle }
         // Detect keyboard-shortcut tables (first column holds the
         // shortcut, second the description) and give them a 20/80

--- a/core/components/settings/members/MemberBadges.tsx
+++ b/core/components/settings/members/MemberBadges.tsx
@@ -10,20 +10,14 @@ export function RoleBadge({ role, size = 'md' }: { role: OrgRole; size?: 'sm' | 
     const fontSize = size === 'sm' ? 10.5 : 11.5
     return (
         <View
-            style={{
-                paddingVertical: py,
-                paddingHorizontal: px,
-                borderRadius: 999,
-                backgroundColor: swatch.bg,
-                borderWidth: 1,
-                borderColor: swatch.ring,
-            }}
+            className={`rounded-full border ${swatch.bg} ${swatch.border}`}
+            style={{ paddingVertical: py, paddingHorizontal: px }}
         >
             <Text
+                className={swatch.text}
                 style={{
                     fontSize,
                     fontWeight: '700',
-                    color: swatch.fg,
                     letterSpacing: 0.3,
                     textTransform: 'uppercase',
                 }}
@@ -35,24 +29,18 @@ export function RoleBadge({ role, size = 'md' }: { role: OrgRole; size?: 'sm' | 
 }
 
 export function PendingBadge() {
+    const warningColor = useThemeColor('warning')
     return (
         <View
-            className="flex-row items-center gap-1"
-            style={{
-                paddingVertical: 3,
-                paddingHorizontal: 8,
-                borderRadius: 999,
-                backgroundColor: 'rgba(217, 119, 6, 0.12)',
-                borderWidth: 1,
-                borderColor: 'rgba(217, 119, 6, 0.35)',
-            }}
+            className="flex-row items-center gap-1 rounded-full border bg-warning/10 border-warning/40"
+            style={{ paddingVertical: 3, paddingHorizontal: 8 }}
         >
-            <Clock size={10} color="#b45309" />
+            <Clock size={10} color={warningColor} />
             <Text
+                className="text-warning"
                 style={{
                     fontSize: 10.5,
                     fontWeight: '700',
-                    color: '#b45309',
                     letterSpacing: 0.3,
                     textTransform: 'uppercase',
                 }}

--- a/core/components/settings/members/MembersDrawer.tsx
+++ b/core/components/settings/members/MembersDrawer.tsx
@@ -39,6 +39,7 @@ import {
     ROLE_ORDER,
     ROLE_SWATCH,
 } from './types'
+import { useRoleColors } from './use-role-color'
 
 // writeIsDemo writes the demo flag onto a pbtsdb users-collection draft. The
 // generated schema doesn't yet include `is_demo` (it regenerates after the
@@ -288,7 +289,8 @@ function RolePicker({
     onChange: (role: OrgRole) => void
 }) {
     const fgColor = useThemeColor('foreground')
-    const borderColor = useThemeColor('border')
+    const roleColors = useRoleColors()
+    const onColor = useThemeColor('primary-foreground')
 
     const helperText = isSelf
         ? 'You can’t change your own role. Ask another owner.'
@@ -318,40 +320,38 @@ function RolePicker({
             <View className="gap-1.5">
                 {availableRoles.map(role => {
                     const swatch = ROLE_SWATCH[role]
+                    const roleColor = roleColors[role]
                     const isActive = role === currentRole
                     const optionDisabled = disabled && !isActive
+                    const activeClasses = isActive
+                        ? `${swatch.bg} ${swatch.border}`
+                        : 'border-border'
                     return (
                         <Pressable
                             key={role}
                             disabled={optionDisabled || isActive}
                             onPress={() => onChange(role)}
-                            className="flex-row items-center gap-3 rounded-xl p-3"
-                            style={{
-                                borderWidth: 1.5,
-                                borderColor: isActive ? swatch.ring : borderColor,
-                                backgroundColor: isActive ? swatch.bg : 'transparent',
-                                opacity: optionDisabled ? 0.45 : 1,
-                            }}
+                            className={`flex-row items-center gap-3 rounded-xl p-3 border-[1.5px] ${activeClasses}`}
+                            style={{ opacity: optionDisabled ? 0.45 : 1 }}
                         >
                             <View
-                                className="items-center justify-center"
+                                className={`items-center justify-center border-2 ${isActive ? '' : 'border-border'}`}
                                 style={{
                                     width: 22,
                                     height: 22,
                                     borderRadius: 11,
-                                    borderWidth: 2,
-                                    borderColor: isActive ? swatch.fg : borderColor,
-                                    backgroundColor: isActive ? swatch.fg : 'transparent',
+                                    borderColor: isActive ? roleColor : undefined,
+                                    backgroundColor: isActive ? roleColor : 'transparent',
                                 }}
                             >
-                                {isActive && <Check size={12} color="#fff" strokeWidth={3} />}
+                                {isActive && <Check size={12} color={onColor} strokeWidth={3} />}
                             </View>
                             <View className="flex-1">
                                 <Text
                                     style={{
                                         fontSize: 13.5,
                                         fontWeight: '700',
-                                        color: isActive ? swatch.fg : fgColor,
+                                        color: isActive ? roleColor : fgColor,
                                     }}
                                 >
                                     {ROLE_LABELS[role]}
@@ -446,7 +446,8 @@ function InviteView({ onDone }: { onDone: () => void }) {
     const mutedColor = useThemeColor('muted-foreground')
     const primaryColor = useThemeColor('primary')
     const primaryFgColor = useThemeColor('primary-foreground')
-    const borderColor = useThemeColor('border')
+    const roleColors = useRoleColors()
+    const onColor = primaryFgColor
 
     const {
         control,
@@ -574,41 +575,35 @@ function InviteView({ onDone }: { onDone: () => void }) {
                                 <View className="gap-1.5">
                                     {inviteRoles.map(role => {
                                         const swatch = ROLE_SWATCH[role]
+                                        const roleColor = roleColors[role]
                                         const isActive = value === role
+                                        const activeClasses = isActive
+                                            ? `${swatch.bg} ${swatch.border}`
+                                            : 'border-border'
                                         return (
                                             <Pressable
                                                 key={role}
                                                 onPress={() => onChange(role)}
-                                                className="flex-row items-center gap-3 rounded-xl p-3"
-                                                style={{
-                                                    borderWidth: 1.5,
-                                                    borderColor: isActive
-                                                        ? swatch.ring
-                                                        : borderColor,
-                                                    backgroundColor: isActive
-                                                        ? swatch.bg
-                                                        : 'transparent',
-                                                }}
+                                                className={`flex-row items-center gap-3 rounded-xl p-3 border-[1.5px] ${activeClasses}`}
                                             >
                                                 <View
-                                                    className="items-center justify-center"
+                                                    className={`items-center justify-center border-2 ${isActive ? '' : 'border-border'}`}
                                                     style={{
                                                         width: 20,
                                                         height: 20,
                                                         borderRadius: 10,
-                                                        borderWidth: 2,
                                                         borderColor: isActive
-                                                            ? swatch.fg
-                                                            : borderColor,
+                                                            ? roleColor
+                                                            : undefined,
                                                         backgroundColor: isActive
-                                                            ? swatch.fg
+                                                            ? roleColor
                                                             : 'transparent',
                                                     }}
                                                 >
                                                     {isActive && (
                                                         <Check
                                                             size={11}
-                                                            color="#fff"
+                                                            color={onColor}
                                                             strokeWidth={3}
                                                         />
                                                     )}
@@ -618,7 +613,7 @@ function InviteView({ onDone }: { onDone: () => void }) {
                                                         style={{
                                                             fontSize: 13.5,
                                                             fontWeight: '700',
-                                                            color: isActive ? swatch.fg : fgColor,
+                                                            color: isActive ? roleColor : fgColor,
                                                         }}
                                                     >
                                                         {ROLE_LABELS[role]}

--- a/core/components/settings/members/types.ts
+++ b/core/components/settings/members/types.ts
@@ -23,11 +23,39 @@ export const ROLE_DESCRIPTIONS: Record<OrgRole, string> = {
     guest: 'Limited access. Scoped to whatever you grant per package.',
 }
 
-export const ROLE_SWATCH: Record<OrgRole, { fg: string; bg: string; ring: string }> = {
-    owner: { fg: '#7c3aed', bg: 'rgba(124, 58, 237, 0.12)', ring: 'rgba(124, 58, 237, 0.35)' },
-    admin: { fg: '#2563eb', bg: 'rgba(37, 99, 235, 0.12)', ring: 'rgba(37, 99, 235, 0.35)' },
-    member: { fg: '#059669', bg: 'rgba(5, 150, 105, 0.12)', ring: 'rgba(5, 150, 105, 0.35)' },
-    guest: { fg: '#ea580c', bg: 'rgba(234, 88, 12, 0.12)', ring: 'rgba(234, 88, 12, 0.35)' },
+// Role → semantic status tokens. Each role tracks the active theme via
+// Tailwind semantic classes (owner=primary, admin=info, member=success,
+// guest=warning) instead of a fixed light-mode hex that clashed in dark mode.
+// `fg` is the theme-color name for the few spots that need a runtime color value
+// (a Lucide icon color, or an inline-styled border); `text`/`bg`/`border` are the
+// className parts (bg/border use an opacity modifier for the soft tint).
+export interface RoleSwatch {
+    fg: 'primary' | 'info' | 'success' | 'warning'
+    text: string
+    bg: string
+    border: string
+}
+
+export const ROLE_SWATCH: Record<OrgRole, RoleSwatch> = {
+    owner: {
+        fg: 'primary',
+        text: 'text-primary',
+        bg: 'bg-primary/10',
+        border: 'border-primary/40',
+    },
+    admin: { fg: 'info', text: 'text-info', bg: 'bg-info/10', border: 'border-info/40' },
+    member: {
+        fg: 'success',
+        text: 'text-success',
+        bg: 'bg-success/10',
+        border: 'border-success/40',
+    },
+    guest: {
+        fg: 'warning',
+        text: 'text-warning',
+        bg: 'bg-warning/10',
+        border: 'border-warning/40',
+    },
 }
 
 export const ROLE_ORDER: OrgRole[] = ['owner', 'admin', 'member', 'guest']

--- a/core/components/settings/members/use-role-color.ts
+++ b/core/components/settings/members/use-role-color.ts
@@ -1,0 +1,15 @@
+import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { type OrgRole, ROLE_SWATCH } from './types'
+
+// Resolves each role's semantic foreground token to a runtime color value, for
+// the handful of spots that need an actual color (a Lucide icon, an inline-styled
+// border/fill) rather than a className. Hooks can't be called inside a `.map`, so
+// this returns the whole role→color map up front for the caller to index.
+export function useRoleColors(): Record<OrgRole, string> {
+    return {
+        owner: useThemeColor(ROLE_SWATCH.owner.fg),
+        admin: useThemeColor(ROLE_SWATCH.admin.fg),
+        member: useThemeColor(ROLE_SWATCH.member.fg),
+        guest: useThemeColor(ROLE_SWATCH.guest.fg),
+    }
+}

--- a/core/components/workspace/SkeletonLayout.tsx
+++ b/core/components/workspace/SkeletonLayout.tsx
@@ -33,7 +33,7 @@ function SkeletonBlock({
                     width: width as number,
                     height,
                     borderRadius: 8,
-                    backgroundColor: borderColor ?? '#88888833',
+                    backgroundColor: borderColor,
                     opacity,
                 },
                 style,


### PR DESCRIPTION
Rule-compliance sweep (§6.2): replace raw hex / light-only colors in core + app-shell with semantic theme tokens so they track light and dark mode.

## Fixed (genuine dark-mode breakers)
- **Member role colors** (`types.ts`, `MemberBadges.tsx`, `MembersDrawer.tsx`): the `ROLE_SWATCH` map went from fixed hex (`#7c3aed` etc. + light-tuned rgba) to semantic tokens — owner=primary, admin=info, member=success, guest=warning — via Tailwind classes (`bg-*/10`, `border-*/40`, `text-*`), plus a small `useRoleColors()` hook for the spots that need a runtime color value (the check-circle fill/border and active label). `PendingBadge` → warning.
- **Audit-log action badges** (`audit-log.tsx`): created/updated/deleted now use `bg-success-soft`/`bg-accent`/`bg-danger-soft` class pairs instead of hardcoded green/blue/red.
- **Members stat pills** (`members.tsx`): warn→warning, owner→primary tokens.
- **StarIcon**: gold `#facc15` → `warning` (the theme's amber, legible in both modes).
- **connect sheet backdrop** → `overlay-backdrop` token; **connect icon well** → `bg-background/10`; **personal + members check icons** → `primary-foreground`; **label add-swatch border** → `border-border`.
- Dropped a dead `#888` / `#88888833` fallback in `MarkdownRenderer` / `SkeletonLayout` (the themed value always flows in).

## Kept (judgment calls, documented)
- **`shadowColor: '#000'`** across the modals/FAB/toasts — a shadow is black in both themes; a token would add indirection without fixing a real bug.
- **Avatar identity palettes** (`NameAvatar`, `MemberAvatar`) — deterministic per-user colors (bg+fg paired, so always legible); making them theme-dependent would lose the stable identity and is exactly the palette churn to avoid.
- **Label color palette** (`LabelManagerDialog`) — user-chosen fixed palette.
- **Rail icon wells** (`UserMenu`, `MoreDrawer`: `rgba(255,255,255,0.15)`) — the rail is a fixed dark color in both themes, so the white tint is theme-consistent.

## Skipped
- `SwipeableRow.tsx:62` — the user has uncommitted WIP on this file; left untouched to avoid fighting the WIP.

## Verification
`pnpm exec tinycld-pkg check` green — biome clean, tsc clean, 570 unit tests pass.