### PR TITLE
fix(server): revalidate HTML entries with no-cache + ETag

### DIFF
--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -2,6 +2,8 @@ package coreserver
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io/fs"
 	"net/http"
@@ -200,14 +202,30 @@ func serveStaticFrom(e *core.RequestEvent, fs fs.FS, path string) (bool, error) 
 		if path == ".well-known/apple-app-site-association" {
 			e.Response.Header().Set("Content-Type", "application/json")
 		}
+		setHTMLRevalidate(e, path)
 		return true, e.FileFS(fs, path)
 	}
 	indexPath := path + "/index.html"
 	if f, err := fs.Open(indexPath); err == nil {
 		f.Close()
+		setHTMLRevalidate(e, indexPath)
 		return true, e.FileFS(fs, indexPath)
 	}
 	return false, nil
+}
+
+// setHTMLRevalidate marks an HTML document as always-revalidate. FileFS serves
+// via http.ServeContent, which emits Last-Modified and answers a conditional
+// GET with 304, so `no-cache` keeps the entry document current without the
+// full-refetch cost of `no-store` — an unchanged page costs one header
+// round-trip. Non-HTML static assets (favicon, images, workers) keep FileFS's
+// default (no directive) and are unaffected. This closes the stale-shell bug:
+// an HTML entry that pins content-hashed asset URLs must never be served from
+// cache without revalidation, or it references asset hashes the client dropped.
+func setHTMLRevalidate(e *core.RequestEvent, path string) {
+	if strings.HasSuffix(path, ".html") {
+		e.Response.Header().Set("Cache-Control", "no-cache")
+	}
 }
 
 // StaticWithDynamicFallback serves static files, then falls back to the active
@@ -264,28 +282,60 @@ func StaticWithDynamicFallback(publicDir, websiteDir, releasesDir string) func(*
 			return e.NotFoundError("", nil)
 		}
 
-		// SPA fallback. Set no-store on app.html so a tab reload always
-		// pulls the active release's shell rather than a cached copy that
-		// may reference asset hashes the client has since dropped.
+		// SPA fallback: the active release's shell. writeAppShell revalidates
+		// via ETag (see its doc) so a tab reload always confirms the shell is
+		// current — a stale shell would reference asset hashes the client has
+		// since dropped — but an unchanged shell 304s instead of re-sending.
 		if releasesDir != "" {
 			currentApp := filepath.Join(releasesDir, "current", "app.html")
 			if data, err := os.ReadFile(currentApp); err == nil {
-				e.Response.Header().Set("Cache-Control", "no-store")
-				e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
-				_, _ = e.Response.Write(injectPublicConfig(data))
-				return nil
+				return writeAppShell(e, injectPublicConfig(data))
 			}
 		}
 
 		// Dev fallback: publicDir/app.html. Read into memory (rather than
 		// streaming via FileFS) so the same public-config injection applies.
 		if data, err := fs.ReadFile(publicFs, "app.html"); err == nil {
-			e.Response.Header().Set("Cache-Control", "no-store")
-			e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
-			_, _ = e.Response.Write(injectPublicConfig(data))
-			return nil
+			return writeAppShell(e, injectPublicConfig(data))
 		}
 
 		return e.NotFoundError("", nil)
 	}
+}
+
+// writeAppShell sends the injected SPA shell HTML with revalidation caching.
+//
+// The shell body changes only per release (a new app.html) or when injected
+// public config changes, so a content-hash ETag identifies it exactly. We set
+// `no-cache` (always revalidate, never serve from cache blindly) plus that
+// ETag: an unchanged shell answers a conditional GET with a 304 and no body,
+// while a changed shell sends the new bytes. This keeps the shell always-fresh
+// — a cached shell would pin content-hashed asset URLs the client has dropped,
+// the stale-shell bug — without `no-store`'s full-refetch-every-load cost.
+//
+// The ETag is computed over the FINAL injected bytes (what the client receives),
+// so two deploys with identical shells + config collide correctly (same ETag →
+// 304), and any change to either busts it.
+func writeAppShell(e *core.RequestEvent, html []byte) error {
+	sum := sha256.Sum256(html)
+	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+
+	e.Response.Header().Set("Cache-Control", "no-cache")
+	e.Response.Header().Set("ETag", etag)
+	e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	// http.ServeContent isn't usable here (the body is built in memory, not a
+	// ReadSeeker file), so match If-None-Match ourselves. A comma-split covers
+	// the multi-value form; weak validators ("W/…") never match our strong tag.
+	if match := e.Request.Header.Get("If-None-Match"); match != "" {
+		for _, candidate := range strings.Split(match, ",") {
+			if strings.TrimSpace(candidate) == etag {
+				e.Response.WriteHeader(http.StatusNotModified)
+				return nil
+			}
+		}
+	}
+
+	_, _ = e.Response.Write(html)
+	return nil
 }

--- a/core/server/coreserver/static_test.go
+++ b/core/server/coreserver/static_test.go
@@ -1,6 +1,8 @@
 package coreserver
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -9,6 +11,14 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
 )
+
+// shellETag mirrors writeAppShell's ETag derivation for a shell whose injected
+// body equals its source (the test app publishes no public config, so
+// injectPublicConfig is a passthrough).
+func shellETag(body string) string {
+	sum := sha256.Sum256([]byte(body))
+	return `"` + hex.EncodeToString(sum[:]) + `"`
+}
 
 // staticDirs builds a publicDir (app's own web static), a websiteDir (marketing
 // site), and a releasesDir with current/app.html (the SPA shell), each populated
