### PR TITLE
fix(core): move the sidebar's home-indicator inset onto its scroll content

### DIFF
--- a/core/components/sidebar-primitives/SidebarNav.tsx
+++ b/core/components/sidebar-primitives/SidebarNav.tsx
@@ -1,12 +1,26 @@
+import { useSafeAreaPadding } from '@tinycld/core/lib/use-safe-area'
 import type { ReactNode } from 'react'
 import { ScrollView, View } from 'react-native'
 
 export function SidebarNav({ children }: { children: ReactNode }) {
+    // The home-indicator inset belongs on the scroll CONTENT, not on the
+    // sidebar box: as outer padding it walled off a dead strip the list could
+    // never scroll into, so the last item stopped short of the bottom on every
+    // gesture-nav device. Here the list scrolls the full height and the inset
+    // is only reserved past the final item. Base 8 matches the horizontal pad
+    // and is a minimum, not an addend — see useSafeAreaPadding.
+    const { paddingBottom } = useSafeAreaPadding({ bottom: 8 })
+
     return (
         <View className="flex-1 bg-sidebar-background">
             <ScrollView
                 className="flex-1"
-                contentContainerStyle={{ padding: 8, gap: 2 }}
+                contentContainerStyle={{
+                    paddingTop: 8,
+                    paddingHorizontal: 8,
+                    paddingBottom,
+                    gap: 2,
+                }}
                 showsVerticalScrollIndicator={false}
             >
                 {children}

--- a/core/components/workspace/MobileDrawer.tsx
+++ b/core/components/workspace/MobileDrawer.tsx
@@ -146,7 +146,11 @@ export function MobileDrawer({ isVisible }: MobileDrawerProps) {
                                 zIndex: 201,
                                 backgroundColor: sidebarBg,
                                 paddingTop: insets.top,
-                                paddingBottom: insets.bottom,
+                                // No paddingBottom: the sidebar this panel
+                                // hosts reserves the home-indicator inset on
+                                // its own ScrollView content (SidebarNav).
+                                // Padding here too would stack both insets and
+                                // re-create the dead strip at the bottom.
                                 // Pinned to the left edge, so in the landscape
                                 // rotation that puts the sensor housing on the
                                 // left it sits over this panel's contents. Pad

--- a/core/components/workspace/PackageRail.tsx
+++ b/core/components/workspace/PackageRail.tsx
@@ -78,12 +78,15 @@ export function PackageRail({
             // The background still reaches the physical edge — the parent applies
             // no horizontal padding, so this box starts at x=0 and its own
             // background covers the gutter it sits in.
-            // pt-3 rather than py-3: the bottom pad adds the home-indicator
-            // inset on top of the same base 12, keeping the last icon tappable.
+            // pt-3 rather than py-3: the bottom pad takes the LARGER of the
+            // base 12 and the home-indicator inset, keeping the last icon
+            // tappable. A minimum, not an addend — summing them double-counts
+            // and pushes the last icon needlessly far off the edge. See
+            // useSafeAreaPadding, which expresses this same rule.
             contentContainerClassName="grow justify-between items-center pt-3"
             contentContainerStyle={{
                 paddingLeft: insetLeft,
-                paddingBottom: 12 + insetBottom,
+                paddingBottom: Math.max(12, insetBottom),
             }}
             showsVerticalScrollIndicator={false}
             alwaysBounceVertical={false}

--- a/core/components/workspace/PackageSidebar.tsx
+++ b/core/components/workspace/PackageSidebar.tsx
@@ -8,13 +8,9 @@ import { SkeletonSidebar } from './SkeletonLayout'
 
 interface PackageSidebarProps {
     width: number
-    /** Home-indicator inset. Applied to the inner fixed-width content rather
-     *  than the animating outer box, so the open/close width transition is
-     *  untouched while the sidebar's own background still runs to the edge. */
-    insetBottom?: number
 }
 
-export function PackageSidebar({ width, insetBottom = 0 }: PackageSidebarProps) {
+export function PackageSidebar({ width }: PackageSidebarProps) {
     const activePkgSlug = useWorkspaceStore(s => s.activePkgSlug)
     const isSidebarOpen = useWorkspaceStore(s => s.isSidebarOpen)
     const pkg = usePackage(activePkgSlug ?? '')
@@ -38,7 +34,10 @@ export function PackageSidebar({ width, insetBottom = 0 }: PackageSidebarProps) 
                     : undefined,
             ]}
         >
-            <View style={{ width, flex: 1, minHeight: 0, paddingBottom: insetBottom }}>
+            {/* No bottom inset here: the sidebar's own ScrollView (SidebarNav)
+                reserves it on its content instead, so the list scrolls to the
+                physical edge rather than stopping above a dead strip. */}
+            <View style={{ width, flex: 1, minHeight: 0 }}>
                 {SidebarComponent ? (
                     // LazySidebarBoundary owns the Suspense + recovery: it
                     // retries the lazy import if it rejects, and remounts if the

--- a/core/components/workspace/WorkspaceLayout.tsx
+++ b/core/components/workspace/WorkspaceLayout.tsx
@@ -76,9 +76,10 @@ export function WorkspaceLayout({ isReady = true }: { isReady?: boolean }) {
                 {isReady && <NotificationDrawer />}
 
                 <PackageProviderWrapper>
-                    {isReady && hasSidebar && (
-                        <PackageSidebar width={sidebarWidth} insetBottom={insets.bottom} />
-                    )}
+                    {/* PackageSidebar takes no bottom inset — its SidebarNav
+                        ScrollView reserves the home-indicator gutter on its own
+                        content so the list can scroll the full height. */}
+                    {isReady && hasSidebar && <PackageSidebar width={sidebarWidth} />}
 
                     <View
                         className="flex-1"


### PR DESCRIPTION
Stacked on #148 — targets `fix/package-rail-scroll`, not `main`. Merge after #148.

The bottom safe-area inset was applied to the sidebar *box*, which walled off a strip the list could never scroll into: the last item stopped short of the bottom on every gesture-nav device. It now sits on `SidebarNav`'s ScrollView content, so the list scrolls the full height and the gutter is only reserved past the final item.

All four package sidebars (mail, contacts, drive, calendar) route through `SidebarNav`, so this is one change rather than four — no sibling repos need touching.

- `SidebarNav` — inset via `useSafeAreaPadding({ bottom: 8 })` on `contentContainerStyle`
- `PackageSidebar` — dropped the now-unused `insetBottom` prop
- `MobileDrawer` — removed `paddingBottom`; it hosts the same sidebar component, so leaving it would have stacked both insets and re-created the dead strip on phones
- `PackageRail` — `12 + inset` → `max(12, inset)`, the rule `useSafeAreaPadding` already documents and the rail's last additive holdout

Native-only by construction (`insets.bottom` is 0 on web). On a phone reporting ~21pt, the rail's bottom pad goes 33pt → 21pt.

Checks green in core (729 tests) plus mail, drive, contacts, and calendar — biome, tsc, unit. Not verified on a simulator; the visual result needs a device to confirm.