### PR TITLE
feat(thumbnails): render RTF thumbnails

### DIFF
--- a/core/server/thumbnails/thumbnails.go
+++ b/core/server/thumbnails/thumbnails.go
@@ -36,6 +36,7 @@ var thumbFormats = []doctaculous.Format{
 	doctaculous.FormatXLSX,
 	doctaculous.FormatPPTX,
 	doctaculous.FormatEPUB,
+	doctaculous.FormatRTF,
 }
 
 // heifMimeTypes lists MIME types we decode via goheif. iPhone photo library

--- a/core/server/thumbnails/thumbnails_test.go
+++ b/core/server/thumbnails/thumbnails_test.go
@@ -47,6 +47,7 @@ func TestGenerateDocumentFormats(t *testing.T) {
 		{"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", doctaculous.FormatXLSX},
 		{"application/vnd.openxmlformats-officedocument.presentationml.presentation", doctaculous.FormatPPTX},
 		{"application/epub+zip", doctaculous.FormatEPUB},
+		{"application/rtf", doctaculous.FormatRTF},
 	}
 	for _, tc := range cases {
 		t.Run(string(tc.format), func(t *testing.T) {
@@ -83,6 +84,8 @@ func TestCanGenerate(t *testing.T) {
 		{"application/vnd.openxmlformats-officedocument.wordprocessingml.document", true},
 		{"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", true},
 		{"application/vnd.openxmlformats-officedocument.presentationml.presentation", true},
+		{"application/rtf", true},
+		{"text/rtf", true},
 		{"image/heic", true},
 		{"image/heif", true},
 		{"IMAGE/HEIC ", true}, // normalizeMime lowercases + trims


### PR DESCRIPTION
Adds `FormatRTF` to the thumbnail formats. doctaculous already opens RTF as a normal `Document` (RTF → HTML → reflow model), so `WriteImage` renders a first-page thumbnail for `.rtf` uploads with no other changes. FTS extraction already handled RTF.

Part of first-class RTF support (companion PRs in `drive` and `text` add reliable `.rtf` MIME mapping, preview/open registration, and the editor RTF↔docx round-trip). This thumbnail change stands alone and can merge independently.

Tested: `TestGenerateDocumentFormats/rtf` renders a valid JPEG; `TestCanGenerate` accepts `application/rtf` + `text/rtf`.