### PR TITLE
feat(cli): shared client/output helpers for package commands

### DIFF
--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -60,6 +60,10 @@ type Client struct {
 	// mu serializes refreshes so concurrent requests can't both rotate the
 	// refresh token (the server invalidates the old one on every rotation).
 	mu sync.Mutex
+
+	// userMu guards userID, the memoized /oauth/userinfo subject.
+	userMu sync.Mutex
+	userID string
 }
 
 func New(origin string, store TokenStore, hc *http.Client) *Client {
@@ -164,6 +168,15 @@ func (c *Client) GetJSON(ctx context.Context, path string, out any) error {
 
 // PostJSON POSTs body (JSON-encoded) to path and decodes the response.
 func (c *Client) PostJSON(ctx context.Context, path string, body, out any) error {
+	return c.sendJSON(ctx, http.MethodPost, path, body, out)
+}
+
+// PatchJSON PATCHes body (JSON-encoded) to path and decodes the response.
+func (c *Client) PatchJSON(ctx context.Context, path string, body, out any) error {
+	return c.sendJSON(ctx, http.MethodPatch, path, body, out)
+}
+
+func (c *Client) sendJSON(ctx context.Context, method, path string, body, out any) error {
 	if err := c.ensure(); err != nil {
 		return err
 	}
@@ -171,7 +184,7 @@ func (c *Client) PostJSON(ctx context.Context, path string, body, out any) error
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.origin+path, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, method, c.origin+path, bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
@@ -180,6 +193,64 @@ func (c *Client) PostJSON(ctx context.Context, path string, body, out any) error
 		return io.NopCloser(bytes.NewReader(data)), nil
 	}
 	return c.doJSON(req, out)
+}
+
+// Delete sends an authenticated DELETE and discards the (typically empty)
+// response body.
+func (c *Client) Delete(ctx context.Context, path string) error {
+	if err := c.ensure(); err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.origin+path, nil)
+	if err != nil {
+		return err
+	}
+	return c.doJSON(req, nil)
+}
+
+// Get performs an authenticated GET and hands back the response body for
+// streaming (file content, downloads). The caller must close it. A non-2xx
+// status is drained into the same error shape doJSON produces.
+func (c *Client) Get(ctx context.Context, path string) (io.ReadCloser, *http.Response, error) {
+	if err := c.ensure(); err != nil {
+		return nil, nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.origin+path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		return nil, nil, apiError(resp.StatusCode, data)
+	}
+	return resp.Body, resp, nil
+}
+
+// UserID returns the authenticated user's record id (the userinfo `sub`
+// claim), memoized for the process lifetime. Commands need it to filter
+// per-user rows and to fill relation fields like created_by.
+func (c *Client) UserID(ctx context.Context) (string, error) {
+	c.userMu.Lock()
+	defer c.userMu.Unlock()
+	if c.userID != "" {
+		return c.userID, nil
+	}
+	var info struct {
+		Sub string `json:"sub"`
+	}
+	if err := c.GetJSON(ctx, "/oauth/userinfo", &info); err != nil {
+		return "", fmt.Errorf("resolving current user: %w", err)
+	}
+	if info.Sub == "" {
+		return "", errors.New("userinfo response carried no subject")
+	}
+	c.userID = info.Sub
+	return c.userID, nil
 }
 
 func (c *Client) doJSON(req *http.Request, out any) error {

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -121,12 +121,34 @@ func (c *Client) Token() (TokenSet, error) {
 // request exactly once — only when the body is rewindable (GetBody set or no
 // body at all).
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	return c.doWith(c.http, req)
+}
+
+// DoStream is Do without the client's total-request timeout. http.Client's
+// Timeout covers reading the whole response body, so an arbitrarily large
+// file transfer through Do would abort mid-stream; transfers bound their
+// lifetime with the request context instead.
+func (c *Client) DoStream(req *http.Request) (*http.Response, error) {
+	return c.doWith(c.streamHTTP(), req)
+}
+
+// streamHTTP mirrors the configured client minus its deadline. The transport
+// (and its connection pool) is shared; only the whole-exchange timeout drops.
+func (c *Client) streamHTTP() *http.Client {
+	return &http.Client{
+		Transport:     c.http.Transport,
+		CheckRedirect: c.http.CheckRedirect,
+		Jar:           c.http.Jar,
+	}
+}
+
+func (c *Client) doWith(hc *http.Client, req *http.Request) (*http.Response, error) {
 	tok, err := c.Token()
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
-	resp, err := c.http.Do(req)
+	resp, err := hc.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +173,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		retry.Body = body
 	}
 	retry.Header.Set("Authorization", "Bearer "+tok.AccessToken)
-	return c.http.Do(retry)
+	return hc.Do(retry)
 }
 
 // GetJSON GETs path (origin-relative) and decodes the response into out.
