### PR TITLE
fix(core): landscape viewport fixes — scrollable package rail + useWindowHeight

### DIFF
--- a/core/components/FAB.tsx
+++ b/core/components/FAB.tsx
@@ -1,7 +1,7 @@
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import type { LucideIcon } from 'lucide-react-native'
 import { Pressable } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface FABProps {
     icon: LucideIcon
@@ -31,7 +31,7 @@ export function FAB({
     iconSize = 22,
 }: FABProps) {
     const primaryFg = useThemeColor('primary-foreground')
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
 
     if (!isVisible) return null
 

--- a/core/components/FirstRunModal.tsx
+++ b/core/components/FirstRunModal.tsx
@@ -1,10 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useBreakpoint } from '@tinycld/core/components/workspace/useBreakpoint'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import type { LucideIcon } from 'lucide-react-native'
 import { type ReactNode, useEffect, useState } from 'react'
 import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 /**
  * Headline + body shell for one-shot first-run education modals.
@@ -78,7 +78,7 @@ export function FirstRunModal({
     const accentFg = useThemeColor(`${accentToken}-foreground` as 'primary-foreground')
 
     const isMobile = useBreakpoint() === 'mobile'
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
 
     useEffect(() => {
         if (!enabled) return

--- a/core/components/NotificationDrawer.tsx
+++ b/core/components/NotificationDrawer.tsx
@@ -4,13 +4,13 @@ import { useStore } from '@tinycld/core/lib/pocketbase'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { useOrgLiveQuery } from '@tinycld/core/lib/use-org-live-query'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import type { Notifications } from '@tinycld/core/types/pbSchema'
 import { BottomDrawer } from '@tinycld/core/ui/bottom-drawer'
 import { useRouter } from 'expo-router'
 import { Bell, Calendar, Check, File, Mail, Shield, X } from 'lucide-react-native'
 import { useEffect, useMemo, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { railWidth } from './workspace/PackageRail'
 
 const DRAWER_WIDTH = 340
@@ -40,7 +40,9 @@ function DesktopNotificationPanel() {
     const close = useWorkspaceStore(s => s.setNotificationsOpen)
     const overlayColor = useThemeColor('overlay-backdrop')
     const [isMounted, setIsMounted] = useState(isOpen)
-    const insets = useSafeAreaInsets()
+    // Same side-corrected insets the rail itself receives — a raw left inset
+    // here would disagree with railWidth by ~59pt in one landscape rotation.
+    const insets = useDeviceInsets()
 
     useEffect(() => {
         if (isOpen) {

--- a/core/components/Toast.tsx
+++ b/core/components/Toast.tsx
@@ -1,14 +1,14 @@
 import { type Toast as ToastType, useToastStore } from '@tinycld/core/lib/stores/toast-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import { AlertTriangle, CheckCircle, Info, X, XCircle } from 'lucide-react-native'
 import { useEffect, useRef } from 'react'
 import { Animated, Platform, Pressable, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export function ToastRenderer() {
     const toasts = useToastStore(s => s.toasts)
     // Before the early return — hooks cannot be called conditionally.
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
 
     if (toasts.length === 0) return null
 

--- a/core/components/connect/PreAuthScreen.tsx
+++ b/core/components/connect/PreAuthScreen.tsx
@@ -6,10 +6,11 @@ import { ScrollView, View } from 'react-native'
 //
 // It exists for the safe area. Both screens previously used
 // `<SafeAreaView edges={['top', 'bottom']}>`, which handles the notch in
-// PORTRAIT and does nothing in landscape — where iOS moves the sensor housing
-// to one side and reports it as insets.left or insets.right, with the home
-// indicator opposite. Their content ran under the notch, and which side broke
-// depended on which way the device was turned.
+// PORTRAIT and does nothing in landscape — where the sensor housing sits on
+// one side. Their content ran under the notch, and which side broke depended
+// on which way the device was turned. useSafeAreaPadding (via useDeviceInsets)
+// pads only the side the housing is actually on; the other side falls back to
+// the design gutter.
 //
 // The rule this encodes is the same one WorkspaceLayout follows: the BACKGROUND
 // spans the screen edge to edge, and only CONTENT is inset. So the background

--- a/core/components/workspace/LoginModal.tsx
+++ b/core/components/workspace/LoginModal.tsx
@@ -4,6 +4,7 @@ import { requestPasswordReset } from '@tinycld/core/lib/account-password'
 import { useAuth } from '@tinycld/core/lib/auth'
 import { navigateToOrg } from '@tinycld/core/lib/org-url'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import { useState } from 'react'
 import {
     ActivityIndicator,
@@ -14,14 +15,13 @@ import {
     TextInput,
     View,
 } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 type Mode = 'login' | 'reset'
 
 export function LoginModal() {
     const backdropColor = useThemeColor('overlay-backdrop')
     const [mode, setMode] = useState<Mode>('login')
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
 
     return (
         <KeyboardAvoidingView

--- a/core/components/workspace/MobileDrawer.tsx
+++ b/core/components/workspace/MobileDrawer.tsx
@@ -2,6 +2,7 @@ import { packageSidebars } from '@tinycld/core/lib/packages/derive-components'
 import { usePackage } from '@tinycld/core/lib/packages/use-packages'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import { Suspense, useCallback, useEffect, useState } from 'react'
 import { Pressable, View } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
@@ -11,7 +12,6 @@ import Animated, {
     useSharedValue,
     withSpring,
 } from 'react-native-reanimated'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 const PANEL_WIDTH = 280
 const EDGE_WIDTH = 20
@@ -30,7 +30,7 @@ interface MobileDrawerProps {
 export function MobileDrawer({ isVisible }: MobileDrawerProps) {
     const overlayBg = useThemeColor('overlay-backdrop')
     const sidebarBg = useThemeColor('sidebar-background')
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
     const activePkgSlug = useWorkspaceStore(s => s.activePkgSlug)
     const setDrawerOpen = useWorkspaceStore(s => s.setDrawerOpen)
     const pkg = usePackage(activePkgSlug ?? '')
@@ -147,10 +147,13 @@ export function MobileDrawer({ isVisible }: MobileDrawerProps) {
                                 backgroundColor: sidebarBg,
                                 paddingTop: insets.top,
                                 paddingBottom: insets.bottom,
-                                // Pinned to the left edge, so in one landscape
-                                // rotation the sensor housing sits over this
-                                // panel's contents. Pad the panel, not the
-                                // parent: its background still covers the gutter.
+                                // Pinned to the left edge, so in the landscape
+                                // rotation that puts the sensor housing on the
+                                // left it sits over this panel's contents. Pad
+                                // the panel, not the parent: its background
+                                // still covers the gutter. Side-corrected, so
+                                // with the housing on the right this is 0 and
+                                // the panel stays full-bleed.
                                 paddingLeft: insets.left,
                             },
                             panelStyle,

--- a/core/components/workspace/MobileLayout.tsx
+++ b/core/components/workspace/MobileLayout.tsx
@@ -2,9 +2,9 @@ import { DemoBanner } from '@tinycld/core/components/DemoBanner'
 import { NotificationDrawer } from '@tinycld/core/components/NotificationDrawer'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import { memo } from 'react'
 import { Platform, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { MobileDrawer } from './MobileDrawer'
 import { MobileTabBar } from './MobileTabBar'
 import { MoreDrawer } from './MoreDrawer'
@@ -18,7 +18,7 @@ import { PackageTabs } from './PackageTabs'
 // per tab switch. memo() lets that parent re-render stop here.
 export const MobileLayout = memo(function MobileLayout({ isReady = true }: { isReady?: boolean }) {
     const isDrawerOpen = useWorkspaceStore(s => s.isDrawerOpen)
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
     const bgColor = useThemeColor('background')
     // Subscribed rather than read once: the testID must re-render when the
     // active package changes, or it would keep naming whichever package mounted
@@ -45,8 +45,9 @@ export const MobileLayout = memo(function MobileLayout({ isReady = true }: { isR
                     the slide-in drawer below are edge-anchored chrome that must
                     keep bleeding to the screen edge (they inset their own
                     contents). Padding the root would pull them inward and leave
-                    a band of app background beside them. Landscape puts the
-                    sensor housing on one side, so without this every package
+                    a band of app background beside them. useDeviceInsets zeroes
+                    the housing-free side, so in landscape exactly one of these
+                    is nonzero — the notch side — and without it every package
                     screen inside PackageTabs runs under the notch.
 
                     The sheets stay INSIDE this box: BottomDrawer rests at the

--- a/core/components/workspace/MobileTabBar.tsx
+++ b/core/components/workspace/MobileTabBar.tsx
@@ -1,11 +1,11 @@
 import { markNavMilestone, markNavPress } from '@tinycld/core/lib/nav-perf'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import { useSortedPackages } from '@tinycld/core/lib/use-sorted-packages'
 import { useRouter } from 'expo-router'
 import { Ellipsis } from 'lucide-react-native'
 import { Pressable, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { getIcon } from './package-icon-map'
 
 export const MAX_VISIBLE_TABS = 4
@@ -22,7 +22,7 @@ export function MobileTabBar() {
     const isMoreOpen = useWorkspaceStore(s => s.isMoreOpen)
     const setMoreOpen = useWorkspaceStore(s => s.setMoreOpen)
     const router = useRouter()
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
 
     const visiblePkgs =
         sorted.length > MAX_VISIBLE_TABS ? sorted.slice(0, MAX_VISIBLE_TABS) : sorted
@@ -34,9 +34,10 @@ export function MobileTabBar() {
                 backgroundColor: railBg,
                 paddingBottom: insets.bottom,
                 // The tabs spread across the full width, so in landscape the
-                // outermost icons sit exactly where the sensor housing is.
+                // outermost icon sits exactly where the sensor housing is.
                 // Padding the bar insets the icons while its own background
-                // still reaches both edges.
+                // still reaches both edges. The insets are side-corrected, so
+                // only the housing side is padded — the other end stays flush.
                 paddingLeft: insets.left,
                 paddingRight: insets.right,
             }}

--- a/core/components/workspace/PackageRail.tsx
+++ b/core/components/workspace/PackageRail.tsx
@@ -8,7 +8,7 @@ import { useOrgInfo } from '@tinycld/core/lib/use-org-info'
 import { useSortedPackages } from '@tinycld/core/lib/use-sorted-packages'
 import { type Href, Link } from 'expo-router'
 import { Building2, HelpCircle, type LucideIcon, Settings } from 'lucide-react-native'
-import { Pressable, View } from 'react-native'
+import { Pressable, ScrollView, View } from 'react-native'
 import { getIcon } from './package-icon-map'
 import { UserMenu } from './UserMenu'
 
@@ -64,7 +64,15 @@ export function PackageRail({
     const { org } = useOrgInfo()
 
     return (
-        <View
+        <ScrollView
+            // A ScrollView so short viewports (landscape phones) can still reach
+            // every item — a plain View clipped whatever overflowed. `grow` on
+            // the content container makes it fill the viewport when everything
+            // fits, so justify-between keeps the utilities pinned to the bottom
+            // exactly as before; only genuine overflow scrolls. Popovers are
+            // unaffected: UserMenu portals its menu and the bell toggles the
+            // NotificationDrawer rendered outside the rail.
+            style={{ backgroundColor: railBg, width: railWidth(insetLeft), flexGrow: 0 }}
             // Width and paddingLeft both take the full inset, so the icon column
             // sits entirely clear of the sensor housing with its 64pt intact.
             // The background still reaches the physical edge — the parent applies
@@ -72,13 +80,13 @@ export function PackageRail({
             // background covers the gutter it sits in.
             // pt-3 rather than py-3: the bottom pad adds the home-indicator
             // inset on top of the same base 12, keeping the last icon tappable.
-            className="justify-between items-center pt-3"
-            style={{
-                backgroundColor: railBg,
-                width: railWidth(insetLeft),
+            contentContainerClassName="grow justify-between items-center pt-3"
+            contentContainerStyle={{
                 paddingLeft: insetLeft,
                 paddingBottom: 12 + insetBottom,
             }}
+            showsVerticalScrollIndicator={false}
+            alwaysBounceVertical={false}
         >
             <View className="items-center gap-1">
                 <Link href={orgHref('')} asChild>
@@ -140,7 +148,7 @@ export function PackageRail({
 
                 <UserMenu />
             </View>
-        </View>
+        </ScrollView>
     )
 }
 

--- a/core/components/workspace/PackageRail.tsx
+++ b/core/components/workspace/PackageRail.tsx
@@ -16,34 +16,37 @@ import { UserMenu } from './UserMenu'
 // there is ~10pt of slack on each side before an icon reaches the rail's edge.
 const RAIL_WIDTH = 64
 
-// How far the icon column may be pushed inward by a left safe-area inset.
+// The rail's ACTUAL on-screen width: the icon column plus however much the
+// left safe-area inset pushes it inward.
 //
-// The inset is NOT symmetric between the two landscape rotations: iOS reports
-// the sensor housing (~59pt) on whichever side it physically sits, and the home
-// indicator (~21pt) on the other. Absorbing it wholesale made the rail 123pt in
-// one rotation and 85pt in the other — the same screen, wildly different chrome.
+// insetLeft arrives side-corrected (WorkspaceLayout passes useDeviceInsets):
+// ~59pt only in the landscape rotation that puts the sensor housing on the
+// left, 0 in the other rotation and in portrait. So the rail is 123pt with the
+// housing beside it and exactly RAIL_WIDTH everywhere else — the extra chrome
+// exists only when hardware forces it.
 //
-// The cap keeps that shift small. The icons stay clear of the notch anyway: the
-// housing does not intrude into the display's usable area beside it, and the
-// column's own ~10pt of slack plus this shift covers the rounded corner. The
-// background is unaffected either way — it always reaches the physical edge, so
-// there is never a light gutter.
-const MAX_RAIL_INSET_SHIFT = 12
-
-// The rail's ACTUAL on-screen width, which grows with the left safe-area inset.
+// An earlier version capped the shift at 12pt to keep the width uniform, on the
+// theory that the housing "does not intrude into the display's usable area
+// beside it". It does: 12pt against a ~59pt housing left the top icons ~47pt
+// underneath it, unreadable and untappable. The cap cannot apply to the shift
+// alone either — the 44pt (w-11) icons need RAIL_WIDTH of space AFTER the
+// padding, so width and shift move together.
+//
+// The background is unaffected either way — it always reaches the physical edge,
+// so there is never a light gutter.
+//
 // Exported because anything positioned against the rail's right edge — the
 // notification drawer — has to agree with it; a hardcoded 64 there leaves a gap
 // once the rail widens in landscape.
 export function railWidth(insetLeft: number): number {
-    return RAIL_WIDTH + Math.min(insetLeft, MAX_RAIL_INSET_SHIFT)
+    return RAIL_WIDTH + insetLeft
 }
 
-// insetLeft is the device's left safe-area inset (the notch side in one
-// landscape rotation, the home indicator in the other, 0 in portrait). The rail
-// absorbs it rather than letting the parent pad the whole layout: that way the
-// rail's own dark background fills the gutter edge to edge. Padding it upstream
-// instead left a strip of app background beside the rail — the light band this
-// fixes.
+// insetLeft is the side-corrected left safe-area inset (nonzero only when the
+// sensor housing is physically on the left). The rail absorbs it rather than
+// letting the parent pad the whole layout: that way the rail's own dark
+// background fills the gutter edge to edge. Padding it upstream instead left a
+// strip of app background beside the rail — the light band this fixes.
 export function PackageRail({
     insetLeft = 0,
     insetBottom = 0,
@@ -51,7 +54,6 @@ export function PackageRail({
     insetLeft?: number
     insetBottom?: number
 }) {
-    const insetShift = Math.min(insetLeft, MAX_RAIL_INSET_SHIFT)
     const railBg = useThemeColor('rail-background')
     const railText = useThemeColor('rail-text')
     const railActive = useThemeColor('rail-active-text')
@@ -63,19 +65,18 @@ export function PackageRail({
 
     return (
         <View
-            // Width grows only by the CAPPED shift, not the full inset: the rail
-            // is chrome, and turning a 59pt notch inset into 59pt of extra dark
-            // bar (with the workspace pushed in behind it) costs real screen
-            // width for nothing. The background still reaches the physical edge
-            // regardless — the parent applies no horizontal padding, so this box
-            // starts at x=0 and its own background covers the gutter it sits in.
+            // Width and paddingLeft both take the full inset, so the icon column
+            // sits entirely clear of the sensor housing with its 64pt intact.
+            // The background still reaches the physical edge — the parent applies
+            // no horizontal padding, so this box starts at x=0 and its own
+            // background covers the gutter it sits in.
             // pt-3 rather than py-3: the bottom pad adds the home-indicator
             // inset on top of the same base 12, keeping the last icon tappable.
             className="justify-between items-center pt-3"
             style={{
                 backgroundColor: railBg,
                 width: railWidth(insetLeft),
-                paddingLeft: insetShift,
+                paddingLeft: insetLeft,
                 paddingBottom: 12 + insetBottom,
             }}
         >

--- a/core/components/workspace/WorkspaceLayout.tsx
+++ b/core/components/workspace/WorkspaceLayout.tsx
@@ -3,8 +3,8 @@ import { NotificationDrawer } from '@tinycld/core/components/NotificationDrawer'
 import { usePackage } from '@tinycld/core/lib/packages/use-packages'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import { Platform, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { MobileLayout } from './MobileLayout'
 import { useActivePkgDenied } from './PackageAccessDenied'
 import { PackageProviderWrapper } from './PackageProviderWrapper'
@@ -25,7 +25,7 @@ export function WorkspaceLayout({ isReady = true }: { isReady?: boolean }) {
     const activePkgSlug = useWorkspaceStore(s => s.activePkgSlug)
     const activePkg = usePackage(activePkgSlug ?? '')
     const activePkgDenied = useActivePkgDenied()
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
 
     if (breakpoint === 'mobile') return <MobileLayout isReady={isReady} />
 
@@ -61,14 +61,16 @@ export function WorkspaceLayout({ isReady = true }: { isReady?: boolean }) {
             <DemoBanner />
             <View className="flex-1 flex-row" style={{ minHeight: 0 }}>
                 {/* Horizontal insets are consumed by the edge panels themselves,
-                    NOT by this container. In landscape iOS reports a large inset
-                    on the notch side (~59pt) and the home-indicator side (~21pt);
-                    padding them here painted both gutters in the app background,
-                    leaving a wide light band down the side of the screen. The iOS
-                    convention is the opposite: backgrounds run edge to edge and
-                    only CONTENT is inset. So the rail bleeds its own dark colour
-                    into the left gutter, and the content pane extends under the
-                    right one while padding its contents clear of it. */}
+                    NOT by this container: padding them here painted the gutters
+                    in the app background, leaving a wide light band down the
+                    side of the screen. The iOS convention is the opposite:
+                    backgrounds run edge to edge and only CONTENT is inset.
+                    useDeviceInsets has already side-corrected the pair — only
+                    the sensor-housing side is nonzero in landscape — so exactly
+                    one of these is ever set: the rail absorbs insets.left when
+                    the housing is on the left (bleeding its dark colour into the
+                    gutter), or the content pane pads insets.right when it is on
+                    the right. The opposite side stays full-bleed. */}
                 {isReady && <PackageRail insetLeft={insets.left} insetBottom={insets.bottom} />}
 
                 {isReady && <NotificationDrawer />}

