### PR TITLE
fix(theme): dark-mode scene background + unread-row token

### DIFF
--- a/core/components/NavigationThemeProvider.tsx
+++ b/core/components/NavigationThemeProvider.tsx
@@ -1,0 +1,29 @@
+import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native'
+import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useThemePreference } from '@tinycld/core/lib/use-theme-preference'
+import type { ReactNode } from 'react'
+
+// React Navigation paints every navigator scene with its theme's
+// `colors.background`, and Expo Router mounts navigators under the built-in
+// `DefaultTheme` — whose background is grey95 (rgb 242,242,242). That light
+// grey never switches with our dark mode, so it bleeds through any scene that
+// leaves its own background transparent (most visibly the "read" mail rows,
+// which are intentionally transparent). Wiring the navigation theme to our
+// resolved color scheme + design tokens keeps scene backgrounds in sync with
+// the rest of the app.
+export function NavigationThemeProvider({ children }: { children: ReactNode }) {
+    const { resolved } = useThemePreference()
+    const background = useThemeColor('background')
+    const card = useThemeColor('surface-secondary')
+    const text = useThemeColor('foreground')
+    const border = useThemeColor('border')
+    const primary = useThemeColor('primary')
+
+    const base = resolved === 'dark' ? DarkTheme : DefaultTheme
+    const theme = {
+        ...base,
+        colors: { ...base.colors, background, card, text, border, primary },
+    }
+
+    return <ThemeProvider value={theme}>{children}</ThemeProvider>
+}

--- a/core/components/Providers.tsx
+++ b/core/components/Providers.tsx
@@ -2,6 +2,7 @@ import '@tinycld/core/lib/crypto-polyfill'
 import '@tinycld/core/file-viewer/register-default-previews'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { CoreShortcuts } from '@tinycld/core/components/CoreShortcuts'
+import { NavigationThemeProvider } from '@tinycld/core/components/NavigationThemeProvider'
 import { OfflineOverlay } from '@tinycld/core/components/OfflineOverlay'
 import { ToastRenderer } from '@tinycld/core/components/Toast'
 import { AuthProvider } from '@tinycld/core/lib/auth'
@@ -22,7 +23,7 @@ function ThemeAwareGluestackProvider({ children }: { children: ReactNode }) {
     useConnectivityDetector()
     return (
         <GluestackUIProvider mode={preference} colorTheme={colorTheme}>
-            {children}
+            <NavigationThemeProvider>{children}</NavigationThemeProvider>
             <ToastRenderer />
             <OfflineOverlay />
             <ShortcutHelp />

--- a/core/lib/use-app-theme.ts
+++ b/core/lib/use-app-theme.ts
@@ -68,6 +68,7 @@ type BuiltInThemeColor =
     | 'success-soft-foreground'
     | 'success-soft-hover'
     | 'surface-secondary'
+    | 'unread-background'
     | 'surface-tertiary'
     | 'on-surface'
     | 'on-surface-foreground'

--- a/core/package.json
+++ b/core/package.json
@@ -65,6 +65,7 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.5.2",
+        "@react-navigation/native": "^7.1.33",
         "@sentry/react-native": "~7.11.0",
         "@tanstack/db": "^0.6.1",
         "@tanstack/react-db": "^0.1.79",

--- a/global.css
+++ b/global.css
@@ -42,6 +42,11 @@
             --surface: 255 255 255;
             --surface-secondary: 248 250 252;
 
+            /* Unread list-row highlight — must read as clearly elevated vs
+               --background in BOTH themes (a faint darker tint on white here,
+               a lighter elevated surface in dark). */
+            --unread-background: 241 245 249;
+
             /* Fields */
             --field-background: 255 255 255;
             --field-placeholder: 148 163 184;
@@ -101,6 +106,10 @@
             /* Surface */
             --surface: 15 22 41;
             --surface-secondary: 18 24 40;
+
+            /* Unread list-row highlight — a lighter, clearly elevated surface
+               so unread rows stand out from the near-black --background. */
+            --unread-background: 30 41 59;
 
             /* Fields */
             --field-background: 15 22 41;
@@ -275,6 +284,7 @@
     --color-accent-foreground: rgb(var(--accent-foreground));
     --color-surface: rgb(var(--surface));
     --color-surface-secondary: rgb(var(--surface-secondary));
+    --color-unread-background: rgb(var(--unread-background));
     --color-field-background: rgb(var(--field-background));
     --color-field-placeholder: rgb(var(--field-placeholder));
     --color-info: rgb(var(--info));


### PR DESCRIPTION
React Navigation's `DefaultTheme` background is grey95 (rgb 242,242,242) and never switches with our color scheme, so it bled through any transparent scene in dark mode — most visibly the mail *read* rows, which rendered near-white with unreadable dark text.

- Add `NavigationThemeProvider` (wired into `Providers`) so every navigator scene background tracks the resolved light/dark theme. Fixes it globally, not just for mail.
- Add a dedicated `--unread-background` token (light `#F1F5F9`, dark `#1E293B`) so unread list rows read as elevated vs `--background` in both themes — `surface-secondary` was indistinguishable from the page background in dark mode.
- Declare `@react-navigation/native` as a core peer dependency.

Consumed by tinycld/mail#40 (mail's read/unread fix uses the new token).