### PR TITLE
fix(cli): fall back to file credentials when the OS keychain refuses writes

### DIFF
--- a/cli/internal/keychain/keychain.go
+++ b/cli/internal/keychain/keychain.go
@@ -20,6 +20,14 @@ const service = "tinycld"
 
 var ErrNotFound = errors.New("keychain: credential not found")
 
+// Seams over the keyring library so tests can simulate a keychain that
+// answers reads but refuses writes — go-keyring's mock cannot split the two.
+var (
+	keyringGet    = keyring.Get
+	keyringSet    = keyring.Set
+	keyringDelete = keyring.Delete
+)
+
 type Store interface {
 	Get(account string) (string, error)
 	Set(account, value string) error
@@ -30,36 +38,71 @@ type Store interface {
 // Open returns the OS keychain when one responds, else a file store with a
 // one-time warning on warn. The probe read distinguishes "backend works but
 // has no such item" (fine) from "no backend at all" (fall back).
+//
+// The keychain store still degrades per-write: a keychain can pass the read
+// probe yet refuse writes (sandboxed processes, locked login sessions), and
+// by the time Set runs after a device login the server has already activated
+// the grant — failing would strand a live credential the user just approved.
 func Open(configDir string, warn io.Writer) Store {
-	_, err := keyring.Get(service, "tinycld-probe")
+	file := fileStore{dir: filepath.Join(configDir, "credentials")}
+	_, err := keyringGet(service, "tinycld-probe")
 	if err == nil || errors.Is(err, keyring.ErrNotFound) {
-		return systemStore{}
+		return &systemStore{file: file, warn: warn}
 	}
-	dir := filepath.Join(configDir, "credentials")
-	fmt.Fprintf(warn, "warning: OS keychain unavailable (%v); storing credentials in %s (mode 0600)\n", err, dir)
-	return fileStore{dir: dir}
+	fmt.Fprintf(warn, "warning: OS keychain unavailable (%v); storing credentials in %s (mode 0600)\n", err, file.dir)
+	return file
 }
 
-type systemStore struct{}
+// systemStore prefers the OS keychain and falls back to the file store when
+// the keychain refuses a write. Reads consult both places, so a credential
+// keeps working regardless of where an earlier Set landed.
+type systemStore struct {
+	file   fileStore
+	warn   io.Writer
+	warned bool
+}
 
-func (systemStore) Get(account string) (string, error) {
-	v, err := keyring.Get(service, account)
+func (s *systemStore) Get(account string) (string, error) {
+	v, err := keyringGet(service, account)
+	if err == nil {
+		return v, nil
+	}
+	if fv, ferr := s.file.Get(account); ferr == nil {
+		return fv, nil
+	}
 	if errors.Is(err, keyring.ErrNotFound) {
 		return "", ErrNotFound
 	}
-	return v, err
+	return "", err
 }
 
-func (systemStore) Set(account, value string) error {
-	return keyring.Set(service, account, value)
-}
-
-func (systemStore) Delete(account string) error {
-	err := keyring.Delete(service, account)
-	if errors.Is(err, keyring.ErrNotFound) {
+func (s *systemStore) Set(account, value string) error {
+	err := keyringSet(service, account, value)
+	if err == nil {
+		// A keychain write supersedes any stale file copy from a degraded
+		// earlier session; drop it so Get cannot resurrect old credentials.
+		s.file.Delete(account)
 		return nil
 	}
-	return err
+	if !s.warned {
+		s.warned = true
+		fmt.Fprintf(s.warn,
+			"warning: OS keychain write failed (%v); storing credentials in %s (mode 0600)\n",
+			err, s.file.dir)
+	}
+	return s.file.Set(account, value)
+}
+
+func (s *systemStore) Delete(account string) error {
+	kerr := keyringDelete(service, account)
+	if errors.Is(kerr, keyring.ErrNotFound) {
+		kerr = nil
+	}
+	ferr := s.file.Delete(account)
+	if kerr != nil {
+		return kerr
+	}
+	return ferr
 }
 
 type fileStore struct{ dir string }

--- a/cli/internal/keychain/keychain_test.go
+++ b/cli/internal/keychain/keychain_test.go
@@ -1,10 +1,15 @@
 package keychain
 
 import (
+	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/zalando/go-keyring"
 )
 
 func TestFileStoreRoundTrip(t *testing.T) {
@@ -106,5 +111,116 @@ func TestJSONHelpers(t *testing.T) {
 	}
 	if err := GetJSON(s, "missing", &out); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+// stubKeyring swaps the keyring seams for the test and restores them after.
+func stubKeyring(
+	t *testing.T,
+	get func(service, account string) (string, error),
+	set func(service, account, value string) error,
+	del func(service, account string) error,
+) {
+	t.Helper()
+	origGet, origSet, origDel := keyringGet, keyringSet, keyringDelete
+	keyringGet, keyringSet, keyringDelete = get, set, del
+	t.Cleanup(func() { keyringGet, keyringSet, keyringDelete = origGet, origSet, origDel })
+}
+
+func TestSystemStoreFallsBackWhenKeychainRefusesWrites(t *testing.T) {
+	// The OS keychain can answer the read probe yet refuse writes (sandboxed
+	// process, locked login session — macOS `security` exits 154). By the
+	// time Set runs after a device login the server has already activated
+	// the grant, so dropping the token would strand a live credential.
+	kcMem := map[string]string{}
+	stubKeyring(t,
+		func(_, account string) (string, error) {
+			v, ok := kcMem[account]
+			if !ok {
+				return "", keyring.ErrNotFound
+			}
+			return v, nil
+		},
+		func(_, _, _ string) error { return errors.New("exit status 154") },
+		func(_, account string) error {
+			delete(kcMem, account)
+			return nil
+		},
+	)
+
+	dir := t.TempDir()
+	var warn bytes.Buffer
+	s := Open(dir, &warn)
+
+	// The probe read succeeded, so Open picked the system store — the write
+	// failure must degrade to the file store, not surface as an error.
+	if err := s.Set("ctx1", `{"t":"v1"}`); err != nil {
+		t.Fatalf("Set must fall back to the file store, got %v", err)
+	}
+	if !strings.Contains(warn.String(), "keychain write failed") {
+		t.Fatalf("expected a one-time warning, got %q", warn.String())
+	}
+	v, err := s.Get("ctx1")
+	if err != nil || v != `{"t":"v1"}` {
+		t.Fatalf("Get after degraded Set = %q, %v", v, err)
+	}
+
+	// Second write must not warn again.
+	warn.Reset()
+	if err := s.Set("ctx1", `{"t":"v2"}`); err != nil {
+		t.Fatal(err)
+	}
+	if warn.String() != "" {
+		t.Fatalf("warning must be one-time, got %q", warn.String())
+	}
+
+	// Delete clears the file copy too.
+	if err := s.Delete("ctx1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Get("ctx1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("after Delete, err = %v", err)
+	}
+}
+
+func TestSystemStoreKeychainWriteClearsStaleFileCopy(t *testing.T) {
+	// A session where the keychain works again must not leave an older file
+	// credential around for Get to resurrect after the keychain entry is
+	// later removed.
+	kcMem := map[string]string{}
+	stubKeyring(t,
+		func(_, account string) (string, error) {
+			v, ok := kcMem[account]
+			if !ok {
+				return "", keyring.ErrNotFound
+			}
+			return v, nil
+		},
+		func(_, account, value string) error {
+			kcMem[account] = value
+			return nil
+		},
+		func(_, account string) error {
+			delete(kcMem, account)
+			return nil
+		},
+	)
+
+	dir := t.TempDir()
+	var warn bytes.Buffer
+	s := Open(dir, &warn)
+
+	// Simulate a stale file credential from an earlier degraded session.
+	stale := fileStore{dir: filepath.Join(dir, "credentials")}
+	if err := stale.Set("ctx1", `{"t":"old"}`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Set("ctx1", `{"t":"new"}`); err != nil {
+		t.Fatal(err)
+	}
+	delete(kcMem, "ctx1")
+	if _, err := s.Get("ctx1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("stale file copy resurrected: err = %v", err)
 	}
 }


### PR DESCRIPTION
Found by the CLI integration run: `auth login` completed the device grant (server-side the grant was already active) and then died on `saving credentials: exit status 154` — the macOS keychain passed Open's read probe but refused the write from a restricted context, and there was no fallback.

The system store now degrades per-write to the 0600 file store with a one-time warning. Reads consult keychain then file; a successful keychain write clears any stale file copy. Tested via seams over go-keyring (its mock can't split read/write behavior).