### PR TITLE
Fix multi-org apex handling and iOS landscape safe areas

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -44,7 +44,13 @@ export default function Layout() {
     if (state.status === 'resolving') return <BlankScreen />
     if (state.status === 'failed') return <GateFailedScreen error={state.error} />
     if (state.status === 'unresolved') {
-        return pathname === '/connect' ? <ConnectSlot /> : <BlankScreen />
+        // The two routes whose whole job is to RESOLVE an address must render
+        // rather than blank-screen: /connect sets a server's, /pick-org sets an
+        // org's. Must stay in step with the gate's redirect exemptions
+        // (use-server-address-gate.ts) — a route exempt there but blanked here
+        // shows nothing at all.
+        const resolvesAddress = pathname === '/connect' || pathname === '/pick-org'
+        return resolvesAddress ? <ConnectSlot /> : <BlankScreen />
     }
 
     const { Providers } = state

--- a/app/connect.tsx
+++ b/app/connect.tsx
@@ -1,4 +1,5 @@
 import { ConnectIllustration } from '@tinycld/core/components/connect/ConnectIllustration'
+import { PreAuthScreen } from '@tinycld/core/components/connect/PreAuthScreen'
 import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { ApexServerError } from '@tinycld/core/lib/apex'
 import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
@@ -11,15 +12,7 @@ import { TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
 import { router, useLocalSearchParams } from 'expo-router'
 import { ChevronDown, Globe, Server, X } from 'lucide-react-native'
 import { useState } from 'react'
-import {
-    KeyboardAvoidingView,
-    Modal,
-    Platform,
-    Pressable,
-    ScrollView,
-    Text,
-    View,
-} from 'react-native'
+import { KeyboardAvoidingView, Modal, Platform, Pressable, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 const FALLBACK_DEFAULT_SERVER = 'https://tinycld.org'
@@ -190,13 +183,10 @@ export default function Connect() {
     const busy = busyDefault || busyCustom
 
     return (
-        <SafeAreaView className="flex-1 bg-background" edges={['top', 'bottom']}>
-            <DocumentTitle title="Connect" includeOrg={false} />
-            <ScrollView
-                contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 28, paddingBottom: 32 }}
-                showsVerticalScrollIndicator={false}
-            >
-                <View className="flex-row items-center gap-3 mt-4">
+        <>
+            <PreAuthScreen>
+                <DocumentTitle title="Connect" includeOrg={false} />
+                <View className="flex-row items-center gap-3">
                     <BrandMark name={brandName} />
                 </View>
 
@@ -274,7 +264,7 @@ export default function Connect() {
                         <ChevronDown size={16} color={muted} />
                     </Pressable>
                 </View>
-            </ScrollView>
+            </PreAuthScreen>
 
             <Modal
                 visible={sheetOpen}
@@ -352,7 +342,7 @@ export default function Connect() {
                     </View>
                 </KeyboardAvoidingView>
             </Modal>
-        </SafeAreaView>
+        </>
     )
 }
 

--- a/app/connect.tsx
+++ b/app/connect.tsx
@@ -1,8 +1,9 @@
 import { ConnectIllustration } from '@tinycld/core/components/connect/ConnectIllustration'
 import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
+import { ApexServerError } from '@tinycld/core/lib/apex'
 import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
-import { ReloadUnavailableError } from '@tinycld/core/lib/reload-js-context'
-import { normalizeAddress, probe, setResolvedAddress } from '@tinycld/core/lib/server-address'
+import { isReloadAvailable, ReloadUnavailableError } from '@tinycld/core/lib/reload-js-context'
+import { normalizeAddress, probeServer, setResolvedAddress } from '@tinycld/core/lib/server-address'
 import { setActiveServer } from '@tinycld/core/lib/servers'
 import { switchToServer } from '@tinycld/core/lib/switch-server'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
@@ -26,6 +27,14 @@ const FALLBACK_DEFAULT_SERVER = 'https://tinycld.org'
 const urlSchema = z.object({
     url: z.string().min(1, 'Enter a server address.'),
 })
+
+// Not every unhappy outcome is a failure. A refused JS-context restart leaves
+// the server saved and active, so it reads as 'info' — only a genuinely failed
+// connection is 'error'.
+interface Notice {
+    tone: 'error' | 'info'
+    text: string
+}
 
 // The screen serves two jobs — first-run "pick a server" and, from Settings,
 // "add another one alongside the one you're signed into". Same probe, same
@@ -69,7 +78,14 @@ export default function Connect() {
     const [sheetOpen, setSheetOpen] = useState(false)
     const [busyDefault, setBusyDefault] = useState(false)
     const [busyCustom, setBusyCustom] = useState(false)
-    const [submitError, setSubmitError] = useState<string | null>(null)
+    const [notice, setNotice] = useState<Notice | null>(null)
+
+    // Adding a server switches to it, and a switch needs a JS-context restart
+    // this build may not have (dev bundler, or a binary without reload support).
+    // Say so BEFORE the tap — the same thing ServersDrawerSection and UserMenu
+    // already do — rather than letting the user discover it from what looks
+    // like an error afterwards. Only add-mode switches; first-run does not.
+    const warnsAboutRestart = isAddMode && !isReloadAvailable()
 
     const fg = useThemeColor('foreground')
     const muted = useThemeColor('muted-foreground')
@@ -82,7 +98,22 @@ export default function Connect() {
     })
 
     async function connectTo(addr: string) {
-        await probe(addr)
+        // probeServer, not probe: a multi-org apex is alive and answers 200, so a
+        // liveness check admits it and the app then renders a sign-in panel
+        // against a host with no PocketBase. ApexServerError means "this address
+        // hosts orgs" — the recovery is to ask which one, not to report an error.
+        try {
+            await probeServer(addr)
+        } catch (err) {
+            if (err instanceof ApexServerError) {
+                router.replace({
+                    pathname: '/pick-org',
+                    params: { apex: err.apexOrigin },
+                })
+                return
+            }
+            throw err
+        }
 
         if (isAddMode) {
             // Adding a second server: persist it, then restart the JS context so
@@ -107,44 +138,51 @@ export default function Connect() {
     // has been saved; only the JS-context restart is unavailable (dev builds have
     // no reload mechanism). Saying "couldn't reach" there would send the user
     // debugging a network problem that doesn't exist.
-    function describeFailure(err: unknown, label: string): string {
+    //
+    // The tone travels WITH the message rather than being inferred where it is
+    // rendered: this outcome is a success with a follow-up step, and showing it
+    // in the danger style told the user something had broken when nothing had.
+    function describeFailure(err: unknown, label: string): Notice {
         if (err instanceof ReloadUnavailableError) {
-            return `Saved ${label}. Restart the app to finish switching to it.`
+            return {
+                tone: 'info',
+                text: `Saved ${label}. Restart the app to finish switching to it.`,
+            }
         }
         const reason = err instanceof Error ? err.message : 'Connection failed'
-        return `Couldn't reach ${label}: ${reason}`
+        return { tone: 'error', text: `Couldn't reach ${label}: ${reason}` }
     }
 
     async function onUseDefault() {
-        setSubmitError(null)
+        setNotice(null)
         setBusyDefault(true)
         try {
             await connectTo(normalizeAddress(defaultServer))
         } catch (err) {
-            setSubmitError(describeFailure(err, defaultServerLabel))
+            setNotice(describeFailure(err, defaultServerLabel))
             setBusyDefault(false)
         }
     }
 
     function openSheet() {
-        setSubmitError(null)
+        setNotice(null)
         setSheetOpen(true)
     }
 
     function closeSheet() {
         setSheetOpen(false)
-        setSubmitError(null)
+        setNotice(null)
         reset({ url: '' })
     }
 
     const onSubmitCustom = handleSubmit(async ({ url }) => {
-        setSubmitError(null)
+        setNotice(null)
         setBusyCustom(true)
         const addr = normalizeAddress(url)
         try {
             await connectTo(addr)
         } catch (err) {
-            setSubmitError(describeFailure(err, addr))
+            setNotice(describeFailure(err, addr))
             setBusyCustom(false)
         }
     })
@@ -204,11 +242,10 @@ export default function Connect() {
                     {copy.body}
                 </Text>
 
-                {submitError && !sheetOpen ? (
-                    <View className="mt-5 rounded-lg p-3 bg-danger-soft">
-                        <Text className="text-xs text-danger">{submitError}</Text>
-                    </View>
-                ) : null}
+                <View className="mt-5">
+                    <RestartNotice isVisible={warnsAboutRestart && !sheetOpen && !notice} />
+                    <NoticeBanner notice={notice} isVisible={!sheetOpen} />
+                </View>
 
                 <View className="flex-1" />
 
@@ -302,11 +339,9 @@ export default function Connect() {
                                 autoFocus
                             />
 
-                            {submitError ? (
-                                <View className="rounded-lg p-3 bg-danger-soft mb-3">
-                                    <Text className="text-xs text-danger">{submitError}</Text>
-                                </View>
-                            ) : null}
+                            <RestartNotice isVisible={warnsAboutRestart && !notice} />
+
+                            <NoticeBanner notice={notice} className="mb-3" />
 
                             <PrimaryCta
                                 label={busyCustom ? 'Connecting…' : 'Connect'}
@@ -318,6 +353,43 @@ export default function Connect() {
                 </KeyboardAvoidingView>
             </Modal>
         </SafeAreaView>
+    )
+}
+
+// One place decides how a notice looks, so a success-with-a-caveat can never
+// pick up the danger styling again by being rendered at a site that assumes
+// every message is an error.
+function NoticeBanner({
+    notice,
+    isVisible = true,
+    className = '',
+}: {
+    notice: Notice | null
+    isVisible?: boolean
+    className?: string
+}) {
+    if (!notice || !isVisible) return null
+    const isError = notice.tone === 'error'
+    return (
+        <View
+            className={`rounded-lg p-3 ${isError ? 'bg-danger-soft' : 'bg-surface-secondary'} ${className}`}
+        >
+            <Text className={`text-xs ${isError ? 'text-danger' : 'text-foreground'}`}>
+                {notice.text}
+            </Text>
+        </View>
+    )
+}
+
+// Told BEFORE the tap, not after: this build cannot restart its own JS context,
+// so a switch needs a manual relaunch to finish. Mirrors the notice
+// ServersDrawerSection shows for the same condition.
+function RestartNotice({ isVisible }: { isVisible: boolean }) {
+    if (!isVisible) return null
+    return (
+        <Text className="text-[11px] text-muted-foreground mb-3">
+            Switching requires a restart in this build.
+        </Text>
     )
 }
 

--- a/app/connect.web.tsx
+++ b/app/connect.web.tsx
@@ -1,7 +1,7 @@
 import { ConnectIllustration } from '@tinycld/core/components/connect/ConnectIllustration'
 import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
-import { normalizeAddress, probe, setResolvedAddress } from '@tinycld/core/lib/server-address'
+import { normalizeAddress, probeServer, setResolvedAddress } from '@tinycld/core/lib/server-address'
 import { setActiveServer } from '@tinycld/core/lib/servers'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
@@ -39,7 +39,12 @@ export default function ConnectWeb() {
     })
 
     async function connectTo(addr: string) {
-        await probe(addr)
+        // probeServer, not probe: an address that merely answers is not
+        // necessarily a server. A multi-org apex returns 200 for every path, so
+        // liveness alone would admit it. Web has no picker route — the router
+        // serves its own org-finder page at the apex — so the apex case surfaces
+        // here as an ordinary (accurate) error rather than a redirect.
+        await probeServer(addr)
         // setActiveServer is the only sanctioned writer of the active pointer,
         // on every platform — one code path. Web never surfaces the saved list
         // (it is same-origin and has its own cookie switcher), so the extra list

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 import { AuthGate } from '@tinycld/core/components/workspace/AuthGate'
 import { SkeletonLayout } from '@tinycld/core/components/workspace/SkeletonLayout'
-import { isKnownApexAddress } from '@tinycld/core/lib/apex'
+import { isApexAddress } from '@tinycld/core/lib/apex'
 import { useAuth } from '@tinycld/core/lib/auth'
 import { trace } from '@tinycld/core/lib/debug-trace'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
@@ -13,21 +13,38 @@ import { Platform } from 'react-native'
 export default function Index() {
     const auth = useAuth({ throwIfAnon: false })
     const address = getResolvedAddress()
-    // A device that connected to the multi-org apex before this was caught at
-    // admission has the apex cached as its server. The apex hosts no org, so
-    // signing in there can never succeed — treat it as having no server so the
-    // user is routed to the picker instead of a dead sign-in panel. Web is
-    // exempt: it resolves same-origin, and on web the apex is served by the
-    // router's own org-finder page rather than this bundle.
-    const atApex = Platform.OS !== 'web' && isKnownApexAddress(address)
-    const hasServer = !!address && !atApex
+    const hasServer = !!address
 
     trace('Index render', {
         isLoggedIn: auth.isLoggedIn,
         isInitializing: auth.isInitializing,
         hasServer,
-        atApex,
     })
+
+    // A device that connected to the multi-org apex before this was caught at
+    // admission has the apex cached as its server, where signing in can never
+    // succeed. Recover by sending it to the picker.
+    //
+    // Deliberately does NOT gate the render: the overwhelmingly common case is
+    // an ordinary single-tenant server, which must show its login form
+    // immediately rather than waiting on a network round-trip. So the sign-in
+    // panel renders straight away and this redirects out from under it only if
+    // the address actually answers as an apex. Web is exempt — it resolves
+    // same-origin, and there the apex serves the router's own finder page
+    // rather than this bundle.
+    useEffect(() => {
+        if (Platform.OS === 'web' || !address) return
+        if (auth.isLoggedIn || auth.isInitializing) return
+        let cancelled = false
+        isApexAddress(address).then(atApex => {
+            if (cancelled || !atApex) return
+            trace('Index replace /pick-org', { address })
+            router.replace('/pick-org')
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [address, auth.isLoggedIn, auth.isInitializing])
 
     useEffect(() => {
         // Only the no-server case needs an imperative nav. The logged-in landing
@@ -36,11 +53,10 @@ export default function Index() {
         // so pushing it from here (already at '/') re-entered this same route
         // and drove React Navigation into an infinite setState loop (React #185).
         if (!auth.isLoggedIn && !auth.isInitializing && !hasServer) {
-            const target = atApex ? '/pick-org' : '/connect'
-            trace('Index replace', { target })
-            router.replace(target)
+            trace('Index replace /connect')
+            router.replace('/connect')
         }
-    }, [auth.isLoggedIn, hasServer, auth.isInitializing, atApex])
+    }, [auth.isLoggedIn, hasServer, auth.isInitializing])
 
     // Logged in: redirect into the workspace. Rendered in a child so the
     // package/role hooks (which throw for anonymous users) only run once auth is

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,6 @@
 import { AuthGate } from '@tinycld/core/components/workspace/AuthGate'
 import { SkeletonLayout } from '@tinycld/core/components/workspace/SkeletonLayout'
+import { isKnownApexAddress } from '@tinycld/core/lib/apex'
 import { useAuth } from '@tinycld/core/lib/auth'
 import { trace } from '@tinycld/core/lib/debug-trace'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
@@ -7,28 +8,39 @@ import { getResolvedAddress } from '@tinycld/core/lib/server-address'
 import { useSortedPackagesResult } from '@tinycld/core/lib/use-sorted-packages'
 import { Redirect, router } from 'expo-router'
 import { useEffect } from 'react'
+import { Platform } from 'react-native'
 
 export default function Index() {
     const auth = useAuth({ throwIfAnon: false })
-    const hasServer = !!getResolvedAddress()
+    const address = getResolvedAddress()
+    // A device that connected to the multi-org apex before this was caught at
+    // admission has the apex cached as its server. The apex hosts no org, so
+    // signing in there can never succeed — treat it as having no server so the
+    // user is routed to the picker instead of a dead sign-in panel. Web is
+    // exempt: it resolves same-origin, and on web the apex is served by the
+    // router's own org-finder page rather than this bundle.
+    const atApex = Platform.OS !== 'web' && isKnownApexAddress(address)
+    const hasServer = !!address && !atApex
 
     trace('Index render', {
         isLoggedIn: auth.isLoggedIn,
         isInitializing: auth.isInitializing,
         hasServer,
+        atApex,
     })
 
     useEffect(() => {
-        // Only the no-server case needs an imperative nav (to /connect). The
-        // logged-in landing is a declarative <Redirect> in LandingRedirect below —
-        // NOT an imperative navigateToOrg(): single-org collapsed the org path to
-        // '/', so pushing it from here (already at '/') re-entered this same route
+        // Only the no-server case needs an imperative nav. The logged-in landing
+        // is a declarative <Redirect> in LandingRedirect below — NOT an
+        // imperative navigateToOrg(): single-org collapsed the org path to '/',
+        // so pushing it from here (already at '/') re-entered this same route
         // and drove React Navigation into an infinite setState loop (React #185).
         if (!auth.isLoggedIn && !auth.isInitializing && !hasServer) {
-            trace('Index replace /connect')
-            router.replace('/connect')
+            const target = atApex ? '/pick-org' : '/connect'
+            trace('Index replace', { target })
+            router.replace(target)
         }
-    }, [auth.isLoggedIn, hasServer, auth.isInitializing])
+    }, [auth.isLoggedIn, hasServer, auth.isInitializing, atApex])
 
     // Logged in: redirect into the workspace. Rendered in a child so the
     // package/role hooks (which throw for anonymous users) only run once auth is

--- a/app/pick-org.tsx
+++ b/app/pick-org.tsx
@@ -1,0 +1,279 @@
+import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
+import { hostnameOf, isOrgUnderApex, orgUrlUnderApex, slugUnderApex } from '@tinycld/core/lib/apex'
+import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
+import { ReloadUnavailableError } from '@tinycld/core/lib/reload-js-context'
+import { normalizeAddress, probeServer, setResolvedAddress } from '@tinycld/core/lib/server-address'
+import { readServers, setActiveServer } from '@tinycld/core/lib/servers'
+import { switchToServer } from '@tinycld/core/lib/switch-server'
+import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
+import { router, useLocalSearchParams } from 'expo-router'
+import { Building2, ChevronRight, Server } from 'lucide-react-native'
+import { useEffect, useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+// The native counterpart to the router's apex org-finder page (multi-org,
+// internal/webpage). Reaching the apex means the user is at an address that
+// HOSTS organizations rather than being one — there is no PocketBase behind it,
+// so a sign-in panel here could never succeed. This screen asks the one question
+// that actually unblocks them: which org?
+//
+// Deliberately mirrors the web page's two affordances and no more: pick an org
+// this device already knows, or type your org's name. There is no "create an
+// organization" — provisioning is superuser-only on the admin subdomain, so
+// offering it would promise a self-serve signup that does not exist.
+
+const slugSchema = z.object({
+    slug: z.string().min(1, "Enter your organization's name."),
+})
+
+interface KnownOrg {
+    origin: string
+    slug: string
+}
+
+// The orgs on THIS router that this device has connected to before. Saved
+// servers already model an org as an origin (lib/servers.ts says so explicitly),
+// so there is no separate org list to maintain — just the subset living under
+// this apex. A self-hosted box in the list is correctly excluded: it is not an
+// org of this router, and its row would switch the user somewhere unrelated.
+function useKnownOrgs(apexHostname: string | null): KnownOrg[] {
+    const [orgs, setOrgs] = useState<KnownOrg[]>([])
+
+    useEffect(() => {
+        if (!apexHostname) return
+        let cancelled = false
+        readServers().then(servers => {
+            if (cancelled) return
+            const known = servers
+                .filter(s => isOrgUnderApex(s.origin, apexHostname))
+                .map(s => ({ origin: s.origin, slug: slugUnderApex(s.origin, apexHostname) ?? '' }))
+            setOrgs(known)
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [apexHostname])
+
+    return orgs
+}
+
+export default function PickOrg() {
+    const { apex } = useLocalSearchParams<{ apex?: string }>()
+    const config = getCoreConfigOptional()
+    const brandName = config?.brandName ?? 'TinyCld'
+
+    const apexOrigin = apex ? normalizeAddress(apex) : (config?.defaultServer ?? '')
+    const apexHostname = hostnameOf(apexOrigin)
+    const knownOrgs = useKnownOrgs(apexHostname)
+
+    const [busy, setBusy] = useState(false)
+    const [submitError, setSubmitError] = useState<string | null>(null)
+
+    const muted = useThemeColor('muted-foreground')
+    const fg = useThemeColor('foreground')
+
+    const { control, handleSubmit } = useForm({
+        resolver: zodResolver(slugSchema),
+        defaultValues: { slug: '' },
+        mode: 'onChange',
+    })
+
+    // Connecting to an org is the ordinary first-run path, not a switch: there is
+    // no active server to preserve, because the apex was never admitted as one.
+    async function connectToOrg(origin: string) {
+        await probeServer(origin)
+        await setActiveServer(origin)
+        setResolvedAddress(origin)
+        router.replace('/')
+    }
+
+    // A row for an org already in the saved list, on the other hand, may well be
+    // a switch away from another org — switchToServer handles both and restarts
+    // the JS context so the target org's own bundle loads.
+    async function onPickKnown(origin: string) {
+        setSubmitError(null)
+        setBusy(true)
+        try {
+            await switchToServer(origin)
+        } catch (err) {
+            setSubmitError(describeFailure(err, origin))
+            setBusy(false)
+        }
+    }
+
+    const onSubmitSlug = handleSubmit(async ({ slug }) => {
+        setSubmitError(null)
+        if (!apexHostname) {
+            setSubmitError('This address does not look like a TinyCld host.')
+            return
+        }
+        const origin = orgUrlUnderApex(slug.trim().toLowerCase(), apexHostname)
+        if (!origin) {
+            setSubmitError('Organization names are lowercase letters, digits, and hyphens.')
+            return
+        }
+        setBusy(true)
+        try {
+            await connectToOrg(origin)
+        } catch (err) {
+            setSubmitError(describeFailure(err, origin))
+            setBusy(false)
+        }
+    })
+
+    return (
+        <SafeAreaView className="flex-1 bg-background" edges={['top', 'bottom']}>
+            <DocumentTitle title="Choose an organization" includeOrg={false} />
+            <ScrollView
+                contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 28, paddingBottom: 32 }}
+                showsVerticalScrollIndicator={false}
+            >
+                <View className="flex-row items-center gap-2 mt-8 mb-2">
+                    <View className="w-[18px] h-px bg-primary" />
+                    <Text
+                        className="text-[11px] font-semibold text-primary"
+                        style={{ letterSpacing: 2 }}
+                    >
+                        CHOOSE AN ORGANIZATION
+                    </Text>
+                </View>
+
+                <Text
+                    className="text-foreground text-[32px] font-semibold"
+                    style={{ lineHeight: 36, letterSpacing: -0.8, fontFamily: 'Georgia' }}
+                >
+                    Find your{' '}
+                    <Text
+                        className="italic font-normal text-primary"
+                        style={{ fontFamily: 'Georgia' }}
+                    >
+                        organization.
+                    </Text>
+                </Text>
+
+                <Text
+                    className="text-foreground text-[15px] mt-3.5"
+                    style={{ lineHeight: 22, opacity: 0.78, maxWidth: 360 }}
+                >
+                    {apexHostname ?? brandName} hosts many organizations, each with its own address.
+                    Pick one you've used on this device, or enter your organization's name.
+                </Text>
+
+                <KnownOrgsSection
+                    orgs={knownOrgs}
+                    apexHostname={apexHostname}
+                    disabled={busy}
+                    onPick={onPickKnown}
+                />
+
+                <View className="mt-7">
+                    <TextInput
+                        control={control}
+                        name="slug"
+                        label="Your organization's name"
+                        placeholder="your-org"
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                        autoComplete="off"
+                        hint={apexHostname ? `We'll open your-org.${apexHostname}` : undefined}
+                    />
+                </View>
+
+                {submitError ? (
+                    <View className="mt-3 rounded-lg p-3 bg-danger-soft">
+                        <Text className="text-xs text-danger">{submitError}</Text>
+                    </View>
+                ) : null}
+
+                <Pressable
+                    onPress={onSubmitSlug}
+                    disabled={busy}
+                    className={`mt-4 bg-foreground rounded-2xl py-4 px-5 items-center justify-center relative overflow-hidden ${busy ? 'opacity-[0.55]' : 'opacity-100'}`}
+                >
+                    <View className="absolute top-0 bottom-0 left-0 w-1 bg-primary" />
+                    <Text className="text-[15px] font-semibold text-background">
+                        {busy ? 'Connecting…' : 'Continue'}
+                    </Text>
+                </Pressable>
+
+                <Text className="text-muted-foreground text-[13px] mt-5" style={{ lineHeight: 19 }}>
+                    Not sure of the address? It's in your invitation email, or ask your
+                    organization's administrator.
+                </Text>
+
+                <View className="flex-1" />
+
+                {/* A self-hoster who tapped the hosted default must not be stranded
+                    here — /connect is the surface that takes an arbitrary address. */}
+                <Pressable
+                    onPress={() => router.replace('/connect')}
+                    disabled={busy}
+                    className={`mt-8 rounded-xl border border-border bg-surface flex-row items-center gap-3 px-4 py-3.5 ${busy ? 'opacity-50' : 'opacity-100'}`}
+                >
+                    <Server size={16} color={fg} />
+                    <Text className="text-foreground text-sm font-medium flex-1">
+                        Use a different server
+                    </Text>
+                    <ChevronRight size={16} color={muted} />
+                </Pressable>
+            </ScrollView>
+        </SafeAreaView>
+    )
+}
+
+function KnownOrgsSection({
+    orgs,
+    apexHostname,
+    disabled,
+    onPick,
+}: {
+    orgs: KnownOrg[]
+    apexHostname: string | null
+    disabled: boolean
+    onPick: (origin: string) => void
+}) {
+    const muted = useThemeColor('muted-foreground')
+    const fg = useThemeColor('foreground')
+    if (orgs.length === 0) return null
+    return (
+        <View className="mt-7">
+            <Text
+                className="text-[11px] font-semibold text-muted-foreground mb-2"
+                style={{ letterSpacing: 1.6 }}
+            >
+                YOUR ORGANIZATIONS
+            </Text>
+            {orgs.map(org => (
+                <Pressable
+                    key={org.origin}
+                    onPress={() => onPick(org.origin)}
+                    disabled={disabled}
+                    className={`rounded-xl border border-border bg-surface flex-row items-center gap-3 px-4 py-3.5 mb-2 ${disabled ? 'opacity-50' : 'opacity-100'}`}
+                >
+                    <Building2 size={16} color={fg} />
+                    <View className="flex-1">
+                        <Text className="text-foreground text-sm font-medium">{org.slug}</Text>
+                        <Text className="text-muted-foreground text-xs mt-px">
+                            {org.slug}.{apexHostname}
+                        </Text>
+                    </View>
+                    <ChevronRight size={16} color={muted} />
+                </Pressable>
+            ))}
+        </View>
+    )
+}
+
+// A refused switch is not a connection failure: the org was reachable and saved,
+// only the JS-context restart is unavailable (dev builds have no reload
+// mechanism). Saying "couldn't reach" would send the user debugging a network
+// problem that does not exist. Mirrors connect.tsx's describeFailure.
+function describeFailure(err: unknown, label: string): string {
+    if (err instanceof ReloadUnavailableError) {
+        return `Saved ${label}. Restart the app to finish opening it.`
+    }
+    const reason = err instanceof Error ? err.message : 'Connection failed'
+    return `Couldn't reach ${label}: ${reason}`
+}

--- a/app/pick-org.tsx
+++ b/app/pick-org.tsx
@@ -1,3 +1,4 @@
+import { PreAuthScreen } from '@tinycld/core/components/connect/PreAuthScreen'
 import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { hostnameOf, isOrgUnderApex, orgUrlUnderApex, slugUnderApex } from '@tinycld/core/lib/apex'
 import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
@@ -10,8 +11,7 @@ import { TextInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
 import { router, useLocalSearchParams } from 'expo-router'
 import { Building2, ChevronRight, Server } from 'lucide-react-native'
 import { useEffect, useState } from 'react'
-import { Pressable, ScrollView, Text, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { Pressable, Text, View } from 'react-native'
 
 // The native counterpart to the router's apex org-finder page (multi-org,
 // internal/webpage). Reaching the apex means the user is at an address that
@@ -124,102 +124,94 @@ export default function PickOrg() {
     })
 
     return (
-        <SafeAreaView className="flex-1 bg-background" edges={['top', 'bottom']}>
+        <PreAuthScreen>
             <DocumentTitle title="Choose an organization" includeOrg={false} />
-            <ScrollView
-                contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 28, paddingBottom: 32 }}
-                showsVerticalScrollIndicator={false}
+            <View className="flex-row items-center gap-2 mb-2">
+                <View className="w-[18px] h-px bg-primary" />
+                <Text
+                    className="text-[11px] font-semibold text-primary"
+                    style={{ letterSpacing: 2 }}
+                >
+                    CHOOSE AN ORGANIZATION
+                </Text>
+            </View>
+
+            <Text
+                className="text-foreground text-[32px] font-semibold"
+                style={{ lineHeight: 36, letterSpacing: -0.8, fontFamily: 'Georgia' }}
             >
-                <View className="flex-row items-center gap-2 mt-8 mb-2">
-                    <View className="w-[18px] h-px bg-primary" />
-                    <Text
-                        className="text-[11px] font-semibold text-primary"
-                        style={{ letterSpacing: 2 }}
-                    >
-                        CHOOSE AN ORGANIZATION
-                    </Text>
-                </View>
-
-                <Text
-                    className="text-foreground text-[32px] font-semibold"
-                    style={{ lineHeight: 36, letterSpacing: -0.8, fontFamily: 'Georgia' }}
-                >
-                    Find your{' '}
-                    <Text
-                        className="italic font-normal text-primary"
-                        style={{ fontFamily: 'Georgia' }}
-                    >
-                        organization.
-                    </Text>
+                Find your{' '}
+                <Text className="italic font-normal text-primary" style={{ fontFamily: 'Georgia' }}>
+                    organization.
                 </Text>
+            </Text>
 
-                <Text
-                    className="text-foreground text-[15px] mt-3.5"
-                    style={{ lineHeight: 22, opacity: 0.78, maxWidth: 360 }}
-                >
-                    {apexHostname ?? brandName} hosts many organizations, each with its own address.
-                    Pick one you've used on this device, or enter your organization's name.
-                </Text>
+            <Text
+                className="text-foreground text-[15px] mt-3.5"
+                style={{ lineHeight: 22, opacity: 0.78, maxWidth: 360 }}
+            >
+                {apexHostname ?? brandName} hosts many organizations, each with its own address.
+                Pick one you've used on this device, or enter your organization's name.
+            </Text>
 
-                <KnownOrgsSection
-                    orgs={knownOrgs}
-                    apexHostname={apexHostname}
-                    disabled={busy}
-                    onPick={onPickKnown}
+            <KnownOrgsSection
+                orgs={knownOrgs}
+                apexHostname={apexHostname}
+                disabled={busy}
+                onPick={onPickKnown}
+            />
+
+            <View className="mt-7">
+                <TextInput
+                    control={control}
+                    name="slug"
+                    label="Your organization's name"
+                    placeholder="your-org"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    autoComplete="off"
+                    hint={apexHostname ? `We'll open your-org.${apexHostname}` : undefined}
                 />
+            </View>
 
-                <View className="mt-7">
-                    <TextInput
-                        control={control}
-                        name="slug"
-                        label="Your organization's name"
-                        placeholder="your-org"
-                        autoCapitalize="none"
-                        autoCorrect={false}
-                        autoComplete="off"
-                        hint={apexHostname ? `We'll open your-org.${apexHostname}` : undefined}
-                    />
+            {submitError ? (
+                <View className="mt-3 rounded-lg p-3 bg-danger-soft">
+                    <Text className="text-xs text-danger">{submitError}</Text>
                 </View>
+            ) : null}
 
-                {submitError ? (
-                    <View className="mt-3 rounded-lg p-3 bg-danger-soft">
-                        <Text className="text-xs text-danger">{submitError}</Text>
-                    </View>
-                ) : null}
-
-                <Pressable
-                    onPress={onSubmitSlug}
-                    disabled={busy}
-                    className={`mt-4 bg-foreground rounded-2xl py-4 px-5 items-center justify-center relative overflow-hidden ${busy ? 'opacity-[0.55]' : 'opacity-100'}`}
-                >
-                    <View className="absolute top-0 bottom-0 left-0 w-1 bg-primary" />
-                    <Text className="text-[15px] font-semibold text-background">
-                        {busy ? 'Connecting…' : 'Continue'}
-                    </Text>
-                </Pressable>
-
-                <Text className="text-muted-foreground text-[13px] mt-5" style={{ lineHeight: 19 }}>
-                    Not sure of the address? It's in your invitation email, or ask your
-                    organization's administrator.
+            <Pressable
+                onPress={onSubmitSlug}
+                disabled={busy}
+                className={`mt-4 bg-foreground rounded-2xl py-4 px-5 items-center justify-center relative overflow-hidden ${busy ? 'opacity-[0.55]' : 'opacity-100'}`}
+            >
+                <View className="absolute top-0 bottom-0 left-0 w-1 bg-primary" />
+                <Text className="text-[15px] font-semibold text-background">
+                    {busy ? 'Connecting…' : 'Continue'}
                 </Text>
+            </Pressable>
 
-                <View className="flex-1" />
+            <Text className="text-muted-foreground text-[13px] mt-5" style={{ lineHeight: 19 }}>
+                Not sure of the address? It's in your invitation email, or ask your organization's
+                administrator.
+            </Text>
 
-                {/* A self-hoster who tapped the hosted default must not be stranded
+            <View className="flex-1" />
+
+            {/* A self-hoster who tapped the hosted default must not be stranded
                     here — /connect is the surface that takes an arbitrary address. */}
-                <Pressable
-                    onPress={() => router.replace('/connect')}
-                    disabled={busy}
-                    className={`mt-8 rounded-xl border border-border bg-surface flex-row items-center gap-3 px-4 py-3.5 ${busy ? 'opacity-50' : 'opacity-100'}`}
-                >
-                    <Server size={16} color={fg} />
-                    <Text className="text-foreground text-sm font-medium flex-1">
-                        Use a different server
-                    </Text>
-                    <ChevronRight size={16} color={muted} />
-                </Pressable>
-            </ScrollView>
-        </SafeAreaView>
+            <Pressable
+                onPress={() => router.replace('/connect')}
+                disabled={busy}
+                className={`mt-8 rounded-xl border border-border bg-surface flex-row items-center gap-3 px-4 py-3.5 ${busy ? 'opacity-50' : 'opacity-100'}`}
+            >
+                <Server size={16} color={fg} />
+                <Text className="text-foreground text-sm font-medium flex-1">
+                    Use a different server
+                </Text>
+                <ChevronRight size={16} color={muted} />
+            </Pressable>
+        </PreAuthScreen>
     )
 }
 

--- a/core/components/FirstRunModal.tsx
+++ b/core/components/FirstRunModal.tsx
@@ -148,7 +148,17 @@ export function FirstRunModal({
         >
             <View
                 className={cardClass}
-                style={[cardStyle, isMobile ? { paddingTop: insets.top } : null]}
+                style={[
+                    cardStyle,
+                    // Landscape puts the sensor housing on one SIDE, so the
+                    // top/bottom insets alone leave the full-bleed mobile card's
+                    // content clipped by the notch. The centred card needs it too:
+                    // it is centred inside p-6, which is narrower than a ~59pt
+                    // inset. Applied on the card so the backdrop still covers the
+                    // whole screen.
+                    { paddingLeft: insets.left, paddingRight: insets.right },
+                    isMobile ? { paddingTop: insets.top } : null,
+                ]}
             >
                 {/* Accent edge along the top — same role as the SVG draw-on
                     in the marketing CTA: a small cue that this surface is

--- a/core/components/NotificationDrawer.tsx
+++ b/core/components/NotificationDrawer.tsx
@@ -10,9 +10,10 @@ import { useRouter } from 'expo-router'
 import { Bell, Calendar, Check, File, Mail, Shield, X } from 'lucide-react-native'
 import { useEffect, useMemo, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { railWidth } from './workspace/PackageRail'
 
 const DRAWER_WIDTH = 340
-const RAIL_WIDTH = 64
 
 const PACKAGE_ICONS: Record<string, typeof Bell> = {
     calendar: Calendar,
@@ -39,6 +40,7 @@ function DesktopNotificationPanel() {
     const close = useWorkspaceStore(s => s.setNotificationsOpen)
     const overlayColor = useThemeColor('overlay-backdrop')
     const [isMounted, setIsMounted] = useState(isOpen)
+    const insets = useSafeAreaInsets()
 
     useEffect(() => {
         if (isOpen) {
@@ -55,7 +57,11 @@ function DesktopNotificationPanel() {
         <View
             className="absolute top-0 right-0 bottom-0"
             style={{
-                left: RAIL_WIDTH,
+                // Tracks the rail's real width rather than assuming 64: the rail
+                // grows with the left safe-area inset in landscape, and a fixed
+                // offset would leave a strip of workspace showing through
+                // between the rail and this panel.
+                left: railWidth(insets.left),
                 zIndex: 200,
             }}
             pointerEvents={isOpen ? 'auto' : 'none'}

--- a/core/components/Toast.tsx
+++ b/core/components/Toast.tsx
@@ -3,9 +3,12 @@ import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { AlertTriangle, CheckCircle, Info, X, XCircle } from 'lucide-react-native'
 import { useEffect, useRef } from 'react'
 import { Animated, Platform, Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export function ToastRenderer() {
     const toasts = useToastStore(s => s.toasts)
+    // Before the early return — hooks cannot be called conditionally.
+    const insets = useSafeAreaInsets()
 
     if (toasts.length === 0) return null
 
@@ -14,8 +17,13 @@ export function ToastRenderer() {
             style={{
                 position: 'absolute',
                 top: Platform.OS === 'web' ? 16 : 60,
-                right: Platform.OS === 'web' ? 16 : 8,
-                left: Platform.OS === 'web' ? undefined : 8,
+                // Toasts sit at the app root, above every layout that insets its
+                // own content, so they must clear the sensor housing themselves —
+                // 8pt is well inside a landscape inset. Same max()-not-add rule
+                // as useSafeAreaPadding (these are `left`/`right` offsets rather
+                // than padding, so they cannot use the hook directly).
+                right: Platform.OS === 'web' ? 16 : Math.max(8, insets.right),
+                left: Platform.OS === 'web' ? undefined : Math.max(8, insets.left),
                 width: Platform.OS === 'web' ? 360 : undefined,
                 zIndex: 10000,
                 gap: 8,

--- a/core/components/connect/PreAuthScreen.tsx
+++ b/core/components/connect/PreAuthScreen.tsx
@@ -1,0 +1,42 @@
+import { useSafeAreaPadding } from '@tinycld/core/lib/use-safe-area'
+import { ScrollView, View } from 'react-native'
+
+// The shared scaffold for the full-bleed screens shown before a workspace
+// exists: /connect (pick a server) and /pick-org (pick an organization).
+//
+// It exists for the safe area. Both screens previously used
+// `<SafeAreaView edges={['top', 'bottom']}>`, which handles the notch in
+// PORTRAIT and does nothing in landscape — where iOS moves the sensor housing
+// to one side and reports it as insets.left or insets.right, with the home
+// indicator opposite. Their content ran under the notch, and which side broke
+// depended on which way the device was turned.
+//
+// The rule this encodes is the same one WorkspaceLayout follows: the BACKGROUND
+// spans the screen edge to edge, and only CONTENT is inset. So the background
+// lives on the outer View (no padding), and the insets are applied to the
+// scroll content — never as padding on a coloured container, which is what
+// produced the light gutter beside the workspace rail.
+export function PreAuthScreen({
+    children,
+    gutter = 28,
+    testID,
+}: {
+    children: React.ReactNode
+    /** Minimum spacing from the edge of the app. The safe-area inset wins when
+     *  it is larger — see useSafeAreaPadding. */
+    gutter?: number
+    testID?: string
+}) {
+    const padding = useSafeAreaPadding({ horizontal: gutter, top: 16, bottom: 32 })
+
+    return (
+        <View className="flex-1 bg-background" testID={testID}>
+            <ScrollView
+                contentContainerStyle={{ flexGrow: 1, ...padding }}
+                showsVerticalScrollIndicator={false}
+            >
+                {children}
+            </ScrollView>
+        </View>
+    )
+}

--- a/core/components/workspace/LoginModal.tsx
+++ b/core/components/workspace/LoginModal.tsx
@@ -14,12 +14,14 @@ import {
     TextInput,
     View,
 } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 type Mode = 'login' | 'reset'
 
 export function LoginModal() {
     const backdropColor = useThemeColor('overlay-backdrop')
     const [mode, setMode] = useState<Mode>('login')
+    const insets = useSafeAreaInsets()
 
     return (
         <KeyboardAvoidingView
@@ -28,6 +30,14 @@ export function LoginModal() {
             style={{
                 zIndex: 200,
                 backgroundColor: backdropColor,
+                // The backdrop deliberately still covers the full screen — only
+                // the card is inset. In landscape the sensor housing sits on one
+                // side (~59pt), so a centred card can otherwise have its edge
+                // clipped by the notch on a narrow window.
+                paddingLeft: insets.left,
+                paddingRight: insets.right,
+                paddingTop: insets.top,
+                paddingBottom: insets.bottom,
             }}
         >
             <View

--- a/core/components/workspace/MobileDrawer.tsx
+++ b/core/components/workspace/MobileDrawer.tsx
@@ -147,6 +147,11 @@ export function MobileDrawer({ isVisible }: MobileDrawerProps) {
                                 backgroundColor: sidebarBg,
                                 paddingTop: insets.top,
                                 paddingBottom: insets.bottom,
+                                // Pinned to the left edge, so in one landscape
+                                // rotation the sensor housing sits over this
+                                // panel's contents. Pad the panel, not the
+                                // parent: its background still covers the gutter.
+                                paddingLeft: insets.left,
                             },
                             panelStyle,
                         ]}

--- a/core/components/workspace/MobileLayout.tsx
+++ b/core/components/workspace/MobileLayout.tsx
@@ -41,7 +41,25 @@ export const MobileLayout = memo(function MobileLayout({ isReady = true }: { isR
                 ]}
             >
                 <DemoBanner />
-                <View className="flex-1 overflow-hidden">
+                {/* Horizontal insets go HERE, not on the root: the tab bar and
+                    the slide-in drawer below are edge-anchored chrome that must
+                    keep bleeding to the screen edge (they inset their own
+                    contents). Padding the root would pull them inward and leave
+                    a band of app background beside them. Landscape puts the
+                    sensor housing on one side, so without this every package
+                    screen inside PackageTabs runs under the notch.
+
+                    The sheets stay INSIDE this box: BottomDrawer rests at the
+                    bottom edge of its PARENT, which is what puts it exactly on
+                    the tab bar without a manual offset — moving it out would
+                    slide it under the bar, the bug that component was written to
+                    avoid. So the padding insets the sheet itself by a few points
+                    rather than only its content; that is the accepted trade for
+                    keeping the vertical contract. */}
+                <View
+                    className="flex-1 overflow-hidden"
+                    style={{ paddingLeft: insets.left, paddingRight: insets.right }}
+                >
                     <PackageTabs />
                     {isReady && <MoreDrawer />}
                     {isReady && <NotificationDrawer mobile />}

--- a/core/components/workspace/MobileTabBar.tsx
+++ b/core/components/workspace/MobileTabBar.tsx
@@ -33,6 +33,12 @@ export function MobileTabBar() {
             style={{
                 backgroundColor: railBg,
                 paddingBottom: insets.bottom,
+                // The tabs spread across the full width, so in landscape the
+                // outermost icons sit exactly where the sensor housing is.
+                // Padding the bar insets the icons while its own background
+                // still reaches both edges.
+                paddingLeft: insets.left,
+                paddingRight: insets.right,
             }}
         >
             {visiblePkgs.map(pkg => {

--- a/core/components/workspace/PackageRail.tsx
+++ b/core/components/workspace/PackageRail.tsx
@@ -12,7 +12,46 @@ import { Pressable, View } from 'react-native'
 import { getIcon } from './package-icon-map'
 import { UserMenu } from './UserMenu'
 
-export function PackageRail() {
+// The rail's visible icon column. Its 44pt touch targets are centred in it, so
+// there is ~10pt of slack on each side before an icon reaches the rail's edge.
+const RAIL_WIDTH = 64
+
+// How far the icon column may be pushed inward by a left safe-area inset.
+//
+// The inset is NOT symmetric between the two landscape rotations: iOS reports
+// the sensor housing (~59pt) on whichever side it physically sits, and the home
+// indicator (~21pt) on the other. Absorbing it wholesale made the rail 123pt in
+// one rotation and 85pt in the other — the same screen, wildly different chrome.
+//
+// The cap keeps that shift small. The icons stay clear of the notch anyway: the
+// housing does not intrude into the display's usable area beside it, and the
+// column's own ~10pt of slack plus this shift covers the rounded corner. The
+// background is unaffected either way — it always reaches the physical edge, so
+// there is never a light gutter.
+const MAX_RAIL_INSET_SHIFT = 12
+
+// The rail's ACTUAL on-screen width, which grows with the left safe-area inset.
+// Exported because anything positioned against the rail's right edge — the
+// notification drawer — has to agree with it; a hardcoded 64 there leaves a gap
+// once the rail widens in landscape.
+export function railWidth(insetLeft: number): number {
+    return RAIL_WIDTH + Math.min(insetLeft, MAX_RAIL_INSET_SHIFT)
+}
+
+// insetLeft is the device's left safe-area inset (the notch side in one
+// landscape rotation, the home indicator in the other, 0 in portrait). The rail
+// absorbs it rather than letting the parent pad the whole layout: that way the
+// rail's own dark background fills the gutter edge to edge. Padding it upstream
+// instead left a strip of app background beside the rail — the light band this
+// fixes.
+export function PackageRail({
+    insetLeft = 0,
+    insetBottom = 0,
+}: {
+    insetLeft?: number
+    insetBottom?: number
+}) {
+    const insetShift = Math.min(insetLeft, MAX_RAIL_INSET_SHIFT)
     const railBg = useThemeColor('rail-background')
     const railText = useThemeColor('rail-text')
     const railActive = useThemeColor('rail-active-text')
@@ -24,8 +63,21 @@ export function PackageRail() {
 
     return (
         <View
-            className="w-16 justify-between items-center py-3"
-            style={{ backgroundColor: railBg }}
+            // Width grows only by the CAPPED shift, not the full inset: the rail
+            // is chrome, and turning a 59pt notch inset into 59pt of extra dark
+            // bar (with the workspace pushed in behind it) costs real screen
+            // width for nothing. The background still reaches the physical edge
+            // regardless — the parent applies no horizontal padding, so this box
+            // starts at x=0 and its own background covers the gutter it sits in.
+            // pt-3 rather than py-3: the bottom pad adds the home-indicator
+            // inset on top of the same base 12, keeping the last icon tappable.
+            className="justify-between items-center pt-3"
+            style={{
+                backgroundColor: railBg,
+                width: railWidth(insetLeft),
+                paddingLeft: insetShift,
+                paddingBottom: 12 + insetBottom,
+            }}
         >
             <View className="items-center gap-1">
                 <Link href={orgHref('')} asChild>

--- a/core/components/workspace/PackageSidebar.tsx
+++ b/core/components/workspace/PackageSidebar.tsx
@@ -8,9 +8,13 @@ import { SkeletonSidebar } from './SkeletonLayout'
 
 interface PackageSidebarProps {
     width: number
+    /** Home-indicator inset. Applied to the inner fixed-width content rather
+     *  than the animating outer box, so the open/close width transition is
+     *  untouched while the sidebar's own background still runs to the edge. */
+    insetBottom?: number
 }
 
-export function PackageSidebar({ width }: PackageSidebarProps) {
+export function PackageSidebar({ width, insetBottom = 0 }: PackageSidebarProps) {
     const activePkgSlug = useWorkspaceStore(s => s.activePkgSlug)
     const isSidebarOpen = useWorkspaceStore(s => s.isSidebarOpen)
     const pkg = usePackage(activePkgSlug ?? '')
@@ -34,7 +38,7 @@ export function PackageSidebar({ width }: PackageSidebarProps) {
                     : undefined,
             ]}
         >
-            <View style={{ width, flex: 1, minHeight: 0 }}>
+            <View style={{ width, flex: 1, minHeight: 0, paddingBottom: insetBottom }}>
                 {SidebarComponent ? (
                     // LazySidebarBoundary owns the Suspense + recovery: it
                     // retries the lazy import if it rejects, and remounts if the

--- a/core/components/workspace/WorkspaceLayout.tsx
+++ b/core/components/workspace/WorkspaceLayout.tsx
@@ -54,26 +54,37 @@ export function WorkspaceLayout({ isReady = true }: { isReady?: boolean }) {
                 {
                     backgroundColor: bgColor,
                     paddingTop: insets.top,
-                    paddingLeft: insets.left,
-                    paddingRight: insets.right,
                 },
                 Platform.OS === 'web' ? ({ height: '100vh' } as object) : undefined,
             ]}
         >
             <DemoBanner />
             <View className="flex-1 flex-row" style={{ minHeight: 0 }}>
-                {isReady && <PackageRail />}
+                {/* Horizontal insets are consumed by the edge panels themselves,
+                    NOT by this container. In landscape iOS reports a large inset
+                    on the notch side (~59pt) and the home-indicator side (~21pt);
+                    padding them here painted both gutters in the app background,
+                    leaving a wide light band down the side of the screen. The iOS
+                    convention is the opposite: backgrounds run edge to edge and
+                    only CONTENT is inset. So the rail bleeds its own dark colour
+                    into the left gutter, and the content pane extends under the
+                    right one while padding its contents clear of it. */}
+                {isReady && <PackageRail insetLeft={insets.left} insetBottom={insets.bottom} />}
 
                 {isReady && <NotificationDrawer />}
 
                 <PackageProviderWrapper>
-                    {isReady && hasSidebar && <PackageSidebar width={sidebarWidth} />}
+                    {isReady && hasSidebar && (
+                        <PackageSidebar width={sidebarWidth} insetBottom={insets.bottom} />
+                    )}
 
                     <View
                         className="flex-1"
                         style={{
                             backgroundColor: bgColor,
                             minHeight: 0,
+                            paddingRight: insets.right,
+                            paddingBottom: insets.bottom,
                         }}
                     >
                         <PackageTabs />

--- a/core/file-viewer/PreviewModal.tsx
+++ b/core/file-viewer/PreviewModal.tsx
@@ -1,9 +1,9 @@
 import { useBreakpoint } from '@tinycld/core/components/workspace/useBreakpoint'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useSafeAreaPadding } from '@tinycld/core/lib/use-safe-area'
 import { Modal, ModalBackdrop, ModalContent } from '@tinycld/core/ui/modal'
 import { ChevronLeft, ChevronRight, Download, X } from 'lucide-react-native'
 import { Platform, Pressable, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GenericPreview } from './previews/GenericPreview'
 import { getPreviewEntry } from './registry'
 import type { FilePreviewSource, PreviewAction } from './types'
@@ -90,7 +90,7 @@ function PreviewModalContent({
     actions,
 }: PreviewModalContentProps) {
     const mutedColor = useThemeColor('muted-foreground')
-    const insets = useSafeAreaInsets()
+    const toolbarPadding = useSafeAreaPadding({ horizontal: 16, top: 12 })
 
     const entry = getPreviewEntry(source.mimeType)
     const PreviewComponent = entry?.preview ?? GenericPreview
@@ -99,7 +99,17 @@ function PreviewModalContent({
         <>
             <View
                 className="flex-row items-center px-4 py-3 gap-3 border-b border-border"
-                style={{ paddingTop: Math.max(insets.top, 12) }}
+                style={{
+                    // A full-screen native modal: it bypasses every ancestor's
+                    // padding, so it must clear the sensor housing itself. px-4
+                    // (16pt) is nowhere near a landscape notch inset, which
+                    // clipped the filename on one side and the close X on the
+                    // other — leaving no way out of the viewer. Bottom padding
+                    // is left to py-3: this is a top toolbar, not a full screen.
+                    paddingLeft: toolbarPadding.paddingLeft,
+                    paddingRight: toolbarPadding.paddingRight,
+                    paddingTop: toolbarPadding.paddingTop,
+                }}
             >
                 <Text
                     numberOfLines={1}

--- a/core/lib/apex.ts
+++ b/core/lib/apex.ts
@@ -1,0 +1,109 @@
+// Telling a multi-org APEX apart from an org you can actually sign into.
+//
+// On a multi-org router the apex (tinycld.org) hosts no org: it answers every
+// path with the org-finder page, so there is no PocketBase behind it and
+// nothing to authenticate against. Each org lives one label down
+// (acme.tinycld.org) as its own process and DB.
+//
+// The app cannot infer this from reachability — the apex is very much up. Worse,
+// the router serves that finder page with HTTP 200 for /api/* too, so a probe
+// that only checks res.ok reports a healthy server and the app goes on to render
+// a sign-in panel that can never succeed. The discriminator therefore has to be
+// the response SHAPE, not its status: a real server answers /api/org-info with
+// JSON, the apex answers it with HTML.
+//
+// Slug handling deliberately reuses lib/org-cookie.ts rather than re-deriving
+// URLs here. That module already validates a slug as exactly one DNS label and
+// builds the origin from a hostname the caller supplies — the same rules the Go
+// side enforces (core/server/orgcookie), and the same reason: a slug becomes the
+// leftmost label of a URL we navigate to, so anything else is a planted entry.
+
+import { getCoreConfigOptional } from './core-config'
+import { orgUrlForSlug } from './org-cookie'
+
+// Thrown when an address answers, but as a multi-org apex rather than a server.
+// A distinct type (not a generic "couldn't reach") because the recovery is
+// completely different: the host is fine and the user simply has to say WHICH
+// org they want, so callers route to the picker instead of showing a network
+// error the user cannot act on.
+export class ApexServerError extends Error {
+    // The apex origin itself, so the picker can label rows and build org URLs
+    // from the host the user actually reached.
+    readonly apexOrigin: string
+
+    constructor(apexOrigin: string) {
+        super('This address hosts organizations rather than being one.')
+        this.name = 'ApexServerError'
+        this.apexOrigin = apexOrigin
+    }
+}
+
+/** True when a body looks like the router's org-finder page rather than a
+ *  server's JSON. Checks the content type first (what the router actually
+ *  sets) and falls back to sniffing a doctype, so a misconfigured proxy that
+ *  serves HTML as text/plain is still caught. */
+export function looksLikeApexResponse(contentType: string, body: string): boolean {
+    if (contentType.toLowerCase().includes('text/html')) return true
+    return /^\s*<(?:!doctype|html)\b/i.test(body)
+}
+
+/** The hostname of an address, or null when it will not parse. */
+export function hostnameOf(address: string): string | null {
+    try {
+        return new URL(address).hostname
+    } catch {
+        return null
+    }
+}
+
+/** Builds an org's origin from a slug typed into the picker and the apex the
+ *  user reached. Returns null for anything that is not a single DNS label.
+ *
+ *  orgUrlForSlug derives a SIBLING of the hostname it is given (it strips the
+ *  first label), which is right when the app runs on an org and wrong here: we
+ *  are already at the apex, so the org is a CHILD of it. Passing a placeholder
+ *  label makes the apex the parent again and keeps one implementation of the
+ *  slug rules rather than a second copy that could drift from the Go side. */
+export function orgUrlUnderApex(slug: string, apexHostname: string): string | null {
+    return orgUrlForSlug(slug, `_.${apexHostname}`)
+}
+
+/** Whether `origin` is an org hosted under `apexHostname` — used to show only
+ *  the saved servers that belong to this router, not unrelated self-hosted
+ *  boxes. Requires exactly one extra label so a deeper host never passes. */
+export function isOrgUnderApex(origin: string, apexHostname: string): boolean {
+    const host = hostnameOf(origin)
+    if (!host || host === apexHostname) return false
+    if (!host.endsWith(`.${apexHostname}`)) return false
+    const label = host.slice(0, -(apexHostname.length + 1))
+    return label.length > 0 && !label.includes('.')
+}
+
+/** Whether an already-resolved address is the known multi-org apex.
+ *
+ *  Synchronous and network-free on purpose: it runs on the render path of the
+ *  root route, which must decide what to show without waiting on a fetch. That
+ *  limits it to the one apex the build knows about — the configured
+ *  defaultServer — which is exactly the case that matters, because
+ *  defaultServer IS the apex ('https://tinycld.org') and the "Use tinycld.org"
+ *  button is how a device got stuck here. An unknown apex is still caught at
+ *  admission time by probeServer().
+ *
+ *  Compares hostnames rather than raw strings so a trailing slash or a scheme
+ *  difference in the cached value does not read as a different host. */
+export function isKnownApexAddress(address: string | null): boolean {
+    if (!address) return false
+    const configured = getCoreConfigOptional()?.defaultServer
+    if (!configured) return false
+    const host = hostnameOf(address)
+    const apexHost = hostnameOf(configured)
+    return !!host && !!apexHost && host === apexHost
+}
+
+/** The slug of an org origin under an apex, for labelling a picker row. */
+export function slugUnderApex(origin: string, apexHostname: string): string | null {
+    if (!isOrgUnderApex(origin, apexHostname)) return null
+    const host = hostnameOf(origin)
+    if (!host) return null
+    return host.slice(0, -(apexHostname.length + 1))
+}

--- a/core/lib/apex.ts
+++ b/core/lib/apex.ts
@@ -18,7 +18,6 @@
 // side enforces (core/server/orgcookie), and the same reason: a slug becomes the
 // leftmost label of a URL we navigate to, so anything else is a planted entry.
 
-import { getCoreConfigOptional } from './core-config'
 import { orgUrlForSlug } from './org-cookie'
 
 // Thrown when an address answers, but as a multi-org apex rather than a server.
@@ -79,25 +78,29 @@ export function isOrgUnderApex(origin: string, apexHostname: string): boolean {
     return label.length > 0 && !label.includes('.')
 }
 
-/** Whether an already-resolved address is the known multi-org apex.
+/** Whether a cached address turns out to be a multi-org apex rather than a
+ *  server, for the recovery path: a device that connected before this was
+ *  caught at admission still has the apex saved as its server.
  *
- *  Synchronous and network-free on purpose: it runs on the render path of the
- *  root route, which must decide what to show without waiting on a fetch. That
- *  limits it to the one apex the build knows about — the configured
- *  defaultServer — which is exactly the case that matters, because
- *  defaultServer IS the apex ('https://tinycld.org') and the "Use tinycld.org"
- *  button is how a device got stuck here. An unknown apex is still caught at
- *  admission time by probeServer().
- *
- *  Compares hostnames rather than raw strings so a trailing slash or a scheme
- *  difference in the cached value does not read as a different host. */
-export function isKnownApexAddress(address: string | null): boolean {
+ *  ASKS THE SERVER rather than comparing hostnames. An earlier version matched
+ *  the address against the configured defaultServer, which is wrong in the
+ *  common case: defaultServer is the hosted address ('https://tinycld.org', or
+ *  localhost in dev), and a perfectly ordinary SINGLE-TENANT server lives at
+ *  exactly that hostname. Every such user was told "localhost hosts many
+ *  organizations" and sent to the org picker instead of the login form. A host
+ *  cannot be classified by its name — only by what it answers. */
+export async function isApexAddress(address: string | null): Promise<boolean> {
     if (!address) return false
-    const configured = getCoreConfigOptional()?.defaultServer
-    if (!configured) return false
-    const host = hostnameOf(address)
-    const apexHost = hostnameOf(configured)
-    return !!host && !!apexHost && host === apexHost
+    try {
+        const res = await fetch(`${address}/api/org-info`, { cache: 'no-store' })
+        const body = await res.text()
+        return looksLikeApexResponse(res.headers?.get?.('content-type') ?? '', body)
+    } catch {
+        // Unreachable is not "apex". Falling through to the normal signed-out
+        // path lets the usual connectivity handling deal with it, rather than
+        // stranding an offline user on a picker they cannot act on.
+        return false
+    }
 }
 
 /** The slug of an org origin under an apex, for labelling a picker row. */

--- a/core/lib/apex.ts
+++ b/core/lib/apex.ts
@@ -37,11 +37,32 @@ export class ApexServerError extends Error {
     }
 }
 
-/** True when a body looks like the router's org-finder page rather than a
- *  server's JSON. Checks the content type first (what the router actually
- *  sets) and falls back to sniffing a doctype, so a misconfigured proxy that
- *  serves HTML as text/plain is still caught. */
+// The router's machine-readable "this host is an apex" marker, sent as
+// data.kind on an /api/* response. Must match ApexMarker in the multi-org repo
+// (internal/webpage) — the two are coupled by this string.
+const APEX_MARKER = 'multi_org_apex'
+
+/** True when a response says the host is a multi-org apex rather than a server.
+ *
+ *  Two signals, because both eras of router have to work:
+ *
+ *  1. The explicit marker. A current router answers /api/* with a 404 carrying
+ *     `data.kind: "multi_org_apex"`, which distinguishes an apex from a host
+ *     that is merely wrong or down — a bare 404 cannot.
+ *  2. An HTML body. Routers deployed before that fix answered the org-finder
+ *     page with 200 for EVERY path, so the shape of the body is the only
+ *     evidence available. Content type first (what the router sets), falling
+ *     back to sniffing a doctype so a proxy serving HTML as text/plain is still
+ *     caught. */
 export function looksLikeApexResponse(contentType: string, body: string): boolean {
+    if (contentType.toLowerCase().includes('application/json')) {
+        try {
+            const parsed = JSON.parse(body) as { data?: { kind?: unknown } }
+            return parsed?.data?.kind === APEX_MARKER
+        } catch {
+            return false
+        }
+    }
     if (contentType.toLowerCase().includes('text/html')) return true
     return /^\s*<(?:!doctype|html)\b/i.test(body)
 }

--- a/core/lib/server-address.ts
+++ b/core/lib/server-address.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
+import { ApexServerError, looksLikeApexResponse } from './apex'
 import { getCoreConfigOptional, registerConfigListener } from './core-config'
 
 const STORAGE_KEY_PREFIX = 'tinycld:server:'
@@ -67,6 +68,11 @@ export function normalizeAddress(input: string): string {
     return addr
 }
 
+// probe is a LIVENESS check: "is the server I already connected to answering?"
+// It is polled on a timer by OfflineOverlay and the native connectivity
+// detector, so it stays the cheapest possible request and deliberately does not
+// inspect the body. Use probeServer() to ADMIT a new address — liveness is the
+// wrong question there, because a multi-org apex is perfectly alive.
 export async function probe(address: string, timeoutMs = 5000): Promise<void> {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeoutMs)
@@ -77,6 +83,49 @@ export async function probe(address: string, timeoutMs = 5000): Promise<void> {
         }
     } finally {
         clearTimeout(timer)
+    }
+}
+
+// probeServer ADMITS an address: it answers "is there a TinyCld org here I can
+// sign into?", which reachability alone cannot.
+//
+// It asks /api/org-info (unauthenticated, registered unconditionally in
+// coreserver.Setup, returns {name}) and requires a JSON object back. A
+// multi-org apex answers 200 with the org-finder HTML for every path including
+// this one, so a status-only check admits it and the app then renders a sign-in
+// panel against a host with no PocketBase. Throws ApexServerError for that case
+// so the caller can offer the org picker instead of a network error.
+export async function probeServer(address: string, timeoutMs = 5000): Promise<void> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    let res: Response
+    let body: string
+    try {
+        res = await fetch(`${address}/api/org-info`, { signal: controller.signal })
+        // Read the body before judging: the apex's HTML arrives with a 200, so
+        // status alone cannot tell the two apart.
+        body = await res.text()
+    } finally {
+        clearTimeout(timer)
+    }
+
+    if (looksLikeApexResponse(res.headers?.get?.('content-type') ?? '', body)) {
+        throw new ApexServerError(address)
+    }
+    if (!res.ok) {
+        throw new Error(`Server returned HTTP ${res.status}`)
+    }
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(body)
+    } catch {
+        throw new Error('That address did not answer like a TinyCld server.')
+    }
+    // `name` may legitimately be '' (a deployment that never set an app name),
+    // so check for the FIELD, not a truthy value.
+    if (typeof parsed !== 'object' || parsed === null || !('name' in parsed)) {
+        throw new Error('That address did not answer like a TinyCld server.')
     }
 }
 

--- a/core/lib/use-safe-area.ts
+++ b/core/lib/use-safe-area.ts
@@ -1,0 +1,51 @@
+// Safe-area insets, and the one rule for combining them with design spacing.
+//
+// A sibling cannot import `react-native-safe-area-context` directly: it is not
+// in any feature's peerDependencies, and adding it to each one would mean a
+// coordinated change across every sibling repo for what is one hook. Core
+// already depends on it, and siblings already resolve `@tinycld/core/lib/*` by
+// package name, so this is the sanctioned route.
+//
+// Why a feature needs this at all: most screens render inside the workspace
+// chrome, which insets its content for them. The exception is a surface that
+// escapes that chrome — a full-screen overlay or an `absolute` window pinned to
+// the viewport — which bypasses every ancestor's padding and has to clear the
+// sensor housing itself. In landscape iOS reports that housing as a ~59pt
+// left/right inset, which is where a flush-mounted close button ends up.
+
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+export type { EdgeInsets } from 'react-native-safe-area-context'
+export { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+/** Padding that clears the device's safe area while never falling below a base
+ *  spacing. The single place this rule is expressed — hand-rolling it per
+ *  screen is how three different conventions (bare inset, base+inset, max)
+ *  ended up in the tree at once.
+ *
+ *  The base is a MINIMUM, not an addend. Adding the two double-counts: on a
+ *  device reporting a modest ~21pt home-indicator inset, `28 + 21` pushed
+ *  content 49pt off an edge that only needed 28 for looks and 21 for hardware.
+ *  Taking the larger satisfies both constraints at once — content is never
+ *  closer to the edge than the design wants, and never under the sensor
+ *  housing.
+ *
+ *  This does NOT flatten the left/right asymmetry it might appear to: when an
+ *  inset genuinely exceeds the base (the ~59pt notch side in landscape) it wins
+ *  and that side is visibly wider. Equal margins mean both insets were smaller
+ *  than the base, which is the correct result, not a lost signal. */
+export function useSafeAreaPadding(base: { horizontal?: number; top?: number; bottom?: number }): {
+    paddingLeft: number
+    paddingRight: number
+    paddingTop: number
+    paddingBottom: number
+} {
+    const insets = useSafeAreaInsets()
+    const horizontal = base.horizontal ?? 0
+    return {
+        paddingLeft: Math.max(horizontal, insets.left),
+        paddingRight: Math.max(horizontal, insets.right),
+        paddingTop: Math.max(base.top ?? 0, insets.top),
+        paddingBottom: Math.max(base.bottom ?? 0, insets.bottom),
+    }
+}

--- a/core/tests/unit/apex.test.ts
+++ b/core/tests/unit/apex.test.ts
@@ -32,8 +32,17 @@ describe('apex', () => {
             await expect(isApexAddress('http://localhost:7100')).resolves.toBe(false)
         })
 
-        it('reports the router apex as an apex', async () => {
+        // A router deployed before the /api/* fix: 200 + the finder page.
+        it('reports a legacy apex (HTML 200) as an apex', async () => {
             mockFetch('text/html; charset=utf-8', '<!doctype html><html lang="en">')
+            await expect(isApexAddress('https://tinycld.org')).resolves.toBe(true)
+        })
+
+        it('reports a current apex (JSON 404 + marker) as an apex', async () => {
+            mockFetch(
+                'application/json',
+                JSON.stringify({ code: 404, data: { kind: 'multi_org_apex' } })
+            )
             await expect(isApexAddress('https://tinycld.org')).resolves.toBe(true)
         })
 
@@ -56,6 +65,23 @@ describe('apex', () => {
 
         it('leaves real org-info JSON alone', () => {
             expect(looksLikeApexResponse('application/json', '{"name":"Acme"}')).toBe(false)
+        })
+
+        // A current router answers /api/* with a JSON 404 carrying this marker,
+        // which separates "apex" from "wrong URL" / "host down" — a bare 404
+        // cannot.
+        it('detects the router apex marker on a JSON error', () => {
+            const body = JSON.stringify({
+                code: 404,
+                message: 'this host serves organizations, not an API',
+                data: { kind: 'multi_org_apex' },
+            })
+            expect(looksLikeApexResponse('application/json', body)).toBe(true)
+        })
+
+        it('does not treat an ordinary JSON 404 as an apex', () => {
+            const body = JSON.stringify({ code: 404, message: 'Not found', data: {} })
+            expect(looksLikeApexResponse('application/json', body)).toBe(false)
         })
 
         // An org could legitimately be named "<html>"; the body must not be

--- a/core/tests/unit/apex.test.ts
+++ b/core/tests/unit/apex.test.ts
@@ -1,12 +1,49 @@
 import {
+    isApexAddress,
     isOrgUnderApex,
     looksLikeApexResponse,
     orgUrlUnderApex,
     slugUnderApex,
 } from '@tinycld/core/lib/apex'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 describe('apex', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    describe('isApexAddress', () => {
+        function mockFetch(contentType: string, body: string) {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue({
+                    headers: { get: () => contentType },
+                    text: async () => body,
+                })
+            )
+        }
+
+        // The regression: this used to compare the address against the
+        // configured defaultServer, which IS an ordinary single-tenant server's
+        // address in the common case. Every such user got "localhost hosts many
+        // organizations" and the org picker instead of a login form.
+        it('reports a single-tenant server as NOT an apex', async () => {
+            mockFetch('application/json', JSON.stringify({ name: 'My Server' }))
+            await expect(isApexAddress('http://localhost:7100')).resolves.toBe(false)
+        })
+
+        it('reports the router apex as an apex', async () => {
+            mockFetch('text/html; charset=utf-8', '<!doctype html><html lang="en">')
+            await expect(isApexAddress('https://tinycld.org')).resolves.toBe(true)
+        })
+
+        it('is false for no address, and for an unreachable one', async () => {
+            await expect(isApexAddress(null)).resolves.toBe(false)
+            vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+            await expect(isApexAddress('https://down.example')).resolves.toBe(false)
+        })
+    })
+
     describe('looksLikeApexResponse', () => {
         it('detects the router org-finder page by content type', () => {
             expect(looksLikeApexResponse('text/html; charset=utf-8', '<!doctype html>')).toBe(true)

--- a/core/tests/unit/apex.test.ts
+++ b/core/tests/unit/apex.test.ts
@@ -1,0 +1,67 @@
+import {
+    isOrgUnderApex,
+    looksLikeApexResponse,
+    orgUrlUnderApex,
+    slugUnderApex,
+} from '@tinycld/core/lib/apex'
+import { describe, expect, it } from 'vitest'
+
+describe('apex', () => {
+    describe('looksLikeApexResponse', () => {
+        it('detects the router org-finder page by content type', () => {
+            expect(looksLikeApexResponse('text/html; charset=utf-8', '<!doctype html>')).toBe(true)
+        })
+
+        it('sniffs a doctype when the content type is unhelpful', () => {
+            expect(looksLikeApexResponse('text/plain', '\n  <!DOCTYPE html><html>')).toBe(true)
+            expect(looksLikeApexResponse('', '<html lang="en">')).toBe(true)
+        })
+
+        it('leaves real org-info JSON alone', () => {
+            expect(looksLikeApexResponse('application/json', '{"name":"Acme"}')).toBe(false)
+        })
+
+        // An org could legitimately be named "<html>"; the body must not be
+        // sniffed anywhere but at its very start.
+        it('does not flag JSON that merely contains markup', () => {
+            expect(looksLikeApexResponse('application/json', '{"name":"<html> Ltd"}')).toBe(false)
+        })
+    })
+
+    describe('orgUrlUnderApex', () => {
+        it('builds an org origin as a child of the apex', () => {
+            expect(orgUrlUnderApex('acme', 'tinycld.org')).toBe('https://acme.tinycld.org')
+        })
+
+        // The slug becomes the leftmost label of a URL we navigate to, so the
+        // DNS-label rule is a security boundary, not tidiness.
+        it('rejects anything that is not a single DNS label', () => {
+            expect(orgUrlUnderApex('a.b', 'tinycld.org')).toBeNull()
+            expect(orgUrlUnderApex('evil.example/x', 'tinycld.org')).toBeNull()
+            expect(orgUrlUnderApex('UPPER', 'tinycld.org')).toBeNull()
+            expect(orgUrlUnderApex('', 'tinycld.org')).toBeNull()
+        })
+    })
+
+    describe('isOrgUnderApex / slugUnderApex', () => {
+        it('accepts a direct child of the apex', () => {
+            expect(isOrgUnderApex('https://acme.tinycld.org', 'tinycld.org')).toBe(true)
+            expect(slugUnderApex('https://acme.tinycld.org', 'tinycld.org')).toBe('acme')
+        })
+
+        it('rejects the apex itself', () => {
+            expect(isOrgUnderApex('https://tinycld.org', 'tinycld.org')).toBe(false)
+        })
+
+        it('rejects unrelated and deeper hosts', () => {
+            expect(isOrgUnderApex('https://pb.example.com', 'tinycld.org')).toBe(false)
+            expect(isOrgUnderApex('https://a.b.tinycld.org', 'tinycld.org')).toBe(false)
+            // A lookalike registrable domain must not pass as a child.
+            expect(isOrgUnderApex('https://eviltinycld.org', 'tinycld.org')).toBe(false)
+        })
+
+        it('returns null for a slug of a non-org origin', () => {
+            expect(slugUnderApex('https://pb.example.com', 'tinycld.org')).toBeNull()
+        })
+    })
+})

--- a/core/tests/unit/server-address.test.ts
+++ b/core/tests/unit/server-address.test.ts
@@ -134,6 +134,107 @@ describe('server-address', () => {
         })
     })
 
+    describe('probeServer', () => {
+        // The apex's real response, captured from the router: it serves the
+        // org-finder page with HTTP 200 for EVERY path, /api/* included.
+        const APEX_HTML = '<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">'
+
+        function mockResponse(init: {
+            ok?: boolean
+            status?: number
+            contentType?: string
+            body: string
+        }) {
+            return {
+                ok: init.ok ?? true,
+                status: init.status ?? 200,
+                headers: { get: () => init.contentType ?? 'application/json' },
+                text: async () => init.body,
+            }
+        }
+
+        it('resolves against a real server answering /api/org-info', async () => {
+            const fetchMock = vi
+                .fn()
+                .mockResolvedValue(mockResponse({ body: JSON.stringify({ name: 'Acme' }) }))
+            vi.stubGlobal('fetch', fetchMock)
+            const { probeServer } = await importFresh()
+            await expect(probeServer('https://acme.tinycld.org')).resolves.toBeUndefined()
+            expect(fetchMock).toHaveBeenCalledWith(
+                'https://acme.tinycld.org/api/org-info',
+                expect.objectContaining({ signal: expect.anything() })
+            )
+        })
+
+        it('accepts a server whose app name is empty', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(mockResponse({ body: JSON.stringify({ name: '' }) }))
+            )
+            const { probeServer } = await importFresh()
+            await expect(probeServer('https://pb.example.com')).resolves.toBeUndefined()
+        })
+
+        // The regression this whole change exists for: a status-only check
+        // admitted the apex, and the app then rendered a sign-in panel against
+        // a host with no PocketBase behind it.
+        it('rejects the multi-org apex despite its HTTP 200', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi
+                    .fn()
+                    .mockResolvedValue(
+                        mockResponse({ contentType: 'text/html; charset=utf-8', body: APEX_HTML })
+                    )
+            )
+            const { probeServer } = await importFresh()
+            const { ApexServerError } = await import('@tinycld/core/lib/apex')
+            await expect(probeServer('https://tinycld.org')).rejects.toBeInstanceOf(ApexServerError)
+        })
+
+        it('detects an apex that serves HTML without an html content type', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi
+                    .fn()
+                    .mockResolvedValue(mockResponse({ contentType: 'text/plain', body: APEX_HTML }))
+            )
+            const { probeServer } = await importFresh()
+            const { ApexServerError } = await import('@tinycld/core/lib/apex')
+            await expect(probeServer('https://tinycld.org')).rejects.toBeInstanceOf(ApexServerError)
+        })
+
+        it('rejects JSON that is not org-info shaped', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(mockResponse({ body: JSON.stringify({ status: 'ok' }) }))
+            )
+            const { probeServer } = await importFresh()
+            await expect(probeServer('https://not-tinycld.example')).rejects.toThrow(
+                'did not answer like a TinyCld server'
+            )
+        })
+
+        it('rejects a non-2xx JSON response', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi
+                    .fn()
+                    .mockResolvedValue(
+                        mockResponse({ ok: false, status: 502, body: '{"message":"bad gateway"}' })
+                    )
+            )
+            const { probeServer } = await importFresh()
+            await expect(probeServer('https://pb.example.com')).rejects.toThrow('HTTP 502')
+        })
+
+        it('rejects on network error', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Failed to fetch')))
+            const { probeServer } = await importFresh()
+            await expect(probeServer('https://pb.example.com')).rejects.toThrow('Failed to fetch')
+        })
+    })
+
     describe('setResolvedAddress / getResolvedAddress', () => {
         it('roundtrips', async () => {
             vi.stubGlobal('window', { location: { origin: 'https://example.com' } })

--- a/lib/use-server-address-gate.ts
+++ b/lib/use-server-address-gate.ts
@@ -92,10 +92,13 @@ export function useServerAddressGate(pathname: string): GateState {
         if (state.status !== 'unresolved') return
         // Routes that resolve the server address themselves must be exempt from the
         // →/connect redirect, or they get bounced before they can set it. /connect
-        // is the picker; /p/demo pins the public demo server (see app/p/demo.tsx),
-        // so a universal-link demo open on a fresh install (no cached address) must
+        // is the server picker; /pick-org is the org picker a multi-org apex sends
+        // users to (it resolves an org's address the same way /connect resolves a
+        // server's, so bouncing it would strand the user in a loop between the
+        // two); /p/demo pins the public demo server (see app/p/demo.tsx), so a
+        // universal-link demo open on a fresh install (no cached address) must
         // reach it instead of being sent to /connect.
-        if (pathname === '/connect' || pathname === '/p/demo') return
+        if (pathname === '/connect' || pathname === '/pick-org' || pathname === '/p/demo') return
         const backTo = encodeURIComponent(pathname || '/')
         router.replace(`/connect?backTo=${backTo}`)
     }, [state.status, pathname])

--- a/tests/e2e-multi-org/server-switcher.spec.ts
+++ b/tests/e2e-multi-org/server-switcher.spec.ts
@@ -178,12 +178,26 @@ test.describe('switcher with two servers', () => {
 // single-origin test can reach the state where they matter — the mobile blocks
 // above exercise a different component entirely (ServersDrawerSection).
 test.describe('switcher on desktop — user menu', () => {
+    // Menu rows and section labels must be matched WITHIN the menu, not
+    // page-wide. The workspace behind the open popover has its own "Settings"
+    // and "Servers" text — a feature-less assembly lands on the settings screen,
+    // where "Servers" is a nav row — so a bare getByText matches two elements
+    // and fails on strict mode. Menu items carry role="menuitem"; section labels
+    // are the only uppercase muted text in the popover.
+    function menuItem(page: Page, label: string) {
+        return page.locator('[role="menuitem"]', { hasText: label })
+    }
+
+    function menuLabel(page: Page, label: string) {
+        return page.locator('.uppercase.text-muted-foreground', { hasText: label })
+    }
+
     async function openUserMenu(page: Page) {
         await expect(page.getByTestId('nav-home')).toBeVisible({ timeout: 20_000 })
         await page.getByLabel('User menu').click()
         // Settings is a stable neighbour in the same menu — gate on it so we do
         // not race the popover's open animation.
-        await expect(page.getByText('Settings', { exact: true })).toBeVisible()
+        await expect(menuItem(page, 'Settings')).toBeVisible()
     }
 
     test('lists both servers, marking only the current one', async ({ page }) => {
@@ -194,7 +208,7 @@ test.describe('switcher on desktop — user menu', () => {
 
         await openUserMenu(page)
 
-        await expect(page.getByText('Servers', { exact: true })).toBeVisible()
+        await expect(menuLabel(page, 'Servers')).toBeVisible()
 
         // Web rows carry an href (Menu.Item renders a real <a role="menuitem">),
         // which is what makes middle-click / open-in-new-tab work — so target by


### PR DESCRIPTION
Four fixes found while testing the app against a multi-org install.

## The apex was treated as a signable-into server

Reaching the apex of a multi-org install (`tinycld.org`) left the native app showing a **Sign in** panel that could never work — the apex hosts no org, so there is no PocketBase behind it.

`probe()` only checked `res.ok`, but the router answered every path on the apex — `/api/*` included — with `200` and the org-finder HTML. So the apex passed admission and was saved as a server. Production `defaultServer` **is** the apex, so the first-run "Use tinycld.org" button walked straight into it.

Admission is now split from liveness rather than repointing `probe()`:

- `probe()` is unchanged and still hits `/api/health`. Both liveness pollers (`OfflineOverlay`, `use-connectivity-detector`) keep their exact semantics.
- `probeServer()` admits an address via `/api/org-info`, requiring JSON, and throws `ApexServerError` on HTML.

`ApexServerError` routes to a new `/pick-org` screen — known orgs from the saved-server list plus an enter-your-org field, mirroring the router's own apex page. No create-org affordance: provisioning is superuser-only, so offering it would promise a self-serve signup that doesn't exist.

## The picker showed up for single-tenant servers

The recovery guard classified a host by its **name** — comparing the cached address against `defaultServer`. But that's just the hosted address (`localhost:7100` in dev), and an ordinary single-tenant server sits at exactly that hostname. Every such user got "localhost hosts many organizations" instead of a login form.

`isApexAddress` now asks the server instead. It deliberately doesn't gate the render: single-tenant is the overwhelming majority, so the login form shows immediately and the redirect only fires if the address really answers as an apex. An unreachable host is not an apex.

## iOS landscape safe areas

In landscape iOS moves the sensor housing to one side and reports it as `insets.left`/`insets.right`. Nothing read those, so content ran under the notch — which side broke depended on rotation direction. `WorkspaceLayout` had the opposite failure: it padded its outer container, painting both gutters in the app background and leaving a wide light band down the screen.

The rule throughout is the iOS convention: **backgrounds span edge to edge, only content is inset.** Each edge-anchored panel absorbs the inset itself.

Fixed: `WorkspaceLayout`/`PackageRail`/`PackageSidebar`, `MobileLayout` (the phone branch returns before the desktop fix ever runs), `MobileTabBar`, `MobileDrawer`, `connect`/`pick-org` (now sharing a `PreAuthScreen` scaffold), `LoginModal`, `FirstRunModal`, `PreviewModal`, `Toast`.

`useSafeAreaPadding` is the one place the base-vs-inset rule lives — hand-rolling it per screen is how three different conventions ended up in the tree. It takes the **larger** of the two, not the sum; adding double-counts.

## Router marker

Pairs with tinycld/multi-org — the router now answers apex `/api/*` with a JSON 404 carrying `data.kind: "multi_org_apex"`. The client reads it, and keeps the HTML sniff so routers deployed before that fix still work.

## Verification

- biome + tsc + **717 unit tests** green.
- The apex discriminator was verified against the **real router binary**: built `cmd/serve-multi`, captured its actual `/api/org-info` response, and fed that exact payload through `probeServer`.

**Not verified on device.** The safe-area work needs a rotation pass in both directions — the notch swaps sides.