### PR TITLE
fix(deploy/bare-metal): place bundled-packages.json next to the binary

### DIFF
--- a/deploy/bare-metal/build.sh
+++ b/deploy/bare-metal/build.sh
@@ -129,6 +129,21 @@ CGO_ENABLED=1 GOOS=linux go build -o ../tinycld .
 if [ -f go.work ]; then go work sync; fi
 cd ..
 
+# Place bundled-packages.json NEXT TO the binary (../server/bundled-packages.json
+# -> ./bundled-packages.json). The generator writes it under server/, but core's
+# coreserver.SyncBundledPackages resolves it relative to the binary's own dir
+# (filepath.Dir(os.Args[0])) — and the entrypoint runs the binary with cwd = this
+# tinycld/ dir, one level ABOVE server/. Without this copy the loader logs
+# "bundled-packages.json not found, skipping sync" and the in-app package registry
+# (Setup → Versions) never learns the bundled versions. The Dockerfile does the
+# identical copy for the container image.
+if [ -f server/bundled-packages.json ]; then
+    cp server/bundled-packages.json bundled-packages.json
+    echo "[build] placed bundled-packages.json next to the binary"
+else
+    echo "[build] WARN: server/bundled-packages.json missing; Setup → Versions will be empty"
+fi
+
 echo "[build] assembled tree ready at ${SCRATCH}/tinycld/tinycld"
 BUILD
 


### PR DESCRIPTION
## Problem
On a **bare-metal** build (`deploy/bare-metal/build.sh`), core logged `pkg_seed: bundled-packages.json not found, skipping sync` at every boot, so the in-app package registry behind **Setup → Versions** was never seeded — the admin showed no bundled-package versions.

## Root cause
The generator emits `bundled-packages.json` under **`server/`**, but `coreserver.SyncBundledPackages` resolves it relative to the binary's own directory (`filepath.Dir(os.Args[0])`) and the cwd — and the entrypoint runs the binary with cwd = the `tinycld/` build dir, **one level above `server/`**. None of the loader's candidate paths match `server/bundled-packages.json`.

The **Dockerfile already handles this** — it `COPY`s `server/bundled-packages.json` to `./bundled-packages.json` next to the binary (image build). `build.sh` just never replicated that step.

## Fix
After `go build`, copy `server/bundled-packages.json` → `bundled-packages.json` (next to the binary), with a WARN if the source is missing. One-line parity with the container image.

## Verification
Reproduced on the live bare-metal tinycld.com box: placing the file at the resolvable path and restarting turned the boot log into `pkg_seed: synced 8 bundled packages`, and the registry populated. `bash -n` clean.