### PR TITLE
refactor: replace useState+useEffect derive/sync with proper primitives (tinycld)

### DIFF
--- a/core/components/settings/members/InviteLinkPanel.tsx
+++ b/core/components/settings/members/InviteLinkPanel.tsx
@@ -1,7 +1,8 @@
+import { useQuery } from '@tanstack/react-query'
 import { useMutation } from '@tinycld/core/lib/mutations'
 import { pb } from '@tinycld/core/lib/pocketbase'
 import * as Clipboard from 'expo-clipboard'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Pressable, Text, TextInput, View } from 'react-native'
 
 export type InviteLinkPanelProps = {
@@ -16,35 +17,17 @@ type LinkState =
     | { kind: 'error'; message: string }
 
 export function InviteLinkPanel({ userOrgId, initialUrl }: InviteLinkPanelProps) {
-    const [state, setState] = useState<LinkState>(
-        initialUrl ? { kind: 'ready', url: initialUrl } : { kind: 'loading' }
-    )
+    // A URL from rotate() (or the initialUrl prop) short-circuits the fetch —
+    // both hand us a ready link with no round-trip needed.
+    const [overrideUrl, setOverrideUrl] = useState<string | undefined>(initialUrl)
 
-    useEffect(() => {
-        if (initialUrl) return
-        let cancelled = false
-        ;(async () => {
-            try {
-                const res = await pb.send<{ inviteUrl: string }>(`/api/invite-link/${userOrgId}`, {
-                    method: 'GET',
-                })
-                if (!cancelled) setState({ kind: 'ready', url: res.inviteUrl })
-            } catch (err) {
-                if (cancelled) return
-                const status = (err as { status?: number })?.status
-                if (status === 404) {
-                    setState({ kind: 'expired' })
-                    return
-                }
-                const message =
-                    (err as { message?: string })?.message ?? 'Failed to load invite link'
-                setState({ kind: 'error', message })
-            }
-        })()
-        return () => {
-            cancelled = true
-        }
-    }, [userOrgId, initialUrl])
+    const linkQuery = useQuery({
+        queryKey: ['invite-link', userOrgId],
+        queryFn: () =>
+            pb.send<{ inviteUrl: string }>(`/api/invite-link/${userOrgId}`, { method: 'GET' }),
+        enabled: !overrideUrl,
+        retry: false,
+    })
 
     const rotate = useMutation({
         mutationFn: async () => {
@@ -52,8 +35,10 @@ export function InviteLinkPanel({ userOrgId, initialUrl }: InviteLinkPanelProps)
                 method: 'POST',
             })
         },
-        onSuccess: data => setState({ kind: 'ready', url: data.inviteUrl }),
+        onSuccess: data => setOverrideUrl(data.inviteUrl),
     })
+
+    const state = deriveLinkState(overrideUrl, linkQuery)
 
     if (state.kind === 'loading') {
         return (
@@ -80,6 +65,25 @@ export function InviteLinkPanel({ userOrgId, initialUrl }: InviteLinkPanelProps)
             rotatePending={rotate.isPending}
         />
     )
+}
+
+// Maps the invite-link query (or a short-circuit override URL) into the panel's
+// view state. A 404 from the endpoint means the link expired; anything else is a
+// surfaced error.
+function deriveLinkState(
+    overrideUrl: string | undefined,
+    query: ReturnType<typeof useQuery<{ inviteUrl: string }>>
+): LinkState {
+    if (overrideUrl) return { kind: 'ready', url: overrideUrl }
+    if (query.isPending) return { kind: 'loading' }
+    if (query.isError) {
+        const status = (query.error as { status?: number })?.status
+        if (status === 404) return { kind: 'expired' }
+        const message =
+            (query.error as { message?: string })?.message ?? 'Failed to load invite link'
+        return { kind: 'error', message }
+    }
+    return { kind: 'ready', url: query.data.inviteUrl }
 }
 
 function ExpiredView({ onRotate, pending }: { onRotate: () => void; pending: boolean }) {

--- a/core/components/setup/OrganizationsTab.tsx
+++ b/core/components/setup/OrganizationsTab.tsx
@@ -13,7 +13,7 @@ import { FormErrorSummary, TextInput, useForm, z, zodResolver } from '@tinycld/c
 import { Building2, ChevronDown, ChevronRight, ExternalLink, Plus, X } from 'lucide-react-native'
 import { newRecordId } from 'pbtsdb/core'
 import type PocketBase from 'pocketbase'
-import { useEffect, useState } from 'react'
+import { useRef, useState } from 'react'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { PageHeader, RowIcon, SectionLabel, SlugTag } from './console-ui'
 
@@ -477,7 +477,6 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
         setValue,
         setError,
         getValues,
-        watch,
         reset,
         formState: { errors, isSubmitted },
     } = useForm({
@@ -494,26 +493,19 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
         mode: 'onChange',
     })
 