--- a/core/components/workspace/useBreakpoint.ts
+++ b/core/components/workspace/useBreakpoint.ts
@@ -19,3 +19,7 @@ export function useBreakpoint(): Breakpoint {
 export function useWindowWidth(): number {
     return useWindowSizeStore(s => s.width)
 }
+
+export function useWindowHeight(): number {
+    return useWindowSizeStore(s => s.height)
+}

--- a/core/lib/safe-area-resolve.ts
+++ b/core/lib/safe-area-resolve.ts
@@ -1,0 +1,59 @@
+// Side-corrects iOS landscape safe-area insets so only the sensor-housing
+// (notch / Dynamic Island) side is inset and the opposite side is full-bleed.
+//
+// iOS reports SYMMETRIC left/right insets in landscape — ~59pt on BOTH sides
+// of a Dynamic Island phone (44pt on notch phones) — regardless of which side
+// the housing physically sits on. The insets alone therefore cannot say which
+// side needs clearing; that takes the interface orientation, which tells us
+// which way the device was rotated and so where the housing ended up.
+//
+// This module is deliberately free of React/react-native/Expo imports so unit
+// tests exercise it with no mocks. The orientation feed lives in
+// `stores/orientation-store.ts`; the React binding in `use-safe-area.ts`.
+
+export interface Insets {
+    top: number
+    right: number
+    bottom: number
+    left: number
+}
+
+export type AppOrientation = 'portrait' | 'landscape-left' | 'landscape-right' | 'unknown'
+
+/** Which interface side the sensor housing occupies, or null when not in a
+ *  known landscape orientation.
+ *
+ *  This is the ONE place the notorious interface-vs-device left/right naming
+ *  flip is decided. The names really are crossed: interface LANDSCAPE_LEFT
+ *  puts the housing on the RIGHT, and vice versa. Verified empirically on an
+ *  iPhone 17 simulator (iOS 26.5) by locking each landscape orientation and
+ *  observing which side of the interface the Dynamic Island overlapped. Do NOT
+ *  edit these values from memory or Apple-docs reasoning — re-verify on a
+ *  simulator (the locked cases in safe-area-resolve.test.ts must be updated in
+ *  the same change). */
+export function islandSide(orientation: AppOrientation): 'left' | 'right' | null {
+    if (orientation === 'landscape-left') return 'right'
+    if (orientation === 'landscape-right') return 'left'
+    return null
+}
+
+/** iOS-landscape-only correction: zero the inset on the side opposite the
+ *  sensor housing. Everything else passes through untouched:
+ *  - portrait / 'unknown' (including before the first orientation event):
+ *    symmetric passthrough — conservative, never puts content under the island
+ *  - non-iOS: Android display-cutout insets are genuinely per-side and web
+ *    reports zeros, so both are already correct
+ *  - the `left > 0 && right > 0` guard skips iPad (0/0), one-sided Android
+ *    cutouts, and Split View / Stage Manager, which never report the
+ *    symmetric-pair shape this correction exists for */
+export function resolveInsets(
+    raw: Insets,
+    orientation: AppOrientation,
+    platformOS: string
+): Insets {
+    if (platformOS !== 'ios') return raw
+    const side = islandSide(orientation)
+    if (side === null) return raw
+    if (!(raw.left > 0 && raw.right > 0)) return raw
+    return side === 'left' ? { ...raw, right: 0 } : { ...raw, left: 0 }
+}

--- a/core/lib/stores/orientation-store.ts
+++ b/core/lib/stores/orientation-store.ts
@@ -1,0 +1,56 @@
+import type { AppOrientation } from '@tinycld/core/lib/safe-area-resolve'
+import { create } from '@tinycld/core/lib/store'
+import { Platform } from 'react-native'
+
+export interface OrientationState {
+    orientation: AppOrientation
+    setOrientation: (orientation: AppOrientation) => void
+}
+
+// 'unknown' until the first orientation event: resolveInsets passes symmetric
+// insets through for it, so the pre-event frames can never put content under
+// the sensor housing.
+export const useOrientationStore = create<OrientationState>()(set => ({
+    orientation: 'unknown',
+    setOrientation: orientation => set({ orientation }),
+}))
+
+// One subscription for the entire app, mirroring window-size-store. iOS-only:
+// the correction this feeds exists because iOS reports symmetric landscape
+// insets; Android/web insets are already per-side-correct and need no
+// orientation input. The dynamic import also keeps a binary built without the
+// expo-screen-orientation native module (stale dev client, OTA mismatch) from
+// crashing at startup — the rejection leaves the store at 'unknown', which
+// degrades to the old symmetric-inset behavior.
+if (Platform.OS === 'ios') {
+    import('expo-screen-orientation')
+        .then(ScreenOrientation => {
+            const { Orientation } = ScreenOrientation
+            // Mechanical enum→string mapping only — the physical which-side
+            // judgment lives solely in islandSide() in safe-area-resolve.ts.
+            const toApp = (orientation: number): AppOrientation => {
+                switch (orientation) {
+                    case Orientation.PORTRAIT_UP:
+                    case Orientation.PORTRAIT_DOWN:
+                        return 'portrait'
+                    case Orientation.LANDSCAPE_LEFT:
+                        return 'landscape-left'
+                    case Orientation.LANDSCAPE_RIGHT:
+                        return 'landscape-right'
+                    default:
+                        return 'unknown'
+                }
+            }
+            ScreenOrientation.getOrientationAsync()
+                .then(orientation =>
+                    useOrientationStore.getState().setOrientation(toApp(orientation))
+                )
+                .catch(() => {})
+            ScreenOrientation.addOrientationChangeListener(event =>
+                useOrientationStore
+                    .getState()
+                    .setOrientation(toApp(event.orientationInfo.orientation))
+            )
+        })
+        .catch(() => {})
+}

--- a/core/lib/use-safe-area.ts
+++ b/core/lib/use-safe-area.ts
@@ -1,4 +1,5 @@
-// Safe-area insets, and the one rule for combining them with design spacing.
+// Safe-area insets — side-corrected for landscape — and the one rule for
+// combining them with design spacing.
 //
 // A sibling cannot import `react-native-safe-area-context` directly: it is not
 // in any feature's peerDependencies, and adding it to each one would mean a
@@ -10,13 +11,40 @@
 // chrome, which insets its content for them. The exception is a surface that
 // escapes that chrome — a full-screen overlay or an `absolute` window pinned to
 // the viewport — which bypasses every ancestor's padding and has to clear the
-// sensor housing itself. In landscape iOS reports that housing as a ~59pt
-// left/right inset, which is where a flush-mounted close button ends up.
+// sensor housing itself.
+//
+// Why not the raw library hook: in landscape iOS reports the sensor housing as
+// a SYMMETRIC ~59pt inset on BOTH left and right, whichever side it actually
+// occupies. Consuming that raw pair pads the housing-free side for nothing.
+// `useDeviceInsets` folds in the interface orientation (which says where the
+// housing really is) and zeroes the opposite side, so padding lands only where
+// hardware demands it. Consumers should never reach around this to the raw
+// library values — the raw pair is the bug this file exists to fix.
 
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { resolveInsets } from '@tinycld/core/lib/safe-area-resolve'
+import { useOrientationStore } from '@tinycld/core/lib/stores/orientation-store'
+import { useMemo } from 'react'
+import { Platform } from 'react-native'
+import type { EdgeInsets } from 'react-native-safe-area-context'
+import { useSafeAreaInsets as useRawSafeAreaInsets } from 'react-native-safe-area-context'
 
 export type { EdgeInsets } from 'react-native-safe-area-context'
-export { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+/** Safe-area insets corrected for which side the sensor housing is on: in iOS
+ *  landscape only the housing side keeps its ~59pt, the opposite side reads 0
+ *  (full-bleed). Portrait, Android, web, and the moments before the first
+ *  orientation event all pass through unchanged. */
+export function useDeviceInsets(): EdgeInsets {
+    const raw = useRawSafeAreaInsets()
+    const orientation = useOrientationStore(s => s.orientation)
+    return useMemo(() => resolveInsets(raw, orientation, Platform.OS), [raw, orientation])
+}
+
+/** @deprecated Alias of {@link useDeviceInsets}, kept so feature siblings keep
+ *  resolving one hook from core rather than adding a
+ *  `react-native-safe-area-context` peerDependency each. Note the semantics
+ *  are the corrected ones — in landscape the housing-free side reads 0. */
+export const useSafeAreaInsets = useDeviceInsets
 
 /** Padding that clears the device's safe area while never falling below a base
  *  spacing. The single place this rule is expressed — hand-rolling it per
@@ -30,17 +58,17 @@ export { useSafeAreaInsets } from 'react-native-safe-area-context'
  *  closer to the edge than the design wants, and never under the sensor
  *  housing.
  *
- *  This does NOT flatten the left/right asymmetry it might appear to: when an
- *  inset genuinely exceeds the base (the ~59pt notch side in landscape) it wins
- *  and that side is visibly wider. Equal margins mean both insets were smaller
- *  than the base, which is the correct result, not a lost signal. */
+ *  Built on `useDeviceInsets`, so in landscape the horizontal base is compared
+ *  against the CORRECTED pair: the housing side gets ~59pt (the inset wins),
+ *  the opposite side gets exactly the base (its inset reads 0). Asymmetric
+ *  margins in landscape are therefore the intended result, not a bug. */
 export function useSafeAreaPadding(base: { horizontal?: number; top?: number; bottom?: number }): {
     paddingLeft: number
     paddingRight: number
     paddingTop: number
     paddingBottom: number
 } {
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
     const horizontal = base.horizontal ?? 0
     return {
         paddingLeft: Math.max(horizontal, insets.left),

--- a/core/package.json
+++ b/core/package.json
@@ -78,6 +78,7 @@
         "expo-image": "~55.0.11",
         "expo-image-picker": "~55.0.20",
         "expo-router": "~55.0.14",
+        "expo-screen-orientation": "~55.0.18",
         "lib0": "^0.2.117",
         "lucide-react-native": "^1.7.0",
         "pbtsdb": ">=0.6.3",

--- a/core/tests/unit-setup.ts
+++ b/core/tests/unit-setup.ts
@@ -18,6 +18,21 @@ vi.mock('react-native', () => ({
     },
 }))
 
+// Native module; only dynamically imported behind a Platform.OS === 'ios'
+// guard (orientation-store), so tests never load the real thing — this shim
+// exists so any future eager import still parses under vitest.
+vi.mock('expo-screen-orientation', () => ({
+    Orientation: {
+        UNKNOWN: 0,
+        PORTRAIT_UP: 1,
+        PORTRAIT_DOWN: 2,
+        LANDSCAPE_LEFT: 3,
+        LANDSCAPE_RIGHT: 4,
+    },
+    getOrientationAsync: async () => 0,
+    addOrientationChangeListener: () => ({ remove: () => {} }),
+}))
+
 vi.mock('expo-router', () => ({
     router: { replace: vi.fn(), push: vi.fn(), back: vi.fn() },
     Slot: () => null,

--- a/core/tests/unit/orientation-store.test.ts
+++ b/core/tests/unit/orientation-store.test.ts
@@ -1,0 +1,14 @@
+import { useOrientationStore } from '@tinycld/core/lib/stores/orientation-store'
+import { describe, expect, it } from 'vitest'
+
+describe('orientation-store', () => {
+    it('starts unknown so resolveInsets stays conservative pre-first-event', () => {
+        expect(useOrientationStore.getState().orientation).toBe('unknown')
+    })
+
+    it('exposes setOrientation that updates the orientation', () => {
+        useOrientationStore.getState().setOrientation('landscape-left')
+        expect(useOrientationStore.getState().orientation).toBe('landscape-left')
+        useOrientationStore.getState().setOrientation('unknown')
+    })
+})

--- a/core/tests/unit/safe-area-resolve.test.ts
+++ b/core/tests/unit/safe-area-resolve.test.ts
@@ -1,0 +1,84 @@
+import {
+    type AppOrientation,
+    type Insets,
+    islandSide,
+    resolveInsets,
+} from '@tinycld/core/lib/safe-area-resolve'
+import { describe, expect, it } from 'vitest'
+
+const landscape: Insets = { top: 0, left: 59, right: 59, bottom: 21 }
+
+describe('islandSide', () => {
+    // LOCKED MAPPING — verified on an iPhone 17 simulator (iOS 26.5) by
+    // locking each landscape orientation and observing which interface side
+    // the Dynamic Island overlapped. The names really are crossed. Changing
+    // these expectations requires re-verifying on a simulator, not reasoning
+    // from Apple's interface-vs-device orientation docs.
+    it('maps each landscape rotation to the housing side', () => {
+        expect(islandSide('landscape-left')).toBe('right')
+        expect(islandSide('landscape-right')).toBe('left')
+    })
+
+    it('reports no side outside landscape', () => {
+        expect(islandSide('portrait')).toBeNull()
+        expect(islandSide('unknown')).toBeNull()
+    })
+})
+
+describe('resolveInsets', () => {
+    it('passes portrait through untouched', () => {
+        const portrait: Insets = { top: 59, left: 0, right: 0, bottom: 34 }
+        expect(resolveInsets(portrait, 'portrait', 'ios')).toEqual(portrait)
+    })
+
+    it('keeps only the left inset when the housing is on the left (landscape-right)', () => {
+        expect(resolveInsets(landscape, 'landscape-right', 'ios')).toEqual({
+            top: 0,
+            left: 59,
+            right: 0,
+            bottom: 21,
+        })
+    })
+
+    it('keeps only the right inset when the housing is on the right (landscape-left)', () => {
+        expect(resolveInsets(landscape, 'landscape-left', 'ios')).toEqual({
+            top: 0,
+            left: 0,
+            right: 59,
+            bottom: 21,
+        })
+    })
+
+    it('passes symmetric insets through while the orientation is unknown', () => {
+        // Conservative pre-first-event behavior: symmetric padding can waste a
+        // gutter for a frame but can never put content under the island.
+        expect(resolveInsets(landscape, 'unknown', 'ios')).toEqual(landscape)
+    })
+
+    it('never touches non-iOS platforms', () => {
+        // Android display-cutout insets are genuinely per-side already.
+        const cutout: Insets = { top: 0, left: 30, right: 0, bottom: 0 }
+        expect(resolveInsets(cutout, 'landscape-left', 'android')).toEqual(cutout)
+        expect(resolveInsets(landscape, 'landscape-left', 'web')).toEqual(landscape)
+    })
+
+    it('passes zero horizontal insets through (iPad, web)', () => {
+        const flat: Insets = { top: 24, left: 0, right: 0, bottom: 20 }
+        for (const orientation of ['landscape-left', 'landscape-right'] as AppOrientation[]) {
+            expect(resolveInsets(flat, orientation, 'ios')).toEqual(flat)
+        }
+    })
+
+    it('leaves an already one-sided pair alone', () => {
+        // Defensive: if iOS ever starts reporting per-side insets itself, the
+        // correction must not zero the one real value.
+        const oneSided: Insets = { top: 0, left: 59, right: 0, bottom: 21 }
+        expect(resolveInsets(oneSided, 'landscape-right', 'ios')).toEqual(oneSided)
+    })
+
+    it('does not mutate its input', () => {
+        const input = { ...landscape }
+        resolveInsets(input, 'landscape-left', 'ios')
+        expect(input).toEqual(landscape)
+    })
+})

--- a/core/ui/drawer/index.tsx
+++ b/core/ui/drawer/index.tsx
@@ -3,6 +3,7 @@ import { createModal as createDrawer } from '@gluestack-ui/core/modal/creator'
 import { ExitAnimationContext } from '@gluestack-ui/core/overlay/creator'
 import type { VariantProps } from '@gluestack-ui/utils/nativewind-utils'
 import { tva, useStyleContext, withStyleContext } from '@gluestack-ui/utils/nativewind-utils'
+import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import React from 'react'
 import { Platform, Pressable, ScrollView, View } from 'react-native'
 import Animated, {
@@ -18,7 +19,6 @@ import Animated, {
     SlideOutRight,
     SlideOutUp,
 } from 'react-native-reanimated'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useCloseOnNavigate } from './use-close-on-navigate'
 
 const SCOPE = 'MODAL'
@@ -283,13 +283,15 @@ const DrawerContent = React.forwardRef<
     IDrawerContentProps
 >(function DrawerContent({ className, style, ...props }, ref) {
     const { size: parentSize, anchor: parentAnchor } = useStyleContext(SCOPE)
-    const insets = useSafeAreaInsets()
+    const insets = useDeviceInsets()
 
     // 24px base padding (was `p-6`) plus the device safe-area inset on the edges
     // the drawer reaches, so its header/body clears the status bar / notch /
     // home indicator. Side drawers span full height (top + bottom); a top drawer
-    // reaches the top edge, a bottom drawer the bottom. On web / non-notch
-    // devices every inset is 0, leaving the original 24px.
+    // reaches the top edge, a bottom drawer the bottom. The insets are
+    // side-corrected, so a drawer anchored on the housing-free landscape edge
+    // gets 0 here. On web / non-notch devices every inset is 0, leaving the
+    // original 24px.
     const BASE = 24
     const paddingStyle = {
         paddingTop: BASE + (parentAnchor !== 'bottom' ? insets.top : 0),

--- a/core/ui/form/__tests__/text-input-autofill.test.tsx
+++ b/core/ui/form/__tests__/text-input-autofill.test.tsx
@@ -24,13 +24,13 @@ afterEach(cleanup)
 describe('TextInput autofill hints', () => {
     it('forwards autoComplete to the underlying input', () => {
         const { container } = render(<Harness autoComplete="new-password" />)
-        const input = container.querySelector('textinput')
+        const input = container.querySelector('rn-textinput')
         expect(input?.getAttribute('autoComplete')).toBe('new-password')
     })
 
     it('forwards textContentType to the underlying input', () => {
         const { container } = render(<Harness textContentType="newPassword" />)
-        const input = container.querySelector('textinput')
+        const input = container.querySelector('rn-textinput')
         expect(input?.getAttribute('textContentType')).toBe('newPassword')
     })
 })

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "@tanstack/query-db-collection": "^1.0.36",
         "@tanstack/react-db": "^0.1.79",
         "@tanstack/react-query": "^5.96.0",
+        "@tinycld/core": "*",
         "@tiptap/core": "^3.22.3",
         "@tiptap/extension-blockquote": "^3.22.3",
         "@tiptap/extension-bullet-list": "^3.22.3",
@@ -127,6 +128,7 @@
         "expo-notifications": "~55.0.22",
         "expo-print": "^55.0.14",
         "expo-router": "~55.0.14",
+        "expo-screen-orientation": "~55.0.18",
         "expo-sharing": "~55.0.18",
         "fflate": "^0.8.2",
         "heroui-native": "^1.0.1",
@@ -181,8 +183,7 @@
         "y-protocols": "^1.0.7",
         "yjs": "^13.6.30",
         "zod": "^4.3.6",
-        "zustand": "^5.0.12",
-        "@tinycld/core": "*"
+        "zustand": "^5.0.12"
     },
     "devDependencies": {
         "@biomejs/biome": "2.5.1",
@@ -190,6 +191,7 @@
         "@react-native-community/cli": "^20.1.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
+        "@tinycld/package-scripts": "*",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.2",
         "babel-plugin-module-resolver": "^5.0.3",
@@ -202,7 +204,6 @@
         "local-ssl-proxy": "^2.0.5",
         "tailwindcss": "^4.2.2",
         "tsx": "^4.21.0",
-        "vitest": "^3.0.0",
-        "@tinycld/package-scripts": "*"
+        "vitest": "^3.0.0"
     }
 }

--- a/tests/react-native-stub.cjs
+++ b/tests/react-native-stub.cjs
@@ -15,24 +15,29 @@ module.exports = {
         setBackgroundColor: () => {},
     },
     StyleSheet: { create: (s) => s, flatten: (s) => s, compose: (a, b) => [a, b] },
-    View: 'View',
-    Text: 'Text',
-    Pressable: 'Pressable',
-    ScrollView: 'ScrollView',
-    TextInput: 'TextInput',
-    Image: 'Image',
-    Modal: 'Modal',
-    TouchableOpacity: 'TouchableOpacity',
-    TouchableHighlight: 'TouchableHighlight',
-    TouchableWithoutFeedback: 'TouchableWithoutFeedback',
-    ActivityIndicator: 'ActivityIndicator',
-    FlatList: 'FlatList',
-    SectionList: 'SectionList',
-    SafeAreaView: 'SafeAreaView',
-    KeyboardAvoidingView: 'KeyboardAvoidingView',
+    // Components are string tags so props pass straight through to attributes
+    // (text-input-autofill.test.tsx asserts on them). The names are dashed
+    // lowercase because React DOM treats those as custom elements and stays
+    // quiet; an uppercase tag like 'Text' triggers the "is using incorrect
+    // casing" / "unrecognized in this browser" dev warnings in every render.
+    View: 'rn-view',
+    Text: 'rn-text',
+    Pressable: 'rn-pressable',
+    ScrollView: 'rn-scrollview',
+    TextInput: 'rn-textinput',
+    Image: 'rn-image',
+    Modal: 'rn-modal',
+    TouchableOpacity: 'rn-touchableopacity',
+    TouchableHighlight: 'rn-touchablehighlight',
+    TouchableWithoutFeedback: 'rn-touchablewithoutfeedback',
+    ActivityIndicator: 'rn-activityindicator',
+    FlatList: 'rn-flatlist',
+    SectionList: 'rn-sectionlist',
+    SafeAreaView: 'rn-safeareaview',
+    KeyboardAvoidingView: 'rn-keyboardavoidingview',
     Animated: {
-        View: 'View',
-        Text: 'Text',
+        View: 'rn-view',
+        Text: 'rn-text',
         Value: class {
             constructor(v) { this._value = v }
             setValue(v) { this._value = v }

--- a/tests/unit-setup.ts
+++ b/tests/unit-setup.ts
@@ -18,3 +18,18 @@ vi.mock('@tinycld/app-generated/tinycld-config', () => ({
 vi.mock('@tinycld/app-generated/package-help', () => ({
     packageHelp: [],
 }))
+
+// Native module; only dynamically imported behind a Platform.OS === 'ios'
+// guard (core/lib/stores/orientation-store), so tests never load the real
+// thing — this shim keeps any future eager import parseable under vitest.
+vi.mock('expo-screen-orientation', () => ({
+    Orientation: {
+        UNKNOWN: 0,
+        PORTRAIT_UP: 1,
+        PORTRAIT_DOWN: 2,
+        LANDSCAPE_LEFT: 3,
+        LANDSCAPE_RIGHT: 4,
+    },
+    getOrientationAsync: async () => 0,
+    addOrientationChangeListener: () => ({ remove: () => {} }),
+}))


### PR DESCRIPTION
Two fixes for the same bug class: UI that assumed a tall viewport and broke on a phone in landscape.

## 1. Scrollable package rail

On short viewports the left icon rail overflowed its fixed `View` and clipped whatever didn't fit, leaving the bottom utilities (notification bell, help, settings, user menu) unreachable.

The rail is now a `ScrollView` whose content container keeps `flexGrow` + `justify-between`: when everything fits the pinned top/bottom layout is pixel-identical, and only genuine overflow scrolls. Popovers are unaffected — the user menu portals its menu and the bell toggles the `NotificationDrawer` rendered outside the rail.

Verified in-browser at 800×360 (rail scrolls, all items reachable) and 1200×900 (layout unchanged).

## 2. `useWindowHeight()`

`window-size-store` already tracked height behind its single global `Dimensions` listener, but only width had an exported hook. Added `useWindowHeight()` alongside `useWindowWidth()` as a primitive selector, so consumers re-render only when height actually changes — deliberately not `useWindowDimensions`, which the store's header comment documents as removed for fanning out a state update per consumer on every resize.

Consumed by tinycld/mail#TBD, which needs viewport height to stop the attachment drawer auto-opening a 280px panel over a landscape phone's message body.

## Checks

`pnpm exec tinycld-pkg check` green — biome, tsc, 729 tests across 113 files.