### PR TITLE
feat(coreserver): add create-owner for bootstrapping a hosted org

### DIFF
--- a/core/server/coreserver/owner_command.go
+++ b/core/server/coreserver/owner_command.go
@@ -1,0 +1,149 @@
+package coreserver
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/spf13/cobra"
+)
+
+// generatedPasswordBytes is the entropy behind an auto-generated owner
+// password: 24 random bytes, base64url-encoded to a 32-character secret. Well
+// past anything brute-forceable, and safe to paste through a shell or a JSON
+// body without escaping.
+const generatedPasswordBytes = 24
+
+// GenerateOwnerPassword returns a URL-safe random password. Exported so a
+// caller that must know the password before invoking this command (the
+// multi-org router returns it to the operator) generates it the same way.
+func GenerateOwnerPassword() (string, error) {
+	b := make([]byte, generatedPasswordBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate password: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// NewCreateOwnerCommand builds the `create-owner` subcommand: mint the app's
+// first operator against an existing pb_data, then exit.
+//
+// WHY THIS EXISTS. A single-tenant deployment gets its first accounts from the
+// setup wizard, whose routes RegisterSetupBootstrap binds — in the HOST
+// composition only. A hosted org has no wizard: the multi-org router
+// provisions it by building an artifact and booting a tenant, and the tenant
+// composition never binds those routes. So a freshly provisioned org served
+// fine but had zero users and nobody could log in.
+//
+// It creates BOTH identities the wizard does, with the same credentials:
+//
+//   - a `_superusers` record — the PocketBase admin behind /_/, which also
+//     keeps PB's installer satisfied and backs the sharelink signing key;
+//   - a `users` record with role=owner plus a `super_admins` grant — the
+//     identity the APP authenticates against and the /admin console runs as.
+//
+// Creating only the first is the trap this command exists to prevent: PB's own
+// `superuser upsert` writes `_superusers` alone, so the app login still fails.
+//
+// Idempotent: provisioning may be retried, and a retry must not fail because
+// one or both records already exist.
+func NewCreateOwnerCommand(app *pocketbase.PocketBase) *cobra.Command {
+	var password string
+
+	cmd := &cobra.Command{
+		Use:   "create-owner <email>",
+		Short: "Create the org's first operator (superuser + owner account), then exit",
+		Long: "Mints the two identities a hosted org needs to be usable: a PocketBase " +
+			"_superusers record (the /_/ admin) and a `users` record with role=owner plus " +
+			"its super_admins grant (the app login). This is what the /setup wizard creates " +
+			"on a single-tenant deployment; a hosted org has no wizard, so its router runs " +
+			"this instead. Pair with PB's --dir flag pointing at the org's pb_data. " +
+			"Without --password a random one is generated and printed. Re-running for an " +
+			"existing email is a no-op.",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			email := strings.TrimSpace(args[0])
+			if email == "" {
+				return fmt.Errorf("create-owner: email is required")
+			}
+
+			if password == "" {
+				generated, err := GenerateOwnerPassword()
+				if err != nil {
+					return fmt.Errorf("create-owner: %w", err)
+				}
+				password = generated
+			}
+
+			// Bootstrap opens the DB and applies SYSTEM migrations; the app's
+			// own collections (`users`, `super_admins`) come from the JS
+			// migrations RunAppMigrations applies. In the router's flow the
+			// tenant has already booted and run them, so this is a no-op —
+			// but running against a fresh pb_data must work rather than fail
+			// on a missing collection.
+			if err := app.Bootstrap(); err != nil {
+				return fmt.Errorf("create-owner: bootstrap: %w", err)
+			}
+			if err := app.RunAppMigrations(); err != nil {
+				return fmt.Errorf("create-owner: run migrations: %w", err)
+			}
+
+			created, err := createOperatorIdentities(app, email, password)
+			if err != nil {
+				return fmt.Errorf("create-owner: %w", err)
+			}
+
+			// Report the password ONLY when this run actually set it. On a
+			// no-op re-run the records already exist with their original
+			// secret, and printing the freshly generated one would hand the
+			// operator a password that does not work.
+			if !created {
+				cmd.Printf("owner: %s\nunchanged: account already exists (password not modified)\n", email)
+				return nil
+			}
+			cmd.Printf("owner: %s\npassword: %s\n", email, password)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&password, "password", "",
+		"password for both identities; omit to generate a random one")
+	return cmd
+}
+
+// createOperatorIdentities creates the _superusers record and the app owner,
+// skipping whichever already exists. The two are created independently so a
+// retry after a partial failure completes the missing half rather than
+// erroring on the half that succeeded.
+//
+// Reports whether it created anything, so the caller knows if `password` was
+// actually applied — on a full no-op the existing records keep their original
+// secret.
+func createOperatorIdentities(app core.App, email, password string) (created bool, err error) {
+	if existing, _ := app.FindAuthRecordByEmail(core.CollectionNameSuperusers, email); existing == nil {
+		superusers, ferr := app.FindCollectionByNameOrId(core.CollectionNameSuperusers)
+		if ferr != nil {
+			return created, fmt.Errorf("find superusers collection: %w", ferr)
+		}
+		su := core.NewRecord(superusers)
+		su.SetEmail(email)
+		su.SetPassword(password)
+		su.SetVerified(true)
+		if serr := app.Save(su); serr != nil {
+			return created, fmt.Errorf("create superuser: %w", serr)
+		}
+		created = true
+	}
+
+	if existing, _ := app.FindAuthRecordByEmail("users", email); existing != nil {
+		return created, nil
+	}
+	if _, cerr := CreateOwnerAccount(app, email, password); cerr != nil {
+		return created, fmt.Errorf("create owner account: %w", cerr)
+	}
+	return true, nil
+}

--- a/core/server/coreserver/setup_bootstrap.go
+++ b/core/server/coreserver/setup_bootstrap.go
@@ -194,6 +194,16 @@ func handleSetupInit(app *pocketbase.PocketBase, re *core.RequestEvent) error {
 // the caller can mint its auth token. The super_admins createRule is null
 // (superuser-only); this runs in the app's Go context, which bypasses record
 // rules, so the insert is authorized without an authenticated superuser.
+//
+// Exported as CreateOwnerAccount for callers outside the setup wizard — a
+// hosted org is provisioned by a router, which has no wizard to run (that
+// route is bound only in the host composition) and would otherwise leave the
+// org with zero users. Both paths must mint the SAME shape of account, so
+// they share this one implementation rather than each assembling the record.
+func CreateOwnerAccount(app core.App, email, password string) (*core.Record, error) {
+	return createSuperAdminOperator(app, email, password)
+}
+
 func createSuperAdminOperator(app core.App, email, password string) (*core.Record, error) {
 	users, err := app.FindCollectionByNameOrId("users")
 	if err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -83,6 +83,12 @@ func main() {
 	// migrations dir, which not every coreserver consumer has.
 	app.RootCmd.AddCommand(coreserver.NewExportTypesCommand(app, coreserver.DefaultTypesDir(), ""))
 
+	// `create-owner` mints the first app account against an existing pb_data.
+	// The multi-org router runs it on this binary when provisioning an org:
+	// a hosted tenant never binds the setup wizard's routes, so without it a
+	// new org serves correctly but has no user who can log in.
+	app.RootCmd.AddCommand(coreserver.NewCreateOwnerCommand(app))
+
 	if err := app.Start(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
A hosted org had no way to get its first account.

A single-tenant deployment gets one from the `/setup` wizard, but `RegisterSetupBootstrap` binds those routes in the **host** composition only — a tenant never serves them (`/api/setup/check` 404s on a hosted org). So provisioning produced an org that served correctly, with **zero users**, and nothing that could create one.

PocketBase's `superuser upsert` is not a substitute: it writes `_superusers` (the admin collection behind `/_/`) while the app authenticates against `users`. Onboarding with it yields an org whose `/_/` login works and whose app login returns **400** — the trap this removes.

## What it does

`create-owner <email>` mints **both** identities the wizard creates, from one set of credentials:

- a `_superusers` record — the `/_/` admin, which also satisfies PB's installer and backs the sharelink signing key
- a `users` record with `role=owner`, verified, plus its `super_admins` grant — the identity the **app** authenticates against

`--password` sets a known secret; omit it and a random 32-character one is generated. The password is reported either way — **except** on a no-op re-run, where the records already exist and printing a freshly generated password would hand the operator one that was never set.

Idempotent: provisioning retries must not fail because one or both records exist. The two are created independently, so a retry after a partial failure completes the missing half.

`createSuperAdminOperator` is exported as `CreateOwnerAccount`, so the wizard and this command mint the same shape of account from one implementation rather than drifting.

## Testing

Verified against a **real provisioned org database** (45 collections, copied from a live host):

- generated-password run creates all three artifacts — `_superusers`, `users` (role=owner, verified), `super_admins` grant
- `--password` is used verbatim
- re-run is a no-op and says so instead of printing a false password
- **both** `users` and `_superusers` authenticate with the same credentials against a running server; `users` auth returns `role: owner`

Full `core/server` suite green.

## Related

tinycld/multi-org#3 consumes this — the router runs it on the org's own artifact binary during provisioning.