### PR TITLE
Core month-grid date picker and local-time date helpers

### DIFF
--- a/core/components/MiniCalendar.tsx
+++ b/core/components/MiniCalendar.tsx
@@ -1,0 +1,163 @@
+import { addMonths, getMonthGrid, isSameDay, toDateString } from '@tinycld/core/lib/dates'
+import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { ChevronLeft, ChevronRight } from 'lucide-react-native'
+import { useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
+
+// Promoted from the calendar package so any package can render a month grid
+// without depending on a sibling. Renders on web and native alike — it is
+// ordinary RN views, not a native module, which is why the workspace uses this
+// rather than one of the platform date pickers (all native-only).
+
+const DAY_LETTERS = [
+    { key: 'sun', label: 'S' },
+    { key: 'mon', label: 'M' },
+    { key: 'tue', label: 'T' },
+    { key: 'wed', label: 'W' },
+    { key: 'thu', label: 'T' },
+    { key: 'fri', label: 'F' },
+    { key: 'sat', label: 'S' },
+]
+
+const MONTHS = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+]
+
+interface MiniCalendarProps {
+    /** The highlighted day. Also picks the month the grid opens on. */
+    selectedDate: Date
+    onDateSelect: (date: Date) => void
+}
+
+export function MiniCalendar({ selectedDate, onDateSelect }: MiniCalendarProps) {
+    const [displayMonth, setDisplayMonth] = useState(
+        () => new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1)
+    )
+    const fgColor = useThemeColor('foreground')
+    const mutedColor = useThemeColor('muted-foreground')
+    const primaryColor = useThemeColor('primary')
+    const primaryFgColor = useThemeColor('primary-foreground')
+    const activeIndicatorColor = useThemeColor('active-indicator')
+
+    const grid = getMonthGrid(displayMonth)
+    const monthLabel = `${MONTHS[displayMonth.getMonth()]} ${displayMonth.getFullYear()}`
+
+    return (
+        <View className="px-3 py-2">
+            <View className="flex-row justify-between items-center mb-2">
+                <Text className="text-foreground" style={{ fontSize: 15, fontWeight: '600' }}>
+                    {monthLabel}
+                </Text>
+                <View className="flex-row gap-2">
+                    <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel="Previous month"
+                        onPress={() => setDisplayMonth(prev => addMonths(prev, -1))}
+                        hitSlop={8}
+                    >
+                        <ChevronLeft size={16} color={mutedColor} />
+                    </Pressable>
+                    <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel="Next month"
+                        onPress={() => setDisplayMonth(prev => addMonths(prev, 1))}
+                        hitSlop={8}
+                    >
+                        <ChevronRight size={16} color={mutedColor} />
+                    </Pressable>
+                </View>
+            </View>
+
+            <View className="flex-row">
+                {DAY_LETTERS.map(day => (
+                    <View key={day.key} className="items-center py-px" style={{ width: '14.28%' }}>
+                        <Text
+                            className="text-muted-foreground"
+                            style={{ fontSize: 12, fontWeight: '600' }}
+                        >
+                            {day.label}
+                        </Text>
+                    </View>
+                ))}
+            </View>
+
+            <View className="flex-row flex-wrap">
+                {grid.map(cell => (
+                    <DayCell
+                        key={toDateString(cell.date)}
+                        date={cell.date}
+                        isCurrentMonth={cell.isCurrentMonth}
+                        isToday={cell.isToday}
+                        isSelected={isSameDay(cell.date, selectedDate)}
+                        onPress={onDateSelect}
+                        colors={{ fgColor, mutedColor, primaryColor, primaryFgColor, activeIndicatorColor }}
+                    />
+                ))}
+            </View>
+        </View>
+    )
+}
+
+interface DayCellProps {
+    date: Date
+    isCurrentMonth: boolean
+    isToday: boolean
+    isSelected: boolean
+    onPress: (date: Date) => void
+    colors: {
+        fgColor: string
+        mutedColor: string
+        primaryColor: string
+        primaryFgColor: string
+        activeIndicatorColor: string
+    }
+}
+
+function DayCell({ date, isCurrentMonth, isToday, isSelected, onPress, colors }: DayCellProps) {
+    const background = isToday
+        ? colors.primaryColor
+        : isSelected
+          ? `${colors.activeIndicatorColor}30`
+          : undefined
+    const textColor = isToday
+        ? colors.primaryFgColor
+        : isCurrentMonth
+          ? colors.fgColor
+          : colors.mutedColor
+
+    return (
+        <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={toDateString(date)}
+            className="items-center py-px"
+            style={{ width: '14.28%' }}
+            onPress={() => onPress(date)}
+        >
+            <View
+                className="rounded-full items-center justify-center"
+                style={{ width: 28, height: 28, backgroundColor: background }}
+            >
+                <Text
+                    style={{
+                        fontSize: 13,
+                        fontWeight: isToday ? '700' : undefined,
+                        color: textColor,
+                    }}
+                >
+                    {date.getDate()}
+                </Text>
+            </View>
+        </Pressable>
+    )
+}