-    const orgName = watch('orgName')
-    const orgSlug = watch('orgSlug')
-    const email = watch('email')
-    const ownerUsername = watch('ownerUsername')
+    // Auto-suggest the slug from the org name and the username from the email in
+    // the source field's change event (not a syncing useEffect). Each stops
+    // auto-tracking once the admin edits the derived field by hand — the ref
+    // flips the moment onSlugEdited/onUsernameEdited fires.
+    const slugEdited = useRef(false)
+    const usernameEdited = useRef(false)
 
-    // Auto-suggest the slug from the org name and the username from the email —
-    // both stop auto-tracking once the admin edits them by hand.
-    useEffect(() => {
-        const prev = deriveSlug(orgName.slice(0, -1))
-        if (!orgSlug || orgSlug === prev) {
-            setValue('orgSlug', deriveSlug(orgName))
-        }
-    }, [orgName, orgSlug, setValue])
-
-    useEffect(() => {
-        const prev = deriveUsername(email.slice(0, -1))
-        if (!ownerUsername || ownerUsername === prev) {
-            setValue('ownerUsername', deriveUsername(email))
-        }
-    }, [email, ownerUsername, setValue])
+    const onOrgNameChange = (value: string) => {
+        if (!slugEdited.current) setValue('orgSlug', deriveSlug(value))
+    }
+    const onEmailChange = (value: string) => {
+        if (!usernameEdited.current) setValue('ownerUsername', deriveUsername(value))
+    }
 
     // The admin picks the owner username; a collision surfaces as a mutation
     // error they can fix and retry. pbtsdb yields run as one optimistic
@@ -559,6 +551,9 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
         }),
         onSuccess: () => {
             reset()
+            // A fresh form re-arms the auto-suggest for the next org.
+            slugEdited.current = false
+            usernameEdited.current = false
             onCreated()
         },
         // A username/slug collision comes back as a PB field error — route it to
@@ -591,6 +586,7 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                                 name="orgName"
                                 label="Name"
                                 placeholder="Acme Corp"
+                                onValueChange={onOrgNameChange}
                             />
                         </View>
                         <View className="flex-1 min-w-[200px]">
@@ -601,6 +597,9 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                                 placeholder="acme-corp"
                                 autoCapitalize="none"
                                 hint="3-15 chars, lowercase, hyphens"
+                                onValueChange={() => {
+                                    slugEdited.current = true
+                                }}
                             />
                         </View>
                     </View>
@@ -629,6 +628,7 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                                 autoCapitalize="none"
                                 autoComplete="email"
                                 textContentType="emailAddress"
+                                onValueChange={onEmailChange}
                             />
                         </View>
                         <View className="flex-1 min-w-[200px]">