@@ -181,5 +191,108 @@ func TestStatic_ApiPathNeverServesShell(t *testing.T) {
 		ExpectedStatus:     http.StatusNotFound,
 		ExpectedContent:    []string{`"status":404`},
 		NotExpectedContent: []string{"APP SHELL", "HOME"},
+	})
+}
+
+// TestStatic_ShellRevalidates guards the stale-shell fix: the SPA shell must be
+// served with `no-cache` + a content ETag so a reload always revalidates rather
+// than serving a cached shell that pins dropped asset hashes.
+func TestStatic_ShellRevalidates(t *testing.T) {
+	const shell = "<html>APP SHELL</html>"
+	publicDir, websiteDir, releasesDir := staticDirs(t, nil, nil, shell)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "shell serves no-cache + ETag",
+		Method:          http.MethodGet,
+		URL:             "/a/acme/mail",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"APP SHELL"},
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			if cc := res.Header.Get("Cache-Control"); cc != "no-cache" {
+				t.Errorf("Cache-Control = %q, want %q", cc, "no-cache")
+			}
+			if et := res.Header.Get("ETag"); et != shellETag(shell) {
+				t.Errorf("ETag = %q, want %q", et, shellETag(shell))
+			}
+		},
+	})
+}
+
+// TestStatic_ShellConditionalGet confirms a matching If-None-Match short-circuits
+// to a 304 with no body — the payoff of no-cache over no-store.
+func TestStatic_ShellConditionalGet(t *testing.T) {
+	const shell = "<html>APP SHELL</html>"
+	publicDir, websiteDir, releasesDir := staticDirs(t, nil, nil, shell)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:           "matching If-None-Match yields 304, empty body",
+		Method:         http.MethodGet,
+		URL:            "/a/acme/mail",
+		Headers:        map[string]string{"If-None-Match": shellETag(shell)},
+		ExpectedStatus: http.StatusNotModified,
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			if cc := res.Header.Get("Cache-Control"); cc != "no-cache" {
+				t.Errorf("Cache-Control = %q, want %q", cc, "no-cache")
+			}
+		},
+	})
+}
+
+// TestStatic_ShellStaleETagRefetches confirms a non-matching validator (a client
+// holding a prior release's shell) gets the full new body, not a 304.
+func TestStatic_ShellStaleETagRefetches(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t, nil, nil, "<html>APP SHELL</html>")
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "stale If-None-Match re-sends the shell",
+		Method:          http.MethodGet,
+		URL:             "/a/acme/mail",
+		Headers:         map[string]string{"If-None-Match": shellETag("<html>OLD SHELL</html>")},
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"APP SHELL"},
+	})
+}
+
+// TestStatic_WebsiteHTMLRevalidates confirms static HTML documents (the
+// marketing site's entry) are served no-cache so they too can't be
+// heuristically cached and pin old asset hashes. FileFS supplies Last-Modified,
+// so revalidation is a cheap 304.
+func TestStatic_WebsiteHTMLRevalidates(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		nil,
+		map[string]string{"index.html": "<html>MARKETING HOME</html>"},
+		"<html>APP SHELL</html>",
+	)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "website / serves no-cache",
+		Method:          http.MethodGet,
+		URL:             "/",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"MARKETING HOME"},
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			if cc := res.Header.Get("Cache-Control"); cc != "no-cache" {
+				t.Errorf("Cache-Control = %q, want %q", cc, "no-cache")
+			}
+		},
+	})
+}
+
+// TestStatic_NonHTMLAssetKeepsDefault confirms the no-cache marking is scoped to
+// HTML — a static JS/asset file is untouched (its caching is set elsewhere, by
+// PoolAssets for hashed bundles).
+func TestStatic_NonHTMLAssetKeepsDefault(t *testing.T) {
+	publicDir, websiteDir, releasesDir := staticDirs(t,
+		map[string]string{"sw.js": "SERVICE_WORKER_BODY"},
+		nil,
+		"<html>APP SHELL</html>",
+	)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "sw.js is not marked no-cache by the HTML path",
+		Method:          http.MethodGet,
+		URL:             "/sw.js",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"SERVICE_WORKER_BODY"},
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			if cc := res.Header.Get("Cache-Control"); cc == "no-cache" {
+				t.Errorf("Cache-Control = %q; HTML-only no-cache leaked onto a non-HTML asset", cc)
+			}
+		},
 	})
 }


### PR DESCRIPTION
Serving the SPA shell and static HTML (marketing-site entry) cacheable-without-revalidation let a browser reuse a stale HTML entry that referenced content-hashed asset URLs the client had since dropped — a normal reload showed stale CSS/JS until a manual force-reload.

The shell used \`no-store\`, which fixes correctness but re-downloads the full document every load; static HTML got no directive at all (heuristically cached — the actual bug source). This serves HTML with \`Cache-Control: no-cache\` instead:

- **Static HTML** (`serveStaticFrom`): `FileFS` already emits `Last-Modified` via `http.ServeContent`, so `no-cache` revalidates cheaply (304 when unchanged).
- **App shell** (in-memory fallback): now carries a content `ETag` over the injected bytes and answers a matching `If-None-Match` with a 304.

Always fresh, but an unchanged entry costs one header round-trip instead of a full refetch.

## Tests
Adds coverage for: shell `no-cache`+ETag, matching `If-None-Match` → 304 empty body, stale ETag → full refetch, website HTML `no-cache`, and non-HTML asset unaffected. Full `coreserver` suite green.

## Deploy note
Server change — ships with the next server/image deploy, not the website-only path.