### PR TITLE
feat(oauth): any-of scope rules and CLI module CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,18 @@ jobs:
       - name: Go test
         working-directory: ws/tinycld/server
         run: go test -tags no_ui ./...
+      # The CLI is a second Go module, and its go.work + cli_extensions.go are
+      # emitted by the generator during the install above. With no --with
+      # features in this assembly the generated extension file is the valid
+      # no-op form, so this covers the shell's own commands (auth, context,
+      # output, keychain, device flow) — member cli modules are tested on
+      # their own repos' CI.
+      - name: Go mod download (cli)
+        working-directory: ws/tinycld/cli
+        run: go mod download
+      - name: Go build & test (cli)
+        working-directory: ws/tinycld/cli
+        run: go build ./... && go test ./...
 
   e2e:
     name: E2E (app shell)

--- a/core/lib/packages/types.ts
+++ b/core/lib/packages/types.ts
@@ -212,18 +212,15 @@ export interface PackageManifest {
      * (scripts/gen-cli.ts): the dir must contain a Go module exposing
      * `Register(root *cobra.Command, c *client.Client)`.
      *
-     * `commands` is display metadata only (settings page, docs) — Cobra is the
-     * source of truth for `--help`. `scopes` declares the OAuth scopes this
-     * package defines (e.g. `'mail:read'`) for the scope registry and consent
-     * screen. Neither is ever interpolated into generated Go.
+     * `scopes` declares the OAuth scopes this package defines (e.g.
+     * `'mail:read'`) for the scope registry and consent screen; it is never
+     * interpolated into generated Go. There is deliberately no command list
+     * here: Cobra owns the command tree and `--help`, and a hand-maintained
+     * copy in the manifest only drifts.
      */
     cli?: {
         package: string
         module: string
-        commands?: {
-            name: string
-            summary: string
-        }[]
         scopes?: string[]
     }
 

--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -39,40 +39,67 @@ const scopeExempt = "-"
 // already set and no-ops (see apis/middlewares.go:190).
 var middlewarePriority = apis.DefaultLoadAuthTokenMiddlewarePriority - 10
 
+// scopeRule is the set of scopes that satisfy a route. A caller passes when it
+// holds ANY of them (see satisfiedBy): a collection shared between packages
+// — `labels` is used by both mail and contacts — must be reachable by either
+// package's grant rather than demanding both. An empty rule denies.
+type scopeRule []string
+
+// collectionAccess pairs the read and write rules for one collection. An empty
+// write rule makes the collection read-only for OAuth callers.
+type collectionAccess struct {
+	read  scopeRule
+	write scopeRule
+}
+
 // collectionScopes maps a PocketBase collection to the scopes governing it.
 // Anything absent is denied for OAuth callers by default.
-var collectionScopes = map[string][2]string{
-	// collection: {read scope, write scope}
-	"mail_messages":      {ScopeMailRead, ScopeMailSend},
-	"mail_threads":       {ScopeMailRead, ScopeMailSend},
-	"mail_thread_state":  {ScopeMailRead, ScopeMailSend},
-	"mail_mailboxes":     {ScopeMailRead, ScopeMailSend},
-	"drive_items":        {ScopeDriveRead, ScopeDriveWrite},
-	"drive_shares":       {ScopeDriveRead, ScopeDriveWrite},
-	"drive_item_state":   {ScopeDriveRead, ScopeDriveWrite},
-	"contacts":           {ScopeContactsRead, ScopeContactsWrite},
-	"calendar_events":    {ScopeCalendarRead, ScopeCalendarWrite},
-	"calendar_calendars": {ScopeCalendarRead, ScopeCalendarWrite},
-	"users":              {ScopeProfile, ""},
+var collectionScopes = map[string]collectionAccess{
+	"mail_messages":      {read: scopeRule{ScopeMailRead}, write: scopeRule{ScopeMailSend}},
+	"mail_threads":       {read: scopeRule{ScopeMailRead}, write: scopeRule{ScopeMailSend}},
+	"mail_thread_state":  {read: scopeRule{ScopeMailRead}, write: scopeRule{ScopeMailSend}},
+	"mail_mailboxes":     {read: scopeRule{ScopeMailRead}, write: scopeRule{ScopeMailSend}},
+	"drive_items":        {read: scopeRule{ScopeDriveRead}, write: scopeRule{ScopeDriveWrite}},
+	"drive_shares":       {read: scopeRule{ScopeDriveRead}, write: scopeRule{ScopeDriveWrite}},
+	"drive_item_state":   {read: scopeRule{ScopeDriveRead}, write: scopeRule{ScopeDriveWrite}},
+	"contacts":           {read: scopeRule{ScopeContactsRead}, write: scopeRule{ScopeContactsWrite}},
+	"calendar_events":    {read: scopeRule{ScopeCalendarRead}, write: scopeRule{ScopeCalendarWrite}},
+	"calendar_calendars": {read: scopeRule{ScopeCalendarRead}, write: scopeRule{ScopeCalendarWrite}},
+	"users":              {read: scopeRule{ScopeProfile}},
 
-	// Read-only surfaces the CLI needs: per-folder unread counts (a view) and
-	// the caller's mailbox memberships. The empty write scope denies writes.
-	"mail_folder_counts":   {ScopeMailRead, ""},
-	"mail_mailbox_members": {ScopeMailRead, ""},
+	// Read-only surfaces the CLI needs: per-folder unread counts (a view), the
+	// caller's mailbox memberships, and the mailbox aliases a send can pick a
+	// From identity from. Aliases are administered in the app, so no write.
+	"mail_folder_counts":   {read: scopeRule{ScopeMailRead}},
+	"mail_mailbox_members": {read: scopeRule{ScopeMailRead}},
+	"mail_mailbox_aliases": {read: scopeRule{ScopeMailRead}},
+
+	// Labels are CORE collections shared across packages (mail threads and
+	// contacts both get labelled through label_assignments), so either
+	// package's scope grants access — requiring both would make labelling
+	// mail impossible for a mail-only grant.
+	"labels":            {read: scopeRule{ScopeMailRead, ScopeContactsRead}, write: scopeRule{ScopeMailSend, ScopeContactsWrite}},
+	"label_assignments": {read: scopeRule{ScopeMailRead, ScopeContactsRead}, write: scopeRule{ScopeMailSend, ScopeContactsWrite}},
+
+	"drive_item_versions": {read: scopeRule{ScopeDriveRead}, write: scopeRule{ScopeDriveWrite}},
 }
 
 // endpointScopes maps a bespoke Go endpoint to its required scope.
-var endpointScopes = map[string]string{
-	"GET /api/mail/search":           ScopeMailRead,
-	"POST /api/mail/send":            ScopeMailSend,
-	"POST /api/mail/draft":           ScopeMailSend,
-	"GET /api/drive/search":          ScopeDriveRead,
-	"POST /api/drive/download-token": ScopeDriveRead,
-	"POST /api/drive/export-token":   ScopeDriveRead,
-	"GET /api/drive/storage-usage":   ScopeDriveRead,
-	"POST /api/drive/upload-version": ScopeDriveWrite,
-	"POST /api/drive/share":          ScopeDriveWrite,
-	"GET /api/contacts/search":       ScopeContactsRead,
+var endpointScopes = map[string]scopeRule{
+	"GET /api/mail/search":              {ScopeMailRead},
+	"POST /api/mail/send":               {ScopeMailSend},
+	"POST /api/mail/draft":              {ScopeMailSend},
+	"GET /api/drive/search":             {ScopeDriveRead},
+	"POST /api/drive/download-token":    {ScopeDriveRead},
+	"POST /api/drive/export-token":      {ScopeDriveRead},
+	"GET /api/drive/storage-usage":      {ScopeDriveRead},
+	"POST /api/drive/upload-version":    {ScopeDriveWrite},
+	"POST /api/drive/share":             {ScopeDriveWrite},
+	"POST /api/drive/share-link":        {ScopeDriveWrite},
+	"GET /api/drive/share-links":        {ScopeDriveRead},
+	"POST /api/drive/versions/restore":  {ScopeDriveWrite},
+	"POST /api/drive/versions/snapshot": {ScopeDriveWrite},
+	"GET /api/contacts/search":          {ScopeContactsRead},
 
 	// Advertised in the discovery document as userinfo_endpoint, so an
 	// integration following the well-known metadata calls it with an ordinary
@@ -80,7 +107,18 @@ var endpointScopes = map[string]string{
 	// deliberately NOT in exemptPaths (only the credential-less endpoints are),
 	// so without this it would fall into default-deny and 403 the very call the
 	// server tells clients to make.
-	"GET /oauth/userinfo": ScopeProfile,
+	"GET /oauth/userinfo": {ScopeProfile},
+}
+
+// endpointPrefixScopes classifies routes whose path carries a record id, which
+// the exact-match table above cannot express. Kept deliberately short: a
+// prefix is broader than it looks, so each entry must end at a path segment
+// boundary and name a route family, never a bare namespace.
+var endpointPrefixScopes = []struct {
+	method, prefix string
+	scopes         scopeRule
+}{
+	{"DELETE", "/api/drive/share-link/", scopeRule{ScopeDriveWrite}},
 }
 
 // exemptPaths need no scope: public probes, and the OAuth endpoints a client
@@ -117,29 +155,37 @@ var writeMethods = map[string]bool{
 	"POST": true, "PUT": true, "PATCH": true, "DELETE": true,
 }
 
-// ScopeForRoute returns the scope required for a request, scopeExempt for
-// public routes, or "" meaning deny.
+// ScopeForRoute returns the scopes that satisfy a request — the caller needs
+// ANY one of them — or scopeExempt for public routes. An empty result means
+// deny.
 //
 // Default deny is deliberate: a route nobody has classified must not be
 // reachable with a third-party token just because someone added it.
-func ScopeForRoute(method, path string) string {
+func ScopeForRoute(method, path string) scopeRule {
 	for _, p := range exemptPaths {
 		if strings.HasPrefix(path, p) {
-			return scopeExempt
+			return scopeRule{scopeExempt}
 		}
 	}
 	if s, ok := endpointScopes[method+" "+path]; ok {
 		return s
 	}
+	for _, r := range endpointPrefixScopes {
+		// The remainder must be non-empty: the prefix ends in "/" and names a
+		// route family, so the bare prefix itself is a different route.
+		if method == r.method && strings.HasPrefix(path, r.prefix) && len(path) > len(r.prefix) {
+			return r.scopes
+		}
+	}
 	if name, ok := collectionFromPath(path); ok {
-		pair, known := collectionScopes[name]
+		access, known := collectionScopes[name]
 		if !known {
-			return ""
+			return nil
 		}
 		if writeMethods[method] {
-			return pair[1] // "" for read-only collections => deny writes
+			return access.write // empty for read-only collections => deny writes
 		}
-		return pair[0]
+		return access.read
 	}
 	if name, ok := fileCollectionFromPath(path); ok {
 		// A stored file (mail body, attachment, drive content) is governed by
@@ -153,15 +199,43 @@ func ScopeForRoute(method, path string) string {
 		// requests are never scope-checked, so a file token minted by a bearer
 		// would be a credential that bypasses the scope table.
 		if method != http.MethodGet && method != http.MethodHead {
-			return ""
+			return nil
 		}
-		pair, known := collectionScopes[name]
+		access, known := collectionScopes[name]
 		if !known {
-			return ""
+			return nil
 		}
-		return pair[0]
+		return access.read
 	}
-	return ""
+	return nil
+}
+
+// isExempt reports whether a rule marks the route as needing no scope.
+func (r scopeRule) isExempt() bool {
+	return len(r) == 1 && r[0] == scopeExempt
+}
+
+// describe renders the rule for an error message: a single scope reads as
+// itself, several as an any-of list.
+func (r scopeRule) describe() string {
+	if len(r) == 1 {
+		return fmt.Sprintf("%q", r[0])
+	}
+	quoted := make([]string, len(r))
+	for i, s := range r {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return "one of " + strings.Join(quoted, ", ")
+}
+
+// satisfiedBy reports whether the granted scopes cover this rule.
+func (r scopeRule) satisfiedBy(granted []string) bool {
+	for _, want := range r {
+		if HasScope(granted, want) {
+			return true
+		}
+	}
+	return false
 }
 
 // fileCollectionFromPath extracts "drive_items" from
@@ -267,14 +341,14 @@ func enforceGrant(re *core.RequestEvent) error {
 	}
 
 	required := ScopeForRoute(re.Request.Method, re.Request.URL.Path)
-	if required == "" {
+	if len(required) == 0 {
 		return re.ForbiddenError(
 			"This endpoint is not available to API tokens", nil)
 	}
-	if required != scopeExempt {
-		if !HasScope(ParseScopes(grant.GetString("scopes")), required) {
+	if !required.isExempt() {
+		if !required.satisfiedBy(ParseScopes(grant.GetString("scopes"))) {
 			return re.ForbiddenError(
-				fmt.Sprintf("Requires the %q scope", required), nil)
+				fmt.Sprintf("Requires the %s scope", required.describe()), nil)
 		}
 	}
 

--- a/core/server/oauth/middleware_test.go
+++ b/core/server/oauth/middleware_test.go
@@ -33,7 +33,7 @@ func TestScopeForRouteMapsKnownRoutes(t *testing.T) {
 		{"HEAD", "/api/files/drive_items/rec123/report_ab12cd34ef.pdf", ScopeDriveRead},
 	}
 	for _, c := range cases {
-		if got := ScopeForRoute(c.method, c.path); got != c.want {
+		if got := ScopeForRoute(c.method, c.path); !onlyScope(got, c.want) {
 			t.Errorf("ScopeForRoute(%s %s) = %q, want %q", c.method, c.path, got, c.want)
 		}
 	}
@@ -42,10 +42,10 @@ func TestScopeForRouteMapsKnownRoutes(t *testing.T) {
 func TestScopeForRouteDefaultDenies(t *testing.T) {
 	// Default deny: a route no rule covers must return "" so the middleware
 	// refuses it for OAuth callers rather than silently allowing it.
-	if got := ScopeForRoute("POST", "/api/admin/packages/install"); got != "" {
+	if got := ScopeForRoute("POST", "/api/admin/packages/install"); len(got) != 0 {
 		t.Fatalf("ScopeForRoute on an uncovered admin route = %q, want \"\"", got)
 	}
-	if got := ScopeForRoute("GET", "/api/collections/pkg_registry/records"); got != "" {
+	if got := ScopeForRoute("GET", "/api/collections/pkg_registry/records"); len(got) != 0 {
 		t.Fatalf("ScopeForRoute on an uncovered collection = %q, want \"\"", got)
 	}
 }
@@ -53,7 +53,7 @@ func TestScopeForRouteDefaultDenies(t *testing.T) {
 func TestScopeForRouteFilePaths(t *testing.T) {
 	// Writes to the read-only view/membership collections must stay denied.
 	for _, c := range []string{"mail_folder_counts", "mail_mailbox_members"} {
-		if got := ScopeForRoute("POST", "/api/collections/"+c+"/records"); got != "" {
+		if got := ScopeForRoute("POST", "/api/collections/"+c+"/records"); len(got) != 0 {
 			t.Errorf("POST on %s = %q, want default-deny (read-only collection)", c, got)
 		}
 	}
@@ -69,7 +69,7 @@ func TestScopeForRouteFilePaths(t *testing.T) {
 		{"GET", "/api/files//rec123/name.pdf", "empty collection segment"},
 	}
 	for _, d := range denied {
-		if got := ScopeForRoute(d.method, d.path); got != "" {
+		if got := ScopeForRoute(d.method, d.path); len(got) != 0 {
 			t.Errorf("ScopeForRoute(%s %s) = %q, want default-deny: %s",
 				d.method, d.path, got, d.why)
 		}
@@ -111,7 +111,7 @@ func TestScopeForRouteAllowsUnauthenticatedPublicRoutes(t *testing.T) {
 		"/api/cli/downloads",
 		"/api/cli/download/darwin-arm64",
 	} {
-		if got := ScopeForRoute("GET", p); got != scopeExempt {
+		if got := ScopeForRoute("GET", p); !got.isExempt() {
 			t.Errorf("ScopeForRoute(GET %s) = %q, want exempt", p, got)
 		}
 	}
@@ -136,7 +136,7 @@ func TestScopeForRouteDeniesConsentEndpoints(t *testing.T) {
 		{"POST", "/oauth/grants/abc123/revoke"},
 	}
 	for _, c := range cases {
-		if got := ScopeForRoute(c.method, c.path); got != "" {
+		if got := ScopeForRoute(c.method, c.path); len(got) != 0 {
 			t.Errorf("ScopeForRoute(%s %s) = %q, want \"\" (default deny) — "+
 				"an OAuth bearer token must never reach a consent/management endpoint",
 				c.method, c.path, got)
@@ -413,5 +413,95 @@ func TestEnforceGrantDefaultDeniesUncoveredRoute(t *testing.T) {
 	}
 	if re.Auth != nil {
 		t.Fatal("enforceGrant must not set e.Auth when it default-denies")
+	}
+}
+
+// onlyScope reports whether the rule is exactly the one expected scope. Most
+// routes are governed by a single scope; the any-of cases assert membership
+// explicitly instead.
+func onlyScope(got scopeRule, want string) bool {
+	return len(got) == 1 && got[0] == want
+}
+
+func TestScopeForRouteAnyOfSharedCollections(t *testing.T) {
+	// labels and label_assignments are core collections used by BOTH mail and
+	// contacts. Requiring both scopes would make labelling mail impossible for
+	// a mail-only grant, so either package's scope satisfies the route.
+	for _, c := range []string{"labels", "label_assignments"} {
+		read := ScopeForRoute("GET", "/api/collections/"+c+"/records")
+		if !read.satisfiedBy([]string{ScopeMailRead}) {
+			t.Errorf("%s read must be reachable with mail:read alone", c)
+		}
+		if !read.satisfiedBy([]string{ScopeContactsRead}) {
+			t.Errorf("%s read must be reachable with contacts:read alone", c)
+		}
+		if read.satisfiedBy([]string{ScopeDriveRead}) {
+			t.Errorf("%s read must NOT be reachable with an unrelated scope", c)
+		}
+
+		write := ScopeForRoute("POST", "/api/collections/"+c+"/records")
+		if !write.satisfiedBy([]string{ScopeMailSend}) {
+			t.Errorf("%s write must be reachable with mail:send alone", c)
+		}
+		if !write.satisfiedBy([]string{ScopeContactsWrite}) {
+			t.Errorf("%s write must be reachable with contacts:write alone", c)
+		}
+		if write.satisfiedBy([]string{ScopeMailRead, ScopeContactsRead}) {
+			t.Errorf("%s write must NOT be satisfied by read-only scopes", c)
+		}
+	}
+}
+
+func TestScopeForRouteNewCollectionsAndEndpoints(t *testing.T) {
+	reachable := []struct {
+		method, path, scope string
+	}{
+		{"GET", "/api/collections/mail_mailbox_aliases/records", ScopeMailRead},
+		{"GET", "/api/collections/drive_item_versions/records", ScopeDriveRead},
+		{"POST", "/api/collections/drive_item_versions/records", ScopeDriveWrite},
+		{"POST", "/api/drive/share-link", ScopeDriveWrite},
+		{"GET", "/api/drive/share-links", ScopeDriveRead},
+		{"POST", "/api/drive/versions/restore", ScopeDriveWrite},
+		{"POST", "/api/drive/versions/snapshot", ScopeDriveWrite},
+	}
+	for _, r := range reachable {
+		if got := ScopeForRoute(r.method, r.path); !onlyScope(got, r.scope) {
+			t.Errorf("ScopeForRoute(%s %s) = %v, want %q", r.method, r.path, got, r.scope)
+		}
+	}
+
+	// Aliases are administered in the app; the CLI only reads them.
+	if got := ScopeForRoute("PATCH", "/api/collections/mail_mailbox_aliases/records/abc"); len(got) != 0 {
+		t.Errorf("alias writes must stay denied, got %v", got)
+	}
+}
+
+func TestScopeForRoutePrefixRules(t *testing.T) {
+	// The exact-match table cannot express a path carrying a record id, so
+	// DELETE /api/drive/share-link/{id} is matched by prefix. The prefix must
+	// require a non-empty remainder and must not leak to other verbs or to
+	// the sibling collection route.
+	if got := ScopeForRoute("DELETE", "/api/drive/share-link/abc123"); !onlyScope(got, ScopeDriveWrite) {
+		t.Errorf("share-link delete = %v, want drive:write", got)
+	}
+	denied := []struct{ method, path, why string }{
+		{"GET", "/api/drive/share-link/abc123", "public metadata route, not the revoke"},
+		{"DELETE", "/api/drive/share-link/", "bare prefix is not a real route"},
+		{"DELETE", "/api/drive/share-links", "plural list route must not match the prefix"},
+		{"DELETE", "/api/drive/other/abc123", "unrelated path"},
+	}
+	for _, d := range denied {
+		if got := ScopeForRoute(d.method, d.path); len(got) != 0 {
+			t.Errorf("ScopeForRoute(%s %s) = %v, want deny: %s", d.method, d.path, got, d.why)
+		}
+	}
+}
+
+func TestScopeRuleDescribe(t *testing.T) {
+	if got := (scopeRule{ScopeMailRead}).describe(); got != `"mail:read"` {
+		t.Errorf("single-scope describe = %s", got)
+	}
+	if got := (scopeRule{ScopeMailRead, ScopeContactsRead}).describe(); got != `one of "mail:read", "contacts:read"` {
+		t.Errorf("any-of describe = %s", got)
 	}
 }

--- a/core/server/oauth/route_classification_test.go
+++ b/core/server/oauth/route_classification_test.go
@@ -32,9 +32,21 @@ func TestEveryRegisteredRouteIsClassified(t *testing.T) {
 		{"GET", "/api/files/drive_items/rec123/report_ab12cd34ef.pdf", "drive content is a file field"},
 		{"GET", "/api/collections/mail_folder_counts/records", "unread counts view"},
 		{"GET", "/api/collections/mail_mailbox_members/records", "mailbox membership resolution"},
+		// The CLI's extended surface: From-identity resolution, label
+		// add/remove, version history, and share links.
+		{"GET", "/api/collections/mail_mailbox_aliases/records", "send --from identities"},
+		{"GET", "/api/collections/labels/records", "mail label list"},
+		{"POST", "/api/collections/label_assignments/records", "mail label add"},
+		{"DELETE", "/api/collections/label_assignments/records/abc123", "mail label remove"},
+		{"GET", "/api/collections/drive_item_versions/records", "drive versions list"},
+		{"POST", "/api/drive/share-link", "drive link create"},
+		{"GET", "/api/drive/share-links", "drive link list"},
+		{"DELETE", "/api/drive/share-link/abc123", "drive link revoke"},
+		{"POST", "/api/drive/versions/restore", "drive versions --restore"},
+		{"POST", "/api/drive/versions/snapshot", "drive versions --snapshot"},
 	}
 	for _, r := range reachable {
-		if ScopeForRoute(r.method, r.path) == "" {
+		if len(ScopeForRoute(r.method, r.path)) == 0 {
 			t.Errorf("%s %s falls into DEFAULT-DENY by omission (%s). Add it to "+
 				"endpointScopes with the scope it needs, or to exemptPaths if it is "+
 				"genuinely credential-less. Silent default-deny 403s only OAuth "+
@@ -58,7 +70,7 @@ func TestEveryRegisteredRouteIsClassified(t *testing.T) {
 		"/oauth/clients", "/oauth/clients/abc123/disabled",
 	}
 	for _, p := range sessionOnly {
-		if got := ScopeForRoute("POST", p); got != "" {
+		if got := ScopeForRoute("POST", p); len(got) != 0 {
 			t.Errorf("POST %s resolved to %q, want default-deny: an OAuth bearer must "+
 				"not reach a consent or management surface", p, got)
 		}
@@ -66,7 +78,7 @@ func TestEveryRegisteredRouteIsClassified(t *testing.T) {
 
 	// GET is classified independently of POST — the list endpoint is a GET,
 	// and a read-side exemption would leak the client registry to any bearer.
-	if got := ScopeForRoute("GET", "/oauth/clients"); got != "" {
+	if got := ScopeForRoute("GET", "/oauth/clients"); len(got) != 0 {
 		t.Errorf("GET /oauth/clients resolved to %q, want default-deny: the client "+
 			"registry must not be readable with an OAuth access token", got)
 	}
@@ -82,7 +94,7 @@ func TestConsentSurfacesAreNotExempt(t *testing.T) {
 		"/oauth/grants/abc123/revoke",
 		"/oauth/clients", "/oauth/clients/abc123/disabled",
 	} {
-		if ScopeForRoute("POST", p) == scopeExempt {
+		if ScopeForRoute("POST", p).isExempt() {
 			t.Errorf("%s must not be scope-exempt — an OAuth bearer would bypass the "+
 				"scope ceiling and could approve a grant for itself", p)
 		}
@@ -92,7 +104,7 @@ func TestConsentSurfacesAreNotExempt(t *testing.T) {
 // The credential-less endpoints must STAY exempt or the device flow cannot start.
 func TestCredentiallessEndpointsStayExempt(t *testing.T) {
 	for _, p := range []string{"/oauth/device", "/oauth/token", "/oauth/revoke"} {
-		if ScopeForRoute("POST", p) != scopeExempt {
+		if !ScopeForRoute("POST", p).isExempt() {
 			t.Errorf("%s must stay exempt — the caller has no credential yet", p)
 		}
 	}

--- a/scripts/gen-cli.ts
+++ b/scripts/gen-cli.ts
@@ -15,9 +15,8 @@ function slugToIdentifier(slug: string): string {
 // package's cli module contributes its Cobra commands via Register(root, c).
 //
 // Only slug and module are ever interpolated (validated below). A manifest's
-// `cli.commands[].summary` (free prose) and `cli.scopes` (contain ':', which
-// SAFE_IMPORT_FIELD rightly rejects) are consumed on the TS side and must
-// never be emitted into Go source.
+// `cli.scopes` values contain ':', which SAFE_IMPORT_FIELD rightly rejects;
+// they are consumed on the TS side and must never reach Go source.
 export function buildCliExtensionsSource(pkgs: CliPkg[]): string {
     if (pkgs.length === 0) {
         return [

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -112,13 +112,12 @@ export interface PackageManifest {
         }
     }
     // CLI commands this package contributes to the `tinycld` binary.
-    // package/module mirror `server` and drive gen-cli.ts; `commands` is
-    // display metadata (Cobra owns --help); `scopes` feeds the OAuth scope
-    // registry. See the PackageManifest doc in core/lib/packages/types.ts.
+    // package/module mirror `server` and drive gen-cli.ts; `scopes` feeds the
+    // OAuth scope registry. Cobra owns the command list and --help. See the
+    // PackageManifest doc in core/lib/packages/types.ts.
     cli?: {
         package: string
         module: string
-        commands?: { name: string; summary: string }[]
         scopes?: string[]
     }
     help?: { directory: string }


### PR DESCRIPTION
Groundwork for the extended drive/mail CLI surfaces, plus the CI gap those surfaces exposed.

**Scope table**
- Entries become rules satisfied by ANY listed scope. `labels`/`label_assignments` are core collections shared by mail and contacts, so demanding both scopes would make labelling mail impossible for a mail-only grant.
- New prefix table for id-bearing paths; first entry `DELETE /api/drive/share-link/{id}`, which the exact-match map cannot express.
- New entries: `mail_mailbox_aliases` (read-only), `drive_item_versions`, share-link create/list, versions restore/snapshot.

**Manifest**
- Drops the unused `cli.commands` list. Nothing read it — the generator excludes it from generated Go and no UI renders it — while Cobra already owns the command tree.

**CI**
- The `cli/` module had no coverage anywhere; the Go job now builds and tests it after the install that generates its go.work.