### PR TITLE
feat(pkgbuild): record where each member was fetched from

### DIFF
--- a/core/server/coreserver/tenant_pkg_state.go
+++ b/core/server/coreserver/tenant_pkg_state.go
@@ -226,10 +226,14 @@ func upsertArtifactMemberRow(app core.App, artifactDir string, member pkgbuild.R
 	if err != nil {
 		return err
 	}
-	// npm_package is the version-discovery + reinstall source: the member's
-	// bare npm name, resolved through the router's control socket in hosted
-	// mode (the tenant has no toolchain).
-	if err := upsertPkgRegistry(app, manifest, member.Name, data); err != nil {
+	// npm_package is the version-discovery + reinstall source, resolved through
+	// the router's control socket in hosted mode (the tenant has no toolchain).
+	// It must be the spec the member was FETCHED from, not merely its npm name:
+	// an org installed from git upgrades against its remote's tags, and storing
+	// the bare name here sent every lookup to the npm registry instead — which
+	// 404s for packages that were never published there. SourceSpec falls back
+	// to the name for artifacts built before the recipe carried a spec.
+	if err := upsertPkgRegistry(app, manifest, member.SourceSpec(), data); err != nil {
 		return err
 	}
 	// upsertPkgRegistry preserves a pre-existing "bundled" status (the
@@ -278,7 +282,18 @@ func upsertArtifactBaseRow(app core.App, member pkgbuild.ResolvedMember) error {
 	rec.Set("version", member.Version)
 	rec.Set("has_server", true)
 	rec.Set("status", "bundled")
-	rec.Set("npm_package", pkgbuild.BaseMemberSlug)
+	// The shell's own fetch spec when the artifact records one (a git-installed
+	// base upgrades from its remote's tags), else its npm name — the
+	// pre-existing behaviour for artifacts built before Spec existed. Note the
+	// base's SourceSpec falls back to Name, which is CorePackageKey
+	// (@tinycld/core), so pin the historical BaseMemberSlug explicitly: the
+	// shell publishes as `tinycld`, and that is what a core version change has
+	// always resolved against.
+	if member.Spec != "" {
+		rec.Set("npm_package", member.Spec)
+	} else {
+		rec.Set("npm_package", pkgbuild.BaseMemberSlug)
+	}
 	rec.Set("manifest_json", json.RawMessage(manifestJSON))
 	return app.Save(rec)
 }

--- a/core/server/coreserver/tenant_pkg_state_test.go
+++ b/core/server/coreserver/tenant_pkg_state_test.go
@@ -309,6 +309,65 @@ func TestReconcileRegistryFromArtifact_CreatesRows(t *testing.T) {
 	}
 }
 
+// npm_package is the spec version discovery resolves against, so a member
+// fetched from git must record its GIT SPEC — not its npm name. Storing the
+// name sent every upgrade check for a git-installed org to the npm registry,
+// which 404s for packages that were never published there; the org's real
+// upgrades are its remote's tags.
+func TestReconcileRegistryFromArtifact_RecordsGitSpecs(t *testing.T) {
+	app := newTenantPkgStateApp(t)
+	members := []pkgbuild.ResolvedMember{
+		{
+			Slug: pkgbuild.BaseMemberSlug, Name: "@tinycld/core", Version: "0.0.4",
+			Spec: "github:tinycld/tinycld#v0.4.0", Integrity: "sha256:aa",
+		},
+		{
+			Slug: "todo", Name: "@tinycld/todo", Version: "1.0.0",
+			Spec: "git+ssh://git@github.com/acme/todo.git#main", Integrity: "sha256:bb",
+		},
+	}
+	dir := writeArtifact(t, members, map[string]string{"todo": todoManifest})
+
+	if err := reconcileRegistryFromArtifact(app, dir, ""); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	coreRow, err := app.FindFirstRecordByFilter("pkg_registry", "slug = 'core'", nil)
+	if err != nil {
+		t.Fatalf("core row not created: %v", err)
+	}
+	if got := coreRow.GetString("npm_package"); got != "github:tinycld/tinycld#v0.4.0" {
+		t.Fatalf("core npm_package = %q, want the git spec the base was fetched from", got)
+	}
+
+	todoRow, err := app.FindFirstRecordByFilter("pkg_registry", "slug = 'todo'", nil)
+	if err != nil {
+		t.Fatalf("todo row not created: %v", err)
+	}
+	if got := todoRow.GetString("npm_package"); got != "git+ssh://git@github.com/acme/todo.git#main" {
+		t.Fatalf("todo npm_package = %q, want the git spec the member was fetched from", got)
+	}
+}
+
+// An artifact built before ResolvedMember carried Spec records none, and must
+// keep resolving against the npm name exactly as it did before — an existing
+// org must not lose version discovery because the format grew a field.
+func TestReconcileRegistryFromArtifact_FallsBackToNpmNameWithoutSpec(t *testing.T) {
+	app := newTenantPkgStateApp(t)
+	dir := writeArtifact(t, baseAndTodoMembers(), map[string]string{"todo": todoManifest})
+
+	if err := reconcileRegistryFromArtifact(app, dir, ""); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	todoRow, err := app.FindFirstRecordByFilter("pkg_registry", "slug = 'todo'", nil)
+	if err != nil {
+		t.Fatalf("todo row not created: %v", err)
+	}
+	if got := todoRow.GetString("npm_package"); got != "@tinycld/todo" {
+		t.Fatalf("todo npm_package = %q, want the npm name when the artifact records no spec", got)
+	}
+}
+
 func TestReconcileRegistryFromArtifact_UpdatesAndNormalizesStatus(t *testing.T) {
 	app := newTenantPkgStateApp(t)
 	// A pre-existing bundled row (e.g. an org whose DB predates hosted

--- a/core/server/pkgbuild/resolve.go
+++ b/core/server/pkgbuild/resolve.go
@@ -18,11 +18,30 @@ const MembersLockFile = "members.lock.json"
 // ResolvedMember is one workspace member of a completed assemble, as resolved
 // facts.
 type ResolvedMember struct {
-	Slug        string `json:"slug"`
-	Name        string `json:"name"`      // npm package name (@tinycld/mail); the base records @tinycld/core
-	Version     string `json:"version"`   // semver read from the build dir, not the delta's target string
+	Slug    string `json:"slug"`
+	Name    string `json:"name"`    // npm package name (@tinycld/mail); the base records @tinycld/core
+	Version string `json:"version"` // semver read from the build dir, not the delta's target string
+	// Spec is the fetch spec this member was resolved FROM — a registry
+	// "name@version", or a git spec like "github:tinycld/mail#v1.2.0". It is
+	// what version discovery must use: a git-installed member's upgrades come
+	// from its remote's tags, and querying its npm NAME instead sends the
+	// lookup to a registry that may not carry it at all. Empty for members
+	// resolved before this field existed (the artifact predates it) — callers
+	// fall back to Name, which is the pre-existing behaviour.
+	Spec        string `json:"spec,omitempty"`
 	Integrity   string `json:"integrity"` // "sha256:<hex>" of the fetched tarball; "" when unknown (pre-lock current build)
 	FromCurrent bool   `json:"fromCurrent,omitempty"`
+}
+
+// SourceSpec is the spec version discovery and reinstall should use for this
+// member: the recorded fetch spec when the artifact carries one, else the npm
+// name. The fallback keeps artifacts built before Spec existed working — they
+// resolve against the registry exactly as they did before.
+func (m ResolvedMember) SourceSpec() string {
+	if m.Spec != "" {
+		return m.Spec
+	}
+	return m.Name
 }
 
 type membersLock struct {
@@ -98,7 +117,8 @@ func readBuildMembers(m RebuildManifest, buildDir string) ([]buildMember, error)
 				version = ms.Version
 			}
 			out = append(out, buildMember{ResolvedMember: ResolvedMember{
-				Slug: ms.Slug, Name: CorePackageKey, Version: version, FromCurrent: ms.FromCurrent,
+				Slug: ms.Slug, Name: CorePackageKey, Version: version,
+				Spec: ms.Spec, FromCurrent: ms.FromCurrent,
 			}})
 			continue
 		}
@@ -122,7 +142,8 @@ func readBuildMembers(m RebuildManifest, buildDir string) ([]buildMember, error)
 		}
 		out = append(out, buildMember{
 			ResolvedMember: ResolvedMember{
-				Slug: ms.Slug, Name: npmName, Version: version, FromCurrent: ms.FromCurrent,
+				Slug: ms.Slug, Name: npmName, Version: version,
+				Spec: ms.Spec, FromCurrent: ms.FromCurrent,
 			},
 			PeerVersions: manifest.PeerVersions,
 		})


