### PR TITLE
fix(ci): drop go mod download from the CLI module steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,12 @@ jobs:
       # no-op form, so this covers the shell's own commands (auth, context,
       # output, keychain, device flow) — member cli modules are tested on
       # their own repos' CI.
-      - name: Go mod download (cli)
-        working-directory: ws/tinycld/cli
-        run: go mod download
+      #
+      # Deliberately no `go mod download`: with no arguments it resolves the
+      # ENTIRE module graph, which once a member cli joins the workspace
+      # includes that member's inherited tinycld.org/core requirement — only
+      # the server's own go.work resolves that. build/test are unaffected
+      # because pruning loads only what is actually imported.
       - name: Go build & test (cli)
         working-directory: ws/tinycld/cli
         run: go build ./... && go test ./...


### PR DESCRIPTION
The step I added in #160 is wrong, and drive/mail CI proved it: `go mod download` with no arguments resolves the entire module graph, including the `tinycld.org/core` requirement a member cli module inherits through its `replace ... => ../server` — which only the server's own go.work resolves.

It passed on this repo only because the assembly has no feature members; it would break the moment that changes. `go build`/`go test` are unaffected, since pruning loads only what is actually imported and the api packages are import-free by design.

Companion fixes in tinycld/drive#54 and tinycld/mail#52.