### PR TITLE
feat(oauth): classify stored-file URLs and mail view collections in the scope table

### DIFF
--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -54,6 +54,11 @@ var collectionScopes = map[string][2]string{
 	"calendar_events":    {ScopeCalendarRead, ScopeCalendarWrite},
 	"calendar_calendars": {ScopeCalendarRead, ScopeCalendarWrite},
 	"users":              {ScopeProfile, ""},
+
+	// Read-only surfaces the CLI needs: per-folder unread counts (a view) and
+	// the caller's mailbox memberships. The empty write scope denies writes.
+	"mail_folder_counts":   {ScopeMailRead, ""},
+	"mail_mailbox_members": {ScopeMailRead, ""},
 }
 
 // endpointScopes maps a bespoke Go endpoint to its required scope.
@@ -136,7 +141,42 @@ func ScopeForRoute(method, path string) string {
 		}
 		return pair[0]
 	}
+	if name, ok := fileCollectionFromPath(path); ok {
+		// A stored file (mail body, attachment, drive content) is governed by
+		// its collection's READ scope. No field is `protected` today, so these
+		// URLs answer a bare unauthenticated GET — but the CLI attaches its
+		// bearer to every request, and without this classification the file
+		// fetch would 403 for OAuth callers only. Writes never go through
+		// /api/files/, so any write verb is denied outright.
+		//
+		// POST /api/files/token deliberately stays default-denied: file-token
+		// requests are never scope-checked, so a file token minted by a bearer
+		// would be a credential that bypasses the scope table.
+		if method != http.MethodGet && method != http.MethodHead {
+			return ""
+		}
+		pair, known := collectionScopes[name]
+		if !known {
+			return ""
+		}
+		return pair[0]
+	}
 	return ""
+}
+
+// fileCollectionFromPath extracts "drive_items" from
+// /api/files/drive_items/{recordId}/{filename}. All three segments must be
+// present and non-empty — "/api/files/token" (2 segments) is not a file path.
+func fileCollectionFromPath(path string) (string, bool) {
+	const prefix = "/api/files/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(path, prefix), "/", 3)
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", false
+	}
+	return parts[0], true
 }
 
 // collectionFromPath extracts "mail_messages" from