@@ -210,7 +232,9 @@ func (c *Client) Delete(ctx context.Context, path string) error {
 
 // Get performs an authenticated GET and hands back the response body for
 // streaming (file content, downloads). The caller must close it. A non-2xx
-// status is drained into the same error shape doJSON produces.
+// status is drained into the same error shape doJSON produces. Uses DoStream:
+// the body may be arbitrarily large, so the whole-exchange timeout must not
+// apply — bound long transfers via ctx.
 func (c *Client) Get(ctx context.Context, path string) (io.ReadCloser, *http.Response, error) {
 	if err := c.ensure(); err != nil {
 		return nil, nil, err
@@ -219,7 +243,7 @@ func (c *Client) Get(ctx context.Context, path string) (io.ReadCloser, *http.Res
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := c.Do(req)
+	resp, err := c.DoStream(req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/client/download.go
+++ b/cli/client/download.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// DownloadToFile streams an authenticated GET of path (origin-relative) into
+// dest, writing through a temp file in dest's directory and renaming into
+// place so a failed transfer never leaves a truncated dest.
+func DownloadToFile(ctx context.Context, c *Client, path, dest string, progress ProgressFunc) error {
+	body, resp, err := c.Get(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+	return writeStream(body, resp.ContentLength, dest, progress)
+}
+
+// DownloadPublic fetches an absolute URL WITHOUT credentials — for
+// single-use-token URLs (folder zip, export) that are credential-less by
+// design and must not have a bearer attached.
+func DownloadPublic(ctx context.Context, hc *http.Client, url, dest string, progress ProgressFunc) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return apiError(resp.StatusCode, data)
+	}
+	return writeStream(resp.Body, resp.ContentLength, dest, progress)
+}
+
+func writeStream(src io.Reader, total int64, dest string, progress ProgressFunc) error {
+	dir := filepath.Dir(dest)
+	tmp, err := os.CreateTemp(dir, ".tinycld-download-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}()
+
+	var out io.Writer = tmp
+	if progress != nil {
+		out = io.MultiWriter(tmp, &countingSink{total: total, progress: progress})
+	}
+	if _, err := io.Copy(out, src); err != nil {
+		return fmt.Errorf("writing %s: %w", dest, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), dest)
+}

--- a/cli/client/download.go
+++ b/cli/client/download.go
@@ -23,8 +23,13 @@ func DownloadToFile(ctx context.Context, c *Client, path, dest string, progress 
 
 // DownloadPublic fetches an absolute URL WITHOUT credentials — for
 // single-use-token URLs (folder zip, export) that are credential-less by
-// design and must not have a bearer attached.
+// design and must not have a bearer attached. A nil hc gets a fresh client
+// with no whole-exchange timeout (the body may be arbitrarily large); pass
+// one explicitly to control transport or deadline.
 func DownloadPublic(ctx context.Context, hc *http.Client, url, dest string, progress ProgressFunc) error {
+	if hc == nil {
+		hc = &http.Client{}
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err

--- a/cli/client/download_test.go
+++ b/cli/client/download_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDownloadToFile(t *testing.T) {
@@ -93,6 +94,36 @@ func TestDownloadPublicSendsNoBearer(t *testing.T) {
 	}
 	got, _ := os.ReadFile(dest)
 	if string(got) != "zip-bytes" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestStreamingOutlivesClientTimeout(t *testing.T) {
+	// http.Client.Timeout covers the ENTIRE exchange including the body read,
+	// so a transfer longer than the configured API timeout would abort
+	// mid-stream if downloads went through Do. This server trickles a body
+	// for ~6× the client's timeout; DownloadToFile must still complete.
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/files/drive_items/r1/big.bin", func(w http.ResponseWriter, r *http.Request) {
+		f := w.(http.Flusher)
+		for range 6 {
+			w.Write([]byte("chunk"))
+			f.Flush()
+			time.Sleep(50 * time.Millisecond)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	hc := &http.Client{Timeout: 50 * time.Millisecond}
+	c := New(srv.URL, validStore("access-1"), hc)
+
+	dest := filepath.Join(t.TempDir(), "big.bin")
+	if err := DownloadToFile(context.Background(), c, "/api/files/drive_items/r1/big.bin", dest, nil); err != nil {
+		t.Fatalf("streaming download died to the API timeout: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != strings.Repeat("chunk", 6) {
 		t.Fatalf("content = %q", got)
 	}
 }

--- a/cli/client/download_test.go
+++ b/cli/client/download_test.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestDownloadToFile(t *testing.T) {
+	content := strings.Repeat("x", 4096)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/files/drive_items/r1/report.pdf", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer access-1" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// PocketBase file responses carry an explicit length; without the
+		// header the httptest server streams chunked and ContentLength is -1.
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		w.Write([]byte(content))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, validStore("access-1"), srv.Client())
+
+	dest := filepath.Join(t.TempDir(), "out.pdf")
+	var lastWritten, lastTotal int64
+	err := DownloadToFile(context.Background(), c, "/api/files/drive_items/r1/report.pdf", dest,
+		func(written, total int64) { lastWritten, lastTotal = written, total })
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Fatalf("content mismatch: %d bytes", len(got))
+	}
+	if lastWritten != int64(len(content)) || lastTotal != int64(len(content)) {
+		t.Fatalf("progress written=%d total=%d", lastWritten, lastTotal)
+	}
+	// No temp litter left beside the destination.
+	entries, _ := os.ReadDir(filepath.Dir(dest))
+	if len(entries) != 1 {
+		t.Fatalf("dest dir has %d entries, want only the download", len(entries))
+	}
+}
+
+func TestDownloadToFileErrorLeavesNoDest(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message":"Requires the \"drive:read\" scope"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, validStore("t"), srv.Client())
+
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	err := DownloadToFile(context.Background(), c, "/api/files/x/y/z", dest, nil)
+	if err == nil || !strings.Contains(err.Error(), "drive:read") {
+		t.Fatalf("err = %v", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatal("failed download must not leave a destination file")
+	}
+}
+
+func TestDownloadPublicSendsNoBearer(t *testing.T) {
+	var sawAuth string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/drive/download-folder", func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.Write([]byte("zip-bytes"))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	dest := filepath.Join(t.TempDir(), "folder.zip")
+	err := DownloadPublic(context.Background(), srv.Client(),
+		srv.URL+"/api/drive/download-folder?token=abc", dest, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sawAuth != "" {
+		t.Fatalf("public download sent Authorization %q — token URLs are credential-less by design", sawAuth)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != "zip-bytes" {
+		t.Fatalf("content = %q", got)
+	}
+}

--- a/cli/client/multipart.go
+++ b/cli/client/multipart.go
@@ -149,5 +149,22 @@ func postMultipart(ctx context.Context, c *Client, path string, build func(*mult
 	req.GetBody = func() (io.ReadCloser, error) {
 		return makeBody(), nil
 	}
-	return c.doJSON(req, out)
+	// DoStream, not Do: the upload body may be arbitrarily large and the
+	// client's whole-exchange timeout would sever it mid-transfer.
+	resp, err := c.DoStream(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return apiError(resp.StatusCode, data)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.Unmarshal(data, out)
 }

--- a/cli/client/multipart.go
+++ b/cli/client/multipart.go
@@ -1,0 +1,153 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"sort"
+)
+
+// FilePart is one file in a multipart request. It is path-backed (not an
+// io.Reader) so the body can be rebuilt from scratch when Do retries after a
+// mid-flight 401 refresh — GetBody reopens the file.
+type FilePart struct {
+	Field string // multipart field name
+	Name  string // filename presented to the server
+	Path  string // local file to read
+}
+
+// ProgressFunc receives cumulative file bytes written and the precomputed
+// total. It is called from the request-body goroutine.
+type ProgressFunc func(written, total int64)
+
+// CreateRecordMultipart creates a record with plain fields plus file uploads,
+// streaming the files rather than buffering them. Field order is
+// deterministic (sorted) so tests can assert the exact body.
+func CreateRecordMultipart[T any](ctx context.Context, c *Client, collection string, fields map[string]string, files []FilePart, progress ProgressFunc) (T, error) {
+	var out T
+	err := postMultipart(ctx, c, recordsPath(collection), func(mw *multipart.Writer, count *countingSink) error {
+		keys := make([]string, 0, len(fields))
+		for k := range fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if err := mw.WriteField(k, fields[k]); err != nil {
+				return err
+			}
+		}
+		return writeFileParts(mw, files, count, progress)
+	}, &out)
+	return out, err
+}
+
+// PostMultipart sends one JSON document under jsonField plus file uploads —
+// the shape endpoints like /api/mail/send accept.
+func PostMultipart[T any](ctx context.Context, c *Client, path, jsonField string, jsonBody any, files []FilePart, progress ProgressFunc) (T, error) {
+	var out T
+	data, err := json.Marshal(jsonBody)
+	if err != nil {
+		return out, err
+	}
+	err = postMultipart(ctx, c, path, func(mw *multipart.Writer, count *countingSink) error {
+		if err := mw.WriteField(jsonField, string(data)); err != nil {
+			return err
+		}
+		return writeFileParts(mw, files, count, progress)
+	}, &out)
+	return out, err
+}
+
+func writeFileParts(mw *multipart.Writer, files []FilePart, count *countingSink, progress ProgressFunc) error {
+	var total int64
+	if progress != nil {
+		for _, f := range files {
+			info, err := os.Stat(f.Path)
+			if err != nil {
+				return fmt.Errorf("stat %s: %w", f.Path, err)
+			}
+			total += info.Size()
+		}
+		count.total = total
+		count.progress = progress
+	}
+	for _, f := range files {
+		part, err := mw.CreateFormFile(f.Field, f.Name)
+		if err != nil {
+			return err
+		}
+		src, err := os.Open(f.Path)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(io.MultiWriter(part, count), src)
+		src.Close()
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", f.Path, err)
+		}
+	}
+	return nil
+}
+
+// countingSink tallies file bytes (only — field boilerplate is excluded) and
+// reports them to the progress callback.
+type countingSink struct {
+	written  int64
+	total    int64
+	progress ProgressFunc
+}
+
+func (s *countingSink) Write(p []byte) (int, error) {
+	s.written += int64(len(p))
+	if s.progress != nil {
+		s.progress(s.written, s.total)
+	}
+	return len(p), nil
+}
+
+// postMultipart streams a multipart POST through an io.Pipe. The boundary is
+// fixed up front so a GetBody rebuild (the 401-refresh retry) produces a body
+// matching the already-sent Content-Type header.
+func postMultipart(ctx context.Context, c *Client, path string, build func(*multipart.Writer, *countingSink) error, out any) error {
+	if err := c.ensure(); err != nil {
+		return err
+	}
+	var raw [15]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return err
+	}
+	boundary := "tinycld" + hex.EncodeToString(raw[:])
+
+	makeBody := func() io.ReadCloser {
+		pr, pw := io.Pipe()
+		mw := multipart.NewWriter(pw)
+		if err := mw.SetBoundary(boundary); err != nil {
+			pw.CloseWithError(err)
+			return pr
+		}
+		go func() {
+			err := build(mw, &countingSink{})
+			if err == nil {
+				err = mw.Close()
+			}
+			pw.CloseWithError(err)
+		}()
+		return pr
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.origin+path, makeBody())
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.GetBody = func() (io.ReadCloser, error) {
+		return makeBody(), nil
+	}
+	return c.doJSON(req, out)
+}

--- a/cli/client/multipart_test.go
+++ b/cli/client/multipart_test.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// parsedUpload is what the test server saw after parsing the multipart body.
+type parsedUpload struct {
+	fields map[string]string
+	files  map[string]struct{ name, content string }
+}
+
+func multipartServer(t *testing.T, acceptToken string, got *[]parsedUpload) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+acceptToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"message": "expired"})
+			return
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("ParseMultipartForm: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		p := parsedUpload{
+			fields: map[string]string{},
+			files:  map[string]struct{ name, content string }{},
+		}
+		for k, v := range r.MultipartForm.Value {
+			p.fields[k] = v[0]
+		}
+		for k, headers := range r.MultipartForm.File {
+			f, err := headers[0].Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]byte, headers[0].Size)
+			f.Read(buf)
+			f.Close()
+			p.files[k] = struct{ name, content string }{headers[0].Filename, string(buf)}
+		}
+		*got = append(*got, p)
+		json.NewEncoder(w).Encode(testRow{ID: "created", Name: p.fields["name"]})
+	})
+	// The refresh endpoint must exist for the retry test.
+	mux.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-2", "token_type": "Bearer",
+			"expires_in": 3600, "refresh_token": "refresh-2", "scope": "profile",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCreateRecordMultipart(t *testing.T) {
+	var got []parsedUpload
+	srv := multipartServer(t, "access-1", &got)
+	c := New(srv.URL, validStore("access-1"), srv.Client())
+
+	path := writeTempFile(t, "report.pdf", "pdf-bytes")
+	var progressCalls int
+	var lastWritten, lastTotal int64
+	out, err := CreateRecordMultipart[testRow](context.Background(), c, "drive_items",
+		map[string]string{"name": "report.pdf", "parent": "", "is_folder": "false"},
+		[]FilePart{{Field: "file", Name: "report.pdf", Path: path}},
+		func(written, total int64) {
+			progressCalls++
+			lastWritten, lastTotal = written, total
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.ID != "created" {
+		t.Fatalf("out = %+v", out)
+	}
+	if len(got) != 1 {
+		t.Fatalf("uploads = %d", len(got))
+	}
+	up := got[0]
+	if up.fields["name"] != "report.pdf" || up.fields["is_folder"] != "false" {
+		t.Fatalf("fields = %v", up.fields)
+	}
+	if f := up.files["file"]; f.name != "report.pdf" || f.content != "pdf-bytes" {
+		t.Fatalf("file part = %+v", f)
+	}
+	if progressCalls == 0 || lastWritten != int64(len("pdf-bytes")) || lastTotal != int64(len("pdf-bytes")) {
+		t.Fatalf("progress: calls=%d written=%d total=%d", progressCalls, lastWritten, lastTotal)
+	}
+}
+
+func TestMultipartRetriesAfter401(t *testing.T) {
+	// The stored token is stale; the first attempt 401s, the client refreshes
+	// and must send a COMPLETE body again — GetBody reopens the source file.
+	var got []parsedUpload
+	srv := multipartServer(t, "access-2", &got)
+	c := New(srv.URL, validStore("access-1"), srv.Client())
+
+	path := writeTempFile(t, "data.txt", "same-bytes-twice")
+	out, err := CreateRecordMultipart[testRow](context.Background(), c, "drive_items",
+		map[string]string{"name": "data.txt"},
+		[]FilePart{{Field: "file", Name: "data.txt", Path: path}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.ID != "created" {
+		t.Fatalf("out = %+v", out)
+	}
+	if len(got) != 1 {
+		t.Fatalf("successful uploads = %d, want exactly 1 (the retry)", len(got))
+	}
+	if f := got[0].files["file"]; f.content != "same-bytes-twice" {
+		t.Fatalf("retried body incomplete: %+v", f)
+	}
+}
+
+func TestPostMultipartJSONField(t *testing.T) {
+	var got []parsedUpload
+	srv := multipartServer(t, "access-1", &got)
+	c := New(srv.URL, validStore("access-1"), srv.Client())
+
+	attach := writeTempFile(t, "a.txt", "attachment-bytes")
+	type sendReq struct {
+		Subject string `json:"subject"`
+	}
+	_, err := PostMultipart[testRow](context.Background(), c, "/api/mail/send",
+		"json", sendReq{Subject: "hello"},
+		[]FilePart{{Field: "attachments", Name: "a.txt", Path: attach}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("uploads = %d", len(got))
+	}
+	var decoded sendReq
+	if err := json.Unmarshal([]byte(got[0].fields["json"]), &decoded); err != nil || decoded.Subject != "hello" {
+		t.Fatalf("json field = %q (%v)", got[0].fields["json"], err)
+	}
+	if f := got[0].files["attachments"]; f.name != "a.txt" || f.content != "attachment-bytes" {
+		t.Fatalf("attachment part = %+v", f)
+	}
+}

--- a/cli/client/records.go
+++ b/cli/client/records.go
@@ -1,0 +1,143 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Generic helpers over the PocketBase record REST API. Package-level
+// functions rather than methods because Go methods cannot be generic.
+
+type ListOptions struct {
+	Filter  string
+	Sort    string
+	Fields  string
+	Page    int
+	PerPage int
+	// SkipTotal skips the server-side COUNT; TotalItems/TotalPages come back
+	// as -1. Use it for paging loops that only care about "was the page full".
+	SkipTotal bool
+}
+
+type ListResult[T any] struct {
+	Page       int `json:"page"`
+	PerPage    int `json:"perPage"`
+	TotalItems int `json:"totalItems"`
+	TotalPages int `json:"totalPages"`
+	Items      []T `json:"items"`
+}
+
+func ListRecords[T any](ctx context.Context, c *Client, collection string, o ListOptions) (ListResult[T], error) {
+	q := url.Values{}
+	if o.Filter != "" {
+		q.Set("filter", o.Filter)
+	}
+	if o.Sort != "" {
+		q.Set("sort", o.Sort)
+	}
+	if o.Fields != "" {
+		q.Set("fields", o.Fields)
+	}
+	if o.Page > 0 {
+		q.Set("page", strconv.Itoa(o.Page))
+	}
+	if o.PerPage > 0 {
+		q.Set("perPage", strconv.Itoa(o.PerPage))
+	}
+	if o.SkipTotal {
+		q.Set("skipTotal", "1")
+	}
+	path := recordsPath(collection)
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	var out ListResult[T]
+	err := c.GetJSON(ctx, path, &out)
+	return out, err
+}
+
+// ListAll pages through every record matching filter. Callers that expect
+// unbounded result sets should prefer ListRecords with an explicit limit.
+func ListAll[T any](ctx context.Context, c *Client, collection, filter, sort string) ([]T, error) {
+	const perPage = 200
+	var all []T
+	for page := 1; ; page++ {
+		res, err := ListRecords[T](ctx, c, collection, ListOptions{
+			Filter: filter, Sort: sort, Page: page, PerPage: perPage, SkipTotal: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, res.Items...)
+		if len(res.Items) < perPage {
+			return all, nil
+		}
+	}
+}
+
+func GetRecord[T any](ctx context.Context, c *Client, collection, id string) (T, error) {
+	var out T
+	err := c.GetJSON(ctx, recordsPath(collection)+"/"+url.PathEscape(id), &out)
+	return out, err
+}
+
+func CreateRecord[T any](ctx context.Context, c *Client, collection string, body any) (T, error) {
+	var out T
+	err := c.PostJSON(ctx, recordsPath(collection), body, &out)
+	return out, err
+}
+
+func UpdateRecord[T any](ctx context.Context, c *Client, collection, id string, body any) (T, error) {
+	var out T
+	err := c.PatchJSON(ctx, recordsPath(collection)+"/"+url.PathEscape(id), body, &out)
+	return out, err
+}
+
+func DeleteRecord(ctx context.Context, c *Client, collection, id string) error {
+	return c.Delete(ctx, recordsPath(collection)+"/"+url.PathEscape(id))
+}
+
+// FileURL builds the origin-relative URL of a stored file. filename must be
+// the record's stored (sanitized, suffixed) file name — never the display
+// name.
+func FileURL(collection, recordID, filename string) string {
+	return "/api/files/" + url.PathEscape(collection) + "/" +
+		url.PathEscape(recordID) + "/" + url.PathEscape(filename)
+}
+
+func recordsPath(collection string) string {
+	return "/api/collections/" + url.PathEscape(collection) + "/records"
+}
+
+// Filter substitutes each {:name} placeholder in expr with the quoted value,
+// using the same quoting as PocketBase's own pb.filter helper (and the web
+// client's inline quote()): strings get `\` and `"` escaped and are wrapped
+// in double quotes; numbers and bools render bare.
+func Filter(expr string, params map[string]any) string {
+	for name, v := range params {
+		expr = strings.ReplaceAll(expr, "{:"+name+"}", filterValue(v))
+	}
+	return expr
+}
+
+func filterValue(v any) string {
+	switch t := v.(type) {
+	case string:
+		s := strings.ReplaceAll(t, `\`, `\\`)
+		s = strings.ReplaceAll(s, `"`, `\"`)
+		return `"` + s + `"`
+	case bool:
+		return strconv.FormatBool(t)
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		return filterValue(fmt.Sprint(t))
+	}
+}

--- a/cli/client/records_test.go
+++ b/cli/client/records_test.go
@@ -1,0 +1,199 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+type testRow struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestListRecordsBuildsQuery(t *testing.T) {
+	var gotQuery url.Values
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/collections/drive_items/records", func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		json.NewEncoder(w).Encode(map[string]any{
+			"page": 2, "perPage": 50, "totalItems": 120, "totalPages": 3,
+			"items": []testRow{{ID: "a", Name: "x"}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, validStore("t"), srv.Client())
+
+	res, err := ListRecords[testRow](context.Background(), c, "drive_items", ListOptions{
+		Filter: `parent = "abc"`, Sort: "-is_folder,name", Fields: "id,name",
+		Page: 2, PerPage: 50,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := url.Values{
+		"filter": {`parent = "abc"`}, "sort": {"-is_folder,name"},
+		"fields": {"id,name"}, "page": {"2"}, "perPage": {"50"},
+	}
+	for k, v := range want {
+		if gotQuery.Get(k) != v[0] {
+			t.Errorf("query %s = %q, want %q", k, gotQuery.Get(k), v[0])
+		}
+	}
+	if gotQuery.Has("skipTotal") {
+		t.Error("skipTotal must be absent unless requested")
+	}
+	if res.TotalItems != 120 || len(res.Items) != 1 || res.Items[0].Name != "x" {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+func TestListAllPages(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/collections/things/records", func(w http.ResponseWriter, r *http.Request) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if r.URL.Query().Get("skipTotal") != "1" {
+			t.Error("ListAll must skip the COUNT")
+		}
+		count := 200
+		if page == 2 {
+			count = 3
+		}
+		items := make([]testRow, count)
+		for i := range items {
+			items[i] = testRow{ID: strconv.Itoa((page-1)*200 + i)}
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"page": page, "perPage": 200, "totalItems": -1, "totalPages": -1,
+			"items": items,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, validStore("t"), srv.Client())
+
+	all, err := ListAll[testRow](context.Background(), c, "things", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 203 {
+		t.Fatalf("len = %d, want 203", len(all))
+	}
+}
+
+func TestRecordCRUDPaths(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotBody = nil
+		if r.Body != nil {
+			json.NewDecoder(r.Body).Decode(&gotBody)
+		}
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		json.NewEncoder(w).Encode(testRow{ID: "r1", Name: "n"})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, validStore("t"), srv.Client())
+	ctx := context.Background()
+
+	if _, err := GetRecord[testRow](ctx, c, "things", "r1"); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "GET" || gotPath != "/api/collections/things/records/r1" {
+		t.Fatalf("get: %s %s", gotMethod, gotPath)
+	}
+
+	if _, err := CreateRecord[testRow](ctx, c, "things", map[string]any{"name": "n"}); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "POST" || gotPath != "/api/collections/things/records" || gotBody["name"] != "n" {
+		t.Fatalf("create: %s %s %v", gotMethod, gotPath, gotBody)
+	}
+
+	if _, err := UpdateRecord[testRow](ctx, c, "things", "r1", map[string]any{"name": "m"}); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "PATCH" || gotPath != "/api/collections/things/records/r1" || gotBody["name"] != "m" {
+		t.Fatalf("update: %s %s %v", gotMethod, gotPath, gotBody)
+	}
+
+	if err := DeleteRecord(ctx, c, "things", "r1"); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "DELETE" || gotPath != "/api/collections/things/records/r1" {
+		t.Fatalf("delete: %s %s", gotMethod, gotPath)
+	}
+}
+
+func TestFilterQuoting(t *testing.T) {
+	cases := []struct {
+		expr   string
+		params map[string]any
+		want   string
+	}{
+		{
+			`parent = {:p} && name = {:n}`,
+			map[string]any{"p": "", "n": `Quo"te\slash`},
+			`parent = "" && name = "Quo\"te\\slash"`,
+		},
+		{
+			`trashed = {:t} && size > {:s}`,
+			map[string]any{"t": true, "s": int64(1024)},
+			`trashed = true && size > 1024`,
+		},
+		{
+			`user = {:u}`,
+			map[string]any{"u": "rec123"},
+			`user = "rec123"`,
+		},
+	}
+	for _, c := range cases {
+		if got := Filter(c.expr, c.params); got != c.want {
+			t.Errorf("Filter(%q) = %q, want %q", c.expr, got, c.want)
+		}
+	}
+}
+
+func TestFileURLEscapes(t *testing.T) {
+	got := FileURL("mail_messages", "rec 1", "body_ab12cd34ef.html")
+	want := "/api/files/mail_messages/rec%201/body_ab12cd34ef.html"
+	if got != want {
+		t.Fatalf("FileURL = %q, want %q", got, want)
+	}
+}
+
+func TestUserIDMemoizesUserinfo(t *testing.T) {
+	calls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /oauth/userinfo", func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		json.NewEncoder(w).Encode(map[string]string{"sub": "user123"})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, validStore("t"), srv.Client())
+
+	for range 3 {
+		id, err := c.UserID(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id != "user123" {
+			t.Fatalf("id = %q", id)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("userinfo calls = %d, want 1 (memoized)", calls)
+	}
+}

--- a/cli/output/bytes.go
+++ b/cli/output/bytes.go
@@ -1,0 +1,25 @@
+package output
+
+import "fmt"
+
+// FormatBytes renders a byte count exactly the way the server's
+// quota.FormatBytes does, so CLI sizes read identically to the app.
+// Reimplemented rather than imported: tinycld.org/core is PocketBase-hook
+// code, and pulling it into the CLI workspace would drag the fork replace
+// into every member cli build (see gen-cli.ts). bytes_test.go pins parity.
+func FormatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	units := []string{"KB", "MB", "GB", "TB"}
+	if exp >= len(units) {
+		exp = len(units) - 1
+	}
+	return fmt.Sprintf("%.1f %s", float64(b)/float64(div), units[exp])
+}

--- a/cli/output/bytes_test.go
+++ b/cli/output/bytes_test.go
@@ -1,0 +1,30 @@
+package output
+
+import "testing"
+
+// The expectations pin parity with core/server/quota.FormatBytes — if either
+// side changes its rendering, this table is the tripwire.
+func TestFormatBytesMatchesQuotaPackage(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{5 * 1024 * 1024 * 1024, "5.0 GB"},
+		{3 * 1024 * 1024 * 1024 * 1024, "3.0 TB"},
+		// Beyond TB quota.FormatBytes caps the LABEL at TB while the divisor
+		// keeps scaling, so 2 PB renders as "2.0 TB". Quirk preserved: parity
+		// with the app matters more than petabyte cosmetics.
+		{2 * 1024 * 1024 * 1024 * 1024 * 1024, "2.0 TB"},
+	}
+	for _, c := range cases {
+		if got := FormatBytes(c.in); got != c.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -8,10 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 type Format string
@@ -84,3 +87,28 @@ func (o Options) Info(w io.Writer, format string, a ...any) {
 }
 
 func (o Options) color() bool { return !o.NoColor && o.TTY }
+
+// FromCommand rebuilds Options and the --yes answer from the root's
+// inherited persistent flags. Member command packages receive only
+// (root, *client.Client) at wiring time, so the flag set — not the root's
+// private deps struct — is their contract with the shell.
+func FromCommand(cmd *cobra.Command) (Options, bool, error) {
+	formatFlag, _ := cmd.Flags().GetString("output")
+	format, err := ParseFormat(formatFlag)
+	if err != nil {
+		return Options{}, false, err
+	}
+	if jsonFlag, _ := cmd.Flags().GetBool("json"); jsonFlag {
+		format = JSON
+	}
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	yes, _ := cmd.Flags().GetBool("yes")
+	tty := term.IsTerminal(int(os.Stdout.Fd()))
+	return Options{
+		Format:  format,
+		Quiet:   quiet,
+		NoColor: noColor || !tty,
+		TTY:     tty,
+	}, yes, nil
+}

--- a/cli/output/output_test.go
+++ b/cli/output/output_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 type widget struct {
@@ -93,5 +95,41 @@ func TestInfoRespectsQuiet(t *testing.T) {
 	Options{Quiet: true}.Info(&buf, "hello %s", "world")
 	if buf.String() != "" {
 		t.Fatalf("quiet info = %q", buf.String())
+	}
+}
+
+func TestFromCommandReadsPersistentFlags(t *testing.T) {
+	root := &cobra.Command{Use: "root", SilenceUsage: true, SilenceErrors: true}
+	pf := root.PersistentFlags()
+	pf.String("output", string(Table), "")
+	pf.Bool("json", false, "")
+	pf.Bool("quiet", false, "")
+	pf.Bool("no-color", false, "")
+	pf.Bool("yes", false, "")
+	var got Options
+	var gotYes bool
+	sub := &cobra.Command{Use: "sub", RunE: func(cmd *cobra.Command, _ []string) error {
+		var err error
+		got, gotYes, err = FromCommand(cmd)
+		return err
+	}}
+	root.AddCommand(sub)
+
+	root.SetArgs([]string{"sub", "--json", "--quiet", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got.Format != JSON || !got.Quiet || !gotYes {
+		t.Fatalf("got = %+v yes=%v", got, gotYes)
+	}
+	// Tests never run on a TTY, so color must be off and TTY false — the
+	// non-TTY degradation the spec requires.
+	if got.TTY || !got.NoColor {
+		t.Fatalf("non-TTY run must disable color: %+v", got)
+	}
+
+	root.SetArgs([]string{"sub", "--output", "nonsense"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("invalid --output must error")
 	}
 }

--- a/cli/ui/progress.go
+++ b/cli/ui/progress.go
@@ -1,0 +1,55 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+
+	"tinycld.org/cli/output"
+)
+
+// Progress is a single-line byte-transfer indicator rewritten in place with
+// \r. It renders only on a TTY without --quiet; otherwise every method is a
+// no-op, so machine-readable output never sees control characters.
+type Progress struct {
+	w       io.Writer
+	label   string
+	active  bool
+	started bool
+}
+
+// NewProgress builds an indicator for label writing to w (conventionally
+// stderr, keeping stdout clean for the command's result).
+func NewProgress(o output.Options, w io.Writer, label string) *Progress {
+	return &Progress{w: w, label: label, active: o.TTY && !o.Quiet}
+}
+
+// Update rewrites the line. total <= 0 (unknown Content-Length) renders the
+// running byte count alone.
+func (p *Progress) Update(written, total int64) {
+	if !p.active {
+		return
+	}
+	p.started = true
+	if total > 0 {
+		pct := written * 100 / total
+		fmt.Fprintf(p.w, "\r%s %s / %s (%d%%)", p.label,
+			output.FormatBytes(written), output.FormatBytes(total), pct)
+		return
+	}
+	fmt.Fprintf(p.w, "\r%s %s", p.label, output.FormatBytes(written))
+}
+
+// Done terminates the rewritten line so subsequent output starts clean.
+func (p *Progress) Done() {
+	if p.active && p.started {
+		fmt.Fprintln(p.w)
+	}
+}
+
+// Func adapts the indicator to the client.ProgressFunc signature.
+func (p *Progress) Func() func(written, total int64) {
+	if !p.active {
+		return nil
+	}
+	return p.Update
+}


### PR DESCRIPTION
Groundwork the drive/mail command packages build on (spec steps 6–7):

- `client`: generic PocketBase record REST helpers (`ListRecords`/`ListAll`/CRUD), a `Filter` substitutor with pb.filter quoting, streaming multipart with a fixed boundary (so the 401-refresh retry rebuilds an identical body from path-backed parts), authed + credential-less download helpers, `PatchJSON`/`Delete`/streaming `Get`, memoized `UserID()` via `/oauth/userinfo`.
- `output`: `FromCommand` (member commands only get the inherited flag set), `FormatBytes` with a parity test against `quota.FormatBytes` (importing core would pull the fork replace into every member cli build).
- `ui`: minimal `\r` progress line, TTY-and-not-quiet only.

All httptest-covered.