### PR DESCRIPTION
An org installed from git showed its installed packages but **never an available upgrade** — every row's version check went to the npm registry and 404'd, because those packages were never published there. Its real upgrades are its remotes' tags.

## Cause

A resolved member kept only the npm name it resolved **to**, not the spec it came **from**. `pkg_registry.npm_package` — the value version discovery resolves against — was therefore `@tinycld/mail` for a member installed from `git+ssh://…/mail#v1.2.0`.

```
mail  current=0.3.1  source=npm  available=[]  ERROR: 404 '@tinycld/mail' is not in this registry
```

## Change

`ResolvedMember` gains `Spec`, so `recipe.json` records each member's fetch spec and the tenant's `pkg_registry` reconcile stores the real source via `SourceSpec()`. The base row gets the same fix — it hardcoded the shell's npm name, which 404s identically for a git-installed base.

**Backward compatible by construction:** `SourceSpec()` falls back to `Name`, so an artifact built before this field resolves exactly as it did before. `Spec` is deliberately **not** part of the recipe hash — where a member came from doesn't change the bytes built from it, so existing artifacts stay cache hits instead of forcing a rebuild.

## Testing

New cases: git specs are recorded for both a feature member and the base, and an artifact with no spec still falls back to the npm name. Full `core/server` suite green.

Verified end-to-end on a real host — after this plus the router-side gate, a git-installed org lists its tags:

```
core      current=0.0.4  source=git  available=[v0.4.0, v0.3.0, v0.2.1, …]
mail      current=0.3.1  source=git  available=[v0.3.1, v0.3.0, v0.2.1, …]
contacts  current=0.1.2  source=git  available=[v0.1.2, v0.1.1, v0.1.0, …]
```

## Related

tinycld/multi-org#4 is the router half (populating `Spec`, and authorizing git-spec discovery per org).