@@ -641,6 +641,9 @@ function CreateOrgSection({ isVisible, onCreated }: { isVisible: boolean; onCrea
                                 autoComplete="username"
                                 textContentType="username"
                                 hint="Must be unique — suggested from the email"
+                                onValueChange={() => {
+                                    usernameEdited.current = true
+                                }}
                             />
                         </View>
                         <View className="flex-1 min-w-[200px]">

--- a/core/lib/use-api-search.ts
+++ b/core/lib/use-api-search.ts
@@ -1,5 +1,6 @@
+import { useQuery } from '@tanstack/react-query'
 import { pb } from '@tinycld/core/lib/pocketbase'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface UseApiSearchOptions<TResult> {
     endpoint: string
@@ -17,12 +18,19 @@ interface UseApiSearchReturn<TResult> {
     error: string | null
 }
 
-function isAbortError(err: unknown): boolean {
-    return err instanceof DOMException && err.name === 'AbortError'
-}
-
 function toErrorMessage(err: unknown): string {
     return err instanceof Error ? err.message : 'Search failed'
+}
+
+// Debounce a value: only surface the latest after `delayMs` of quiet. Genuine
+// timer side-effect (not a server-data sync), so it stays in an effect.
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+    const [debounced, setDebounced] = useState(value)
+    useEffect(() => {
+        const timer = setTimeout(() => setDebounced(value), delayMs)
+        return () => clearTimeout(timer)
+    }, [value, delayMs])
+    return debounced
 }
 
 export function useApiSearch<TResult>(
@@ -38,70 +46,36 @@ export function useApiSearch<TResult>(
         debounceMs = 300,
     } = options
 
-    const [results, setResults] = useState<TResult[]>([])
-    const [total, setTotal] = useState(0)
-    const [isSearching, setIsSearching] = useState(false)
-    const [error, setError] = useState<string | null>(null)
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-    const abortRef = useRef<AbortController | null>(null)
+    const debouncedQuery = useDebouncedValue(query, debounceMs)
+    const enabled = debouncedQuery.length >= minQueryLength
 
-    const search = useCallback(
-        async (q: string) => {
-            abortRef.current?.abort()
-            const controller = new AbortController()
-            abortRef.current = controller
+    // React Query owns the fetch lifecycle: it aborts a superseded request via
+    // the queryFn `signal`, tracks in-flight/error state, and caches by the
+    // debounced query — replacing the hand-rolled AbortController + useState
+    // machinery this hook used to carry.
+    const search = useQuery({
+        queryKey: ['api-search', endpoint, debouncedQuery, buildQueryParams?.(debouncedQuery)],
+        queryFn: ({ signal }) =>
+            pb.send(endpoint, {
+                method: 'GET',
+                query: buildQueryParams ? buildQueryParams(debouncedQuery) : { q: debouncedQuery },
+                signal,
+            }),
+        enabled,
+        // A search is inherently point-in-time; don't retry a failed query
+        // (the user will just keep typing) and don't refetch on focus.
+        retry: false,
+        refetchOnWindowFocus: false,
+    })
 
-            setIsSearching(true)
-            setError(null)
+    if (!enabled) {
+        return { results: [], total: 0, isSearching: false, error: null }
+    }
 
-            try {
-                const queryParams = buildQueryParams ? buildQueryParams(q) : { q }
-                const response: unknown = await pb.send(endpoint, {
-                    method: 'GET',
-                    query: queryParams,
-                    signal: controller.signal,
-                })
-                if (controller.signal.aborted) return
-                setResults(extractResults(response))
-                setTotal(extractTotal ? extractTotal(response) : 0)
-            } catch (err: unknown) {
-                if (isAbortError(err) || controller.signal.aborted) return
-                setError(toErrorMessage(err))
-                setResults([])
-                setTotal(0)
-            } finally {
-                if (!controller.signal.aborted) {
-                    setIsSearching(false)
-                }
-            }
-        },
-        [endpoint, buildQueryParams, extractResults, extractTotal]
-    )
-
-    useEffect(() => {
-        if (timerRef.current) clearTimeout(timerRef.current)
-
-        if (query.length < minQueryLength) {
-            setResults([])
-            setTotal(0)
-            setIsSearching(false)
-            setError(null)
-            abortRef.current?.abort()
-            return
-        }
-
-        timerRef.current = setTimeout(() => search(query), debounceMs)
-
-        return () => {
-            if (timerRef.current) clearTimeout(timerRef.current)
-        }
-    }, [query, search, minQueryLength, debounceMs])
-
-    useEffect(() => {
-        return () => {
-            abortRef.current?.abort()
-        }
-    }, [])
-
-    return { results, total, isSearching, error }
+    return {
+        results: search.data ? extractResults(search.data) : [],
+        total: search.data && extractTotal ? extractTotal(search.data) : 0,
+        isSearching: search.isFetching,
+        error: search.error ? toErrorMessage(search.error) : null,
+    }
 }

--- a/core/ui/form/TextInput.tsx
+++ b/core/ui/form/TextInput.tsx
@@ -37,6 +37,10 @@ export type TextInputProps<T extends FieldValues = Record<string, unknown>> = Om
     wrapperProps?: ViewProps
     addon?: ReactNode
     onBlur?: () => void
+    // Optional side-effect fired with the new value on each keystroke, in
+    // addition to RHF's own field.onChange. Lets a form derive a sibling field
+    // (e.g. slug from name) in the change event instead of a syncing useEffect.
+    onValueChange?: (value: string) => void
 }
 
 export function TextInput<T extends FieldValues = Record<string, unknown>>(
@@ -52,6 +56,7 @@ export function TextInput<T extends FieldValues = Record<string, unknown>>(
         wrapperProps = {},
         addon,
         onBlur: onBlurProp,
+        onValueChange,
         ...inputProps
     } = props
     const {
@@ -69,7 +74,10 @@ export function TextInput<T extends FieldValues = Record<string, unknown>>(
             <View className="flex-row gap-2 items-center">
                 <RNTextInput
                     value={field.value || ''}
-                    onChangeText={field.onChange}
+                    onChangeText={value => {
+                        field.onChange(value)
+                        onValueChange?.(value)
+                    }}
                     onBlur={() => {
                         field.onBlur()
                         onBlurProp?.()


### PR DESCRIPTION
Rule-compliance sweep (§6.4): replace `useState`+`useEffect` that syncs/derives server or cross-field data with the right primitive (per CLAUDE.md: server/async → React Query, derived → compute during render / event handlers).

## Changes
- **`InviteLinkPanel.tsx`** — the invite-link fetch was a `useEffect` that hand-rolled loading/error/cancellation into `useState`. Now a `useQuery`; the panel's view state is derived during render (`deriveLinkState`), and `rotate()` sets a short-circuit override URL rather than driving the same state.
- **`use-api-search.ts`** — the debounced API-search hook carried four data `useState`s + a manual `AbortController` effect. React Query now owns the fetch lifecycle (abort via the `queryFn` signal, in-flight/error state, caching by the debounced query); only a small `useDebouncedValue` timer remains. **The public `{ results, total, isSearching, error }` contract is unchanged**, so the `contacts` and `drive` consumers keep working (verified: contacts' `filter-contacts.test.ts` — 13 tests — passes, and the whole workspace typechecks).
- **`OrganizationsTab.tsx`** — the slug/username auto-suggest was two `useEffect`s syncing one form field from another. Now derived in the source field's change event via a new optional `onValueChange` on the shared form `TextInput` (additive, zero impact on existing usages), with `useRef` flags tracking manual edits — no effect, no cross-field `setState` sync. The flags re-arm on form reset.

## Verification
`pnpm exec tinycld-pkg check` green — biome clean, tsc clean across the workspace (incl. the contacts/drive siblings that consume `useApiSearch`), 570 app unit tests + 13 contacts tests pass.