--- a/core/server/oauth/middleware_test.go
+++ b/core/server/oauth/middleware_test.go
@@ -24,6 +24,13 @@ func TestScopeForRouteMapsKnownRoutes(t *testing.T) {
 		{"POST", "/api/collections/drive_items/records", ScopeDriveWrite},
 		{"GET", "/api/collections/contacts/records", ScopeContactsRead},
 		{"PATCH", "/api/collections/calendar_events/records/abc", ScopeCalendarWrite},
+		{"GET", "/api/collections/mail_folder_counts/records", ScopeMailRead},
+		{"GET", "/api/collections/mail_mailbox_members/records", ScopeMailRead},
+		// Stored files carry the owning collection's read scope: mail bodies
+		// and attachments, drive content.
+		{"GET", "/api/files/mail_messages/rec123/body_ab12cd34ef.html", ScopeMailRead},
+		{"GET", "/api/files/drive_items/rec123/report_ab12cd34ef.pdf", ScopeDriveRead},
+		{"HEAD", "/api/files/drive_items/rec123/report_ab12cd34ef.pdf", ScopeDriveRead},
 	}
 	for _, c := range cases {
 		if got := ScopeForRoute(c.method, c.path); got != c.want {
@@ -40,6 +47,56 @@ func TestScopeForRouteDefaultDenies(t *testing.T) {
 	}
 	if got := ScopeForRoute("GET", "/api/collections/pkg_registry/records"); got != "" {
 		t.Fatalf("ScopeForRoute on an uncovered collection = %q, want \"\"", got)
+	}
+}
+
+func TestScopeForRouteFilePaths(t *testing.T) {
+	// Writes to the read-only view/membership collections must stay denied.
+	for _, c := range []string{"mail_folder_counts", "mail_mailbox_members"} {
+		if got := ScopeForRoute("POST", "/api/collections/"+c+"/records"); got != "" {
+			t.Errorf("POST on %s = %q, want default-deny (read-only collection)", c, got)
+		}
+	}
+
+	denied := []struct{ method, path, why string }{
+		{"POST", "/api/files/token", "a file token minted by a bearer would bypass the scope table"},
+		{"GET", "/api/files/oauth_clients/rec123/logo_ab12cd34ef.png", "unclassified collection"},
+		{"GET", "/api/files/pkg_registry/rec123/bundle_ab12cd34ef.zip", "unclassified collection"},
+		{"POST", "/api/files/drive_items/rec123/report_ab12cd34ef.pdf", "no write goes through /api/files/"},
+		{"DELETE", "/api/files/drive_items/rec123/report_ab12cd34ef.pdf", "no write goes through /api/files/"},
+		{"GET", "/api/files/drive_items/rec123", "missing filename segment"},
+		{"GET", "/api/files/drive_items", "missing record and filename segments"},
+		{"GET", "/api/files//rec123/name.pdf", "empty collection segment"},
+	}
+	for _, d := range denied {
+		if got := ScopeForRoute(d.method, d.path); got != "" {
+			t.Errorf("ScopeForRoute(%s %s) = %q, want default-deny: %s",
+				d.method, d.path, got, d.why)
+		}
+	}
+}
+
+func TestFileCollectionFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"/api/files/drive_items/rec123/name_ab12cd34ef.pdf", "drive_items", true},
+		{"/api/files/mail_messages/rec123/body_ab12cd34ef.html", "mail_messages", true},
+		{"/api/files/token", "", false},
+		{"/api/files/drive_items/rec123", "", false},
+		{"/api/files/drive_items/rec123/", "", false},
+		{"/api/files//rec123/name.pdf", "", false},
+		{"/api/files/drive_items//name.pdf", "", false},
+		{"/api/collections/drive_items/records", "", false},
+	}
+	for _, c := range cases {
+		got, ok := fileCollectionFromPath(c.path)
+		if got != c.want || ok != c.ok {
+			t.Errorf("fileCollectionFromPath(%q) = (%q, %v), want (%q, %v)",
+				c.path, got, ok, c.want, c.ok)
+		}
 	}
 }
 

--- a/core/server/oauth/route_classification_test.go
+++ b/core/server/oauth/route_classification_test.go
@@ -24,6 +24,14 @@ func TestEveryRegisteredRouteIsClassified(t *testing.T) {
 		{"POST", "/oauth/token", "the grant itself is the credential"},
 		{"POST", "/oauth/revoke", "RFC 7009: presenting the token is the authority"},
 		{"GET", "/oauth/userinfo", "advertised in discovery; needs the profile scope"},
+		// The CLI's read paths: `mail read` fetches the body_html file the
+		// record points at, `drive get` fetches drive content, `mail status`
+		// reads the folder-counts view, and send/list resolve the caller's
+		// mailbox memberships.
+		{"GET", "/api/files/mail_messages/rec123/body_ab12cd34ef.html", "mail bodies are file fields"},
+		{"GET", "/api/files/drive_items/rec123/report_ab12cd34ef.pdf", "drive content is a file field"},
+		{"GET", "/api/collections/mail_folder_counts/records", "unread counts view"},
+		{"GET", "/api/collections/mail_mailbox_members/records", "mailbox membership resolution"},
 	}
 	for _, r := range reachable {
 		if ScopeForRoute(r.method, r.path) == "" {


### PR DESCRIPTION
ScopeForRoute default-denies unclassified routes, so the CLI's authenticated fetches of PocketBase file URLs (mail bodies, attachments, drive content) 403'd for OAuth bearers only.

- `GET/HEAD /api/files/{collection}/{recordId}/{filename}` now resolves to the collection's read scope; unknown collections and all write verbs stay denied.
- `POST /api/files/token` deliberately stays default-denied — a file token minted by a bearer would bypass the scope table.
- Adds `mail_folder_counts` (view) and `mail_mailbox_members` as read-only `mail:read` collections for `mail status` / mailbox resolution.

Groundwork for the drive/mail CLI commands (spec steps 6–7).