### PR TITLE
fix(drawer): respect device safe-area insets

### DIFF
--- a/core/components/help/HelpDrawer.tsx
+++ b/core/components/help/HelpDrawer.tsx
@@ -12,7 +12,6 @@ import {
 import { router } from 'expo-router'
 import { ArrowLeft, X } from 'lucide-react-native'
 import { Pressable, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useHelpStore } from '../../lib/help/store'
 import { useHelpGroupForPackage, useHelpTopic } from '../../lib/help/use-help-topics'
 import { HelpTopicView } from './HelpTopicView'
@@ -31,7 +30,6 @@ export function HelpDrawer() {
     const pkgGroup = useHelpGroupForPackage(pkgSlug)
     const muted = useThemeColor('muted-foreground')
     const orgHref = useOrgHref()
-    const insets = useSafeAreaInsets()
 
     const showBackArrow = mode === 'topic' && cameFrom !== null
 
@@ -50,7 +48,7 @@ export function HelpDrawer() {
         <Drawer isOpen={isOpen} onClose={close} anchor="right" size="md">
             <DrawerBackdrop />
             <DrawerContent>
-                <DrawerHeader style={{ paddingTop: insets.top }}>
+                <DrawerHeader>
                     <View className="flex-row items-center justify-between flex-1">
                         <View className="flex-row items-center flex-1">
                             {showBackArrow && (

--- a/core/ui/drawer/index.tsx
+++ b/core/ui/drawer/index.tsx
@@ -18,6 +18,7 @@ import Animated, {
     SlideOutRight,
     SlideOutUp,
 } from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useCloseOnNavigate } from './use-close-on-navigate'
 
 const SCOPE = 'MODAL'
@@ -87,8 +88,12 @@ const drawerBackdropStyle = tva({
 // modes prevents the content from jumping when the inner subview changes.
 // Vertical drawers (top/bottom) keep height scaling per `size`. Use
 // `size="full"` for an edge-to-edge drawer.
+// Base padding (`p-6` = 24px) is applied via inline style in DrawerContent so
+// the device safe-area inset can be *added* to it per edge — an inline padding
+// value would otherwise fully override a className padding, zeroing the base on
+// non-notch platforms.
 const drawerContentStyle = tva({
-    base: 'bg-background shadow-hard-5 p-6 absolute',
+    base: 'bg-background shadow-hard-5 absolute',
     parentVariants: {
         size: {
             sm: '',
@@ -276,8 +281,22 @@ const DrawerBackdrop = React.forwardRef<
 const DrawerContent = React.forwardRef<
     React.ComponentRef<typeof UIDrawer.Content>,
     IDrawerContentProps
->(function DrawerContent({ className, ...props }, ref) {
+>(function DrawerContent({ className, style, ...props }, ref) {
     const { size: parentSize, anchor: parentAnchor } = useStyleContext(SCOPE)
+    const insets = useSafeAreaInsets()
+
+    // 24px base padding (was `p-6`) plus the device safe-area inset on the edges
+    // the drawer reaches, so its header/body clears the status bar / notch /
+    // home indicator. Side drawers span full height (top + bottom); a top drawer
+    // reaches the top edge, a bottom drawer the bottom. On web / non-notch
+    // devices every inset is 0, leaving the original 24px.
+    const BASE = 24
+    const paddingStyle = {
+        paddingTop: BASE + (parentAnchor !== 'bottom' ? insets.top : 0),
+        paddingBottom: BASE + (parentAnchor !== 'top' ? insets.bottom : 0),
+        paddingLeft: BASE + (parentAnchor === 'left' ? insets.left : 0),
+        paddingRight: BASE + (parentAnchor === 'right' ? insets.right : 0),
+    }
 
     const customClass =
         parentAnchor === 'left' || parentAnchor === 'right'
@@ -315,6 +334,7 @@ const DrawerContent = React.forwardRef<
                 },
                 class: `${className || ''} ${customClass}`,
             })}
+            style={[paddingStyle, style]}
             pointerEvents="auto"
         />
     )


### PR DESCRIPTION
On notched devices the shared `Drawer`'s flat 24px content padding let a side drawer's header run under the status bar / dynamic island (and bottom drawers under the home indicator). Add the safe-area inset to the base padding per edge the drawer reaches — top+bottom for side drawers, the touched edge for top/bottom drawers.

Insets are 0 on web / non-notch devices, so desktop is unchanged. Also removes the now-redundant per-drawer `paddingTop` workaround in `HelpDrawer`.