### PR TITLE
refactor(core): drop takeout-import fallbackActive store field (§4.26)

### DIFF
--- a/core/lib/stores/takeout-import-store.ts
+++ b/core/lib/stores/takeout-import-store.ts
@@ -40,7 +40,6 @@ interface TakeoutImportState {
     overallError: string | null
     activeServices: ImportService[]
     cancelRequested: boolean
-    fallbackActive: boolean
 
     setFiles: (files: File[]) => void
     setDetection: (detection: TakeoutDetection) => void
@@ -50,7 +49,6 @@ interface TakeoutImportState {
     setOverallError: (error: string | null) => void
     setActiveServices: (services: ImportService[]) => void
     requestCancel: () => void
-    setFallbackActive: (active: boolean) => void
     reset: () => void
 }
 
@@ -88,7 +86,6 @@ export const useTakeoutImportStore = create<TakeoutImportState>()(set => ({
     overallError: null,
     activeServices: [],
     cancelRequested: false,
-    fallbackActive: false,
 
     setFiles: files => set({ files }),
     setDetection: detection =>
@@ -132,7 +129,6 @@ export const useTakeoutImportStore = create<TakeoutImportState>()(set => ({
     setOverallError: overallError => set({ overallError }),
     setActiveServices: activeServices => set({ activeServices }),
     requestCancel: () => set({ cancelRequested: true }),
-    setFallbackActive: active => set({ fallbackActive: active }),
     reset: () =>
         set({
             files: [],
@@ -143,6 +139,5 @@ export const useTakeoutImportStore = create<TakeoutImportState>()(set => ({
             overallError: null,
             activeServices: [],
             cancelRequested: false,
-            fallbackActive: false,
         }),
 }))


### PR DESCRIPTION
Part of §4.26 (takeout importer data-integrity cluster).

Removes the `fallbackActive` field + `setFallbackActive` setter from the shared takeout-import store. They only drove the "importing in the foreground" banner for the dead web-worker path, which is deleted in the companion PR.

**Land this PR first** — the companion google-takeout-import PR removes the last consumers of these fields.

Companion PR: tinycld/google-takeout-import#10