--- a/core/components/workspace/PackageRail.tsx
+++ b/core/components/workspace/PackageRail.tsx
@@ -2,12 +2,20 @@ import { NotificationBell } from '@tinycld/core/components/NotificationBell'
 import { OrgLogo } from '@tinycld/core/components/OrgLogo'
 import { ImportIndicator } from '@tinycld/core/components/workspace/ImportIndicator'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
+import { usePackage } from '@tinycld/core/lib/packages/use-packages'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { useOrgInfo } from '@tinycld/core/lib/use-org-info'
 import { useSortedPackages } from '@tinycld/core/lib/use-sorted-packages'
 import { type Href, Link } from 'expo-router'
-import { Building2, HelpCircle, type LucideIcon, Settings } from 'lucide-react-native'
+import {
+    Building2,
+    HelpCircle,
+    type LucideIcon,
+    PanelLeftClose,
+    PanelLeftOpen,
+    Settings,
+} from 'lucide-react-native'
 import { Pressable, ScrollView, View } from 'react-native'
 import { getIcon } from './package-icon-map'
 import { UserMenu } from './UserMenu'
@@ -126,6 +134,7 @@ export function PackageRail({
             </View>
 
             <View className="items-center gap-2">
+                <SidebarToggle color={railText} activePkgSlug={activePkgSlug} />
                 <ImportIndicator />
                 <NotificationBell color={railText} />
 
@@ -152,6 +161,32 @@ export function PackageRail({
                 <UserMenu />
             </View>
         </ScrollView>
+    )
+}
+
+/**
+ * Collapses/reopens the docked package sidebar. Rendered only when the active
+ * package contributes a sidebar — without it there is no panel to toggle, and
+ * historically the store's isSidebarOpen had no UI writer at all, so a
+ * persisted `false` left the sidebar stuck closed with no way back.
+ */
+function SidebarToggle({ color, activePkgSlug }: { color: string; activePkgSlug: string | null }) {
+    const isSidebarOpen = useWorkspaceStore(s => s.isSidebarOpen)
+    const toggleSidebar = useWorkspaceStore(s => s.toggleSidebar)
+    const activePkg = usePackage(activePkgSlug ?? '')
+    if (activePkg?.sidebar == null) return null
+
+    const Icon = isSidebarOpen ? PanelLeftClose : PanelLeftOpen
+    return (
+        <Pressable
+            testID="nav-sidebar-toggle"
+            onPress={toggleSidebar}
+            className="w-11 h-11 rounded-xl justify-center items-center"
+            accessibilityRole="button"
+            accessibilityLabel={isSidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+        >
+            <Icon size={20} color={color} />
+        </Pressable>
     )
 }
 

--- a/core/lib/dates.ts
+++ b/core/lib/dates.ts
@@ -1,0 +1,154 @@
+// Calendar-day arithmetic, in local time.
+//
+// Promoted here from the calendar package (its `useCalendarNavigation` /
+// `useMonthGrid`), which was the only place in the workspace that could build a
+// month grid — so cards could not offer a due-date picker without either
+// duplicating it or importing a sibling, and siblings must not depend on each
+// other.
+//
+// EVERY FUNCTION HERE IS LOCAL-TIME AND DAY-GRANULAR. That is the whole
+// contract: a due date, a month grid cell and a "which day is this" comparison
+// are calendar-day concepts, and converting through UTC is what makes a date
+// render as the previous day for anyone west of Greenwich. `new Date(y, m, d)`
+// and the `setDate`/`setMonth` mutators used below all operate in local time and
+// normalize overflow (Jan 31 + 1 month, Dec 31 + 1 day) for us.
+
+/** A copy of `date` shifted by whole days. */
+export function addDays(date: Date, days: number): Date {
+    const result = new Date(date)
+    result.setDate(result.getDate() + days)
+    return result
+}
+
+/** A copy of `date` shifted by whole weeks. */
+export function addWeeks(date: Date, weeks: number): Date {
+    return addDays(date, weeks * 7)
+}
+
+/**
+ * A copy of `date` shifted by whole months.
+ *
+ * Clamps rather than overflows the way `setMonth` alone would: Jan 31 + 1 month
+ * is Feb 28 (or 29), not Mar 3. Month-stepping a calendar grid from a 31st is
+ * exactly how the naive version surfaces.
+ */
+export function addMonths(date: Date, months: number): Date {
+    const result = new Date(date)
+    const targetDay = result.getDate()
+    result.setDate(1)
+    result.setMonth(result.getMonth() + months)
+    const lastDay = endOfMonth(result).getDate()
+    result.setDate(Math.min(targetDay, lastDay))
+    return result
+}
+
+/** Midnight on the first day of `date`'s week. `startDay` 0 = Sunday. */
+export function startOfWeek(date: Date, startDay = 0): Date {
+    const result = new Date(date)
+    result.setHours(0, 0, 0, 0)
+    const day = result.getDay()
+    const diff = (day - startDay + 7) % 7
+    result.setDate(result.getDate() - diff)
+    return result
+}
+
+/** Midnight on the first of `date`'s month. */
+export function startOfMonth(date: Date): Date {
+    return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+/** The last day of `date`'s month — day 0 of the next one. */
+export function endOfMonth(date: Date): Date {
+    return new Date(date.getFullYear(), date.getMonth() + 1, 0)
+}
+
+/** Midnight at the start of `date`'s day. */
+export function startOfDay(date: Date): Date {
+    const result = new Date(date)
+    result.setHours(0, 0, 0, 0)
+    return result
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+    return (
+        a.getFullYear() === b.getFullYear() &&
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate()
+    )
+}
+
+export function isToday(date: Date): boolean {
+    return isSameDay(date, new Date())
+}
+
+export function getDaysInMonth(date: Date): number {
+    return endOfMonth(date).getDate()
+}
+
+/**
+ * `YYYY-MM-DD` in LOCAL time.
+ *
+ * Deliberately not `toISOString().slice(0, 10)`, which converts to UTC first
+ * and therefore returns the previous day for any local time before the UTC
+ * offset — an evening in New York stamps as tomorrow's date in Europe.
+ */
+export function toDateString(date: Date): string {
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${date.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * Parse `YYYY-MM-DD` as a LOCAL calendar day, or null if malformed.
+ *
+ * `new Date('2026-03-14')` parses as UTC midnight per the ECMAScript spec, so
+ * it renders as March 13 anywhere west of Greenwich. Splitting the parts and
+ * handing them to the local-time constructor is what avoids that.
+ */
+export function fromDateString(value: string): Date | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim())
+    if (!match) return null
+
+    const year = Number(match[1])
+    const month = Number(match[2])
+    const day = Number(match[3])
+    const parsed = new Date(year, month - 1, day)
+
+    // Rejects real-looking impossibilities (2026-02-31, month 13): the Date
+    // constructor rolls those over silently rather than failing.
+    if (
+        parsed.getFullYear() !== year ||
+        parsed.getMonth() !== month - 1 ||
+        parsed.getDate() !== day
+    ) {
+        return null
+    }
+    return parsed
+}
+
+export interface MonthGridCell {
+    date: Date
+    isCurrentMonth: boolean
+    isToday: boolean
+}
+
+/**
+ * The 6×7 cell grid a month view renders.
+ *
+ * Always 42 cells, even when the month fits in five rows: a grid that changes
+ * height as you page through months makes the surrounding layout jump.
+ */
+export function getMonthGrid(monthDate: Date, weekStartDay = 0): MonthGridCell[] {
+    const monthStart = startOfMonth(monthDate)
+    const gridStart = startOfWeek(monthStart, weekStartDay)
+    const currentMonth = monthDate.getMonth()
+
+    return Array.from({ length: 42 }, (_, i) => {
+        const date = addDays(gridStart, i)
+        return {
+            date,
+            isCurrentMonth: date.getMonth() === currentMonth,
+            isToday: isToday(date),
+        }
+    })
+}

--- a/core/tests/unit/dates.test.ts
+++ b/core/tests/unit/dates.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import {
+    addDays,
+    addMonths,
+    endOfMonth,
+    fromDateString,
+    getMonthGrid,
+    isSameDay,
+    startOfMonth,
+    startOfWeek,
+    toDateString,
+} from '../../lib/dates'
+
+// These helpers are day-granular and LOCAL-TIME. The cases below are the ones
+// hand-rolled date math actually gets wrong: month-length clamping, DST
+// transitions, and the UTC round-trip that shifts a date by one day.
+
+describe('addDays', () => {
+    it('crosses a month boundary', () => {
+        expect(toDateString(addDays(new Date(2026, 0, 31), 1))).toBe('2026-02-01')
+    })
+
+    it('crosses a year boundary', () => {
+        expect(toDateString(addDays(new Date(2026, 11, 31), 1))).toBe('2027-01-01')
+    })
+
+    it('handles leap day', () => {
+        expect(toDateString(addDays(new Date(2028, 1, 28), 1))).toBe('2028-02-29')
+        expect(toDateString(addDays(new Date(2026, 1, 28), 1))).toBe('2026-03-01')
+    })
+
+    it('goes backwards', () => {
+        expect(toDateString(addDays(new Date(2026, 2, 1), -1))).toBe('2026-02-28')
+    })
+
+    it('does not mutate its argument', () => {
+        const original = new Date(2026, 5, 15)
+        addDays(original, 10)
+        expect(toDateString(original)).toBe('2026-06-15')
+    })
+
+    // In US timezones 2026-03-08 is the spring-forward day (23 hours long).
+    // Adding a day by hours would land mid-afternoon on the same date; the
+    // setDate-based implementation steps the calendar day instead.
+    it('steps one calendar day across a DST transition', () => {
+        expect(toDateString(addDays(new Date(2026, 2, 7), 1))).toBe('2026-03-08')
+        expect(toDateString(addDays(new Date(2026, 2, 8), 1))).toBe('2026-03-09')
+    })
+})
+
+describe('addMonths', () => {
+    it('clamps to the last day of a shorter month', () => {
+        // The bug this exists for: setMonth alone turns Jan 31 into Mar 3.
+        expect(toDateString(addMonths(new Date(2026, 0, 31), 1))).toBe('2026-02-28')
+        expect(toDateString(addMonths(new Date(2028, 0, 31), 1))).toBe('2028-02-29')
+        expect(toDateString(addMonths(new Date(2026, 4, 31), 1))).toBe('2026-06-30')
+    })
+
+    it('keeps the day when the target month is long enough', () => {
+        expect(toDateString(addMonths(new Date(2026, 0, 15), 1))).toBe('2026-02-15')
+    })
+
+    it('crosses a year boundary in both directions', () => {
+        expect(toDateString(addMonths(new Date(2026, 11, 15), 1))).toBe('2027-01-15')
+        expect(toDateString(addMonths(new Date(2026, 0, 15), -1))).toBe('2025-12-15')
+    })
+
+    it('does not mutate its argument', () => {
+        const original = new Date(2026, 0, 31)
+        addMonths(original, 1)
+        expect(toDateString(original)).toBe('2026-01-31')
+    })
+})
+
+describe('startOfWeek', () => {
+    it('returns the Sunday of the week by default', () => {
+        // 2026-06-17 is a Wednesday.
+        expect(toDateString(startOfWeek(new Date(2026, 5, 17)))).toBe('2026-06-14')
+    })
+
+    it('honours a Monday week start', () => {
+        expect(toDateString(startOfWeek(new Date(2026, 5, 17), 1))).toBe('2026-06-15')
+    })
+
+    it('is a no-op on the first day of the week', () => {
+        expect(toDateString(startOfWeek(new Date(2026, 5, 14)))).toBe('2026-06-14')
+    })
+
+    it('zeroes the time', () => {
+        const result = startOfWeek(new Date(2026, 5, 17, 23, 59, 59))
+        expect([result.getHours(), result.getMinutes(), result.getSeconds()]).toEqual([0, 0, 0])
+    })
+})
+
+describe('startOfMonth / endOfMonth', () => {
+    it('finds both ends of a month', () => {
+        expect(toDateString(startOfMonth(new Date(2026, 5, 17)))).toBe('2026-06-01')
+        expect(toDateString(endOfMonth(new Date(2026, 5, 17)))).toBe('2026-06-30')
+    })
+
+    it('gets February right in leap and common years', () => {
+        expect(toDateString(endOfMonth(new Date(2026, 1, 10)))).toBe('2026-02-28')
+        expect(toDateString(endOfMonth(new Date(2028, 1, 10)))).toBe('2028-02-29')
+    })
+})
+
+describe('toDateString', () => {
+    it('pads month and day', () => {
+        expect(toDateString(new Date(2026, 0, 5))).toBe('2026-01-05')
+    })
+
+    // The regression this function exists for: toISOString() converts to UTC,
+    // so a late-evening local time stamps as the NEXT day in any timezone west
+    // of Greenwich. Formatting from the local getters cannot drift.
+    it('uses the local calendar day, not the UTC one', () => {
+        const lateEvening = new Date(2026, 2, 14, 23, 30)
+        expect(toDateString(lateEvening)).toBe('2026-03-14')
+        const earlyMorning = new Date(2026, 2, 14, 0, 30)
+        expect(toDateString(earlyMorning)).toBe('2026-03-14')
+    })
+})
+
+describe('fromDateString', () => {
+    it('round-trips with toDateString', () => {
+        const parsed = fromDateString('2026-03-14')
+        expect(parsed && toDateString(parsed)).toBe('2026-03-14')
+    })
+
+    it('parses as a local day rather than UTC midnight', () => {
+        // new Date('2026-03-14') is UTC midnight — the previous day in the US.
+        const parsed = fromDateString('2026-03-14')
+        expect(parsed?.getDate()).toBe(14)
+        expect(parsed?.getMonth()).toBe(2)
+        expect(parsed?.getHours()).toBe(0)
+    })
+
+    it('rejects malformed input', () => {
+        for (const bad of ['', 'tomorrow', '2026-3-14', '26-03-14', '2026/03/14', 'x2026-03-14']) {
+            expect(fromDateString(bad)).toBeNull()
+        }
+    })
+
+    it('rejects dates that do not exist', () => {
+        // The Date constructor rolls these over silently; the caller must not
+        // get a valid-looking date back from an impossible string.
+        expect(fromDateString('2026-02-31')).toBeNull()
+        expect(fromDateString('2026-13-01')).toBeNull()
+        expect(fromDateString('2026-00-10')).toBeNull()
+    })
+
+    it('accepts a real leap day and rejects a fake one', () => {
+        expect(fromDateString('2028-02-29')).not.toBeNull()
+        expect(fromDateString('2026-02-29')).toBeNull()
+    })
+
+    it('tolerates surrounding whitespace', () => {
+        expect(fromDateString('  2026-03-14 ')).not.toBeNull()
+    })
+})
+
+describe('getMonthGrid', () => {
+    it('always returns 42 cells so the grid height never changes', () => {
+        // February 2026 starts on a Sunday and fits in exactly 4 weeks — the
+        // month most likely to collapse a naive grid.
+        for (const month of [0, 1, 5, 11]) {
+            expect(getMonthGrid(new Date(2026, month, 1))).toHaveLength(42)
+        }
+    })
+
+    it('starts on the week containing the first of the month', () => {
+        // 2026-06-01 is a Monday, so a Sunday-start grid opens on May 31.
+        const grid = getMonthGrid(new Date(2026, 5, 1))
+        expect(toDateString(grid[0].date)).toBe('2026-05-31')
+        expect(grid[0].isCurrentMonth).toBe(false)
+    })
+
+    it('runs consecutive days with no gaps or repeats', () => {
+        const grid = getMonthGrid(new Date(2026, 5, 1))
+        for (let i = 1; i < grid.length; i += 1) {
+            expect(isSameDay(grid[i].date, addDays(grid[i - 1].date, 1))).toBe(true)
+        }
+    })
+
+    it('marks in-month cells', () => {
+        const grid = getMonthGrid(new Date(2026, 5, 1))
+        expect(grid.filter(cell => cell.isCurrentMonth)).toHaveLength(30)
+    })
+
+    it('honours a Monday week start', () => {
+        const grid = getMonthGrid(new Date(2026, 5, 1), 1)
+        expect(toDateString(grid[0].date)).toBe('2026-06-01')
+    })
+
+    it('marks exactly one cell as today when the month is the current one', () => {
+        const now = new Date()
+        const grid = getMonthGrid(now)
+        expect(grid.filter(cell => cell.isToday && cell.isCurrentMonth)).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
Promotes calendar's month grid into core as MiniCalendar plus day-granular, local-time date helpers in @tinycld/core/lib/dates (30 unit tests). Calendar now imports both; its duplicates are deleted. Fixes calendar's addMonths skipping February when stepping from a month's 31st.