### PR TITLE
fix(pkgbuild): don't preserve ownership when copying build trees

### DIFF
--- a/core/server/pkgbuild/exec.go
+++ b/core/server/pkgbuild/exec.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -130,9 +131,92 @@ func RunCmdStreaming(onLine func(line string), dir, name string, args ...string)
 	return out, err
 }
 
-// CopyDir copies src's contents into dst, preserving attributes and symlinks
-// (cp -a semantics — pnpm workspace trees rely on both).
+// CopyDir copies src's contents into dst, preserving mode, timestamps and
+// symlinks (pnpm workspace trees rely on all three) but NOT ownership.
+//
+// This replaced a `cp -a`. `-a` implies --preserve=all, which makes cp chown
+// every entry to the source's uid/gid — and that FAILS with EINVAL when the
+// copy runs inside a user namespace that does not map the source owner. The
+// confined builder is exactly that case: the job maps only its own uid, so a
+// root-owned pre-fetched member tree is unmappable, every entry errors, and cp
+// exits nonzero after a copy that otherwise succeeded. Ownership is not
+// something a copy into a job's own workspace should carry anyway — the
+// destination belongs to whoever runs the build.
+//
+// Done in Go rather than by re-flagging cp because the flag spellings diverge:
+// GNU wants --preserve=mode,timestamps,links while BSD/macOS cp rejects it
+// outright (exit 64), and BSD -p attempts ownership regardless. This runs the
+// same everywhere and makes the ownership decision explicit.
 func CopyDir(src, dst string) error {
-	_, err := RunCmd(".", "cp", "-a", src+"/.", dst+"/")
-	return err
+	return copyTree(src, dst)
+}
+
+// copyTree recursively copies src into dst. Symlinks are recreated as symlinks
+// (never followed), so a dangling link — the generator emits plenty — copies
+// as a dangling link instead of failing.
+func copyTree(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		srcPath := filepath.Join(src, e.Name())
+		dstPath := filepath.Join(dst, e.Name())
+		info, err := e.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.RemoveAll(dstPath); err != nil {
+				return err
+			}
+			if err := os.Symlink(target, dstPath); err != nil {
+				return err
+			}
+			continue // symlink mode/times belong to the target, not the link
+		case e.IsDir():
+			if err := copyTree(srcPath, dstPath); err != nil {
+				return err
+			}
+		default:
+			if err := copyFileMode(srcPath, dstPath, info); err != nil {
+				return err
+			}
+		}
+		if err := os.Chmod(dstPath, info.Mode().Perm()); err != nil {
+			return err
+		}
+		if err := os.Chtimes(dstPath, info.ModTime(), info.ModTime()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyFileMode copies one regular file, creating the destination with the
+// source's permission bits. Distinct from nativeexport.go's copyFile, which
+// fsyncs for OTA durability and does not carry mode.
+func copyFileMode(src, dst string, info os.FileInfo) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/core/server/pkgbuild/exec_test.go
+++ b/core/server/pkgbuild/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -74,5 +75,80 @@ func TestCopyDir_CopiesContentsAndSymlinks(t *testing.T) {
 	target, err := os.Readlink(filepath.Join(dst, "link"))
 	if err != nil || target != "sub/f.txt" {
 		t.Fatalf("symlink not preserved: %v %q", err, target)
+	}
+}
+
+// Permission bits carry: the pipeline copies executable scripts (bin/, hooks)
+// between build trees, and a copy that flattened the mode would produce an
+// artifact whose entrypoints cannot run.
+func TestCopyDir_PreservesMode(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "data.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+	for name, want := range map[string]os.FileMode{"run.sh": 0o755, "data.json": 0o600} {
+		info, err := os.Stat(filepath.Join(dst, name))
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Errorf("%s mode = %o, want %o", name, got, want)
+		}
+	}
+}
+
+// A dangling symlink must copy as a dangling symlink rather than fail the
+// whole tree: the generator emits pb_hooks/pb_migrations as symlink farms, and
+// a link whose target is not yet materialized is normal mid-assembly.
+func TestCopyDir_DanglingSymlink(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	if err := os.Symlink("does/not/exist", filepath.Join(src, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir with a dangling symlink: %v", err)
+	}
+	target, err := os.Readlink(filepath.Join(dst, "dangling"))
+	if err != nil || target != "does/not/exist" {
+		t.Fatalf("dangling symlink not preserved: %v %q", err, target)
+	}
+}
+
+// The regression this function exists for: CopyDir must not try to reproduce
+// the SOURCE's ownership on the destination. `cp -a` did, which fails with
+// EINVAL inside the builder's user namespace (the pre-fetched member tree is
+// root-owned and root is unmapped there). Asserting the destination is owned
+// by the copying process — not the source uid — pins the behavior without
+// needing a namespace to reproduce it in.
+func TestCopyDir_DoesNotPreserveOwnership(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: every uid is writable, so the assertion proves nothing")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dst, "f"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("no stat_t on this platform")
+	}
+	if int(st.Uid) != os.Geteuid() {
+		t.Errorf("copied file uid = %d, want the copying process's %d", st.Uid, os.Geteuid())
 	}
 }


### PR DESCRIPTION
`CopyDir` shelled `cp -a`, which implies `--preserve=all` and chowns every copied entry to the source's uid/gid. Inside a user namespace that doesn't map the source owner, that chown fails with `EINVAL` — cp reports `failed to preserve ownership` for every entry and exits nonzero even though the copy succeeded.

The multi-org builder hits this on **every confined build**: the job maps only its own uid, while the pre-fetched member tree it copies from is root-owned and therefore unmappable. Builds died at `assemble: fetch <member>: exit status 1` with no visible cause.

```
cp: failed to preserve ownership for '.../third_party/pocketbase/ui/.env': Invalid argument
```

## Approach

Reimplemented in Go rather than re-flagging cp — the spellings diverge: GNU wants `--preserve=mode,timestamps,links`, BSD/macOS cp rejects that outright (exit 64), and BSD `-p` attempts ownership regardless.

Preserved exactly as before: mode, timestamps, symlinks (including dangling ones, which the generator's symlink farms produce mid-assembly). Not preserved: ownership — correct for a copy into a build's own workspace.

## Testing

New cases for mode preservation, dangling symlinks, and that the destination is owned by the copying process rather than the source uid. Full `core/server` suite green.

Verified end-to-end on a real host: with this fix a confined build completes and the resulting tenant boots and serves.