### PR TITLE
chore: e2e hygiene — sanctioned nav helpers, no raw-REST data setup (tinycld)

### DIFF
--- a/tests/e2e/invite-flow.spec.ts
+++ b/tests/e2e/invite-flow.spec.ts
@@ -2,6 +2,17 @@ import { expect, type Page, test } from '@playwright/test'
 import { clearEmailLog, waitForEmailTo } from './email-log-helpers'
 import { isPackageLinked, login, ORG_SLUG, TEST_USER_EMAIL, TEST_USER_PASSWORD } from './helpers'
 
+// SPA-navigate to Settings → Members via the shell chrome (rail → settings
+// index → Members). A page.goto here would tear down the SPA and cancel the
+// in-flight lazy route chunks (see the note on navigateToPackage in helpers.ts),
+// so we click through expo-router instead.
+async function openMembersSettings(page: Page) {
+    await page.getByTestId('nav-settings').click()
+    await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/settings(/|$|\\?)`))
+    await page.getByText('Members', { exact: true }).click()
+    await page.waitForURL(new RegExp(`/a/${ORG_SLUG}/settings/members`))
+}
+
 // Reads the logged-in PocketBase auth token from the web auth store (the
 // AsyncStorage→localStorage 'pb_auth' entry, JSON.stringify({ token, record })).
 async function authTokenFromStore(page: Page): Promise<string> {
@@ -67,7 +78,7 @@ test.describe('Invite flow', () => {
         // --- 1. Owner signs in and sends an invite ---
         await login(page)
 
-        await page.goto(`/a/${ORG_SLUG}/settings/members`)
+        await openMembersSettings(page)
         // Open the invite drawer.
         await page.getByText('Invite', { exact: true }).click()
         await expect(page.getByText('Invite a teammate', { exact: true })).toBeVisible({
@@ -154,7 +165,7 @@ test.describe('Invite flow', () => {
         const altEmail = `personal-${Date.now()}@example.com`
 
         await login(page)
-        await page.goto(`/a/${ORG_SLUG}/settings/members`)
+        await openMembersSettings(page)
         await page.getByText('Invite', { exact: true }).click()
         await expect(page.getByText('Invite a teammate', { exact: true })).toBeVisible({
             timeout: 10_000,
@@ -182,7 +193,7 @@ test.describe('Invite flow', () => {
         const rotateInviteUsername = `inviteerotate${Date.now()}`
 
         await login(page)
-        await page.goto(`/a/${ORG_SLUG}/settings/members`)
+        await openMembersSettings(page)
         await page.getByText('Invite', { exact: true }).click()
         await expect(page.getByText('Invite a teammate', { exact: true })).toBeVisible({
             timeout: 10_000,


### PR DESCRIPTION
Rule-compliance sweep (§6.3): stop using `page.goto` for in-app navigation in the app-shell e2e specs, and confirm no raw-REST data setup slipped in.

## Fixed
- `invite-flow.spec.ts` navigated to Settings → Members via `page.goto(`/a/${ORG_SLUG}/settings/members`)` after `login()` — a hard browser navigation that tears down the SPA and cancels the in-flight lazy route chunks (the exact failure the `navigateToPackage` helper documents). Replaced all three call sites with an in-spec `openMembersSettings(page)` that clicks through expo-router (`nav-settings` rail → `Members` link → `waitForURL`), mirroring the sanctioned `navigateToPackage` / `navigateToAdmin` pattern. (An in-spec helper because `helpers.ts` is in the user's uncommitted WIP and must not be touched.)

## Left as-is — verified legitimate, not violations
- **`document-title.spec.ts`, `admin.spec.ts`, `sourcemaps.spec.ts`, `signup-flow.spec.ts`** deep-link / load an initial URL on purpose to test URL/title/route resolution — the sanctioned use of `page.goto` (the specs even say so).
- **`invite-flow.spec.ts` raw REST** (`page.request.get('/api/collections/...')`) is read-only mailbox verification — explicitly allowed.
- **`demo-lead.spec.ts`** enters via the `/api/demo/start` product entry endpoint (not a collection write, and there's no UI to drive it) and deep-links `/a/demo` after staging auth in an init script.

## Skipped (user WIP)
- `helpers.ts`, `change-password.spec.ts`, `password-reset.spec.ts` — the user has uncommitted changes to these; left untouched.

## Verification
`pnpm exec tinycld-pkg check` green — biome clean, tsc clean (specs compile), 570 unit tests pass.