### PR TITLE
docs(help): link the package command groups from the CLI topic

### DIFF
--- a/core/help/command-line.md
+++ b/core/help/command-line.md
@@ -58,3 +58,11 @@ sign that terminal out remotely.
 
 Every command accepts `--json` for scripting, and prompts are skipped with
 `--yes` so commands run cleanly in CI.
+
+## Package commands
+
+Each installed package contributes its own command group. See
+[Drive from the command line](help://drive:command-line) for working with
+files (`tinycld drive ls`, `put`, `get`, …) and
+[Mail from the command line](help://mail:command-line) for searching,
+reading, and sending mail (`tinycld mail search`, `read`, `send`, …).


### PR DESCRIPTION
Points the core command-line topic at the new drive and mail command-group topics. Links degrade gracefully on deployments without those packages (drawer shows no topic).