### PR TITLE
feat(search): cross-package / search palette + shared FTS engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       # across independent assemblies, so they are a stable key in the absence
       # of a lockfile.
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ws/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('ws/package.json', 'ws/pnpm-workspace.yaml') }}
@@ -100,7 +100,7 @@ jobs:
             ws/tinycld/core/server/go.sum
             ws/tinycld/cli/go.sum
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ws/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('ws/package.json', 'ws/pnpm-workspace.yaml') }}
@@ -165,7 +165,7 @@ jobs:
             ws/tinycld/core/server/go.sum
             ws/tinycld/cli/go.sum
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ws/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('ws/package.json', 'ws/pnpm-workspace.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,15 @@ jobs:
         with:
           path: ws/tinycld
       # tinycld carries its own .node-version; read it from the checkout (no
-      # dependency on bootstrap having generated ws/.node-version yet). No
-      # package-manager cache: no committed lockfile (pnpm resolves fresh;
-      # corepack enable selects the pnpm pinned in the workspace package.json).
+      # dependency on bootstrap having generated ws/.node-version yet).
+      #
+      # No package-manager cache, deliberately. setup-node's `cache: pnpm` keys
+      # on a lockfile hash, and the workspace root here is bootstrap-GENERATED —
+      # no lockfile exists until the install produces one. Caching pnpm's store
+      # by another key was measured and rejected: the store is ~1.2GB across
+      # ~96k files, and packing/restoring it costs more than the ~24s of package
+      # fetching it would save. The install's real cost is its postinstall (Go
+      # module downloads), which the setup-go cache below covers instead.
       - uses: actions/setup-node@v5
         with:
           node-version-file: ws/tinycld/.node-version
@@ -39,9 +45,19 @@ jobs:
         working-directory: ws
         run: TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only
       # Go toolchain after assembly: .go-version is bootstrap-generated into ws/.
+      #
+      # cache-dependency-path matters more than it looks: the install below runs
+      # a postinstall that generates the PB schema, which shells out to Go and
+      # pulls ~48 modules. That download — not package fetching — is the bulk of
+      # the install step's runtime, so keying setup-go's module cache on the
+      # checked-out go.sum files is what actually makes this job faster.
       - uses: actions/setup-go@v6
         with:
           go-version-file: ws/.go-version
+          cache-dependency-path: |
+            ws/tinycld/server/go.sum
+            ws/tinycld/core/server/go.sum
+            ws/tinycld/cli/go.sum
       - name: Install (workspace root)
         working-directory: ws
         run: corepack enable && pnpm install --no-frozen-lockfile
@@ -71,6 +87,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: ws/.go-version
+          cache-dependency-path: |
+            ws/tinycld/server/go.sum
+            ws/tinycld/core/server/go.sum
+            ws/tinycld/cli/go.sum
       - name: Install (workspace root)
         working-directory: ws
         run: corepack enable && pnpm install --no-frozen-lockfile
@@ -126,6 +146,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: ws/.go-version
+          cache-dependency-path: |
+            ws/tinycld/server/go.sum
+            ws/tinycld/core/server/go.sum
+            ws/tinycld/cli/go.sum
       - name: Install (workspace root)
         working-directory: ws
         run: corepack enable && pnpm install --no-frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,10 @@ jobs:
       # tinycld carries its own .node-version; read it from the checkout (no
       # dependency on bootstrap having generated ws/.node-version yet).
       #
-      # No package-manager cache, deliberately. setup-node's `cache: pnpm` keys
-      # on a lockfile hash, and the workspace root here is bootstrap-GENERATED —
-      # no lockfile exists until the install produces one. Caching pnpm's store
-      # by another key was measured and rejected: the store is ~1.2GB across
-      # ~96k files, and packing/restoring it costs more than the ~24s of package
-      # fetching it would save. The install's real cost is its postinstall (Go
-      # module downloads), which the setup-go cache below covers instead.
+      # setup-node's built-in `cache: pnpm` can't be used: it keys on a lockfile
+      # hash, and the workspace root here is bootstrap-GENERATED — no lockfile
+      # exists until the install produces one. The pnpm store is cached below
+      # by an explicit key instead.
       - uses: actions/setup-node@v5
         with:
           node-version-file: ws/tinycld/.node-version
@@ -58,9 +55,20 @@ jobs:
             ws/tinycld/server/go.sum
             ws/tinycld/core/server/go.sum
             ws/tinycld/cli/go.sum
+      # Cache pnpm's content-addressable store. Keyed on the GENERATED root's
+      # package.json + pnpm-workspace.yaml (which carries the overrides block):
+      # together those fully determine resolution, and both are byte-identical
+      # across independent assemblies, so they are a stable key in the absence
+      # of a lockfile.
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ws/.pnpm-store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('ws/package.json', 'ws/pnpm-workspace.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
       - name: Install (workspace root)
         working-directory: ws
-        run: corepack enable && pnpm install --no-frozen-lockfile
+        run: corepack enable && pnpm install --no-frozen-lockfile --store-dir=.pnpm-store
       - name: Check (lint + typecheck + unit)
         working-directory: ws/tinycld
         run: pnpm exec tinycld-pkg check
@@ -91,9 +99,15 @@ jobs:
             ws/tinycld/server/go.sum
             ws/tinycld/core/server/go.sum
             ws/tinycld/cli/go.sum
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ws/.pnpm-store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('ws/package.json', 'ws/pnpm-workspace.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
       - name: Install (workspace root)
         working-directory: ws
-        run: corepack enable && pnpm install --no-frozen-lockfile
+        run: corepack enable && pnpm install --no-frozen-lockfile --store-dir=.pnpm-store
       # Warm go.work.sum: in workspace mode `go mod download` writes the
       # transitive `/go.mod` hashes (reached through go.work's `use ../core/server`)
       # into go.work.sum so the build below verifies cleanly.
@@ -150,9 +164,15 @@ jobs:
             ws/tinycld/server/go.sum
             ws/tinycld/core/server/go.sum
             ws/tinycld/cli/go.sum
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ws/.pnpm-store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('ws/package.json', 'ws/pnpm-workspace.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
       - name: Install (workspace root)
         working-directory: ws
-        run: corepack enable && pnpm install --no-frozen-lockfile
+        run: corepack enable && pnpm install --no-frozen-lockfile --store-dir=.pnpm-store
       # Warm go.work.sum before E2E so the webServer (which builds PB via
       # pnpm run e2e:serve → reset-dev-db) doesn't fail verifying a transitive
       # dep reached through go.work's `use ../core/server`.

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -4,6 +4,7 @@ import { DocumentTitle } from '@tinycld/core/components/DocumentTitle'
 import { HelpDrawer } from '@tinycld/core/components/help/HelpDrawer'
 import { HelpSearchPalette } from '@tinycld/core/components/help/HelpSearchPalette'
 import { NotifyContextSync } from '@tinycld/core/components/NotifyContextSync'
+import { SearchPalette } from '@tinycld/core/components/search-palette/SearchPalette'
 import { AuthGate } from '@tinycld/core/components/workspace/AuthGate'
 import { ImportNotifier } from '@tinycld/core/components/workspace/ImportNotifier'
 import { SkeletonLayout } from '@tinycld/core/components/workspace/SkeletonLayout'
@@ -57,6 +58,7 @@ function OrgLayoutInner() {
             <DemoFollowUpModal />
             <HelpDrawer />
             <HelpSearchPalette />
+            <SearchPalette />
         </>
     )
 }

--- a/core/components/CoreShortcuts.tsx
+++ b/core/components/CoreShortcuts.tsx
@@ -1,5 +1,7 @@
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import { packageRegistry } from '@tinycld/core/lib/packages/static-registry'
+import { useSearchPaletteStore } from '@tinycld/core/lib/search/search-palette-store'
+import { useActivePackageSlug } from '@tinycld/core/lib/search/use-active-package-slug'
 import { type Shortcut, useRegisterShortcuts } from '@tinycld/core/lib/shortcuts'
 import { useShortcutHelp, useShortcutHelpStore } from '@tinycld/core/lib/shortcuts/help'
 import { useRouter } from 'expo-router'
@@ -14,6 +16,7 @@ export function CoreShortcuts() {
     const helpStore = useShortcutHelp()
     const router = useRouter()
     const orgHref = useOrgHref()
+    const activeSlug = useActivePackageSlug()
 
     const shortcuts = useMemo<Shortcut[]>(() => {
         const list: Shortcut[] = [
@@ -39,6 +42,16 @@ export function CoreShortcuts() {
                 when: () => useShortcutHelpStore.getState().isOpen,
                 run: () => helpStore.close(),
             },
+            {
+                id: 'core.search.open',
+                keys: '/',
+                scope: 'global',
+                group: 'General',
+                description: 'Search across packages',
+                // allowInInputs omitted deliberately: `/` must stay suppressed
+                // while the user is typing in the app.
+                run: () => useSearchPaletteStore.getState().open(activeSlug),
+            },
         ]
 
         for (const pkg of packageRegistry) {
@@ -54,7 +67,7 @@ export function CoreShortcuts() {
             })
         }
         return list
-    }, [helpStore, router, orgHref])
+    }, [helpStore, router, orgHref, activeSlug])
 
     useRegisterShortcuts(shortcuts)
 

--- a/core/components/MiniCalendar.tsx
+++ b/core/components/MiniCalendar.tsx
@@ -101,7 +101,13 @@ export function MiniCalendar({ selectedDate, onDateSelect }: MiniCalendarProps) 
                         isToday={cell.isToday}
                         isSelected={isSameDay(cell.date, selectedDate)}
                         onPress={onDateSelect}
-                        colors={{ fgColor, mutedColor, primaryColor, primaryFgColor, activeIndicatorColor }}
+                        colors={{
+                            fgColor,
+                            mutedColor,
+                            primaryColor,
+                            primaryFgColor,
+                            activeIndicatorColor,
+                        }}
                     />
                 ))}
             </View>

--- a/core/components/SortableList.tsx
+++ b/core/components/SortableList.tsx
@@ -1,3 +1,4 @@
+import { hapticImpactLight } from '@tinycld/core/lib/haptics'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { GripVertical } from 'lucide-react-native'
 import type { ReactNode } from 'react'
@@ -42,6 +43,7 @@ export function SortableList<T>({
         keyExtractor,
         onReorder: event => onReorder(event.data),
         longPressDelay: 1,
+        onDragStart: () => hapticImpactLight(),
     })
 
     return (

--- a/core/components/search-palette/SearchPalette.tsx
+++ b/core/components/search-palette/SearchPalette.tsx
@@ -1,0 +1,5 @@
+// Web-only for now: the palette is a keyboard surface, and the mobile
+// equivalent is a separate design problem. Mirrors HelpSearchPalette's split.
+export function SearchPalette() {
+    return null
+}

--- a/core/components/search-palette/SearchPalette.web.tsx
+++ b/core/components/search-palette/SearchPalette.web.tsx
@@ -1,0 +1,437 @@
+import { useQuery } from '@tanstack/react-query'
+import { getIcon } from '@tinycld/core/components/workspace/package-icon-map'
+import type { SearchSection } from '@tinycld/core/lib/search/build-sections'
+import { chipsToText, textAfterChips } from '@tinycld/core/lib/search/chip-text'
+import { parseQuery } from '@tinycld/core/lib/search/parse-query'
+import { loadSearchAdapter, searchPackages } from '@tinycld/core/lib/search/registry'
+import { useSearchPaletteStore } from '@tinycld/core/lib/search/search-palette-store'
+import type { SearchAdapterModule, SearchRow } from '@tinycld/core/lib/search/types'
+import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { type ReactNode, type RefObject, useCallback, useEffect, useMemo, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { Pressable, Text, TextInput, View } from 'react-native'
+import { useSearchResults } from './useSearchResults'
+
+const PALETTE_WIDTH_PX = 560
+const PALETTE_TOP_OFFSET_PX = 96
+
+// Inject the open-animation keyframes once at module load — distinct id from
+// the help palette's <style> tag so the two injections cannot collide. React
+// Native's StyleSheet doesn't expose @keyframes, so a tiny static <style> tag
+// is simpler than a JS-driven Animated value for an animation that runs once
+// on mount and never again. Guarded for SSR.
+if (typeof document !== 'undefined' && !document.getElementById('tinycld-search-palette-styles')) {
+    const styleEl = document.createElement('style')
+    styleEl.id = 'tinycld-search-palette-styles'
+    styleEl.textContent = `@keyframes tinycld-search-palette-in {
+        from { opacity: 0; transform: translateY(-4px); }
+        to { opacity: 1; transform: translateY(0); }
+    }`
+    document.head.appendChild(styleEl)
+}
+
+const INSTALLED_SLUGS = searchPackages.map(p => p.slug)
+
+// SearchPalette renders the global cross-package command palette. Listens to
+// the Zustand store driven by the `/` shortcut. Web-only: portals to
+// document.body so the overlay sits above any package's own scroll
+// container.
+export function SearchPalette() {
+    const isOpen = useSearchPaletteStore(s => s.isOpen)
+    const text = useSearchPaletteStore(s => s.text)
+    const selectedRowId = useSearchPaletteStore(s => s.selectedRowId)
+    const setText = useSearchPaletteStore(s => s.setText)
+    const setSelectedRowId = useSearchPaletteStore(s => s.setSelectedRowId)
+    const close = useSearchPaletteStore(s => s.close)
+
+    const parsed = useMemo(() => parseQuery(text, INSTALLED_SLUGS), [text])
+    const { sections } = useSearchResults(parsed)
+
+    const flatRows = useMemo(() => sections.flatMap(s => s.rows), [sections])
+    const selectedRow = flatRows.find(r => r.id === selectedRowId) ?? flatRows[0]
+
+    const handlersRef = useRef<Record<string, (row: SearchRow) => void>>({})
+    const registerHandler = useCallback((slug: string, handler: (row: SearchRow) => void) => {
+        handlersRef.current[slug] = handler
+    }, [])
+
+    const selectRow = useCallback(
+        (row: SearchRow) => {
+            handlersRef.current[row.slug]?.(row)
+            close()
+        },
+        [close]
+    )
+
+    const moveSelection = useCallback(
+        (delta: number) => {
+            if (flatRows.length === 0) return
+            const current = flatRows.findIndex(r => r.id === selectedRow?.id)
+            const next = (current + delta + flatRows.length) % flatRows.length
+            setSelectedRowId(flatRows[next].id)
+        },
+        [flatRows, selectedRow, setSelectedRowId]
+    )
+
+    const inputRef = useRef<TextInput>(null)
+
+    useEffect(() => {
+        if (!isOpen) return
+        // Focus the input on open. RN's TextInput needs a microtask before its
+        // DOM node is mounted under the portal, so we defer via
+        // requestAnimationFrame.
+        const raf = requestAnimationFrame(() => {
+            inputRef.current?.focus()
+        })
+        return () => cancelAnimationFrame(raf)
+    }, [isOpen])
+
+    // Click-outside dismiss. Anything outside the palette card closes it —
+    // matches Spotlight + the help palette's pattern.
+    useEffect(() => {
+        if (!isOpen || typeof document === 'undefined') return
+        function onPointerDown(event: MouseEvent) {
+            const target = event.target
+            if (!(target instanceof Element)) return
+            if (target.closest('[data-tinycld-search-palette]')) return
+            close()
+        }
+        document.addEventListener('mousedown', onPointerDown, true)
+        return () => document.removeEventListener('mousedown', onPointerDown, true)
+    }, [isOpen, close])
+
+    // Keyboard navigation. Bound to document keydown in CAPTURE phase while
+    // the palette is open. Capture phase matters because react-native-web's
+    // TextInput swallows Escape on its own internal bubble-phase handler — a
+    // non-capturing listener never sees it. ArrowUp/ArrowDown likewise need
+    // this because TextInput.onKeyPress doesn't fire for non-character keys.
+    useEffect(() => {
+        if (!isOpen || typeof document === 'undefined') return
+        function onKeyDown(event: KeyboardEvent) {
+            const key = event.key
+            if (key === 'Escape') {
+                event.preventDefault()
+                close()
+                return
+            }
+            if (key === 'ArrowDown') {
+                event.preventDefault()
+                moveSelection(1)
+                return
+            }
+            if (key === 'ArrowUp') {
+                event.preventDefault()
+                moveSelection(-1)
+                return
+            }
+            if (key === 'Enter') {
+                event.preventDefault()
+                if (selectedRow) selectRow(selectedRow)
+                return
+            }
+            // Backspace on empty text pops the trailing chip, so widening the
+            // search to everywhere is one keystroke from the seeded state.
+            if (key === 'Backspace') {
+                const remainder = textAfterChips(text, parsed.chips)
+                if (remainder.length === 0 && parsed.chips.length > 0) {
+                    event.preventDefault()
+                    setText(chipsToText(parsed.chips.slice(0, -1)))
+                }
+            }
+        }
+        document.addEventListener('keydown', onKeyDown, true)
+        return () => document.removeEventListener('keydown', onKeyDown, true)
+    }, [isOpen, close, text, parsed.chips, moveSelection, selectedRow, selectRow, setText])
+
+    if (!isOpen || typeof document === 'undefined') return null
+
+    const remainder = textAfterChips(text, parsed.chips)
+
+    return createPortal(
+        <>
+            {searchPackages.map(pkg => (
+                <PackageActions key={pkg.slug} slug={pkg.slug} onReady={registerHandler} />
+            ))}
+            <PaletteOverlay>
+                <PaletteCard>
+                    <SearchField inputRef={inputRef} value={text} onChange={setText} />
+                    <ResultList
+                        sections={sections}
+                        selectedRowId={selectedRow?.id ?? null}
+                        onPick={selectRow}
+                        onHover={id => setSelectedRowId(id)}
+                    />
+                    <FooterHints chips={parsed.chips} remainder={remainder} />
+                </PaletteCard>
+            </PaletteOverlay>
+        </>,
+        document.body
+    )
+}
+
+function useAdapterModule(slug: string): SearchAdapterModule | null {
+    const { data } = useQuery({
+        queryKey: ['search-adapter', slug],
+        queryFn: () => loadSearchAdapter(slug),
+        staleTime: Number.POSITIVE_INFINITY,
+    })
+    return (data as SearchAdapterModule | null) ?? null
+}
+
+/**
+ * Registers one package's selection handler. A component per package rather
+ * than a loop of hook calls inside the palette: `useSearchActions` is a hook,
+ * and calling it in a loop would break the Rules of Hooks the moment the
+ * package list changed. Renders nothing.
+ */
+function PackageActions({
+    slug,
+    onReady,
+}: {
+    slug: string
+    onReady: (slug: string, handler: (row: SearchRow) => void) => void
+}) {
+    const adapter = useAdapterModule(slug)
+    const actions = adapter?.useSearchActions()
+    // Registering during render would mutate a parent ref mid-render; a ref
+    // write in an effect is the standard imperative-handle pattern.
+    useEffect(() => {
+        if (actions) onReady(slug, actions.onSelect)
+    }, [slug, actions, onReady])
+    return null
+}
+
+function PaletteOverlay({ children }: { children: ReactNode }) {
+    // Full-viewport fixed layer so the click-outside listener has somewhere
+    // to fire. The card itself is positioned within.
+    return (
+        <View
+            style={
+                {
+                    position: 'fixed',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    alignItems: 'center',
+                    paddingTop: PALETTE_TOP_OFFSET_PX,
+                    zIndex: 1000,
+                } as object
+            }
+            pointerEvents="box-none"
+        >
+            {children}
+        </View>
+    )
+}
+
+function PaletteCard({ children }: { children: ReactNode }) {
+    // animationName drives the open animation defined in the module-level
+    // <style> tag. RN ignores CSS animation properties on native, but this
+    // component is .web.tsx so we're safe to use browser semantics directly.
+    const animationStyle = {
+        animationName: 'tinycld-search-palette-in',
+        animationDuration: '120ms',
+        animationTimingFunction: 'ease-out',
+    } as object
+    const cardDomProps = {
+        'data-tinycld-search-palette': 'true',
+        role: 'dialog',
+        'aria-label': 'Search',
+    } as object
+    return (
+        <View
+            {...(cardDomProps as Record<string, unknown>)}
+            style={
+                {
+                    width: PALETTE_WIDTH_PX,
+                    maxWidth: '90%',
+                    maxHeight: '60vh',
+                    ...animationStyle,
+                } as object
+            }
+            className="rounded-xl border border-border bg-background shadow-lg overflow-hidden"
+        >
+            {children}
+        </View>
+    )
+}
+
+interface SearchFieldProps {
+    inputRef: RefObject<TextInput | null>
+    value: string
+    onChange: (v: string) => void
+}
+
+function SearchField({ inputRef, value, onChange }: SearchFieldProps) {
+    const placeholderColor = useThemeColor('muted-foreground')
+    return (
+        <View className="px-4 pt-4 pb-2">
+            <TextInput
+                ref={inputRef}
+                value={value}
+                onChangeText={onChange}
+                placeholder="Search everywhere…"
+                placeholderTextColor={placeholderColor}
+                className="text-base text-foreground"
+                style={{ outlineWidth: 0 } as object}
+                accessibilityLabel="Search across packages"
+            />
+        </View>
+    )
+}
+
+interface ResultListProps {
+    sections: SearchSection[]
+    selectedRowId: string | null
+    onPick: (row: SearchRow) => void
+    onHover: (id: string) => void
+}
+
+function ResultList({ sections, selectedRowId, onPick, onHover }: ResultListProps) {
+    if (sections.length === 0 || sections.every(s => s.rows.length === 0)) {
+        return <EmptyState />
+    }
+    return (
+        <View style={{ maxHeight: '40vh', overflowY: 'auto' } as object}>
+            {sections.map((section, index) => (
+                <SectionBlock
+                    key={section.title ?? `flat-${index}`}
+                    section={section}
+                    selectedRowId={selectedRowId}
+                    onPick={onPick}
+                    onHover={onHover}
+                />
+            ))}
+        </View>
+    )
+}
+
+interface SectionBlockProps {
+    section: SearchSection
+    selectedRowId: string | null
+    onPick: (row: SearchRow) => void
+    onHover: (id: string) => void
+}
+
+function SectionBlock({ section, selectedRowId, onPick, onHover }: SectionBlockProps) {
+    return (
+        <View>
+            {section.title && <SectionHeading title={section.title} icon={section.icon} />}
+            {section.rows.map(row => (
+                <ResultRow
+                    key={`${row.slug}:${row.id}`}
+                    row={row}
+                    showBadge={section.showBadges}
+                    isSelected={row.id === selectedRowId}
+                    onPress={() => onPick(row)}
+                    onHoverIn={() => onHover(row.id)}
+                />
+            ))}
+        </View>
+    )
+}
+
+function SectionHeading({ title, icon }: { title: string; icon?: string }) {
+    const Icon = getIcon(icon ?? '')
+    const iconColor = useThemeColor('muted-foreground')
+    return (
+        <View className="flex-row items-center gap-2 px-4 pt-3 pb-1">
+            <Icon size={14} color={iconColor} />
+            <Text className="text-xs font-medium text-muted-foreground uppercase">{title}</Text>
+        </View>
+    )
+}
+
+interface ResultRowProps {
+    row: SearchRow
+    showBadge: boolean
+    isSelected: boolean
+    onPress: () => void
+    onHoverIn: () => void
+}
+
+function ResultRow({ row, showBadge, isSelected, onPress, onHoverIn }: ResultRowProps) {
+    const pkg = useMemo(() => searchPackages.find(p => p.slug === row.slug), [row.slug])
+    const optionDomProps = {
+        role: 'option',
+        'aria-selected': isSelected,
+    } as const
+    return (
+        <Pressable
+            onPress={onPress}
+            onHoverIn={onHoverIn}
+            {...optionDomProps}
+            className={`px-4 py-3 flex-row items-center justify-between gap-3 ${
+                isSelected ? 'bg-surface-secondary' : 'bg-transparent'
+            }`}
+        >
+            <View className="flex-1">
+                <Text className="text-base font-medium text-foreground" numberOfLines={1}>
+                    {row.title}
+                </Text>
+                {row.subtitle && (
+                    <Text className="text-xs text-muted-foreground mt-0.5" numberOfLines={1}>
+                        {row.subtitle}
+                    </Text>
+                )}
+            </View>
+            {row.meta && (
+                <Text className="text-xs text-muted-foreground" numberOfLines={1}>
+                    {row.meta}
+                </Text>
+            )}
+            {showBadge && pkg && (
+                <Text className="text-xs text-muted-foreground px-2 py-0.5 rounded bg-surface-secondary">
+                    {pkg.label}
+                </Text>
+            )}
+        </Pressable>
+    )
+}
+
+function EmptyState() {
+    return (
+        <View className="px-4 py-8 items-center">
+            <Text className="text-sm text-muted-foreground">No results.</Text>
+        </View>
+    )
+}
+
+interface FooterHintsProps {
+    chips: string[]
+    remainder: string
+}
+
+// The footer is where the `:` and ⌫ grammar is discoverable, so it reacts to
+// what the user has typed rather than showing three static hints.
+function FooterHints({ chips, remainder }: FooterHintsProps) {
+    // The last word matches a package but has no colon yet — offer the gesture.
+    const lastWord = remainder.trim().split(/\s+/).pop() ?? ''
+    const pending = searchPackages.find(
+        p => p.slug === lastWord.toLowerCase() && !chips.includes(p.slug)
+    )
+    if (pending) {
+        return <Hints items={['↑↓ move', '↵ open', `: scope to ${pending.slug}`, 'esc close']} />
+    }
+    if (chips.length > 0 && remainder.length === 0) {
+        return (
+            <Hints
+                items={['↑↓ move', '↵ open', `⌫ remove ${chips[chips.length - 1]}`, 'esc close']}
+            />
+        )
+    }
+    return <Hints items={['↑↓ move', '↵ open', 'esc close']} />
+}
+
+function Hints({ items }: { items: string[] }) {
+    return (
+        <View className="flex-row gap-4 px-4 py-2 border-t border-border">
+            {items.map(item => (
+                <Text key={item} className="text-xs text-muted-foreground">
+                    {item}
+                </Text>
+            ))}
+        </View>
+    )
+}

--- a/core/components/search-palette/SearchPalette.web.tsx
+++ b/core/components/search-palette/SearchPalette.web.tsx
@@ -154,7 +154,12 @@ export function SearchPalette() {
             ))}
             <PaletteOverlay>
                 <PaletteCard>
-                    <SearchField inputRef={inputRef} value={text} onChange={setText} />
+                    <SearchField
+                        inputRef={inputRef}
+                        chips={parsed.chips}
+                        remainder={remainder}
+                        onChangeRemainder={next => setText(chipsToText(parsed.chips) + next)}
+                    />
                     <ResultList
                         sections={sections}
                         selectedRowId={selectedRow?.id ?? null}
@@ -281,24 +286,47 @@ function PaletteCard({ children }: { children: ReactNode }) {
 
 interface SearchFieldProps {
     inputRef: RefObject<TextInput | null>
-    value: string
-    onChange: (v: string) => void
+    chips: string[]
+    remainder: string
+    onChangeRemainder: (v: string) => void
 }
 
-function SearchField({ inputRef, value, onChange }: SearchFieldProps) {
+// Scope chips render as their own row of pills — separate from the text
+// input — so a test (and a user) can see and target "cards" as a discrete
+// unit rather than parsing it back out of a raw "cards: " string prefix.
+// The input itself only ever holds the free-text remainder; typing composes
+// chips + remainder back into the store's single `text` field, which stays
+// the source of truth parseQuery re-derives chips from on every render.
+function SearchField({ inputRef, chips, remainder, onChangeRemainder }: SearchFieldProps) {
     const placeholderColor = useThemeColor('muted-foreground')
     return (
-        <View className="px-4 pt-4 pb-2">
+        <View className="px-4 pt-4 pb-2 flex-row items-center flex-wrap gap-1.5">
+            {chips.map(slug => (
+                <SearchChip key={slug} slug={slug} />
+            ))}
             <TextInput
                 ref={inputRef}
-                value={value}
-                onChangeText={onChange}
-                placeholder="Search everywhere…"
+                value={remainder}
+                onChangeText={onChangeRemainder}
+                placeholder={chips.length === 0 ? 'Search everywhere…' : 'Search…'}
                 placeholderTextColor={placeholderColor}
-                className="text-base text-foreground"
+                className="text-base text-foreground flex-1 min-w-[80px]"
                 style={{ outlineWidth: 0 } as object}
                 accessibilityLabel="Search across packages"
             />
+        </View>
+    )
+}
+
+function SearchChip({ slug }: { slug: string }) {
+    const pkg = searchPackages.find(p => p.slug === slug)
+    const chipDomProps = { 'data-testid': `search-chip-${slug}` } as Record<string, unknown>
+    return (
+        <View
+            {...chipDomProps}
+            className="rounded-md bg-surface-secondary px-2 py-1 flex-row items-center"
+        >
+            <Text className="text-xs font-medium text-foreground">{pkg?.label ?? slug}</Text>
         </View>
     )
 }
@@ -357,8 +385,9 @@ function SectionBlock({ section, selectedRowId, onPick, onHover }: SectionBlockP
 function SectionHeading({ title, icon }: { title: string; icon?: string }) {
     const Icon = getIcon(icon ?? '')
     const iconColor = useThemeColor('muted-foreground')
+    const headingDomProps = { 'data-testid': 'search-section-heading' } as Record<string, unknown>
     return (
-        <View className="flex-row items-center gap-2 px-4 pt-3 pb-1">
+        <View {...headingDomProps} className="flex-row items-center gap-2 px-4 pt-3 pb-1">
             <Icon size={14} color={iconColor} />
             <Text className="text-xs font-medium text-muted-foreground uppercase">{title}</Text>
         </View>

--- a/core/components/search-palette/SearchPalette.web.tsx
+++ b/core/components/search-palette/SearchPalette.web.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { getIcon } from '@tinycld/core/components/workspace/package-icon-map'
 import type { SearchSection } from '@tinycld/core/lib/search/build-sections'
-import { chipsToText, textAfterChips } from '@tinycld/core/lib/search/chip-text'
+import { chipsToText, runHandlerFor } from '@tinycld/core/lib/search/chip-text'
 import { parseQuery } from '@tinycld/core/lib/search/parse-query'
 import { loadSearchAdapter, searchPackages } from '@tinycld/core/lib/search/registry'
 import { useSearchPaletteStore } from '@tinycld/core/lib/search/search-palette-store'
@@ -57,8 +57,9 @@ export function SearchPalette() {
 
     const selectRow = useCallback(
         (row: SearchRow) => {
-            handlersRef.current[row.slug]?.(row)
-            close()
+            // Only close when a handler actually ran — see runHandlerFor's
+            // doc comment for why a row can outlive its own adapter.
+            if (runHandlerFor(row, handlersRef.current)) close()
         },
         [close]
     )
@@ -132,8 +133,7 @@ export function SearchPalette() {
             // Backspace on empty text pops the trailing chip, so widening the
             // search to everywhere is one keystroke from the seeded state.
             if (key === 'Backspace') {
-                const remainder = textAfterChips(text, parsed.chips)
-                if (remainder.length === 0 && parsed.chips.length > 0) {
+                if (parsed.remainder.length === 0 && parsed.chips.length > 0) {
                     event.preventDefault()
                     setText(chipsToText(parsed.chips.slice(0, -1)))
                 }
@@ -141,11 +141,20 @@ export function SearchPalette() {
         }
         document.addEventListener('keydown', onKeyDown, true)
         return () => document.removeEventListener('keydown', onKeyDown, true)
-    }, [isOpen, close, text, parsed.chips, moveSelection, selectedRow, selectRow, setText])
+    }, [
+        isOpen,
+        close,
+        parsed.chips,
+        parsed.remainder,
+        moveSelection,
+        selectedRow,
+        selectRow,
+        setText,
+    ])
 
     if (!isOpen || typeof document === 'undefined') return null
 
-    const remainder = textAfterChips(text, parsed.chips)
+    const remainder = parsed.remainder
 
     return createPortal(
         <>
@@ -296,7 +305,8 @@ interface SearchFieldProps {
 // unit rather than parsing it back out of a raw "cards: " string prefix.
 // The input itself only ever holds the free-text remainder; typing composes
 // chips + remainder back into the store's single `text` field, which stays
-// the source of truth parseQuery re-derives chips from on every render.
+// the source of truth parseQuery re-derives BOTH chips and remainder from on
+// every render — the renderer never re-slices the remainder itself.
 function SearchField({ inputRef, chips, remainder, onChangeRemainder }: SearchFieldProps) {
     const placeholderColor = useThemeColor('muted-foreground')
     return (

--- a/core/components/search-palette/SearchPalette.web.tsx
+++ b/core/components/search-palette/SearchPalette.web.tsx
@@ -178,26 +178,48 @@ function useAdapterModule(slug: string): SearchAdapterModule | null {
     return (data as SearchAdapterModule | null) ?? null
 }
 
-/**
- * Registers one package's selection handler. A component per package rather
- * than a loop of hook calls inside the palette: `useSearchActions` is a hook,
- * and calling it in a loop would break the Rules of Hooks the moment the
- * package list changed. Renders nothing.
- */
-function PackageActions({
-    slug,
-    onReady,
-}: {
+interface PackageActionsProps {
     slug: string
     onReady: (slug: string, handler: (row: SearchRow) => void) => void
-}) {
+}
+
+/**
+ * Loads one package's adapter module. A component per package rather than a
+ * loop of hook calls inside the palette: the adapter's `useSearchActions` is
+ * a hook, and calling it in a loop would break the Rules of Hooks the moment
+ * the package list changed.
+ *
+ * This component itself renders nothing until the adapter has resolved, and
+ * deliberately does NOT call `adapter?.useSearchActions()` here — that would
+ * call a hook conditionally (skipped while the dynamic import is pending,
+ * called once it lands), which is exactly the "rendered more hooks than
+ * during the previous render" crash the Rules of Hooks forbid. Instead the
+ * hook call is pushed into `ResolvedPackageActions`, a component that only
+ * ever mounts once `adapter` is non-null — so for that component's entire
+ * lifetime the hook call is unconditional.
+ */
+export function PackageActions({ slug, onReady }: PackageActionsProps) {
     const adapter = useAdapterModule(slug)
-    const actions = adapter?.useSearchActions()
+    if (!adapter) return null
+    return <ResolvedPackageActions slug={slug} adapter={adapter} onReady={onReady} />
+}
+
+/**
+ * Registers one resolved adapter's selection handler. Split out from
+ * `PackageActions` so `adapter` is non-null for this component's entire
+ * lifetime, making the `useSearchActions()` call unconditional.
+ */
+function ResolvedPackageActions({
+    slug,
+    adapter,
+    onReady,
+}: PackageActionsProps & { adapter: SearchAdapterModule }) {
+    const { onSelect } = adapter.useSearchActions()
     // Registering during render would mutate a parent ref mid-render; a ref
     // write in an effect is the standard imperative-handle pattern.
     useEffect(() => {
-        if (actions) onReady(slug, actions.onSelect)
-    }, [slug, actions, onReady])
+        onReady(slug, onSelect)
+    }, [slug, onSelect, onReady])
     return null
 }
 

--- a/core/components/search-palette/useSearchResults.ts
+++ b/core/components/search-palette/useSearchResults.ts
@@ -1,0 +1,86 @@
+import { useQueries } from '@tanstack/react-query'
+import { pb } from '@tinycld/core/lib/pocketbase'
+import { buildSections, type SearchSection } from '@tinycld/core/lib/search/build-sections'
+import { loadSearchAdapter, searchPackages } from '@tinycld/core/lib/search/registry'
+import type { ParsedQuery, SearchAdapterModule, SearchRow } from '@tinycld/core/lib/search/types'
+import { useDebouncedValue } from '@tinycld/core/lib/use-debounced-value'
+
+const MIN_QUERY_LENGTH = 2
+const DEBOUNCE_MS = 300
+
+/**
+ * Fan out one search per in-scope package and merge the results.
+ *
+ * useQueries rather than a loop of single-query hooks: the in-scope list
+ * changes as the user adds and removes chips, and a hook called per iteration
+ * of a `for` loop breaks the Rules of Hooks. React Query also gives each
+ * package independent caching and abort-on-supersede for free, so a slow
+ * package cannot hold up the rest.
+ */
+export function useSearchResults(parsed: ParsedQuery): {
+    sections: SearchSection[]
+    isSearching: boolean
+} {
+    const scoped =
+        parsed.chips.length > 0
+            ? searchPackages.filter(p => parsed.chips.includes(p.slug))
+            : searchPackages
+
+    const query = useDebouncedValue(parsed.include.join(' '), DEBOUNCE_MS)
+    const not = useDebouncedValue(parsed.exclude.join(' '), DEBOUNCE_MS)
+    const enabled = query.length >= MIN_QUERY_LENGTH
+
+    // Adapter modules are dynamic imports. Running them through Query rather
+    // than an effect keeps the resolution cached and out of component state;
+    // loadSearchAdapter already memoizes, so this is belt-and-braces.
+    const adapterQueries = useQueries({
+        queries: scoped.map(pkg => ({
+            queryKey: ['search-adapter', pkg.slug],
+            queryFn: () => loadSearchAdapter(pkg.slug),
+            staleTime: Number.POSITIVE_INFINITY,
+        })),
+    })
+
+    const searchQueries = useQueries({
+        queries: scoped.map(pkg => ({
+            queryKey: ['package-search', pkg.slug, query, not],
+            queryFn: ({ signal }: { signal: AbortSignal }) =>
+                pb.send(pkg.endpoint, {
+                    method: 'GET',
+                    query: not ? { q: query, not } : { q: query },
+                    signal,
+                }),
+            enabled,
+            // A search is point-in-time: don't retry a failure (the user is
+            // still typing) and don't refetch on window focus.
+            retry: false,
+            refetchOnWindowFocus: false,
+        })),
+    })
+
+    const rowsBySlug: Record<string, SearchRow[]> = {}
+    let isSearching = false
+
+    scoped.forEach((pkg, i) => {
+        if (searchQueries[i]?.isFetching) isSearching = true
+
+        const adapter = adapterQueries[i]?.data as SearchAdapterModule | null | undefined
+        const data = searchQueries[i]?.data as { items?: unknown[] } | undefined
+        if (!adapter || !data?.items) return
+
+        // A package whose request failed simply contributes no rows — one
+        // backend erroring must not empty the whole palette.
+        rowsBySlug[pkg.slug] = data.items
+            .map(hit => adapter.toRow(hit))
+            .filter((r): r is Omit<SearchRow, 'slug'> => r !== null)
+            .map(r => ({ ...r, slug: pkg.slug }))
+    })
+
+    return {
+        // Ordering lives entirely here and is unaffected by fetch order:
+        // compareRows tie-breaks on nav.order precisely so a late-arriving
+        // package cannot change the ranking of what already landed.
+        sections: buildSections(rowsBySlug, searchPackages, parsed.chips, parsed.include),
+        isSearching,
+    }
+}

--- a/core/components/workspace/MobileDrawer.tsx
+++ b/core/components/workspace/MobileDrawer.tsx
@@ -33,6 +33,7 @@ export function MobileDrawer({ isVisible }: MobileDrawerProps) {
     const insets = useDeviceInsets()
     const activePkgSlug = useWorkspaceStore(s => s.activePkgSlug)
     const setDrawerOpen = useWorkspaceStore(s => s.setDrawerOpen)
+    const isEdgeSwipeSuspended = useWorkspaceStore(s => s.isEdgeSwipeSuspended)
     const pkg = usePackage(activePkgSlug ?? '')
     const translateX = useSharedValue(-PANEL_WIDTH)
 
@@ -55,7 +56,13 @@ export function MobileDrawer({ isVisible }: MobileDrawerProps) {
         }
     }, [isVisible, translateX, activePkgSlug, openedForSlug])
 
+    // Disabled while a package drag is live (plus a short grace after it
+    // ends): on a physical phone, a fingertip dragged into the left edge of
+    // the glass can micro-lift as it reverses, and the replacement touch is
+    // born inside this strip — indistinguishable from a deliberate edge
+    // swipe. See setEdgeSwipeSuspended in workspace-store.
     const edgeGesture = Gesture.Pan()
+        .enabled(!isEdgeSwipeSuspended)
         .activeOffsetX(10)
         .onUpdate(e => {
             translateX.value = Math.max(-PANEL_WIDTH, Math.min(0, -PANEL_WIDTH + e.translationX))

--- a/core/docs/keyboard-shortcuts.md
+++ b/core/docs/keyboard-shortcuts.md
@@ -58,6 +58,28 @@ Sequences like `t m` are two presses in quick succession (up to 1 second between
 | `Enter` | Open focused contact |
 | `c` | New contact |
 
+### Cards board
+
+| Keys | Action |
+|---|---|
+| `j` / `↓` | Focus next card |
+| `k` / `↑` | Focus previous card |
+| `←` / `→` | Focus the adjacent column's card at the same row |
+| `Enter` / `o` | Open focused card |
+| `Escape` | Clear the focus ring |
+| `Shift + ←` / `Shift + →` | Move focused card to the adjacent column |
+| `Shift + ↑` / `Shift + ↓` | Move focused card within its column |
+| `x` | Archive focused card |
+
+Moving and archiving need edit rights on the board; a viewer sees only the navigation keys.
+
+### Cards detail
+
+| Keys | Action |
+|---|---|
+| `j` / `k` | Next / previous card, in board order |
+| `Escape` | Close the card |
+
 ### Calendar schedule view
 
 | Keys | Action |
@@ -76,7 +98,7 @@ Shortcuts live under `lib/shortcuts/`. The system is intentionally small and avo
 - `lib/shortcuts/matcher.ts` — the sequence state machine. A 1-second inter-key timeout matches the tinykeys default. Both providers feed raw atoms into the same matcher so web and native share behaviour.
 - `lib/shortcuts/provider.web.tsx` — wires single atoms to `window` via [tinykeys](https://github.com/jamiebuilds/tinykeys). Tinykeys handles `$mod` (⌘ on macOS, Ctrl elsewhere) and key normalization.
 - `lib/shortcuts/provider.native.tsx` — wraps the app in `KeyboardExtendedView` from [`react-native-external-keyboard`](https://github.com/dorian-marchal/react-native-external-keyboard) and translates native `KeyPress` events to the same atom format.
-- `lib/shortcuts/help.tsx` + `ui/Kbd.tsx` — the `?` overlay and key badge component.
+- `lib/shortcuts/help.tsx` + `ui/Kbd.tsx` — the `?` overlay and key badge component. The overlay lists only shortcuts whose scope is currently active (`isScopeActive`), not everything registered: a screen shadowed by an inner scope, or one left mounted by `freezeOnBlur`, still has its shortcuts in the registry but none of them can fire.
 
 The matcher dispatches a shortcut only when:
 
@@ -121,7 +143,7 @@ Fields:
 - **`id`** — stable string, namespaced by package (`mail.list.next`). Re-registering with the same id overwrites the previous entry.
 - **`keys`** — tinykeys syntax: `"j"`, `"Shift+F"`, `"$mod+Enter"`, `"t i"`.
 - **`scope`** — `global` (always active) or one of `list`, `thread`, `compose`, `modal` (active only when at the top of the scope stack).
-- **`description`** / **`group`** — displayed in the `?` help overlay.
+- **`description`** / **`group`** — displayed in the `?` help overlay, which renders one row per shortcut sorted by description. Two shortcuts that do the same thing under different keys therefore need distinct wording, or they read as the action listed twice; suffix the alias `(alt)` (`'Open card'` / `'Open card (alt)'`).
 - **`allowInInputs`** — defaults to `false`. Set `true` for shortcuts that should fire while an input is focused (`⌘+Enter` to send, `Escape` to close).
 - **`when`** — optional guard, e.g. `when: () => !selection.isEmpty`.
 
@@ -139,7 +161,9 @@ const manifest = {
 }
 ```
 
-`scripts/generate-packages.ts` fails fast if two manifests claim the same letter. At runtime, `components/CoreShortcuts.tsx` iterates `packageRegistry` and registers `t <letter>` jumps for every package that declares one.
+`validateNavShortcuts` (`scripts/describe-packages.ts`, run from `scripts/generate.ts`) fails generation if two manifests claim the same letter — otherwise both register and `t <letter>` fires whichever the matcher reaches first, leaving one package unreachable. At runtime, `components/CoreShortcuts.tsx` iterates `packageRegistry` and registers `t <letter>` jumps for every package that declares one.
+
+Letters in use: `c` calendar, `d` drive, `k` cards, `m` mail, `o` contacts, `s` calc, `t` text.
 
 ## Testing
 

--- a/core/help/search.md
+++ b/core/help/search.md
@@ -1,0 +1,56 @@
+---
+title: Searching across packages
+summary: Find anything from anywhere with the / palette
+tags: [search, keyboard, packages]
+order: 20
+---
+
+Press `/` anywhere in the app to open the search palette. It opens already
+scoped to whatever package you're looking at, so searching the current
+package costs nothing extra. `/` typed inside a text field types a literal
+slash instead — the palette only opens when nothing else is capturing your
+keystrokes.
+
+## Searching everywhere
+
+Press ⌫ (backspace) with an empty search box to remove the scope chip and
+search every installed package at once. With no chip, results are one flat
+list ordered by match quality, with a small badge on each row showing which
+package it came from.
+
+## Scoping to a package
+
+Type a package name followed by a colon — `drive:` — to turn it into a chip
+that limits the search to that package. The name only becomes a chip once you
+type the colon, so you can still search for the word itself: typing `mail`
+with no colon finds anything containing the word "mail", chip or no chip.
+
+Add a second chip to search exactly those packages together:
+
+    drive: mail: budget
+
+That finds anything matching "budget" in Drive or Mail, grouped by package,
+and nothing else. With two or more chips the badge disappears from each
+row — you already know which package you're looking at from the group it's
+under.
+
+## Excluding words
+
+Put a minus sign in front of a word to exclude it:
+
+    budget -draft
+
+A hyphen inside a word is left alone, so a term like `q1-report` still
+searches for it as written.
+
+The palette does not support `AND`, `OR`, quotes, or parentheses — every word
+you type has to match, and excluded words never do. That's a deliberate
+limit, not a gap: plain words plus `:` for scope and `-` for exclusion cover
+what search-as-you-type needs.
+
+## Keys
+
+- `↑` `↓` — move through results
+- `↵` — open the selected result
+- `⌫` — remove the last scope chip (only when the box is otherwise empty)
+- `esc` — close the palette without opening anything

--- a/core/lib/haptics.ts
+++ b/core/lib/haptics.ts
@@ -1,0 +1,29 @@
+import * as Haptics from 'expo-haptics'
+import { Platform } from 'react-native'
+
+const isTouchDevice = Platform.OS === 'ios' || Platform.OS === 'android'
+
+/**
+ * Haptics are garnish: a simulator, a device with no vibrator, or a platform
+ * quirk rejecting the call must never surface an error into the gesture
+ * callback that asked for a tick — swallow instead of reporting.
+ */
+function fire(perform: () => Promise<void>) {
+    if (!isTouchDevice) return
+    perform().catch(() => {})
+}
+
+/** Light physical tick for grabbing or lifting something (drag activation). */
+export function hapticImpactLight() {
+    fire(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light))
+}
+
+/** Selection change — crossing into a new container or slot mid-gesture. */
+export function hapticSelection() {
+    fire(() => Haptics.selectionAsync())
+}
+
+/** A completed operation the user should feel land (a successful drop). */
+export function hapticSuccess() {
+    fire(() => Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success))
+}

--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -77,6 +77,11 @@ export interface PackageEntry<S extends SchemaDeclaration, R> {
     settings?: PackageSettingsPanel[]
     systemSettings?: PackageSystemSettingsPanel[]
     sidebarContributions?: SidebarContribution[]
+    search?: {
+        endpoint: string
+        label?: string
+        load: () => Promise<unknown>
+    }
     seed?: (pb: PocketBase, ctx: SeedContext) => Promise<void>
 }
 
@@ -99,6 +104,7 @@ export function definePackageEntry<S extends SchemaDeclaration>() {
         settings?: PackageEntry<S, R>['settings']
         systemSettings?: PackageEntry<S, R>['systemSettings']
         sidebarContributions?: PackageEntry<S, R>['sidebarContributions']
+        search?: PackageEntry<S, R>['search']
         seed?: PackageEntry<S, R>['seed']
     }): PackageEntry<S, R> => entry as unknown as PackageEntry<S, R>
 }

--- a/core/lib/packages/types.ts
+++ b/core/lib/packages/types.ts
@@ -228,6 +228,19 @@ export interface PackageManifest {
         directory: string
     }
 
+    /**
+     * How this package participates in the global `/` search palette.
+     * `endpoint` is its search route; `adapter` is a package-exports subpath
+     * to a module exporting `toRow` and `useSearchActions`. Omit to stay out
+     * of the palette.
+     */
+    search?: {
+        endpoint: string
+        adapter: string
+        /** Chip and group label. Defaults to `nav.label`. */
+        label?: string
+    }
+
     repository?: {
         url: string
         issueTemplate?: string

--- a/core/lib/search/build-sections.ts
+++ b/core/lib/search/build-sections.ts
@@ -44,7 +44,8 @@ export function buildSections(
     if (all.length === 0) return []
 
     // One chip means one package, whose backend already ranked its own rows —
-    // re-sorting would discard that judgement for no gain.
+    // re-sorting would discard that judgement for no gain. (rowsBySlug is populated
+    // only for scoped packages by the caller, so `all` contains only the chip's rows.)
     if (chips.length === 1) {
         return [{ showBadges: false, rows: all }]
     }

--- a/core/lib/search/build-sections.ts
+++ b/core/lib/search/build-sections.ts
@@ -1,0 +1,54 @@
+import { compareRows } from './score'
+import type { SearchPackage, SearchRow } from './types'
+
+export interface SearchSection {
+    /** Group heading; undefined for a flat list. */
+    title?: string
+    /** Lucide icon name for the heading. */
+    icon?: string
+    /** Whether rows show a per-row package badge (flat multi-package only). */
+    showBadges: boolean
+    rows: SearchRow[]
+}
+
+/**
+ * Arrange per-package results for rendering.
+ *
+ * Unscoped search is FLAT and score-ordered: it is the "I don't know where it
+ * is" case, so the best answer has to be able to reach the top. Grouping would
+ * pin a perfect match below every row of an earlier package. With 2+ explicit
+ * chips the user has already narrowed the field, and scan-by-package is the
+ * more useful affordance.
+ */
+export function buildSections(
+    rowsBySlug: Record<string, SearchRow[]>,
+    packages: SearchPackage[],
+    chips: string[],
+    includeTerms: string[]
+): SearchSection[] {
+    const orderBySlug: Record<string, number> = {}
+    for (const pkg of packages) orderBySlug[pkg.slug] = pkg.order
+
+    if (chips.length >= 2) {
+        const sections: SearchSection[] = []
+        for (const pkg of [...packages].sort((a, b) => a.order - b.order)) {
+            if (!chips.includes(pkg.slug)) continue
+            const rows = rowsBySlug[pkg.slug] ?? []
+            if (rows.length === 0) continue
+            sections.push({ title: pkg.label, icon: pkg.icon, showBadges: false, rows })
+        }
+        return sections
+    }
+
+    const all = Object.values(rowsBySlug).flat()
+    if (all.length === 0) return []
+
+    // One chip means one package, whose backend already ranked its own rows —
+    // re-sorting would discard that judgement for no gain.
+    if (chips.length === 1) {
+        return [{ showBadges: false, rows: all }]
+    }
+
+    const sorted = [...all].sort((a, b) => compareRows(a, b, includeTerms, orderBySlug))
+    return [{ showBadges: true, rows: sorted }]
+}

--- a/core/lib/search/chip-text.ts
+++ b/core/lib/search/chip-text.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure string operations on the palette's chip-prefixed text.
+ *
+ * Split out from SearchPalette.web.tsx (rather than left as local helpers) so
+ * they can be unit tested without pulling in that module's React Native /
+ * lucide-icon dependency chain.
+ */
+
+/** Render a chip list back into the `slug: slug: ` prefix form. */
+export function chipsToText(chips: string[]): string {
+    return chips.map(c => `${c}: `).join('')
+}
+
+/** The free-text remainder after every leading chip. */
+export function textAfterChips(text: string, chips: string[]): string {
+    return text.slice(chipsToText(chips).length)
+}

--- a/core/lib/search/chip-text.ts
+++ b/core/lib/search/chip-text.ts
@@ -1,17 +1,41 @@
 /**
- * Pure string operations on the palette's chip-prefixed text.
+ * Pure helpers pulled out of SearchPalette.web.tsx so they can be unit tested
+ * without pulling in that module's React Native / lucide-icon dependency
+ * chain.
  *
- * Split out from SearchPalette.web.tsx (rather than left as local helpers) so
- * they can be unit tested without pulling in that module's React Native /
- * lucide-icon dependency chain.
+ * There is deliberately no "text after chips" helper here: that used to be
+ * computed by slicing on `chipsToText(chips).length`, which assumes chips are
+ * always a leading prefix of the raw text. `parseQuery` recognizes `pkg:`
+ * anywhere in the string, so a chip created after free text broke that
+ * assumption and silently corrupted typed words. `parseQuery` now returns the
+ * exact remainder itself (`ParsedQuery.remainder`) from the same pass that
+ * finds the chips, so there is only one source of truth.
  */
+
+import type { SearchRow } from './types'
 
 /** Render a chip list back into the `slug: slug: ` prefix form. */
 export function chipsToText(chips: string[]): string {
     return chips.map(c => `${c}: `).join('')
 }
 
-/** The free-text remainder after every leading chip. */
-export function textAfterChips(text: string, chips: string[]): string {
-    return text.slice(chipsToText(chips).length)
+/**
+ * Look up `row.slug`'s registered selection handler and run it.
+ *
+ * Returns whether a handler actually ran, so the caller (SearchPalette's
+ * selectRow) can close the palette ONLY on a real selection. Rows and
+ * handlers resolve through separate useQuery instances — row-building in
+ * useSearchResults, handler-registration in PackageActions — so a row can
+ * render before, or despite, its package's adapter module failing to load.
+ * Closing unconditionally made that a silent dismiss: Enter did nothing
+ * visible, indistinguishable from a working selection.
+ */
+export function runHandlerFor(
+    row: SearchRow,
+    handlers: Record<string, (row: SearchRow) => void>
+): boolean {
+    const handler = handlers[row.slug]
+    if (!handler) return false
+    handler(row)
+    return true
 }

--- a/core/lib/search/parse-query.ts
+++ b/core/lib/search/parse-query.ts
@@ -1,17 +1,44 @@
 import type { ParsedQuery } from './types'
 
-// Bare boolean operators and grouping/quoting characters. Stripped rather than
-// supported: every backend already strips them (core/fts sanitize.go), and
-// passing incomplete expressions like `foo AND ` through to FTS5 turns a
-// half-typed query into a parse error under search-as-you-type.
-// Operator words must be bounded by whitespace or string edges, not word
-// boundaries — \b would treat hyphens as boundaries and split hyphenated
-// literals like "plan-NOT-final.docx" when the operator is stripped.
-const OPERATOR_WORDS = /(^|\s)(AND|OR|NOT)(?=\s|$)/g
+// Grouping/quoting characters, stripped per-token rather than supported:
+// every backend already strips them (core/fts sanitize.go), and passing
+// incomplete expressions like `foo AND ` through to FTS5 turns a half-typed
+// query into a parse error under search-as-you-type. A straight character
+// class is position-independent, so applying it per-token (below) is
+// equivalent to applying it to the whole string.
 const OPERATOR_CHARS = /[&|!"'()]/g
 
+// Bare boolean operator words are dropped only when a token is EXACTLY one of
+// these — never a substring of a larger token — so hyphenated literals like
+// "plan-NOT-final.docx" (a single whitespace-delimited token) keep NOT
+// embedded and literal instead of having it stripped out.
+const OPERATOR_WORD = /^(AND|OR|NOT)$/
+
 /**
- * Parse palette input into scope chips and include/exclude terms.
+ * Parse palette input into scope chips, include/exclude terms, and the exact
+ * free-text remainder the renderer should display in the input box.
+ *
+ * Chips are recognized ONLY from a leading, contiguous run of `pkg:` tokens
+ * at the very start of the input — never from a `pkg:` token that appears
+ * after other text. This mirrors the UI: chips render as their own pinned
+ * row BEFORE the text field (see SearchField in SearchPalette.web.tsx), so
+ * structurally a chip can only ever be a prefix. A `pkg:`-shaped token typed
+ * after free text is therefore parsed as ordinary literal text, exactly like
+ * a non-matching word — never silently promoted to a chip, and never
+ * dropped from the query either.
+ *
+ * `remainder` is a substring of `input` itself — the raw text starting right
+ * after the leading chip run — never re-derived by the caller. That used to
+ * be the renderer's job (`textAfterChips`, computing
+ * `chipsToText(chips).length` and slicing), which assumed chips were always
+ * a leading prefix of the raw text. They usually are, but the RENDERED box
+ * always showed `chipsToText(chips) + remainder`, a reconstruction rather
+ * than the actual text — so the instant a later keystroke round-tripped that
+ * reconstruction back into the store (`onChangeRemainder`), any free text
+ * that preceded a chip-forming token was silently discarded. Recognizing
+ * chips only as a leading run — and returning the remainder from the same
+ * pass — makes `chipsToText(chips) + remainder` byte-identical to `input`
+ * whenever no chip is a case/duplicate rewrite, and never lossy.
  *
  * A word becomes a chip only when the user types `:` after it AND it names an
  * installed package — so "mail" alone stays searchable text and the email
@@ -22,37 +49,61 @@ export function parseQuery(input: string, installedSlugs: string[]): ParsedQuery
     const chips: string[] = []
     const include: string[] = []
     const exclude: string[] = []
+    // Everything after this offset in `input` (raw, unmodified) is the
+    // remainder — advanced only while still inside the leading chip run.
+    let remainderStart = 0
+    let scanningChips = true
 
-    const cleaned = input.replace(OPERATOR_WORDS, '$1').replace(OPERATOR_CHARS, ' ')
+    // Iterate raw whitespace-delimited tokens WITH their position in `input`
+    // (matchAll on \S+ rather than split, so we know exactly where each token
+    // ends and can advance remainderStart to that point for chip tokens).
+    for (const match of input.matchAll(/\S+/g)) {
+        const rawToken = match[0]
+        const tokenEnd = (match.index ?? 0) + rawToken.length
+        const cleanedToken = rawToken.replace(OPERATOR_CHARS, ' ').trim()
+        if (!cleanedToken) continue
 
-    for (const rawToken of cleaned.split(/\s+/)) {
-        const token = rawToken.trim()
-        if (!token) continue
-
-        if (token.endsWith(':')) {
-            const candidate = token.slice(0, -1).toLowerCase()
-            if (slugSet.has(candidate)) {
+        if (scanningChips) {
+            const candidate = cleanedToken.endsWith(':')
+                ? cleanedToken.slice(0, -1).toLowerCase()
+                : null
+            if (candidate && slugSet.has(candidate)) {
                 if (!chips.includes(candidate)) chips.push(candidate)
+                // Consume exactly one following space too, mirroring
+                // chipsToText's `${slug}: ` — keeps the common case (chips
+                // first, as the seeded-open and backspace-pop flows always
+                // produce) byte-identical on the round trip.
+                remainderStart = input[tokenEnd] === ' ' ? tokenEnd + 1 : tokenEnd
                 continue
             }
-            // Not a package name — keep it as text, minus the trailing colon.
-            const literal = token.slice(0, -1)
+            // First token that isn't a chip ends the leading run for good —
+            // every later `pkg:`-shaped token is parsed as literal text below.
+            scanningChips = false
+        }
+
+        if (OPERATOR_WORD.test(cleanedToken)) continue
+
+        if (cleanedToken.endsWith(':')) {
+            // Either not a package name, or a package name typed after the
+            // leading chip run has already ended — either way, keep it as
+            // text, minus the trailing colon.
+            const literal = cleanedToken.slice(0, -1)
             if (literal) include.push(literal)
             continue
         }
 
         // A leading hyphen negates only when a term follows it. Because we
-        // split on whitespace first, any hyphen still inside a token is
-        // mid-token by construction (budget-2026) and stays literal. Strip
-        // all leading hyphens (--draft becomes draft).
-        if (token.startsWith('-')) {
-            const term = token.replace(/^-+/, '')
+        // matched on \S+, any hyphen still inside a token is mid-token by
+        // construction (budget-2026) and stays literal. Strip all leading
+        // hyphens (--draft becomes draft).
+        if (cleanedToken.startsWith('-')) {
+            const term = cleanedToken.replace(/^-+/, '')
             if (term) exclude.push(term)
             continue
         }
 
-        include.push(token)
+        include.push(cleanedToken)
     }
 
-    return { chips, include, exclude }
+    return { chips, include, exclude, remainder: input.slice(remainderStart) }
 }

--- a/core/lib/search/parse-query.ts
+++ b/core/lib/search/parse-query.ts
@@ -1,0 +1,54 @@
+import type { ParsedQuery } from './types'
+
+// Bare boolean operators and grouping/quoting characters. Stripped rather than
+// supported: every backend already strips them (core/fts sanitize.go), and
+// passing incomplete expressions like `foo AND ` through to FTS5 turns a
+// half-typed query into a parse error under search-as-you-type.
+const OPERATOR_WORDS = /\b(AND|OR|NOT)\b/g
+const OPERATOR_CHARS = /[&|!"'()]/g
+
+/**
+ * Parse palette input into scope chips and include/exclude terms.
+ *
+ * A word becomes a chip only when the user types `:` after it AND it names an
+ * installed package — so "mail" alone stays searchable text and the email
+ * titled "mail server migration" remains findable.
+ */
+export function parseQuery(input: string, installedSlugs: string[]): ParsedQuery {
+    const slugSet = new Set(installedSlugs.map(s => s.toLowerCase()))
+    const chips: string[] = []
+    const include: string[] = []
+    const exclude: string[] = []
+
+    const cleaned = input.replace(OPERATOR_WORDS, ' ').replace(OPERATOR_CHARS, ' ')
+
+    for (const rawToken of cleaned.split(/\s+/)) {
+        const token = rawToken.trim()
+        if (!token) continue
+
+        if (token.endsWith(':')) {
+            const candidate = token.slice(0, -1).toLowerCase()
+            if (slugSet.has(candidate)) {
+                if (!chips.includes(candidate)) chips.push(candidate)
+                continue
+            }
+            // Not a package name — keep it as text, minus the trailing colon.
+            const literal = token.slice(0, -1)
+            if (literal) include.push(literal)
+            continue
+        }
+
+        // A leading hyphen negates only when a term follows it. Because we
+        // split on whitespace first, any hyphen still inside a token is
+        // mid-token by construction (budget-2026) and stays literal.
+        if (token.startsWith('-')) {
+            const term = token.slice(1)
+            if (term) exclude.push(term)
+            continue
+        }
+
+        include.push(token)
+    }
+
+    return { chips, include, exclude }
+}

--- a/core/lib/search/parse-query.ts
+++ b/core/lib/search/parse-query.ts
@@ -4,7 +4,10 @@ import type { ParsedQuery } from './types'
 // supported: every backend already strips them (core/fts sanitize.go), and
 // passing incomplete expressions like `foo AND ` through to FTS5 turns a
 // half-typed query into a parse error under search-as-you-type.
-const OPERATOR_WORDS = /\b(AND|OR|NOT)\b/g
+// Operator words must be bounded by whitespace or string edges, not word
+// boundaries — \b would treat hyphens as boundaries and split hyphenated
+// literals like "plan-NOT-final.docx" when the operator is stripped.
+const OPERATOR_WORDS = /(^|\s)(AND|OR|NOT)(?=\s|$)/g
 const OPERATOR_CHARS = /[&|!"'()]/g
 
 /**
@@ -20,7 +23,7 @@ export function parseQuery(input: string, installedSlugs: string[]): ParsedQuery
     const include: string[] = []
     const exclude: string[] = []
 
-    const cleaned = input.replace(OPERATOR_WORDS, ' ').replace(OPERATOR_CHARS, ' ')
+    const cleaned = input.replace(OPERATOR_WORDS, '$1').replace(OPERATOR_CHARS, ' ')
 
     for (const rawToken of cleaned.split(/\s+/)) {
         const token = rawToken.trim()
@@ -40,9 +43,10 @@ export function parseQuery(input: string, installedSlugs: string[]): ParsedQuery
 
         // A leading hyphen negates only when a term follows it. Because we
         // split on whitespace first, any hyphen still inside a token is
-        // mid-token by construction (budget-2026) and stays literal.
+        // mid-token by construction (budget-2026) and stays literal. Strip
+        // all leading hyphens (--draft becomes draft).
         if (token.startsWith('-')) {
-            const term = token.slice(1)
+            const term = token.replace(/^-+/, '')
             if (term) exclude.push(term)
             continue
         }

--- a/core/lib/search/registry.ts
+++ b/core/lib/search/registry.ts
@@ -1,0 +1,44 @@
+import { tinycldConfig } from '@tinycld/app-generated/tinycld-config'
+import type { SearchAdapterModule, SearchPackage } from './types'
+
+type SearchEntryLike = {
+    manifest: { slug: string; nav?: { label?: string; icon?: string; order?: number } }
+    search?: { endpoint: string; label?: string; load: () => Promise<unknown> }
+}
+
+/** Packages that declare `search`, ordered by nav.order. */
+export function deriveSearchPackages(entries: readonly SearchEntryLike[]): SearchPackage[] {
+    const out: SearchPackage[] = []
+    for (const e of entries) {
+        if (!e.search) continue
+        out.push({
+            slug: e.manifest.slug,
+            label: e.search.label ?? e.manifest.nav?.label ?? e.manifest.slug,
+            icon: e.manifest.nav?.icon ?? 'search',
+            order: e.manifest.nav?.order ?? 0,
+            endpoint: e.search.endpoint,
+        })
+    }
+    return out.sort((a, b) => a.order - b.order)
+}
+
+export const searchPackages = deriveSearchPackages(tinycldConfig as readonly SearchEntryLike[])
+
+const loaders = new Map<string, () => Promise<unknown>>()
+for (const e of tinycldConfig as readonly SearchEntryLike[]) {
+    if (e.search) loaders.set(e.manifest.slug, e.search.load)
+}
+
+// Adapter modules are cached after first load so opening the palette in an
+// eight-package workspace does not re-import on every keystroke.
+const cache = new Map<string, SearchAdapterModule>()
+
+export async function loadSearchAdapter(slug: string): Promise<SearchAdapterModule | null> {
+    const cached = cache.get(slug)
+    if (cached) return cached
+    const load = loaders.get(slug)
+    if (!load) return null
+    const mod = (await load()) as SearchAdapterModule
+    cache.set(slug, mod)
+    return mod
+}

--- a/core/lib/search/score.ts
+++ b/core/lib/search/score.ts
@@ -1,0 +1,74 @@
+import type { SearchRow } from './types'
+
+const TIER_EXACT_TITLE = 1000
+const TIER_TITLE_PREFIX = 800
+const TIER_ALL_TERMS_IN_TITLE = 600
+const TIER_TITLE_SUBSTRING = 400
+const TIER_SECONDARY_MATCH = 200
+const TIER_NO_VISIBLE_MATCH = 100
+
+/**
+ * Fold case and punctuation so 'Budget 2026' and 'budget-2026' compare equal.
+ * Punctuation becomes a space rather than being deleted, so 'budget-2026' and
+ * 'budget 2026' normalize identically instead of collapsing to 'budget2026'.
+ */
+function normalize(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim()
+}
+
+/**
+ * Score how well a row matches the query, using only text the row displays.
+ *
+ * Deliberately NOT BM25: FTS5 ranks weight terms by frequency within their own
+ * table's corpus, so scores from two packages are in different units and a
+ * perfect filename match can sort below a marginal mail hit. Match quality
+ * against visible text is unit-free and identical for every package.
+ */
+export function scoreRow(includeTerms: string[], row: SearchRow): number {
+    const terms = includeTerms.map(normalize).filter(Boolean)
+    if (terms.length === 0) return TIER_NO_VISIBLE_MATCH
+
+    const title = normalize(row.title)
+    const query = terms.join(' ')
+
+    if (title === query) return TIER_EXACT_TITLE
+    if (title.startsWith(query)) return TIER_TITLE_PREFIX
+
+    const titleWords = title.split(' ')
+    const everyTermPrefixesAWord = terms.every(term =>
+        titleWords.some(word => word.startsWith(term))
+    )
+    if (everyTermPrefixesAWord) return TIER_ALL_TERMS_IN_TITLE
+
+    if (title.includes(query)) return TIER_TITLE_SUBSTRING
+
+    const secondary = normalize([row.subtitle, row.meta].filter(Boolean).join(' '))
+    if (secondary && terms.some(term => secondary.includes(term))) return TIER_SECONDARY_MATCH
+
+    // The backend matched something we cannot see — a mail body or drive file
+    // content. Keep it, but below anything with a visible match.
+    return TIER_NO_VISIBLE_MATCH
+}
+
+/**
+ * Sort comparator for a flat cross-package list. Tie-breaks, in order:
+ * shorter title (a tighter match), then the package's nav.order so the
+ * ordering is stable while results stream in from several packages.
+ */
+export function compareRows(
+    a: SearchRow,
+    b: SearchRow,
+    includeTerms: string[],
+    orderBySlug: Record<string, number>
+): number {
+    const scoreDelta = scoreRow(includeTerms, b) - scoreRow(includeTerms, a)
+    if (scoreDelta !== 0) return scoreDelta
+
+    const lengthDelta = a.title.length - b.title.length
+    if (lengthDelta !== 0) return lengthDelta
+
+    return (orderBySlug[a.slug] ?? 0) - (orderBySlug[b.slug] ?? 0)
+}

--- a/core/lib/search/search-palette-store.ts
+++ b/core/lib/search/search-palette-store.ts
@@ -22,7 +22,8 @@ export const useSearchPaletteStore = create<SearchPaletteState>()(set => ({
     isOpen: false,
     text: '',
     selectedRowId: null,
-    open: seedSlug => set({ isOpen: true, text: seedSlug ? `${seedSlug}: ` : '', selectedRowId: null }),
+    open: seedSlug =>
+        set({ isOpen: true, text: seedSlug ? `${seedSlug}: ` : '', selectedRowId: null }),
     close: () => set({ isOpen: false, text: '', selectedRowId: null }),
     // A new query invalidates the old selection — the row may no longer exist.
     setText: value => set({ text: value, selectedRowId: null }),

--- a/core/lib/search/search-palette-store.ts
+++ b/core/lib/search/search-palette-store.ts
@@ -1,0 +1,30 @@
+import { create } from '@tinycld/core/lib/store'
+
+interface SearchPaletteState {
+    isOpen: boolean
+    text: string
+    /**
+     * The selected row's id rather than its index: the flat list re-sorts as
+     * slower packages resolve, and an index would leave the cursor pointing at
+     * whatever row happened to land in that slot.
+     */
+    selectedRowId: string | null
+    /** Open, seeding the active package as a chip so the common case is free. */
+    open: (seedSlug: string | null) => void
+    close: () => void
+    setText: (value: string) => void
+    setSelectedRowId: (id: string | null) => void
+}
+
+// Not persisted: a restored palette would open a dialog the user did not ask
+// for, and a restored query would run against data that has since changed.
+export const useSearchPaletteStore = create<SearchPaletteState>()(set => ({
+    isOpen: false,
+    text: '',
+    selectedRowId: null,
+    open: seedSlug => set({ isOpen: true, text: seedSlug ? `${seedSlug}: ` : '', selectedRowId: null }),
+    close: () => set({ isOpen: false, text: '', selectedRowId: null }),
+    // A new query invalidates the old selection — the row may no longer exist.
+    setText: value => set({ text: value, selectedRowId: null }),
+    setSelectedRowId: id => set({ selectedRowId: id }),
+}))

--- a/core/lib/search/types.ts
+++ b/core/lib/search/types.ts
@@ -1,0 +1,57 @@
+/** One rendered row in the palette. Every adapter maps its hits to this. */
+export interface SearchRow {
+    /** The package slug this row came from. Set by the palette, not the adapter. */
+    slug: string
+    /** Record id, unique within the package. */
+    id: string
+    /** The name a user would recognize — file name, subject, card title. */
+    title: string
+    /** Identifying detail, e.g. 'Grace Hopper · Inbox · 1d'. */
+    subtitle?: string
+    /** Right-aligned trailing detail, e.g. a board name. */
+    meta?: string
+}
+
+/**
+ * What an adapter module exports. Two halves because rendering is pure but
+ * selection needs router and store handles.
+ */
+export interface SearchAdapterModule {
+    /**
+     * Pure: one raw hit from this package's endpoint → one row, or null to
+     * skip the hit (e.g. its parent record has not synced yet).
+     *
+     * Takes `unknown` because the palette holds a heterogeneous map of
+     * adapters and cannot thread per-package types through it. Each adapter
+     * casts to its own response type on its first line.
+     */
+    toRow: (hit: unknown) => Omit<SearchRow, 'slug'> | null
+    /**
+     * Returns this package's selection handler.
+     *
+     * MUST be side-effect free: the palette calls every in-scope package's
+     * hook at the top level (hooks cannot be called conditionally at selection
+     * time), so this runs even for packages with no visible results. Wire up
+     * router/store handles here — never fetch, subscribe or mutate.
+     */
+    useSearchActions: () => { onSelect: (row: SearchRow) => void }
+}
+
+/** The result of parsing the palette input. */
+export interface ParsedQuery {
+    /** Package slugs to search. Empty = every package declaring `search`. */
+    chips: string[]
+    /** Terms that must match. */
+    include: string[]
+    /** Terms that must NOT match. */
+    exclude: string[]
+}
+
+/** A package the palette can search, derived from the manifest registry. */
+export interface SearchPackage {
+    slug: string
+    label: string
+    icon: string
+    order: number
+    endpoint: string
+}

--- a/core/lib/search/types.ts
+++ b/core/lib/search/types.ts
@@ -45,6 +45,15 @@ export interface ParsedQuery {
     include: string[]
     /** Terms that must NOT match. */
     exclude: string[]
+    /**
+     * The exact free-text remainder to display in the input box: a substring
+     * of the raw input starting right after the last recognized chip token.
+     * The renderer must use this rather than re-deriving it (e.g. by slicing
+     * on `chipsToText(chips).length`) — that computed-length approach assumes
+     * chips are a leading prefix, which breaks the moment a chip is created
+     * after free text already typed.
+     */
+    remainder: string
 }
 
 /** A package the palette can search, derived from the manifest registry. */

--- a/core/lib/search/use-active-package-slug.ts
+++ b/core/lib/search/use-active-package-slug.ts
@@ -1,0 +1,19 @@
+import { usePathname } from 'expo-router'
+import { searchPackages } from './registry'
+
+/**
+ * The slug of the package the user is currently viewing, or null outside one.
+ *
+ * Derived from the path rather than stored, because the route IS the source of
+ * truth — a separate store would drift on back/forward navigation. Only
+ * packages that declare `search` can be seeded, so a match here is always a
+ * valid chip.
+ */
+export function useActivePackageSlug(): string | null {
+    const pathname = usePathname()
+    const segments = pathname.split('/').filter(Boolean)
+    for (const segment of segments) {
+        if (searchPackages.some(p => p.slug === segment)) return segment
+    }
+    return null
+}

--- a/core/lib/shortcuts/help.tsx
+++ b/core/lib/shortcuts/help.tsx
@@ -3,6 +3,7 @@ import { Kbd } from '@tinycld/core/ui/Kbd'
 import { Modal, ModalBackdrop, ModalContent } from '@tinycld/core/ui/modal'
 import { useMemo } from 'react'
 import { ScrollView, Text, View } from 'react-native'
+import { isScopeActive } from './matcher'
 import { useShortcutRegistry } from './registry'
 import type { Shortcut } from './types'
 
@@ -30,6 +31,13 @@ function groupShortcuts(map: Map<string, Shortcut>): Record<string, Shortcut[]> 
         // The "Help" group documents how to open/close this very overlay, so
         // showing it inside the overlay is redundant.
         if (s.group === 'Help') continue
+        // Only what can actually fire right now. The registry holds every
+        // MOUNTED screen's shortcuts, which is more than the live set two ways:
+        // an inner scope shadows the screen underneath (a board's keys cannot
+        // fire while a card is open), and `freezeOnBlur` keeps a departed
+        // package's screens registered. Listing those advertises keys that do
+        // nothing, and duplicates every entry the two screens have in common.
+        if (!isScopeActive(s)) continue
         const key = s.group ?? 'General'
         if (!groups[key]) groups[key] = []
         groups[key].push(s)

--- a/core/lib/shortcuts/matcher.ts
+++ b/core/lib/shortcuts/matcher.ts
@@ -1,5 +1,5 @@
 import { getShortcuts } from './registry'
-import { topScope } from './scopes'
+import { topScope, topScopeId } from './scopes'
 import type { Shortcut } from './types'
 
 const SEQUENCE_TIMEOUT_MS = 1000
@@ -28,9 +28,25 @@ export interface MatcherContext {
     inInput: boolean
 }
 
+/**
+ * Is this shortcut's scope the one currently holding the keyboard? Exported so
+ * the help overlay lists exactly what can fire, rather than restating this and
+ * drifting from it.
+ */
+export function isScopeActive(shortcut: Shortcut): boolean {
+    if (shortcut.scope === 'global') return true
+    if (shortcut.scope !== topScope()) return false
+    // A screen frozen by `freezeOnBlur` stays mounted and keeps its shortcuts
+    // registered, so the live screen is not the only owner of its scope's keys
+    // — mail's list and a cards board both register 'list' j/k/x. Only the
+    // instance holding the keyboard may fire. Shortcuts registered before this
+    // stamp existed (scopeId undefined) keep the old scope-only behavior.
+    if (shortcut.scopeId != null && shortcut.scopeId !== topScopeId()) return false
+    return true
+}
+
 function matches(shortcut: Shortcut, ctx: MatcherContext): boolean {
-    const top = topScope()
-    if (shortcut.scope !== 'global' && shortcut.scope !== top) return false
+    if (!isScopeActive(shortcut)) return false
     if (ctx.inInput && !shortcut.allowInInputs) return false
     if (shortcut.when && !shortcut.when()) return false
     return true

--- a/core/lib/shortcuts/scopes.ts
+++ b/core/lib/shortcuts/scopes.ts
@@ -1,4 +1,5 @@
-import { useEffect } from 'react'
+import { useFocusEffect } from 'expo-router'
+import { useCallback, useRef } from 'react'
 import type { Scope } from './types'
 
 const stack: { id: number; scope: Scope }[] = []
@@ -19,6 +20,27 @@ export function topScope(): Scope | null {
     return stack.length > 0 ? stack[stack.length - 1].scope : null
 }
 
+/**
+ * The id of the scope entry currently on top — which screen owns the keyboard
+ * right now, as opposed to merely which KIND of screen it is.
+ *
+ * The distinction matters because `freezeOnBlur` leaves a departed screen
+ * mounted: mail's list and a cards board can both hold registered 'list'
+ * shortcuts at the same time, and several of them collide (j, k, x). Scope
+ * alone cannot separate them; the owning instance can.
+ */
+export function topScopeId(): number | null {
+    return stack.length > 0 ? stack[stack.length - 1].id : null
+}
+
+/** The id a scope-bound shortcut registered under, for `Shortcut.scopeId`. */
+export function currentScopeId(scope: Scope): number | null {
+    for (let i = stack.length - 1; i >= 0; i -= 1) {
+        if (stack[i].scope === scope) return stack[i].id
+    }
+    return null
+}
+
 /** Reset all scope state — for use in tests only. */
 export function resetScopes() {
     stack.length = 0
@@ -26,13 +48,27 @@ export function resetScopes() {
 }
 
 /**
- * Push a scope onto the stack for the lifetime of the mounted component.
- * The matcher fires a shortcut only when its scope === 'global' or matches
- * the top of the stack.
+ * Push a scope onto the stack while the owning route is focused. The matcher
+ * fires a shortcut only when its scope === 'global' or matches the top of the
+ * stack.
+ *
+ * Keyed on FOCUS, not mount: the package tabs render with `freezeOnBlur`, which
+ * leaves a blurred screen mounted. A mount-keyed push therefore never popped
+ * when the user switched packages — the departed screen's scope stayed on top,
+ * and every shortcut belonging to the package they switched BACK to silently
+ * stopped matching (resuming a frozen screen remounts nothing, so it pushed
+ * nothing). useFocusEffect's cleanup runs on blur, including the blur that
+ * precedes a freeze, and re-runs on refocus.
  */
 export function useShortcutScope(scope: Scope) {
-    useEffect(() => {
-        const id = pushScope(scope)
-        return () => popScope(id)
-    }, [scope])
+    const idRef = useRef<number | null>(null)
+    useFocusEffect(
+        useCallback(() => {
+            idRef.current = pushScope(scope)
+            return () => {
+                if (idRef.current !== null) popScope(idRef.current)
+                idRef.current = null
+            }
+        }, [scope])
+    )
 }

--- a/core/lib/shortcuts/types.ts
+++ b/core/lib/shortcuts/types.ts
@@ -13,4 +13,14 @@ export interface Shortcut {
     allowInInputs?: boolean
     when?: () => boolean
     run: (e: ShortcutEvent) => void
+    /**
+     * Which scope instance owns this shortcut. Stamped by `useRegisterShortcut`
+     * at registration; never set by hand.
+     *
+     * A frozen screen keeps its shortcuts registered, so two packages can hold
+     * the same key at the same scope (mail's list `j` and a cards board's `j`).
+     * The matcher uses this to fire the one belonging to the screen that
+     * actually has the keyboard.
+     */
+    scopeId?: number | null
 }

--- a/core/lib/shortcuts/use-register.ts
+++ b/core/lib/shortcuts/use-register.ts
@@ -1,6 +1,21 @@
 import { useEffect } from 'react'
 import { useShortcutRegistry } from './registry'
+import { currentScopeId } from './scopes'
 import type { Shortcut } from './types'
+
+/**
+ * Stamp the scope instance that owns this shortcut, so the matcher can tell a
+ * live screen's 'list' shortcuts from those of a frozen screen that still has
+ * the same keys registered. A 'global' shortcut belongs to no instance.
+ *
+ * Call `useShortcutScope(scope)` ABOVE the register hook in the same component:
+ * effects run in call order, so the scope must already be pushed for the
+ * shortcut to be stamped with it rather than with an outer screen's instance.
+ */
+function withScopeId(shortcut: Shortcut): Shortcut {
+    if (shortcut.scope === 'global') return shortcut
+    return { ...shortcut, scopeId: currentScopeId(shortcut.scope) }
+}
 
 /**
  * Register a shortcut for the lifetime of the component. Pass a stable
@@ -13,7 +28,7 @@ export function useRegisterShortcut(shortcut: Shortcut | null | false | undefine
 
     useEffect(() => {
         if (!shortcut) return
-        register(shortcut)
+        register(withScopeId(shortcut))
         return () => unregister(shortcut.id)
     }, [shortcut, register, unregister])
 }
@@ -27,7 +42,7 @@ export function useRegisterShortcuts(shortcuts: Shortcut[]) {
     const unregister = useShortcutRegistry(s => s.unregister)
 
     useEffect(() => {
-        for (const s of shortcuts) register(s)
+        for (const s of shortcuts) register(withScopeId(s))
         return () => {
             for (const s of shortcuts) unregister(s.id)
         }

--- a/core/lib/stores/workspace-store.ts
+++ b/core/lib/stores/workspace-store.ts
@@ -1,10 +1,24 @@
 import { asyncStorage, create, persist } from '@tinycld/core/lib/store'
 
+/**
+ * How long the drawer edge-swipe stays suppressed after a package drag ends.
+ * On a physical phone a fingertip pressed into the left edge of the glass can
+ * micro-lift as it reverses direction: iOS ends the touch and starts a new one
+ * a few ms later, and that new touch is born inside the edge strip — to the
+ * drawer it looks exactly like a deliberate edge swipe, so a card dragged to
+ * the left edge and back would fling the drawer open. The grace window
+ * swallows that re-touch; a real edge swipe moments later still works.
+ */
+const EDGE_SWIPE_RESUME_GRACE_MS = 400
+
+let edgeSwipeResumeTimer: ReturnType<typeof setTimeout> | null = null
+
 interface WorkspaceStoreState {
     isSidebarOpen: boolean
     isDrawerOpen: boolean
     isMoreOpen: boolean
     isNotificationsOpen: boolean
+    isEdgeSwipeSuspended: boolean
     activePkgSlug: string | null
     // Per-package "last visited href" map. Packages may persist the
     // last deep-link the user opened (e.g. a calc file path) so the
@@ -15,6 +29,13 @@ interface WorkspaceStoreState {
     setSidebarOpen: (open: boolean) => void
     toggleDrawer: () => void
     setDrawerOpen: (open: boolean) => void
+    /**
+     * Packages with their own drag interactions (board cards, grid tiles)
+     * call this with `true` at drag start and `false` at drag end so the
+     * mobile drawer's edge-swipe can't hijack a touch near the left edge
+     * mid-drag. Resuming is deferred by EDGE_SWIPE_RESUME_GRACE_MS.
+     */
+    setEdgeSwipeSuspended: (suspended: boolean) => void
     setMoreOpen: (open: boolean) => void
     setNotificationsOpen: (open: boolean) => void
     setActivePkgSlug: (slug: string | null) => void
@@ -29,6 +50,7 @@ export const useWorkspaceStore = create<WorkspaceStoreState>()(
             isDrawerOpen: false,
             isMoreOpen: false,
             isNotificationsOpen: false,
+            isEdgeSwipeSuspended: false,
             activePkgSlug: null,
             lastPackageHref: {},
 
@@ -36,6 +58,20 @@ export const useWorkspaceStore = create<WorkspaceStoreState>()(
             setSidebarOpen: open => set({ isSidebarOpen: open }),
             toggleDrawer: () => set(s => ({ isDrawerOpen: !s.isDrawerOpen })),
             setDrawerOpen: open => set({ isDrawerOpen: open }),
+            setEdgeSwipeSuspended: suspended => {
+                if (edgeSwipeResumeTimer) {
+                    clearTimeout(edgeSwipeResumeTimer)
+                    edgeSwipeResumeTimer = null
+                }
+                if (suspended) {
+                    set({ isEdgeSwipeSuspended: true })
+                    return
+                }
+                edgeSwipeResumeTimer = setTimeout(() => {
+                    edgeSwipeResumeTimer = null
+                    set({ isEdgeSwipeSuspended: false })
+                }, EDGE_SWIPE_RESUME_GRACE_MS)
+            },
             setMoreOpen: open => set({ isMoreOpen: open }),
             setNotificationsOpen: open => set({ isNotificationsOpen: open }),
             setActivePkgSlug: slug => set({ activePkgSlug: slug }),

--- a/core/lib/use-api-search.ts
+++ b/core/lib/use-api-search.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { pb } from '@tinycld/core/lib/pocketbase'
-import { useEffect, useState } from 'react'
+import { useDebouncedValue } from '@tinycld/core/lib/use-debounced-value'
 
 interface UseApiSearchOptions<TResult> {
     endpoint: string
@@ -20,17 +20,6 @@ interface UseApiSearchReturn<TResult> {
 
 function toErrorMessage(err: unknown): string {
     return err instanceof Error ? err.message : 'Search failed'
-}
-
-// Debounce a value: only surface the latest after `delayMs` of quiet. Genuine
-// timer side-effect (not a server-data sync), so it stays in an effect.
-function useDebouncedValue<T>(value: T, delayMs: number): T {
-    const [debounced, setDebounced] = useState(value)
-    useEffect(() => {
-        const timer = setTimeout(() => setDebounced(value), delayMs)
-        return () => clearTimeout(timer)
-    }, [value, delayMs])
-    return debounced
 }
 
 export function useApiSearch<TResult>(

--- a/core/lib/use-debounced-value.ts
+++ b/core/lib/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+
+// Debounce a value: only surface the latest after `delayMs` of quiet. Genuine
+// timer side-effect (not a server-data sync), so it stays in an effect.
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+    const [debounced, setDebounced] = useState(value)
+    useEffect(() => {
+        const timer = setTimeout(() => setDebounced(value), delayMs)
+        return () => clearTimeout(timer)
+    }, [value, delayMs])
+    return debounced
+}

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tinycld/core",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "license": "AGPL-3.0-only",
     "main": "./index.ts",
     "type": "module",

--- a/core/package.json
+++ b/core/package.json
@@ -75,6 +75,7 @@
         "expo-crypto": "^55.0.12",
         "expo-document-picker": "~55.0.11",
         "expo-file-system": "~55.0.19",
+        "expo-haptics": "~55.0.14",
         "expo-image": "~55.0.11",
         "expo-image-picker": "~55.0.20",
         "expo-router": "~55.0.14",

--- a/core/server/fts/config.go
+++ b/core/server/fts/config.go
@@ -16,7 +16,7 @@
 package fts
 
 // Config describes one feature collection's FTS index. One Config drives both
-// the index-sync hooks (Table + Columns) and the search route (Route + Owner +
+// the index-sync hooks (Table + Columns) and the search route (Scope +
 // Output). It is the single interface both the manifest reader and the direct
 // wiring use.
 type Config struct {
@@ -38,8 +38,17 @@ type Config struct {
 	// before indexing (editor fields).
 	Columns []Column
 
-	// Owner scopes search to the records owned by the requesting user.
-	Owner OwnerScope
+	// Scope constrains results to rows the caller may see.
+	Scope Scope
+
+	// ExcludeField, when set, drops rows whose BOOL field is true (e.g.
+	// cards' `archived`).
+	//
+	// Deliberately distinct from SoftDeleteField: that one splits on
+	// `field = ''` vs `!= ''`, which is correct for a TEXT timestamp but
+	// misbehaves against a bool column under SQLite's loose typing. Two
+	// mechanisms, two column types — do not conflate them.
+	ExcludeField string
 
 	// Output lists the collection columns the search route returns per hit,
 	// in addition to the record id. These are read straight from the joined
@@ -72,12 +81,52 @@ type Column struct {
 	Strip bool
 }
 
-// OwnerScope declares how a record's owner resolves to the requesting user, so
-// search results stay scoped to the caller's own records. Single-org: the owner
-// field holds a users id directly (the former user_org junction is gone), so
-// search is scoped to owner == the authenticated user's id.
+// Scope constrains search results to rows the requesting user may see. It is an
+// interface because ownership is not uniform: some collections hold the owner's
+// id directly, others grant access through a membership table.
+type Scope interface {
+	// clause returns a SQL fragment ANDed into the WHERE. Identifiers come
+	// from config (trusted); the user id is always a bound parameter.
+	clause() string
+	params(userID string) map[string]any
+}
+
+// OwnerScope resolves ownership through a single relation field holding the
+// user's id directly (single-org: the former user_org junction is gone).
 type OwnerScope struct {
-	// Field is the collection field holding the owner reference
-	// (e.g. "owner", a relation to users).
+	// Field is the collection field holding the owner reference.
 	Field string
+}
+
+func (s OwnerScope) clause() string {
+	return "c." + s.Field + " IN ({:scopeUser})"
+}
+
+func (s OwnerScope) params(userID string) map[string]any {
+	return map[string]any{"scopeUser": userID}
+}
+
+// MemberScope resolves access through a membership table: the record is visible
+// when the user holds a row granting them its parent. Emitted as a live
+// subquery rather than a cached grant, so removing a member takes effect on the
+// next search.
+type MemberScope struct {
+	// Table is the membership collection (e.g. "cards_project_members").
+	Table string
+	// MemberField is the column in Table pointing at the parent record.
+	MemberField string
+	// UserField is the column in Table pointing at the user.
+	UserField string
+	// RecordField is the column on the SEARCHED collection pointing at the
+	// same parent.
+	RecordField string
+}
+
+func (s MemberScope) clause() string {
+	return "c." + s.RecordField + " IN (SELECT " + s.MemberField +
+		" FROM " + s.Table + " WHERE " + s.UserField + " = {:scopeUser})"
+}
+
+func (s MemberScope) params(userID string) map[string]any {
+	return map[string]any{"scopeUser": userID}
 }

--- a/core/server/fts/register.go
+++ b/core/server/fts/register.go
@@ -45,6 +45,7 @@ func registerSearchRoute(app *pocketbase.PocketBase, e *core.ServeEvent, cfg Con
 			Limit:          clampInt(q.Get("limit"), 25, 1, 100),
 			Offset:         clampInt(q.Get("offset"), 0, 0, 1<<30),
 			IncludeDeleted: q.Get("deleted") == "true",
+			Exclude:        q.Get("not"),
 		}
 
 		empty := searchResponse{Items: []map[string]any{}, Total: 0}

--- a/core/server/fts/sanitize.go
+++ b/core/server/fts/sanitize.go
@@ -17,41 +17,38 @@ import (
 // in-between tokens.
 var fts5SpecialChars = regexp.MustCompile(`[":*^{}()\[\]~\-@.]`)
 
+// quoteTerms strips FTS5 operator characters and returns each remaining word
+// as a quoted prefix term. Shared by the include and exclude paths so their
+// escaping cannot drift apart — this is the trust boundary: everything past
+// this function is validated FTS5 syntax, so both callers must go through it.
+func quoteTerms(input string) []string {
+	cleaned := fts5SpecialChars.ReplaceAllString(input, " ")
+	terms := strings.Fields(cleaned)
+	quoted := make([]string, len(terms))
+	for i, term := range terms {
+		term = strings.ReplaceAll(term, `"`, `""`)
+		quoted[i] = `"` + term + `"*`
+	}
+	return quoted
+}
+
 // SanitizeQuery escapes special FTS5 characters and turns the input into
 // AND-ed prefix terms for safe search-as-you-type MATCH queries. Returns "" when
 // the input has no usable terms.
+//
+// Prefix matches (term*) let search-as-you-type find partial words like
+// "joh" -> "john", "johnson". FTS5's bare phrase syntax ("joh") is an exact
+// token match and would only fire when the user types a whole indexed word.
 func SanitizeQuery(input string) string {
-	input = strings.TrimSpace(input)
-	if input == "" {
-		return ""
-	}
-
-	cleaned := fts5SpecialChars.ReplaceAllString(input, " ")
-	terms := strings.Fields(cleaned)
-	if len(terms) == 0 {
-		return ""
-	}
-
-	// Use prefix matches (term*) so search-as-you-type finds partial words
-	// like "joh" -> "john", "johnson". FTS5's bare phrase syntax ("joh")
-	// is an exact token match and would only fire when the user types a
-	// whole indexed word. Each term is also quoted to keep any residual
-	// punctuation from being interpreted as FTS5 operators.
-	prefixed := make([]string, len(terms))
-	for i, term := range terms {
-		term = strings.ReplaceAll(term, `"`, `""`)
-		prefixed[i] = `"` + term + `"*`
-	}
-
-	return strings.Join(prefixed, " ")
+	return strings.Join(quoteTerms(input), " ")
 }
 
 // SanitizeQueryWithExclusions builds an FTS5 MATCH expression requiring every
 // include term and rejecting every exclude term.
 //
 // Both sides arrive as already-split plain terms from the client's parseQuery —
-// no operator syntax ever reaches this function, so the quoting below stays the
-// only trust boundary. An exclude-only query returns "" rather than a bare NOT,
+// no operator syntax ever reaches this function, so quoteTerms stays the only
+// trust boundary. An exclude-only query returns "" rather than a bare NOT,
 // which FTS5 rejects: there is no result set to subtract from.
 func SanitizeQueryWithExclusions(include, exclude string) string {
 	base := SanitizeQuery(include)
@@ -59,10 +56,8 @@ func SanitizeQueryWithExclusions(include, exclude string) string {
 		return ""
 	}
 
-	cleaned := fts5SpecialChars.ReplaceAllString(exclude, " ")
-	for _, term := range strings.Fields(cleaned) {
-		term = strings.ReplaceAll(term, `"`, `""`)
-		base += ` NOT "` + term + `"*`
+	for _, term := range quoteTerms(exclude) {
+		base += " NOT " + term
 	}
 	return base
 }

--- a/core/server/fts/sanitize.go
+++ b/core/server/fts/sanitize.go
@@ -46,6 +46,27 @@ func SanitizeQuery(input string) string {
 	return strings.Join(prefixed, " ")
 }
 
+// SanitizeQueryWithExclusions builds an FTS5 MATCH expression requiring every
+// include term and rejecting every exclude term.
+//
+// Both sides arrive as already-split plain terms from the client's parseQuery —
+// no operator syntax ever reaches this function, so the quoting below stays the
+// only trust boundary. An exclude-only query returns "" rather than a bare NOT,
+// which FTS5 rejects: there is no result set to subtract from.
+func SanitizeQueryWithExclusions(include, exclude string) string {
+	base := SanitizeQuery(include)
+	if base == "" {
+		return ""
+	}
+
+	cleaned := fts5SpecialChars.ReplaceAllString(exclude, " ")
+	for _, term := range strings.Fields(cleaned) {
+		term = strings.ReplaceAll(term, `"`, `""`)
+		base += ` NOT "` + term + `"*`
+	}
+	return base
+}
+
 // htmlTagRegex strips HTML tags for plain-text indexing of editor fields.
 var htmlTagRegex = regexp.MustCompile(`<[^>]*>`)
 

--- a/core/server/fts/sanitize_test.go
+++ b/core/server/fts/sanitize_test.go
@@ -198,3 +198,47 @@ func TestFTSNotesAreSearchableAfterStrip(t *testing.T) {
 
 	assertMatches(t, db, "kayaking", "carol")
 }
+
+func TestSanitizeQueryWithExclusions(t *testing.T) {
+	cases := []struct {
+		name             string
+		include, exclude string
+		want             string
+	}{
+		{"no exclusions", "budget", "", `"budget"*`},
+		{"one exclusion", "budget", "draft", `"budget"* NOT "draft"*`},
+		{"two exclusions", "budget", "draft old", `"budget"* NOT "draft"* NOT "old"*`},
+		{"exclude only yields nothing", "", "draft", ""},
+		{"blank both", "", "", ""},
+	}
+	for _, tc := range cases {
+		if got := SanitizeQueryWithExclusions(tc.include, tc.exclude); got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// An exclusion must actually remove the row, not merely fail to boost it.
+func TestExclusionRemovesMatchingRow(t *testing.T) {
+	db := newContactsShapedFTS(t, liveFTSTokenizer,
+		seedRow{id: "1", first: "Ada", notes: "budget planning"},
+		seedRow{id: "2", first: "Grace", notes: "budget draft"},
+	)
+	q := SanitizeQueryWithExclusions("budget", "draft")
+	rows, err := db.Query(`SELECT record_id FROM fts_contacts WHERE fts_contacts MATCH ?`, q)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) != 1 || ids[0] != "1" {
+		t.Errorf("got %v, want [1]", ids)
+	}
+}

--- a/core/server/fts/sanitize_test.go
+++ b/core/server/fts/sanitize_test.go
@@ -210,6 +210,12 @@ func TestSanitizeQueryWithExclusions(t *testing.T) {
 		{"two exclusions", "budget", "draft old", `"budget"* NOT "draft"* NOT "old"*`},
 		{"exclude only yields nothing", "", "draft", ""},
 		{"blank both", "", "", ""},
+		// Defense in depth: the client is the only thing that should ever parse
+		// operator syntax. These prove the server never lets an exclude term act
+		// as an FTS5 operator — it is always folded into a quoted literal.
+		{"exclude term spelled NOT is a literal, not an operator", "budget", "NOT draft", `"budget"* NOT "NOT"* NOT "draft"*`},
+		{"sql/fts injection attempt is quoted apart, not executed", "budget", `" OR 1=1 --`, `"budget"* NOT "OR"* NOT "1=1"*`},
+		{"embedded quotes are stripped as special chars", "budget", `say "hi"`, `"budget"* NOT "say"* NOT "hi"*`},
 	}
 	for _, tc := range cases {
 		if got := SanitizeQueryWithExclusions(tc.include, tc.exclude); got != tc.want {

--- a/core/server/fts/search.go
+++ b/core/server/fts/search.go
@@ -25,16 +25,17 @@ type SearchOpts struct {
 	IncludeDeleted bool
 }
 
-// Search runs an owner-scoped FTS5 MATCH for one config, returning hits
-// (ordered by FTS rank) and the total count. It returns no rows — never an
-// error to the caller path — for an empty/too-short query or an
-// unauthenticated caller; a genuine DB failure is returned so the route can log
+// Search runs a scoped FTS5 MATCH for one config, returning hits (ordered by
+// FTS rank) and the total count. It returns no rows — never an error to the
+// caller path — for an empty/too-short query, an unauthenticated caller, or a
+// disabled/missing user; a genuine DB failure is returned so the route can log
 // it. Column identifiers come from config (trusted); only the MATCH value and
-// owner id are bound parameters.
+// the Scope's bound params (always including the user id) are bound
+// parameters.
 //
-// Single-org: a record's owner field holds the requesting user's id directly
-// (the former user_org junction is gone), so search is scoped to owner ==
-// userID — no membership lookup.
+// cfg.Scope determines how access is resolved — a direct owner field
+// (OwnerScope) or a membership table (MemberScope) — so this function stays
+// agnostic to which.
 func Search(app *pocketbase.PocketBase, cfg Config, userID string, opts SearchOpts) ([]SearchResult, int, error) {
 	match := SanitizeQuery(opts.Query)
 	if match == "" {
@@ -45,8 +46,18 @@ func Search(app *pocketbase.PocketBase, cfg Config, userID string, opts SearchOp
 		return nil, 0, nil
 	}
 
-	params := map[string]any{"match": match, "owner": userID}
-	inClause := "({:owner})"
+	// Search is raw SQL behind requireAuth, so PocketBase's collection rules
+	// never run on this path. Without this check a disabled account keeps
+	// reading titles and content until its token expires — the same hole drive
+	// had to patch separately.
+	if isDisabled(app, userID) {
+		return nil, 0, nil
+	}
+
+	params := map[string]any{"match": match}
+	for k, v := range cfg.Scope.params(userID) {
+		params[k] = v
+	}
 
 	// Soft-delete split is a fixed SQL fragment (no user input).
 	deletedClause := ""
@@ -71,8 +82,9 @@ func Search(app *pocketbase.PocketBase, cfg Config, userID string, opts SearchOp
 	base := " FROM " + cfg.Table +
 		" JOIN " + cfg.Collection + " c ON c.id = " + cfg.Table + ".record_id" +
 		" WHERE " + cfg.Table + " MATCH {:match}" +
-		" AND c." + cfg.Owner.Field + " IN " + inClause +
-		deletedClause
+		" AND " + cfg.Scope.clause() +
+		deletedClause +
+		excludeClause(cfg)
 
 	searchSQL := "SELECT " + strings.Join(selectCols, ", ") + base +
 		" ORDER BY " + cfg.Table + ".rank LIMIT {:limit} OFFSET {:offset}"
@@ -113,6 +125,25 @@ func Search(app *pocketbase.PocketBase, cfg Config, userID string, opts SearchOp
 	}
 
 	return results, count.Total, nil
+}
+
+// excludeClause drops rows whose bool ExcludeField is true.
+func excludeClause(cfg Config) string {
+	if cfg.ExcludeField == "" {
+		return ""
+	}
+	return " AND c." + cfg.ExcludeField + " != true"
+}
+
+// isDisabled reports whether the user record is missing or flagged disabled.
+// A missing record is treated as disabled: a token for a deleted user must not
+// keep reading.
+func isDisabled(app *pocketbase.PocketBase, userID string) bool {
+	user, err := app.FindRecordById("users", userID)
+	if err != nil || user == nil {
+		return true
+	}
+	return user.GetBool("disabled")
 }
 
 // coerce converts a raw string cell to the JSON type an output column declares,

--- a/core/server/fts/search.go
+++ b/core/server/fts/search.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/pocketbase/dbx"
-	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // SearchResult is one search hit: the record id plus the configured Output
@@ -36,7 +36,11 @@ type SearchOpts struct {
 // cfg.Scope determines how access is resolved — a direct owner field
 // (OwnerScope) or a membership table (MemberScope) — so this function stays
 // agnostic to which.
-func Search(app *pocketbase.PocketBase, cfg Config, userID string, opts SearchOpts) ([]SearchResult, int, error) {
+//
+// Takes core.App (not the concrete *pocketbase.PocketBase) so it can run
+// against tests.TestApp — that is what makes the disabled-user and nil-Scope
+// checks below unit-testable at all, matching drive's equivalent function.
+func Search(app core.App, cfg Config, userID string, opts SearchOpts) ([]SearchResult, int, error) {
 	match := SanitizeQuery(opts.Query)
 	if match == "" {
 		return nil, 0, nil
@@ -51,6 +55,15 @@ func Search(app *pocketbase.PocketBase, cfg Config, userID string, opts SearchOp
 	// reading titles and content until its token expires — the same hole drive
 	// had to patch separately.
 	if isDisabled(app, userID) {
+		return nil, 0, nil
+	}
+
+	// A Config that omits Scope has a nil interface value. Failing closed here
+	// (rather than dereferencing it, or worse, silently skipping the clause)
+	// matters because an unscoped FTS query would hand every row in the table
+	// to any authenticated caller — "no scope declared" must mean "no
+	// results", never "all results".
+	if cfg.Scope == nil {
 		return nil, 0, nil
 	}
 
@@ -137,8 +150,8 @@ func excludeClause(cfg Config) string {
 
 // isDisabled reports whether the user record is missing or flagged disabled.
 // A missing record is treated as disabled: a token for a deleted user must not
-// keep reading.
-func isDisabled(app *pocketbase.PocketBase, userID string) bool {
+// keep reading. Takes core.App for the same testability reason as Search.
+func isDisabled(app core.App, userID string) bool {
 	user, err := app.FindRecordById("users", userID)
 	if err != nil || user == nil {
 		return true

--- a/core/server/fts/search.go
+++ b/core/server/fts/search.go
@@ -23,6 +23,8 @@ type SearchOpts struct {
 	Limit          int
 	Offset         int
 	IncludeDeleted bool
+	// Exclude holds space-separated terms that must NOT match.
+	Exclude string
 }
 
 // Search runs a scoped FTS5 MATCH for one config, returning hits (ordered by
@@ -41,7 +43,7 @@ type SearchOpts struct {
 // against tests.TestApp — that is what makes the disabled-user and nil-Scope
 // checks below unit-testable at all, matching drive's equivalent function.
 func Search(app core.App, cfg Config, userID string, opts SearchOpts) ([]SearchResult, int, error) {
-	match := SanitizeQuery(opts.Query)
+	match := SanitizeQueryWithExclusions(opts.Query, opts.Exclude)
 	if match == "" {
 		return nil, 0, nil
 	}

--- a/core/server/fts/search_disabled_test.go
+++ b/core/server/fts/search_disabled_test.go
@@ -1,0 +1,109 @@
+package fts
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// search_disabled_test.go covers the two seams Search's security checks pass
+// through: the disabled/missing-user gate (isDisabled) and the nil-Scope
+// fail-closed guard. It does not attempt an end-to-end proof against a real
+// FTS-backed collection with rows and a membership table — that harness
+// (tests.NewTestApp() plus a seeded collection, à la drive's
+// search_disabled_test.go) belongs to the cards package task that actually
+// owns such a collection. Here we only have the "users" collection PocketBase
+// ships in every test app, which is exactly what isDisabled reads.
+
+// setupUsersApp returns a test app with the standard "users" collection
+// extended with a `disabled` bool field, plus one enabled user record.
+func setupUsersApp(t *testing.T) (*tests.TestApp, *core.Record) {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	users.Fields.Add(&core.BoolField{Name: "disabled"})
+	if err := app.Save(users); err != nil {
+		t.Fatal(err)
+	}
+
+	user := core.NewRecord(users)
+	user.SetEmail("enabled@test.local")
+	user.SetPassword("Password123!")
+	if err := app.Save(user); err != nil {
+		t.Fatal(err)
+	}
+
+	return app, user
+}
+
+func TestIsDisabled_EnabledUserReturnsFalse(t *testing.T) {
+	app, user := setupUsersApp(t)
+
+	if isDisabled(app, user.Id) {
+		t.Error("isDisabled(enabled user) = true, want false")
+	}
+}
+
+func TestIsDisabled_DisabledUserReturnsTrue(t *testing.T) {
+	app, user := setupUsersApp(t)
+
+	fresh, err := app.FindRecordById("users", user.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fresh.Set("disabled", true)
+	if err := app.Save(fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isDisabled(app, user.Id) {
+		t.Error("isDisabled(disabled user) = false, want true")
+	}
+}
+
+func TestIsDisabled_NonexistentUserFailsClosed(t *testing.T) {
+	app, _ := setupUsersApp(t)
+
+	if !isDisabled(app, "does-not-exist") {
+		t.Error("isDisabled(nonexistent user) = false, want true — a token for a deleted user must not keep reading")
+	}
+}
+
+func TestIsDisabled_EmptyUserIDFailsClosed(t *testing.T) {
+	app, _ := setupUsersApp(t)
+
+	if !isDisabled(app, "") {
+		t.Error("isDisabled(\"\") = false, want true")
+	}
+}
+
+// TestSearch_NilScopeReturnsNoRowsNotPanic proves the fail-closed guard: a
+// Config that omits Scope must return zero rows, never an unscoped query
+// (which would hand every row in the table to any authenticated caller) and
+// never a panic (the zero value of the Scope interface is nil).
+func TestSearch_NilScopeReturnsNoRowsNotPanic(t *testing.T) {
+	app, user := setupUsersApp(t)
+
+	cfg := Config{
+		Slug:       "test",
+		Collection: "users",
+		Table:      "fts_users_missing", // never reached if the guard fires first
+	}
+
+	results, total, err := Search(app, cfg, user.Id, SearchOpts{Query: "anything", Limit: 25})
+	if err != nil {
+		t.Fatalf("Search with nil Scope returned an error instead of failing closed: %v", err)
+	}
+	if results != nil || total != 0 {
+		t.Fatalf("Search with nil Scope = (%v, %d), want (nil, 0)", results, total)
+	}
+}

--- a/core/server/fts/search_test.go
+++ b/core/server/fts/search_test.go
@@ -2,6 +2,41 @@ package fts
 
 import "testing"
 
+func TestOwnerScopeClause(t *testing.T) {
+	s := OwnerScope{Field: "owner"}
+	if got := s.clause(); got != "c.owner IN ({:scopeUser})" {
+		t.Errorf("clause() = %q", got)
+	}
+	if got := s.params("u1")["scopeUser"]; got != "u1" {
+		t.Errorf("params()[scopeUser] = %v", got)
+	}
+}
+
+func TestMemberScopeClause(t *testing.T) {
+	s := MemberScope{
+		Table:       "cards_project_members",
+		MemberField: "project",
+		UserField:   "user",
+		RecordField: "project",
+	}
+	want := "c.project IN (SELECT project FROM cards_project_members WHERE user = {:scopeUser})"
+	if got := s.clause(); got != want {
+		t.Errorf("clause() = %q, want %q", got, want)
+	}
+	if got := s.params("u1")["scopeUser"]; got != "u1" {
+		t.Errorf("params()[scopeUser] = %v", got)
+	}
+}
+
+func TestExcludeClause(t *testing.T) {
+	if got := excludeClause(Config{}); got != "" {
+		t.Errorf("no ExcludeField should emit nothing, got %q", got)
+	}
+	if got := excludeClause(Config{ExcludeField: "archived"}); got != " AND c.archived != true" {
+		t.Errorf("excludeClause = %q", got)
+	}
+}
+
 func TestCoerce(t *testing.T) {
 	cases := []struct {
 		raw  string

--- a/core/server/fts/search_test.go
+++ b/core/server/fts/search_test.go
@@ -13,13 +13,17 @@ func TestOwnerScopeClause(t *testing.T) {
 }
 
 func TestMemberScopeClause(t *testing.T) {
+	// MemberField and RecordField are deliberately DISTINCT here (unlike the
+	// real cards config, where both are "project") so a bug that swaps the two
+	// fields in clause() changes the emitted SQL and this test catches it. Do
+	// not "tidy" these back to matching values.
 	s := MemberScope{
 		Table:       "cards_project_members",
-		MemberField: "project",
+		MemberField: "proj_id",
 		UserField:   "user",
 		RecordField: "project",
 	}
-	want := "c.project IN (SELECT project FROM cards_project_members WHERE user = {:scopeUser})"
+	want := "c.project IN (SELECT proj_id FROM cards_project_members WHERE user = {:scopeUser})"
 	if got := s.clause(); got != want {
 		t.Errorf("clause() = %q, want %q", got, want)
 	}

--- a/core/tests/unit/search-build-sections.test.ts
+++ b/core/tests/unit/search-build-sections.test.ts
@@ -33,14 +33,14 @@ describe('buildSections', () => {
 
     it('returns one unbadged section when exactly one chip is set', () => {
         const sections = buildSections(
-            { mail: [row('mail', 'm1', 'budget'), row('mail', 'm2', 'Q3')] },
+            { mail: [row('mail', 'm1', 'Q3'), row('mail', 'm2', 'budget')] },
             PACKAGES,
             ['mail'],
             ['budget']
         )
         expect(sections).toHaveLength(1)
         expect(sections[0].showBadges).toBe(false)
-        // A single package keeps its own backend rank order.
+        // A single package keeps its own backend rank order (m1 first despite being a worse match).
         expect(sections[0].rows.map(r => r.id)).toEqual(['m1', 'm2'])
     })
 

--- a/core/tests/unit/search-build-sections.test.ts
+++ b/core/tests/unit/search-build-sections.test.ts
@@ -1,0 +1,71 @@
+import { buildSections } from '@tinycld/core/lib/search/build-sections'
+import type { SearchPackage, SearchRow } from '@tinycld/core/lib/search/types'
+import { describe, expect, it } from 'vitest'
+
+const PACKAGES: SearchPackage[] = [
+    { slug: 'mail', label: 'Mail', icon: 'mail', order: 5, endpoint: '/api/mail/search' },
+    { slug: 'drive', label: 'Drive', icon: 'hard-drive', order: 12, endpoint: '/api/drive/search' },
+    {
+        slug: 'cards',
+        label: 'Cards',
+        icon: 'square-kanban',
+        order: 25,
+        endpoint: '/api/cards/search',
+    },
+]
+
+const row = (slug: string, id: string, title: string): SearchRow => ({ slug, id, title })
+
+describe('buildSections', () => {
+    it('returns one flat badged section when no chips are set', () => {
+        const sections = buildSections(
+            { mail: [row('mail', 'm1', 'Q3 approval')], drive: [row('drive', 'd1', 'budget')] },
+            PACKAGES,
+            [],
+            ['budget']
+        )
+        expect(sections).toHaveLength(1)
+        expect(sections[0].title).toBeUndefined()
+        expect(sections[0].showBadges).toBe(true)
+        // Drive's exact match outranks mail despite mail's lower nav.order.
+        expect(sections[0].rows.map(r => r.id)).toEqual(['d1', 'm1'])
+    })
+
+    it('returns one unbadged section when exactly one chip is set', () => {
+        const sections = buildSections(
+            { mail: [row('mail', 'm1', 'budget'), row('mail', 'm2', 'Q3')] },
+            PACKAGES,
+            ['mail'],
+            ['budget']
+        )
+        expect(sections).toHaveLength(1)
+        expect(sections[0].showBadges).toBe(false)
+        // A single package keeps its own backend rank order.
+        expect(sections[0].rows.map(r => r.id)).toEqual(['m1', 'm2'])
+    })
+
+    it('groups by package ordered by nav.order when 2+ chips are set', () => {
+        const sections = buildSections(
+            { cards: [row('cards', 'c1', 'budget')], mail: [row('mail', 'm1', 'budget')] },
+            PACKAGES,
+            ['cards', 'mail'],
+            ['budget']
+        )
+        expect(sections.map(s => s.title)).toEqual(['Mail', 'Cards'])
+        expect(sections.map(s => s.icon)).toEqual(['mail', 'square-kanban'])
+    })
+
+    it('omits a package that returned no rows', () => {
+        const sections = buildSections(
+            { cards: [], mail: [row('mail', 'm1', 'budget')] },
+            PACKAGES,
+            ['cards', 'mail'],
+            ['budget']
+        )
+        expect(sections.map(s => s.title)).toEqual(['Mail'])
+    })
+
+    it('returns no sections when nothing matched', () => {
+        expect(buildSections({}, PACKAGES, [], ['budget'])).toEqual([])
+    })
+})

--- a/core/tests/unit/search-chip-text.test.ts
+++ b/core/tests/unit/search-chip-text.test.ts
@@ -1,5 +1,6 @@
-import { chipsToText, textAfterChips } from '@tinycld/core/lib/search/chip-text'
-import { describe, expect, it } from 'vitest'
+import { chipsToText, runHandlerFor } from '@tinycld/core/lib/search/chip-text'
+import type { SearchRow } from '@tinycld/core/lib/search/types'
+import { describe, expect, it, vi } from 'vitest'
 
 describe('chipsToText', () => {
     it('renders one chip as a single colon-space prefix', () => {
@@ -15,25 +16,38 @@ describe('chipsToText', () => {
     })
 })
 
-describe('textAfterChips', () => {
-    it('strips exactly the rendered chip prefix, leaving the typed remainder', () => {
-        expect(textAfterChips('mail: budget report', ['mail'])).toBe('budget report')
+// The former "text after chips" behavior (slicing the raw text by
+// chipsToText(chips).length) is now covered as part of parseQuery's
+// `remainder` field — see search-parse-query.test.ts. There is no standalone
+// helper left to test here: computing the remainder by length assumed chips
+// are always a leading prefix, which is exactly the assumption that broke
+// once a chip could be created after free text.
+
+const row: SearchRow = { slug: 'mail', id: 'm1', title: 'Q3 Budget' }
+
+// Regression guard (I2): the palette used to close unconditionally after
+// `handlers[row.slug]?.(row)`, so a row whose package's adapter module never
+// registered a handler (e.g. it failed to load) made Enter a silent dismiss
+// — indistinguishable from a working selection. runHandlerFor's return value
+// is what SearchPalette's selectRow gates the close on.
+describe('runHandlerFor', () => {
+    it('runs the matching handler and reports that one ran', () => {
+        const onSelect = vi.fn()
+        const ran = runHandlerFor(row, { mail: onSelect })
+
+        expect(onSelect).toHaveBeenCalledWith(row)
+        expect(ran).toBe(true)
     })
 
-    it('returns the full text unchanged when there are no chips', () => {
-        expect(textAfterChips('budget report', [])).toBe('budget report')
+    it('does nothing and reports false when no handler is registered for the slug', () => {
+        const onSelect = vi.fn()
+        const ran = runHandlerFor(row, { drive: onSelect })
+
+        expect(onSelect).not.toHaveBeenCalled()
+        expect(ran).toBe(false)
     })
 
-    it('returns an empty string when the text is exactly the chip prefix', () => {
-        expect(textAfterChips('mail: ', ['mail'])).toBe('')
-    })
-
-    // Regression guard for the backspace-pop path: the prefix must be computed
-    // from the CURRENT chip list, not the previous one, or popping a chip would
-    // strip the wrong length and truncate real query text.
-    it('recomputes against a shorter chip list rather than the text that produced it', () => {
-        // Text was built from two chips; simulate having already popped one so
-        // only 'mail' remains — the remainder must start right after 'mail: '.
-        expect(textAfterChips('mail: drive: budget', ['mail'])).toBe('drive: budget')
+    it('reports false against an empty handler map', () => {
+        expect(runHandlerFor(row, {})).toBe(false)
     })
 })

--- a/core/tests/unit/search-chip-text.test.ts
+++ b/core/tests/unit/search-chip-text.test.ts
@@ -1,0 +1,39 @@
+import { chipsToText, textAfterChips } from '@tinycld/core/lib/search/chip-text'
+import { describe, expect, it } from 'vitest'
+
+describe('chipsToText', () => {
+    it('renders one chip as a single colon-space prefix', () => {
+        expect(chipsToText(['mail'])).toBe('mail: ')
+    })
+
+    it('renders multiple chips in order, each with its own colon-space', () => {
+        expect(chipsToText(['mail', 'drive'])).toBe('mail: drive: ')
+    })
+
+    it('renders no chips as an empty string', () => {
+        expect(chipsToText([])).toBe('')
+    })
+})
+
+describe('textAfterChips', () => {
+    it('strips exactly the rendered chip prefix, leaving the typed remainder', () => {
+        expect(textAfterChips('mail: budget report', ['mail'])).toBe('budget report')
+    })
+
+    it('returns the full text unchanged when there are no chips', () => {
+        expect(textAfterChips('budget report', [])).toBe('budget report')
+    })
+
+    it('returns an empty string when the text is exactly the chip prefix', () => {
+        expect(textAfterChips('mail: ', ['mail'])).toBe('')
+    })
+
+    // Regression guard for the backspace-pop path: the prefix must be computed
+    // from the CURRENT chip list, not the previous one, or popping a chip would
+    // strip the wrong length and truncate real query text.
+    it('recomputes against a shorter chip list rather than the text that produced it', () => {
+        // Text was built from two chips; simulate having already popped one so
+        // only 'mail' remains — the remainder must start right after 'mail: '.
+        expect(textAfterChips('mail: drive: budget', ['mail'])).toBe('drive: budget')
+    })
+})

--- a/core/tests/unit/search-palette-package-actions.test.tsx
+++ b/core/tests/unit/search-palette-package-actions.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+//
+// Regression test for a Rules of Hooks violation: PackageActions must call
+// `useSearchActions` unconditionally once the adapter module resolves, not
+// through `adapter?.useSearchActions()`. That form calls zero hooks on the
+// first render (while the dynamic import is pending, `useQuery` returns
+// `data: undefined`) and one hook once it resolves — a different hook count
+// between renders of the SAME component instance, which React detects and
+// throws on ("Rendered more hooks than during the previous render").
+//
+// This is exercised here rather than through the full SearchPalette because
+// SearchPalette.web.tsx also imports the icon map, which transitively pulls
+// in the generated lucide-react-native deep imports that this Vite-based
+// unit environment cannot resolve (see chip-text.ts extraction for the same
+// constraint). Stubbing the icon map import lets PackageActions render on
+// its own without touching that unrelated resolution problem.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useRef } from 'react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+vi.mock('@tinycld/core/components/workspace/package-icon-map', () => ({
+    getIcon: () => () => null,
+}))
+
+// Simulates the async dynamic import: the adapter resolves only after
+// `resolveAdapter()` is called from within a test, so the component is
+// guaranteed to render at least once with the query still pending.
+let resolveAdapter: (() => void) | undefined
+// This mock MUST call a real hook. React only counts hooks it actually sees,
+// so a plain `vi.fn(() => ({ onSelect }))` leaves the hook count unchanged
+// between renders and the conditional-call bug goes undetected — verified:
+// the test passed against the original buggy code until this used useRef.
+// Real adapters call useRouter/useOrgHref/useStore, so this mirrors them.
+const searchActions = vi.fn(() => {
+    const onSelect = useRef(vi.fn()).current
+    return { onSelect }
+})
+const adapterModule = {
+    toRow: () => null,
+    useSearchActions: searchActions,
+}
+
+vi.mock('@tinycld/core/lib/search/registry', () => ({
+    loadSearchAdapter: () =>
+        new Promise(resolve => {
+            resolveAdapter = () => resolve(adapterModule)
+        }),
+    searchPackages: [],
+}))
+
+import { PackageActions } from '@tinycld/core/components/search-palette/SearchPalette.web'
+
+function Providers({ children }: { children: ReactNode }) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+afterEach(() => {
+    cleanup()
+    resolveAdapter = undefined
+    searchActions.mockClear()
+})
+
+test('does not throw, and registers the handler, when the adapter resolves after the first render', async () => {
+    const onReady = vi.fn()
+
+    // First render: loadSearchAdapter's promise is still pending, so
+    // useAdapterModule's useQuery returns `data: undefined` and
+    // PackageActions renders null. If this were the version that calls
+    // `adapter?.useSearchActions()` inline, this render already differs in
+    // hook count from the one that follows adapter resolution.
+    expect(() => {
+        render(
+            <Providers>
+                <PackageActions slug="mail" onReady={onReady} />
+            </Providers>
+        )
+    }).not.toThrow()
+
+    expect(onReady).not.toHaveBeenCalled()
+
+    // Resolve the adapter — triggers the re-render where the adapter becomes
+    // available and ResolvedPackageActions mounts fresh, calling
+    // useSearchActions for the first time in ITS lifetime (never a second
+    // hook count for the outer PackageActions instance).
+    resolveAdapter?.()
+
+    await waitFor(() => {
+        expect(onReady).toHaveBeenCalledWith('mail', expect.any(Function))
+    })
+    expect(searchActions).toHaveBeenCalledTimes(1)
+})

--- a/core/tests/unit/search-palette-store.test.ts
+++ b/core/tests/unit/search-palette-store.test.ts
@@ -1,0 +1,48 @@
+import { useSearchPaletteStore } from '@tinycld/core/lib/search/search-palette-store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('useSearchPaletteStore', () => {
+    beforeEach(() => {
+        useSearchPaletteStore.getState().close()
+    })
+
+    it('opens seeded with the current package as a chip', () => {
+        useSearchPaletteStore.getState().open('mail')
+        const state = useSearchPaletteStore.getState()
+        expect(state.isOpen).toBe(true)
+        expect(state.text).toBe('mail: ')
+    })
+
+    it('opens with empty text when no package is active', () => {
+        useSearchPaletteStore.getState().open(null)
+        expect(useSearchPaletteStore.getState().text).toBe('')
+    })
+
+    it('resets text and selection on close', () => {
+        const store = useSearchPaletteStore.getState()
+        store.open('mail')
+        store.setText('mail: budget')
+        store.setSelectedRowId('m1')
+        store.close()
+        const state = useSearchPaletteStore.getState()
+        expect(state.isOpen).toBe(false)
+        expect(state.text).toBe('')
+        expect(state.selectedRowId).toBeNull()
+    })
+
+    it('clears the selection when the text changes', () => {
+        const store = useSearchPaletteStore.getState()
+        store.open(null)
+        store.setSelectedRowId('m1')
+        store.setText('budget')
+        expect(useSearchPaletteStore.getState().selectedRowId).toBeNull()
+    })
+
+    it('keeps the selection when set explicitly', () => {
+        const store = useSearchPaletteStore.getState()
+        store.open(null)
+        store.setText('budget')
+        store.setSelectedRowId('d1')
+        expect(useSearchPaletteStore.getState().selectedRowId).toBe('d1')
+    })
+})

--- a/core/tests/unit/search-parse-query.test.ts
+++ b/core/tests/unit/search-parse-query.test.ts
@@ -89,6 +89,14 @@ describe('parseQuery — negation', () => {
             exclude: [],
         })
     })
+
+    it('strips all leading hyphens from exclusion terms', () => {
+        expect(parseQuery('--draft', SLUGS)).toEqual({
+            chips: [],
+            include: [],
+            exclude: ['draft'],
+        })
+    })
 })
 
 describe('parseQuery — operator stripping', () => {
@@ -103,6 +111,14 @@ describe('parseQuery — operator stripping', () => {
         ['(grouped)', ['grouped']],
     ])('strips operators from %s', (input, expected) => {
         expect(parseQuery(input, SLUGS).include).toEqual(expected)
+    })
+
+    it('preserves operator words embedded in hyphenated literals', () => {
+        expect(parseQuery('plan-NOT-final.docx', SLUGS)).toEqual({
+            chips: [],
+            include: ['plan-NOT-final.docx'],
+            exclude: [],
+        })
     })
 })
 

--- a/core/tests/unit/search-parse-query.test.ts
+++ b/core/tests/unit/search-parse-query.test.ts
@@ -1,3 +1,4 @@
+import { chipsToText } from '@tinycld/core/lib/search/chip-text'
 import { parseQuery } from '@tinycld/core/lib/search/parse-query'
 import { describe, expect, it } from 'vitest'
 
@@ -9,6 +10,7 @@ describe('parseQuery — chips', () => {
             chips: ['mail'],
             include: ['budget'],
             exclude: [],
+            remainder: 'budget',
         })
     })
 
@@ -17,6 +19,7 @@ describe('parseQuery — chips', () => {
             chips: [],
             include: ['budget', 'q3'],
             exclude: [],
+            remainder: 'budget: q3',
         })
     })
 
@@ -27,6 +30,7 @@ describe('parseQuery — chips', () => {
             chips: [],
             include: ['mail', 'server'],
             exclude: [],
+            remainder: 'mail server',
         })
     })
 
@@ -35,6 +39,7 @@ describe('parseQuery — chips', () => {
             chips: ['mail', 'drive'],
             include: ['budget'],
             exclude: [],
+            remainder: 'budget',
         })
     })
 
@@ -43,6 +48,7 @@ describe('parseQuery — chips', () => {
             chips: ['mail'],
             include: ['budget'],
             exclude: [],
+            remainder: 'budget',
         })
     })
 
@@ -51,7 +57,66 @@ describe('parseQuery — chips', () => {
             chips: ['mail'],
             include: ['budget'],
             exclude: [],
+            remainder: 'budget',
         })
+    })
+})
+
+describe('parseQuery — chip-after-text ordering (C1 regression)', () => {
+    // THE BUG: textAfterChips used to strip the chip prefix by COMPUTED
+    // LENGTH (text.slice(chipsToText(chips).length)), which assumes chips are
+    // always a leading prefix of the raw text. parseQuery recognizes `pkg:`
+    // ANYWHERE in the string, so typing a chip-forming token AFTER free text
+    // ("budget mail: q3") made the slice cut into "budget" instead of the
+    // chip prefix — the word survived the first parse and was destroyed on
+    // the next keystroke once the corrupted display got written back to the
+    // store. parseQuery now recognizes chips ONLY from a leading run at the
+    // very start of input, so a later `pkg:`-shaped token is parsed as plain
+    // text — never promoted to a chip, and never dropped either.
+    it('keeps free text that precedes a chip-forming token as literal words', () => {
+        expect(parseQuery('budget mail: q3', SLUGS)).toEqual({
+            chips: [],
+            include: ['budget', 'mail', 'q3'],
+            exclude: [],
+            remainder: 'budget mail: q3',
+        })
+    })
+
+    // Seeded-chip case: a real leading chip (as the palette seeds on open)
+    // followed by free text, followed by a SECOND `pkg:`-shaped token. The
+    // second token must not be promoted to a chip (only the leading run
+    // counts) and "budget" must not be lost.
+    it('does not promote a second pkg: token once free text has broken the leading run', () => {
+        expect(parseQuery('cards: budget drive: q3', SLUGS)).toEqual({
+            chips: ['cards'],
+            include: ['budget', 'drive', 'q3'],
+            exclude: [],
+            remainder: 'budget drive: q3',
+        })
+    })
+
+    // The palette displays chipsToText(chips) + remainder and writes that
+    // same reconstruction back to the store on every keystroke
+    // (onChangeRemainder). If that reconstruction ever drops a word, the
+    // word is gone for good the next time the user types. This simulates the
+    // exact multi-keystroke sequence from the bug report: open with no
+    // chips, type "budget mail:", then continue typing " q3".
+    it('loses no word across a simulated keystroke round-trip', () => {
+        let storeText = ''
+        const type = (nextRemainder: string) => {
+            const parsed = parseQuery(storeText, SLUGS)
+            storeText = chipsToText(parsed.chips) + nextRemainder
+        }
+
+        type('budget mail:')
+        let parsed = parseQuery(storeText, SLUGS)
+        expect(parsed.include).toContain('budget')
+
+        type(`${parsed.remainder} q3`)
+        parsed = parseQuery(storeText, SLUGS)
+
+        expect(parsed.include).toEqual(['budget', 'mail', 'q3'])
+        expect(parsed.chips).toEqual([])
     })
 })
 
@@ -61,6 +126,7 @@ describe('parseQuery — negation', () => {
             chips: [],
             include: ['budget'],
             exclude: ['draft'],
+            remainder: 'budget -draft',
         })
     })
 
@@ -71,6 +137,7 @@ describe('parseQuery — negation', () => {
             chips: [],
             include: ['budget-2026.xlsx'],
             exclude: [],
+            remainder: 'budget-2026.xlsx',
         })
     })
 
@@ -79,6 +146,7 @@ describe('parseQuery — negation', () => {
             chips: [],
             include: [],
             exclude: ['draft'],
+            remainder: '-draft',
         })
     })
 
@@ -87,6 +155,7 @@ describe('parseQuery — negation', () => {
             chips: [],
             include: ['budget', 'draft'],
             exclude: [],
+            remainder: 'budget - draft',
         })
     })
 
@@ -95,6 +164,7 @@ describe('parseQuery — negation', () => {
             chips: [],
             include: [],
             exclude: ['draft'],
+            remainder: '--draft',
         })
     })
 })
@@ -118,12 +188,18 @@ describe('parseQuery — operator stripping', () => {
             chips: [],
             include: ['plan-NOT-final.docx'],
             exclude: [],
+            remainder: 'plan-NOT-final.docx',
         })
     })
 })
 
 describe('parseQuery — empty input', () => {
     it('returns empty arrays for blank input', () => {
-        expect(parseQuery('   ', SLUGS)).toEqual({ chips: [], include: [], exclude: [] })
+        expect(parseQuery('   ', SLUGS)).toEqual({
+            chips: [],
+            include: [],
+            exclude: [],
+            remainder: '   ',
+        })
     })
 })

--- a/core/tests/unit/search-parse-query.test.ts
+++ b/core/tests/unit/search-parse-query.test.ts
@@ -1,0 +1,113 @@
+import { parseQuery } from '@tinycld/core/lib/search/parse-query'
+import { describe, expect, it } from 'vitest'
+
+const SLUGS = ['mail', 'drive', 'cards', 'contacts']
+
+describe('parseQuery — chips', () => {
+    it('turns a matching word followed by a colon into a chip', () => {
+        expect(parseQuery('mail: budget', SLUGS)).toEqual({
+            chips: ['mail'],
+            include: ['budget'],
+            exclude: [],
+        })
+    })
+
+    it('leaves a non-matching word with a colon as literal text', () => {
+        expect(parseQuery('budget: q3', SLUGS)).toEqual({
+            chips: [],
+            include: ['budget', 'q3'],
+            exclude: [],
+        })
+    })
+
+    // The regression test for "mail server migration": a package name typed
+    // WITHOUT a colon must stay searchable text, or that email is unfindable.
+    it('leaves a package name without a colon as searchable text', () => {
+        expect(parseQuery('mail server', SLUGS)).toEqual({
+            chips: [],
+            include: ['mail', 'server'],
+            exclude: [],
+        })
+    })
+
+    it('accepts multiple chips', () => {
+        expect(parseQuery('mail: drive: budget', SLUGS)).toEqual({
+            chips: ['mail', 'drive'],
+            include: ['budget'],
+            exclude: [],
+        })
+    })
+
+    it('ignores a duplicate chip but still consumes the word', () => {
+        expect(parseQuery('mail: mail: budget', SLUGS)).toEqual({
+            chips: ['mail'],
+            include: ['budget'],
+            exclude: [],
+        })
+    })
+
+    it('matches a slug case-insensitively', () => {
+        expect(parseQuery('Mail: budget', SLUGS)).toEqual({
+            chips: ['mail'],
+            include: ['budget'],
+            exclude: [],
+        })
+    })
+})
+
+describe('parseQuery — negation', () => {
+    it('splits a boundary hyphen into an exclusion', () => {
+        expect(parseQuery('budget -draft', SLUGS)).toEqual({
+            chips: [],
+            include: ['budget'],
+            exclude: ['draft'],
+        })
+    })
+
+    // The hyphen is in the FTS strip set precisely because of filenames like
+    // this one. A mid-token hyphen must stay literal.
+    it('keeps a mid-token hyphen literal', () => {
+        expect(parseQuery('budget-2026.xlsx', SLUGS)).toEqual({
+            chips: [],
+            include: ['budget-2026.xlsx'],
+            exclude: [],
+        })
+    })
+
+    it('excludes when the hyphen starts the input', () => {
+        expect(parseQuery('-draft', SLUGS)).toEqual({
+            chips: [],
+            include: [],
+            exclude: ['draft'],
+        })
+    })
+
+    it('drops a bare hyphen with no attached term', () => {
+        expect(parseQuery('budget - draft', SLUGS)).toEqual({
+            chips: [],
+            include: ['budget', 'draft'],
+            exclude: [],
+        })
+    })
+})
+
+describe('parseQuery — operator stripping', () => {
+    it.each([
+        ['a && b', ['a', 'b']],
+        ['a || b', ['a', 'b']],
+        ['a AND b', ['a', 'b']],
+        ['a OR b', ['a', 'b']],
+        ['a NOT b', ['a', 'b']],
+        ['!urgent', ['urgent']],
+        ['"quoted phrase"', ['quoted', 'phrase']],
+        ['(grouped)', ['grouped']],
+    ])('strips operators from %s', (input, expected) => {
+        expect(parseQuery(input, SLUGS).include).toEqual(expected)
+    })
+})
+
+describe('parseQuery — empty input', () => {
+    it('returns empty arrays for blank input', () => {
+        expect(parseQuery('   ', SLUGS)).toEqual({ chips: [], include: [], exclude: [] })
+    })
+})

--- a/core/tests/unit/search-registry.test.ts
+++ b/core/tests/unit/search-registry.test.ts
@@ -1,0 +1,53 @@
+import { deriveSearchPackages } from '@tinycld/core/lib/search/registry'
+import { describe, expect, it } from 'vitest'
+
+const entry = (
+    slug: string,
+    label: string,
+    icon: string,
+    order: number,
+    search?: { endpoint: string; label?: string }
+) => ({
+    manifest: { slug, name: label, nav: { label, icon, order } },
+    search: search
+        ? {
+              ...search,
+              load: async () => ({
+                  toRow: () => null,
+                  useSearchActions: () => ({ onSelect: () => {} }),
+              }),
+          }
+        : undefined,
+})
+
+describe('deriveSearchPackages', () => {
+    it('includes only packages declaring search', () => {
+        const packages = deriveSearchPackages([
+            entry('mail', 'Mail', 'mail', 5, { endpoint: '/api/mail/search' }),
+            entry('calc', 'Calc', 'table', 30),
+        ])
+        expect(packages.map(p => p.slug)).toEqual(['mail'])
+    })
+
+    it('sorts by nav.order', () => {
+        const packages = deriveSearchPackages([
+            entry('cards', 'Cards', 'square-kanban', 25, { endpoint: '/api/cards/search' }),
+            entry('mail', 'Mail', 'mail', 5, { endpoint: '/api/mail/search' }),
+        ])
+        expect(packages.map(p => p.slug)).toEqual(['mail', 'cards'])
+    })
+
+    it('defaults the label to nav.label', () => {
+        const packages = deriveSearchPackages([
+            entry('mail', 'Mail', 'mail', 5, { endpoint: '/api/mail/search' }),
+        ])
+        expect(packages[0].label).toBe('Mail')
+    })
+
+    it('prefers an explicit search label over nav.label', () => {
+        const packages = deriveSearchPackages([
+            entry('mail', 'Mail', 'mail', 5, { endpoint: '/api/mail/search', label: 'Email' }),
+        ])
+        expect(packages[0].label).toBe('Email')
+    })
+})

--- a/core/tests/unit/search-score.test.ts
+++ b/core/tests/unit/search-score.test.ts
@@ -40,10 +40,26 @@ describe('scoreRow — tiers', () => {
         )
     })
 
+    it('normalizes punctuation by replacement, not deletion', () => {
+        // With separate terms ['budget', '2026'], a replacement normalizer joins them
+        // with spaces ('budget 2026') which matches 'budget-2026'. Deletion would create
+        // 'budget2026' and then fail to split back to separate terms, scoring lower.
+        expect(scoreRow(['budget', '2026'], row({ title: 'budget-2026' }))).toBe(
+            scoreRow(['budget-2026'], row({ title: 'budget-2026' }))
+        )
+    })
+
     it('requires every term to match for the all-terms tier', () => {
         const both = scoreRow(['q3', 'budget'], row({ title: 'Q3 budget plan' }))
         const one = scoreRow(['q3', 'budget'], row({ title: 'Q3 plan' }))
         expect(both).toBeGreaterThan(one)
+    })
+
+    it('handles degenerate inputs (empty or punctuation-only queries)', () => {
+        const empty = scoreRow([], row({ title: 'x' }))
+        const punctuationOnly = scoreRow(['---'], row({ title: 'x' }))
+        // Both should land on the lowest tier (no visible match).
+        expect(empty).toBe(punctuationOnly)
     })
 })
 

--- a/core/tests/unit/search-score.test.ts
+++ b/core/tests/unit/search-score.test.ts
@@ -1,0 +1,97 @@
+import { compareRows, scoreRow } from '@tinycld/core/lib/search/score'
+import type { SearchRow } from '@tinycld/core/lib/search/types'
+import { describe, expect, it } from 'vitest'
+
+const row = (over: Partial<SearchRow>): SearchRow => ({
+    slug: 'mail',
+    id: '1',
+    title: 'untitled',
+    ...over,
+})
+
+describe('scoreRow — tiers', () => {
+    it('ranks an exact title match highest', () => {
+        expect(scoreRow(['budget'], row({ title: 'budget' }))).toBeGreaterThan(
+            scoreRow(['budget'], row({ title: 'budget review' }))
+        )
+    })
+
+    it('ranks a title prefix above a word-prefix match', () => {
+        expect(scoreRow(['budget'], row({ title: 'budget review' }))).toBeGreaterThan(
+            scoreRow(['budget'], row({ title: 'Q3 budgeting notes' }))
+        )
+    })
+
+    it('ranks a title match above a subtitle-only match', () => {
+        expect(scoreRow(['grace'], row({ title: 'grace period' }))).toBeGreaterThan(
+            scoreRow(['grace'], row({ title: 'Q3 approval', subtitle: 'Grace Hopper' }))
+        )
+    })
+
+    it('ranks a subtitle match above a body-only hit with no visible match', () => {
+        expect(
+            scoreRow(['budget'], row({ title: 'Q3 approval', subtitle: 'budget team' }))
+        ).toBeGreaterThan(scoreRow(['budget'], row({ title: 'Q3 approval' })))
+    })
+
+    it('is case- and punctuation-insensitive on an exact match', () => {
+        expect(scoreRow(['budget-2026'], row({ title: 'Budget 2026' }))).toBe(
+            scoreRow(['budget-2026'], row({ title: 'budget-2026' }))
+        )
+    })
+
+    it('requires every term to match for the all-terms tier', () => {
+        const both = scoreRow(['q3', 'budget'], row({ title: 'Q3 budget plan' }))
+        const one = scoreRow(['q3', 'budget'], row({ title: 'Q3 plan' }))
+        expect(both).toBeGreaterThan(one)
+    })
+})
+
+describe('compareRows — cross-package ordering', () => {
+    const order = { mail: 5, drive: 12, cards: 25 }
+
+    // The case that motivates scoring at all: without it, nav.order alone
+    // would put Mail's weak hit above Drive's exact filename match.
+    it('puts a high-tier hit from a later package above a low-tier earlier one', () => {
+        const driveExact = row({ slug: 'drive', id: 'd1', title: 'budget-2026' })
+        const mailWeak = row({
+            slug: 'mail',
+            id: 'm1',
+            title: 'Q3 approval',
+            subtitle: 'budget team',
+        })
+        const sorted = [mailWeak, driveExact].sort((a, b) =>
+            compareRows(a, b, ['budget-2026'], order)
+        )
+        expect(sorted[0].id).toBe('d1')
+    })
+
+    it('prefers the shorter title within a tier', () => {
+        const short = row({ slug: 'mail', id: 'a', title: 'budget review' })
+        const long = row({
+            slug: 'drive',
+            id: 'b',
+            title: 'budget review for the third quarter of the year',
+        })
+        const sorted = [long, short].sort((a, b) => compareRows(a, b, ['budget'], order))
+        expect(sorted[0].id).toBe('a')
+    })
+
+    it('falls back to nav.order when tier and title length tie', () => {
+        const cards = row({ slug: 'cards', id: 'c', title: 'budget' })
+        const mail = row({ slug: 'mail', id: 'm', title: 'budget' })
+        const sorted = [cards, mail].sort((a, b) => compareRows(a, b, ['budget'], order))
+        expect(sorted[0].id).toBe('m')
+    })
+
+    it('is deterministic regardless of input order', () => {
+        const rows = [
+            row({ slug: 'cards', id: 'c', title: 'budget plan' }),
+            row({ slug: 'drive', id: 'd', title: 'budget' }),
+            row({ slug: 'mail', id: 'm', title: 'Q3', subtitle: 'budget' }),
+        ]
+        const forward = [...rows].sort((a, b) => compareRows(a, b, ['budget'], order))
+        const backward = [...rows].reverse().sort((a, b) => compareRows(a, b, ['budget'], order))
+        expect(forward.map(r => r.id)).toEqual(backward.map(r => r.id))
+    })
+})

--- a/core/tests/unit/search-score.test.ts
+++ b/core/tests/unit/search-score.test.ts
@@ -56,10 +56,14 @@ describe('scoreRow — tiers', () => {
     })
 
     it('handles degenerate inputs (empty or punctuation-only queries)', () => {
+        // Both should land on the lowest tier (no visible match).
+        const noVisibleMatch = scoreRow(['zzzz'], row({ title: 'unrelated' }))
         const empty = scoreRow([], row({ title: 'x' }))
         const punctuationOnly = scoreRow(['---'], row({ title: 'x' }))
-        // Both should land on the lowest tier (no visible match).
-        expect(empty).toBe(punctuationOnly)
+        expect(empty).toBe(noVisibleMatch)
+        expect(punctuationOnly).toBe(noVisibleMatch)
+        // Additionally, verify they are strictly below any real match.
+        expect(empty).toBeLessThan(scoreRow(['budget'], row({ title: 'budget' })))
     })
 })
 

--- a/core/tests/unit/shortcuts.test.ts
+++ b/core/tests/unit/shortcuts.test.ts
@@ -1,4 +1,4 @@
-import { createMatcher } from '@tinycld/core/lib/shortcuts/matcher'
+import { createMatcher, isScopeActive } from '@tinycld/core/lib/shortcuts/matcher'
 import { useShortcutRegistry } from '@tinycld/core/lib/shortcuts/registry'
 import { popScope, pushScope, resetScopes } from '@tinycld/core/lib/shortcuts/scopes'
 import type { Shortcut } from '@tinycld/core/lib/shortcuts/types'
@@ -110,6 +110,76 @@ describe('matcher', () => {
         popScope(modalId)
         expect(m.feedAtom('j', { inInput: false })).toBe(true)
         expect(run).toHaveBeenCalledTimes(1)
+        popScope(listId)
+    })
+
+    // A screen frozen by `freezeOnBlur` keeps its shortcuts registered, so two
+    // packages can hold the same key at the same scope. Only the one owned by
+    // the scope instance on top may fire.
+    it('fires the live screen’s shortcut when a frozen screen shares its key', () => {
+        const frozen = vi.fn()
+        const live = vi.fn()
+        const frozenId = pushScope('list')
+        register({
+            id: 'frozen.j',
+            keys: 'j',
+            scope: 'list',
+            description: 'frozen next',
+            scopeId: frozenId,
+            run: frozen,
+        })
+        const liveId = pushScope('list')
+        register({
+            id: 'live.j',
+            keys: 'j',
+            scope: 'list',
+            description: 'live next',
+            scopeId: liveId,
+            run: live,
+        })
+        const m = createMatcher()
+
+        expect(m.feedAtom('j', { inInput: false })).toBe(true)
+        expect(live).toHaveBeenCalledTimes(1)
+        expect(frozen).not.toHaveBeenCalled()
+
+        // Returning to the other screen hands its own shortcut back.
+        popScope(liveId)
+        expect(m.feedAtom('j', { inInput: false })).toBe(true)
+        expect(frozen).toHaveBeenCalledTimes(1)
+        expect(live).toHaveBeenCalledTimes(1)
+        popScope(frozenId)
+    })
+
+    // The help overlay lists exactly what isScopeActive admits, so a board's
+    // keys must disappear from it while a card (a 'modal' scope) is open —
+    // otherwise it advertises keys that cannot fire, and duplicates every
+    // entry the two screens share.
+    it('reports only the scope holding the keyboard as active', () => {
+        const boardKey: Shortcut = {
+            id: 'board.x',
+            keys: 'x',
+            scope: 'list',
+            description: 'archive',
+            run: () => {},
+        }
+        const jumpKey: Shortcut = {
+            id: 'core.jump',
+            keys: 't m',
+            scope: 'global',
+            description: 'jump',
+            run: () => {},
+        }
+        const listId = pushScope('list')
+        expect(isScopeActive(boardKey)).toBe(true)
+
+        const modalId = pushScope('modal')
+        expect(isScopeActive(boardKey)).toBe(false)
+        // A global shortcut stays reachable from inside a modal.
+        expect(isScopeActive(jumpKey)).toBe(true)
+
+        popScope(modalId)
+        expect(isScopeActive(boardKey)).toBe(true)
         popScope(listId)
     })
 

--- a/core/tests/unit/use-active-package-slug.test.ts
+++ b/core/tests/unit/use-active-package-slug.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+// Drive usePathname from a mutable module-level value, following the pattern
+// in use-close-on-navigate.test.tsx, so each test can simulate a different
+// route without touching the router.
+let pathname = '/'
+vi.mock('expo-router', () => ({ usePathname: () => pathname }))
+
+// Control the installed-package list independently of whatever happens to be
+// assembled in this dev workspace, so the test doesn't drift if a sibling is
+// added or removed.
+vi.mock('@tinycld/core/lib/search/registry', () => ({
+    searchPackages: [
+        { slug: 'mail', label: 'Mail', icon: 'mail', order: 5, endpoint: '/api/mail/search' },
+        {
+            slug: 'drive',
+            label: 'Drive',
+            icon: 'hard-drive',
+            order: 12,
+            endpoint: '/api/drive/search',
+        },
+    ],
+}))
+
+import { useActivePackageSlug } from '@tinycld/core/lib/search/use-active-package-slug'
+
+afterEach(() => {
+    pathname = '/'
+})
+
+test('returns the slug when the path starts with an installed package', () => {
+    pathname = '/mail/thread-1'
+    const { result } = renderHook(() => useActivePackageSlug())
+    expect(result.current).toBe('mail')
+})
+
+test('returns null when no segment matches an installed package', () => {
+    pathname = '/settings/profile'
+    const { result } = renderHook(() => useActivePackageSlug())
+    expect(result.current).toBeNull()
+})
+
+// The scan walks segments left-to-right and returns on the first match, so a
+// non-package prefix segment (here 'org-slug', which names no installed
+// package) must not stop it from finding the package segment that follows.
+test('skips a leading non-package segment to find the package segment', () => {
+    pathname = '/org-slug/drive/folder-1'
+    const { result } = renderHook(() => useActivePackageSlug())
+    expect(result.current).toBe('drive')
+})
+
+// If TWO segments each name an installed package, the leftmost one wins —
+// pinning this down guards against a future rewrite that scans in reverse.
+test('prefers the earliest matching segment when two segments both match', () => {
+    pathname = '/mail/drive'
+    const { result } = renderHook(() => useActivePackageSlug())
+    expect(result.current).toBe('mail')
+})
+
+test('returns null for the root path', () => {
+    pathname = '/'
+    const { result } = renderHook(() => useActivePackageSlug())
+    expect(result.current).toBeNull()
+})

--- a/core/tests/unit/workspace-store-edge-swipe.test.ts
+++ b/core/tests/unit/workspace-store-edge-swipe.test.ts
@@ -1,0 +1,60 @@
+import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('workspace-store edge-swipe suspension', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.runAllTimers()
+        vi.useRealTimers()
+    })
+
+    it('suspends immediately when a drag starts', () => {
+        useWorkspaceStore.getState().setEdgeSwipeSuspended(true)
+        expect(useWorkspaceStore.getState().isEdgeSwipeSuspended).toBe(true)
+    })
+
+    it('stays suspended through the grace window after a drag ends', () => {
+        const store = useWorkspaceStore.getState()
+        store.setEdgeSwipeSuspended(true)
+        store.setEdgeSwipeSuspended(false)
+
+        // The micro-lifted re-touch arrives within milliseconds of the drag
+        // ending — the suspension must still be in force then.
+        vi.advanceTimersByTime(100)
+        expect(useWorkspaceStore.getState().isEdgeSwipeSuspended).toBe(true)
+
+        vi.advanceTimersByTime(400)
+        expect(useWorkspaceStore.getState().isEdgeSwipeSuspended).toBe(false)
+    })
+
+    it('cancels a pending resume when a new drag starts inside the grace window', () => {
+        const store = useWorkspaceStore.getState()
+        store.setEdgeSwipeSuspended(true)
+        store.setEdgeSwipeSuspended(false)
+        vi.advanceTimersByTime(100)
+
+        store.setEdgeSwipeSuspended(true)
+        vi.advanceTimersByTime(1000)
+        expect(useWorkspaceStore.getState().isEdgeSwipeSuspended).toBe(true)
+
+        store.setEdgeSwipeSuspended(false)
+        vi.advanceTimersByTime(1000)
+        expect(useWorkspaceStore.getState().isEdgeSwipeSuspended).toBe(false)
+    })
+
+    it('collapses repeated resumes into the latest grace window', () => {
+        const store = useWorkspaceStore.getState()
+        store.setEdgeSwipeSuspended(true)
+        store.setEdgeSwipeSuspended(false)
+        vi.advanceTimersByTime(300)
+        store.setEdgeSwipeSuspended(false)
+
+        vi.advanceTimersByTime(300)
+        expect(useWorkspaceStore.getState().isEdgeSwipeSuspended).toBe(true)
+        vi.advanceTimersByTime(200)
+        expect(useWorkspaceStore.getState().isEdgeSwipeSuspended).toBe(false)
+    })
+})

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
         "react-hook-form": "^7.72.0",
         "react-native": "0.83.6",
         "react-native-blob-util": "^0.24.7",
-        "react-native-drax": "github:nathanstitt/react-native-drax#e9b5dcdb9217cdb0ad47c5db779e51588dd9dfe0",
+        "react-native-drax": "github:nathanstitt/react-native-drax#7966ff5e339ab7ee59f712fb1b1f0e806fb6ba6e",
         "react-native-external-keyboard": "^0.8.4",
         "react-native-gesture-handler": "~3.0.1",
         "react-native-get-random-values": "~1.11.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
         "react-hook-form": "^7.72.0",
         "react-native": "0.83.6",
         "react-native-blob-util": "^0.24.7",
-        "react-native-drax": "^1.1.0",
+        "react-native-drax": "github:nathanstitt/react-native-drax#989bfb605df558b7b64d3d64f392efc6f7678e15",
         "react-native-external-keyboard": "^0.8.4",
         "react-native-gesture-handler": "~3.0.1",
         "react-native-get-random-values": "~1.11.0",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "expo-dev-client": "~55.0.32",
         "expo-document-picker": "~55.0.11",
         "expo-file-system": "~55.0.19",
+        "expo-haptics": "~55.0.14",
         "expo-image": "~55.0.11",
         "expo-image-picker": "~55.0.20",
         "expo-linking": "~55.0.15",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
         "react-hook-form": "^7.72.0",
         "react-native": "0.83.6",
         "react-native-blob-util": "^0.24.7",
-        "react-native-drax": "github:nathanstitt/react-native-drax#989bfb605df558b7b64d3d64f392efc6f7678e15",
+        "react-native-drax": "github:nathanstitt/react-native-drax#e9b5dcdb9217cdb0ad47c5db779e51588dd9dfe0",
         "react-native-external-keyboard": "^0.8.4",
         "react-native-gesture-handler": "~3.0.1",
         "react-native-get-random-values": "~1.11.0",

--- a/scripts/__tests__/describe-packages.test.ts
+++ b/scripts/__tests__/describe-packages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
     manifestToConfigPkg,
     schemaTypeName,
+    validateNavShortcuts,
     validateSidebarContributions,
 } from '../describe-packages'
 
@@ -156,5 +157,34 @@ describe('validateSidebarContributions', () => {
         } finally {
             warn.mockRestore()
         }
+    })
+})
+
+describe('validateNavShortcuts', () => {
+    const withShortcut = (slug: string, shortcut?: string) =>
+        manifestToConfigPkg(`@tinycld/${slug}`, {
+            name: slug,
+            slug,
+            version: '0.1.0',
+            description: 'd',
+            nav: { label: slug, icon: 'box', order: 1, ...(shortcut ? { shortcut } : {}) },
+        })
+
+    it('accepts distinct letters', () => {
+        expect(() =>
+            validateNavShortcuts([withShortcut('mail', 'm'), withShortcut('cards', 'k')])
+        ).not.toThrow()
+    })
+
+    it('rejects two packages claiming the same letter', () => {
+        expect(() =>
+            validateNavShortcuts([withShortcut('cards', 'k'), withShortcut('kanban', 'k')])
+        ).toThrow(/'k' is claimed by both 'cards' and 'kanban'/)
+    })
+
+    it('ignores packages that declare no shortcut', () => {
+        expect(() =>
+            validateNavShortcuts([withShortcut('a'), withShortcut('b'), withShortcut('c', 'c')])
+        ).not.toThrow()
     })
 })

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -58,6 +58,34 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
 }
 
 /**
+ * Cross-package validation for `nav.shortcut`. Two packages claiming the same
+ * letter make `t <letter>` ambiguous: CoreShortcuts registers both under
+ * different ids, and the matcher fires whichever it reaches first, so one
+ * package simply becomes unreachable by keyboard.
+ *
+ * docs/keyboard-shortcuts.md has always claimed generation "fails fast if two
+ * manifests claim the same letter". It did not, and the e2e shortcut stub and
+ * cards silently collided on 'k' until this was added.
+ */
+export function validateNavShortcuts(pkgs: ConfigPkg[]): void {
+    const claimedBy = new Map<string, string>()
+    for (const p of pkgs) {
+        // ConfigPkg.manifest carries extra fields under an index signature, so
+        // nav arrives as `unknown` and has to be narrowed here.
+        const nav = p.manifest.nav as { shortcut?: string } | undefined
+        const letter = nav?.shortcut
+        if (!letter) continue
+        const existing = claimedBy.get(letter)
+        if (existing) {
+            throw new Error(
+                `[generate] nav.shortcut '${letter}' is claimed by both '${existing}' and '${p.slug}'. Each package needs its own letter — 't ${letter}' cannot resolve to two packages.`
+            )
+        }
+        claimedBy.set(letter, p.slug)
+    }
+}
+
+/**
  * Cross-package validation for sidebar contributions. Run once with the full set
  * of present packages. Targets that aren't in this workspace are tolerated
  * (normal for a partial checkout — the contribution just won't appear). A

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -43,6 +43,7 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
             component: c.component,
             order: c.order ?? 0,
         })),
+        ...(manifest.search ? { search: manifest.search } : {}),
         manifest: {
             name: manifest.name,
             slug: manifest.slug,

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -17,6 +17,12 @@ export interface ConfigSidebarContribution {
     order: number
 }
 
+export interface ConfigSearch {
+    endpoint: string
+    adapter: string // package-exports subpath e.g. 'search-adapter'
+    label?: string
+}
+
 export interface ConfigPkg {
     packageName: string
     slug: string
@@ -29,6 +35,7 @@ export interface ConfigPkg {
     systemSettings: ConfigSystemSettingsPanel[]
     slots: string[]
     sidebarContributions: ConfigSidebarContribution[]
+    search?: ConfigSearch
     manifest: { name: string; slug: string; version: string; description: string } & Record<
         string,
         unknown
@@ -60,6 +67,7 @@ function validateConfigPkg(p: ConfigPkg): void {
     for (const c of p.sidebarContributions) {
         assertSafeImportField('sidebarContributions[].component', c.component)
     }
+    if (p.search) assertSafeImportField('search.adapter', p.search.adapter)
 }
 
 export function buildConfigSource(pkgs: ConfigPkg[]): string {
@@ -134,6 +142,15 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
                 )
             }
             lines.push('        ],')
+        }
+        if (p.search) {
+            lines.push('        search: {')
+            lines.push(`            endpoint: ${jsonLiteral(p.search.endpoint)},`)
+            if (p.search.label) lines.push(`            label: ${jsonLiteral(p.search.label)},`)
+            // A bare thunk, NOT lazy(): the adapter module exports two
+            // non-component values, which React.lazy cannot wrap.
+            lines.push(`            load: () => import('${p.packageName}/${p.search.adapter}'),`)
+            lines.push('        },')
         }
         lines.push('    }),')
     }

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -2,7 +2,11 @@ import { execFileSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { getPackages } from '../../tinycld.packages'
-import { manifestToConfigPkg, validateSidebarContributions } from './describe-packages'
+import {
+    manifestToConfigPkg,
+    validateNavShortcuts,
+    validateSidebarContributions,
+} from './describe-packages'
 import { type BuildPkg, runPackageBuilds } from './gen-build'
 import {
     buildCliExtensionsSource,
@@ -596,6 +600,7 @@ async function main() {
     // --- 1. tinycld.config.ts + tinycld.seeds.ts (at app root) -------------
     const configPkgs: ConfigPkg[] = features.map(f => manifestToConfigPkg(f.name, f.manifest))
     validateSidebarContributions(configPkgs)
+    validateNavShortcuts(configPkgs)
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.config.ts'), buildConfigSource(configPkgs))
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.seeds.ts'), buildSeedsSource(configPkgs))
 

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -121,6 +121,7 @@ export interface PackageManifest {
         scopes?: string[]
     }
     help?: { directory: string }
+    search?: { endpoint: string; adapter: string; label?: string }
     repository?: { url: string; issueTemplate?: string }
     dependencies?: string[]
     // Semver ranges this version requires of other packages / @tinycld/core,

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -15,7 +15,14 @@ import { login, navigateToPackage, packageScreen, skipWithoutShortcutStub } from
 // CI runs the scaffold step as part of the e2e job.
 const STUB_NAV_LABEL = 'Shortcut Stub'
 const STUB_SLUG = 'shortcut-stub'
-const STUB_SHORTCUT = 'k'
+// Must match STUB_NAV_SHORTCUT in tests/scripts/scaffold-shortcut-stub.ts.
+// (Not imported from there: that module runs main() on load and would
+// re-scaffold the stub every time this spec is collected.)
+//
+// It must also be a letter no real package claims, or `t <letter>` is
+// ambiguous. This read 'k' until cards shipped with nav.shortcut 'k' and made
+// the chord unresolvable — real letters in use today: c d k m o s t.
+const STUB_SHORTCUT = 'z'
 test.describe('Keyboard shortcuts', () => {
     // Needs the shortcut-stub package scaffolded; skip on a plain dev workspace
     // where it isn't present (CI's scaffold step makes it mandatory there — see

--- a/tests/e2e/search-palette.spec.ts
+++ b/tests/e2e/search-palette.spec.ts
@@ -230,6 +230,37 @@ test.describe('Search palette', () => {
         expect(page.url()).toBe(url)
     })
 
+    // Regression guard for the C1 bug: parseQuery used to recognize `pkg:`
+    // ANYWHERE in the raw text, but the renderer stripped the chip prefix by
+    // COMPUTED LENGTH (assuming chips were always a leading prefix). Typing a
+    // chip-forming token AFTER free text made that slice cut into the free
+    // text instead of the chip prefix, silently destroying it on the very
+    // next keystroke. Seeded-chip case: the palette opens with "cards"
+    // already a chip (see navigateToPackage below), then the user types free
+    // text, then a SECOND `pkg:`-shaped token ("mail:") that must NOT be
+    // promoted to a chip (only the leading run counts) and must NOT eat
+    // either neighboring word. Asserts on the actual input DOM value — not
+    // just a result matching, which could pass by coincidence.
+    test('typing free text then a second pkg:-looking token loses no word', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await expect(page.getByTestId('search-chip-cards')).toBeVisible()
+
+        const input = page.getByLabel('Search across packages')
+        await page.keyboard.type('Onboarding mail: checklist')
+
+        // "mail:" typed after free text must stay literal text, not a
+        // second chip — only the leading run (the seeded "cards" chip) can
+        // ever become a chip. Checked against the real DOM value, not just
+        // the parsed result: this is exactly what the C1 bug corrupted —
+        // the box used to strip a computed-length prefix that disagreed with
+        // where the chip token actually sat, cutting into "Onboarding".
+        await expect(page.getByTestId('search-chip-mail')).toHaveCount(0)
+        await expect(page.getByTestId('search-chip-cards')).toBeVisible()
+        await expect(input).toHaveValue('Onboarding mail: checklist')
+    })
+
     // '/' inside an RN TextInput never reaches the global shortcut listener
     // at all: react-native-web's TextInput.handleKeyDown unconditionally
     // calls stopPropagation() on every keydown, and the shortcuts provider

--- a/tests/e2e/search-palette.spec.ts
+++ b/tests/e2e/search-palette.spec.ts
@@ -1,0 +1,251 @@
+import { expect, type Page, test } from '@playwright/test'
+import { login, navigateToPackage } from './helpers'
+
+// The palette's own dialog role/label — see SearchPalette.web.tsx's
+// PaletteCard, which sets role="dialog" aria-label="Search".
+function paletteDialog(page: Page) {
+    return page.getByRole('dialog', { name: 'Search' })
+}
+
+// Open the palette from a closed state. Never call this (or press '/') while
+// the palette is already open — the shortcut is deliberately suppressed
+// while focus sits in an input (see the "slash inside a text input" test
+// below), which means the browser's default keystroke still lands a literal
+// '/' character in whatever is focused, corrupting an in-progress query.
+async function openPalette(page: Page) {
+    await page.keyboard.press('/')
+    await expect(paletteDialog(page)).toBeVisible()
+}
+
+// useSearchResults debounces 300ms and only fires once >=2 chars of include
+// text are typed (MIN_QUERY_LENGTH), so every assertion here waits on the
+// actual `/search` network response or the resulting DOM — never a fixed
+// timeout, which flakes under CI load and doesn't prove the request landed.
+async function typeAndWait(page: Page, text: string) {
+    await page.keyboard.type(text)
+    await page.waitForResponse(r => r.url().includes('/search') && r.status() === 200)
+}
+
+test.describe('Search palette', () => {
+    test('opens seeded with the current package as a chip', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await expect(page.getByTestId('search-chip-cards')).toBeVisible()
+    })
+
+    test('backspace on empty text pops the chip and widens to every package', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await expect(page.getByTestId('search-chip-cards')).toBeVisible()
+
+        await page.keyboard.press('Backspace')
+        await expect(page.getByTestId('search-chip-cards')).toHaveCount(0)
+    })
+
+    test('typing a package name plus a colon turns it into a scope chip', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace') // widen first: start from zero chips
+        await page.keyboard.type('drive:')
+        await expect(page.getByTestId('search-chip-drive')).toBeVisible()
+    })
+
+    // Regression guard (the bug this exists to prevent: a literal package
+    // name becoming an unwanted scope chip). Real seeded data: the "Sentry
+    // alert: high error rate in production" thread's snippet reads "...in the
+    // mail service...", so the word "mail" is genuinely indexed and findable
+    // with zero chips — proving the guard protects real search results, not
+    // just an absent testid.
+    test('a package name without a colon stays literal search text', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace') // zero chips: search everywhere
+        await typeAndWait(page, 'mail')
+
+        await expect(page.getByTestId('search-chip-mail')).toHaveCount(0)
+        await expect(
+            paletteDialog(page).getByText('Sentry alert: high error rate in production')
+        ).toBeVisible()
+    })
+
+    test('two chips search exactly those packages, grouped by nav.order', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace')
+        // drive (nav.order 12) before cards (nav.order 25) — real seeded
+        // "onboarding" hits in both: drive's "Onboarding Slides.pptx" and
+        // cards' "Onboarding checklist for new members".
+        await typeAndWait(page, 'drive: cards: onboarding')
+
+        await expect(page.getByTestId('search-chip-drive')).toBeVisible()
+        await expect(page.getByTestId('search-chip-cards')).toBeVisible()
+
+        const rows = page.getByRole('option')
+        await expect(rows.filter({ hasText: 'Onboarding Slides.pptx' })).toBeVisible()
+        await expect(rows.filter({ hasText: 'Onboarding checklist for new members' })).toBeVisible()
+
+        // Grouped by package (2+ chips) uses a section HEADING naming the
+        // package, not a per-row badge — that only appears in the flat,
+        // unscoped list (see the zero-chips test below).
+        const headings = page.getByTestId('search-section-heading')
+        await expect(headings.filter({ hasText: 'Drive' })).toBeVisible()
+        await expect(headings.filter({ hasText: 'Cards' })).toBeVisible()
+
+        const optionTexts = await rows.allTextContents()
+        const driveIndex = optionTexts.findIndex(t => t.includes('Onboarding Slides.pptx'))
+        const cardsIndex = optionTexts.findIndex(t =>
+            t.includes('Onboarding checklist for new members')
+        )
+        expect(driveIndex).toBeGreaterThanOrEqual(0)
+        expect(cardsIndex).toBeGreaterThanOrEqual(0)
+        expect(driveIndex).toBeLessThan(cardsIndex)
+    })
+
+    test('zero chips is a flat, score-ordered list with per-row package badges', async ({
+        page,
+    }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace')
+        await typeAndWait(page, 'onboarding')
+
+        // Title-PREFIX matches (drive, cards both start with "Onboarding")
+        // must outrank mail's title-SUBSTRING match ("Design review: new
+        // onboarding flow" contains but doesn't start with the term) — this
+        // is the actual scoring behavior wired end to end, not merely that
+        // all three appear.
+        const rows = page.getByRole('option')
+        const texts = await rows.allTextContents()
+        const driveIndex = texts.findIndex(t => t.includes('Onboarding Slides.pptx'))
+        const cardsIndex = texts.findIndex(t => t.includes('Onboarding checklist for new members'))
+        const mailIndex = texts.findIndex(t => t.includes('Design review: new onboarding flow'))
+        expect(driveIndex).toBeGreaterThanOrEqual(0)
+        expect(cardsIndex).toBeGreaterThanOrEqual(0)
+        expect(mailIndex).toBeGreaterThanOrEqual(0)
+        expect(driveIndex).toBeLessThan(mailIndex)
+        expect(cardsIndex).toBeLessThan(mailIndex)
+
+        // Flat list (no chips) shows a badge naming each row's package —
+        // the thing that disappears once a chip scopes the list to one
+        // package (see the single-chip test below). Badges render inside the
+        // matching row, so scope to it rather than the whole dialog.
+        await expect(
+            rows.filter({ hasText: 'Onboarding Slides.pptx' }).getByText('Drive', { exact: true })
+        ).toBeVisible()
+        await expect(
+            rows
+                .filter({ hasText: 'Design review: new onboarding flow' })
+                .getByText('Mail', { exact: true })
+        ).toBeVisible()
+        await expect(
+            rows
+                .filter({ hasText: 'Onboarding checklist for new members' })
+                .getByText('Cards', { exact: true })
+        ).toBeVisible()
+    })
+
+    test('exactly one chip is a flat list with no package badges', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace') // drop the seeded "cards" chip
+        await typeAndWait(page, 'drive: onboarding')
+
+        await expect(page.getByTestId('search-chip-drive')).toBeVisible()
+        const row = page.getByRole('option').filter({ hasText: 'Onboarding Slides.pptx' })
+        await expect(row).toBeVisible()
+        // Single-chip results are already scoped to one package, so no badge
+        // is shown on the row (the label would be redundant with the chip).
+        await expect(row.getByText('Drive', { exact: true })).toHaveCount(0)
+    })
+
+    // Excludes a word using real seeded data: "Q2 Product Roadmap Review" and
+    // "Design review: new onboarding flow" both contain "review", but only
+    // the second contains "onboarding" — so -onboarding is a genuine
+    // discriminator, not a cousin case that would pass even if exclusion were
+    // broken.
+    test('a -term excludes matching results end to end', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace') // drop the seeded "cards" chip
+        await typeAndWait(page, 'mail: review -onboarding')
+
+        await expect(page.getByTestId('search-chip-mail')).toBeVisible()
+        await expect(
+            page.getByRole('option').filter({ hasText: 'Q2 Product Roadmap Review' })
+        ).toBeVisible()
+        await expect(
+            page.getByRole('option').filter({ hasText: 'Design review: new onboarding flow' })
+        ).toHaveCount(0)
+    })
+
+    test('a hyphen inside a word stays literal and still matches', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace') // drop the seeded "cards" chip
+        // "Product Roadmap 2026.docx" (description: "Full product roadmap
+        // for 2026") is real seeded drive content containing both words.
+        // Typing the mid-token-hyphen form "roadmap-2026" must not be torn
+        // into an exclusion of "2026" (parseQuery keeps a mid-token hyphen
+        // literal) — the backend's own FTS sanitizer then re-splits it into
+        // two AND-ed prefix terms, both of which this file satisfies.
+        await typeAndWait(page, 'drive: roadmap-2026')
+
+        await expect(
+            page.getByRole('option').filter({ hasText: 'Product Roadmap 2026.docx' })
+        ).toBeVisible()
+    })
+
+    test('selecting a result with Enter navigates to it', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        await openPalette(page)
+        await page.keyboard.press('Backspace') // drop the seeded "cards" chip
+        await typeAndWait(page, 'mail: Q2 Product Roadmap')
+
+        await expect(page.getByRole('option').first()).toBeVisible()
+        await page.keyboard.press('Enter')
+
+        await expect(page.getByTestId('mail-thread-detail')).toBeVisible()
+        await expect(page).toHaveTitle(/Q2 Product Roadmap Review/)
+    })
+
+    test('escape closes the palette without navigating', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'cards')
+        const url = page.url()
+
+        await openPalette(page)
+        await page.keyboard.press('Escape')
+
+        await expect(paletteDialog(page)).toHaveCount(0)
+        expect(page.url()).toBe(url)
+    })
+
+    // '/' inside an RN TextInput never reaches the global shortcut listener
+    // at all: react-native-web's TextInput.handleKeyDown unconditionally
+    // calls stopPropagation() on every keydown, and the shortcuts provider
+    // listens on `window` in the bubble phase — so this holds regardless of
+    // which package owns the field. Asserting on a literal '/' landing in
+    // the box (not just the dialog's absence) proves the keystroke reached
+    // the input rather than being dropped by some unrelated failure.
+    test('slash inside a text input does not open the palette', async ({ page }) => {
+        await login(page)
+        await navigateToPackage(page, 'contacts')
+        const searchBox = page.getByPlaceholder('Search contacts...')
+        await searchBox.click()
+
+        await page.keyboard.press('/')
+
+        await expect(searchBox).toHaveValue('/')
+        await expect(paletteDialog(page)).toHaveCount(0)
+    })
+})

--- a/tests/install/run-todo-install.sh
+++ b/tests/install/run-todo-install.sh
@@ -423,7 +423,11 @@ run_phase 'delete landed' 'verify delete'
 
 CORE_CUR=$(docker exec "${CONTAINER}" node -e "console.log(require('/workspace/current/core/package.json').version)")
 echo "[runner] current base version: ${CORE_CUR}"
-CORE_NEXT="0.0.5"   # synthetic upgrade target; must be > CORE_CUR (0.0.4)
+# Synthetic upgrade target: bump CORE_CUR's patch number rather than a
+# hardcoded literal, so this stays > CORE_CUR automatically as core's real
+# version advances (a stale literal here silently becomes a DOWNGRADE target
+# the moment core's actual version catches up to it).
+CORE_NEXT=$(node -e "const v='${CORE_CUR}'.split('.'); v[2]=String(Number(v[2])+1); console.log(v.join('.'))")
 
 provision_base_remote() {
     echo "[runner] provisioning local base remote with v${CORE_CUR} + v${CORE_NEXT}"

--- a/tests/install/todo-install.spec.ts
+++ b/tests/install/todo-install.spec.ts
@@ -116,9 +116,12 @@ const TODO_SPEC_BUGGY_MIGRATION = 'github:tinycld/todo#v0.0.1-pre-buggy-migratio
 const TODO_SPEC_BUGGY_FE = 'github:tinycld/todo#v0.0.1-pre-buggy-fe'
 
 // Core (base) upgrade target + the baked current version, supplied by the
-// runner (run-todo-install.sh provisions a local base remote with these tags).
-const CORE_CUR = process.env.PW_CORE_CUR ?? '0.0.4'
-const CORE_NEXT = process.env.PW_CORE_NEXT ?? '0.0.5'
+// runner (run-todo-install.sh provisions a local base remote with these
+// tags). The runner always sets both env vars — these fallbacks only matter
+// for a standalone run of this spec without the runner, so they just need to
+// be A valid current/next pair, not the actual live core version.
+const CORE_CUR = process.env.PW_CORE_CUR ?? '0.0.6'
+const CORE_NEXT = process.env.PW_CORE_NEXT ?? '0.0.7'
 
 // The app user this spec logs in as to drive the todo UI. Single-org: the
 // console has no user-creation form (that was the org-create flow), so the

--- a/tests/scripts/scaffold-shortcut-stub.ts
+++ b/tests/scripts/scaffold-shortcut-stub.ts
@@ -9,7 +9,7 @@
  * at real packages (mail, contacts) couples app's CI to those packages'
  * presence — when a feature's branch breaks, app's CI goes red over a
  * bug that doesn't live in app. The stub registers a minimal package
- * with `nav.shortcut: 'o'` and a single placeholder screen, giving the
+ * with its own `nav.shortcut` and a single placeholder screen, giving the
  * shortcut tests exactly what they need to verify app's OWN contract:
  * "shortcut chord navigates to the package whose manifest registered it."
  *
@@ -42,7 +42,12 @@ import { fileURLToPath } from 'node:url'
 // keyboard-shortcuts spec asserts on. Changing any of these requires
 // updating both this script AND tests/e2e/keyboard-shortcuts.spec.ts.
 export const STUB_SLUG = 'shortcut-stub'
-export const STUB_NAV_SHORTCUT = 'k'
+// Must not collide with any real package's nav.shortcut, or `t <letter>`
+// becomes ambiguous and the chord test fails on whichever registration the
+// matcher happens to reach first. This previously read 'k', which cards later
+// claimed. Real letters in use: c d k m o s t — 'z' is deliberately far from
+// anything a feature would want.
+export const STUB_NAV_SHORTCUT = 'z'
 export const STUB_NAV_LABEL = 'Shortcut Stub'
 // Pin a known-good bootstrap so CI is reproducible — `@latest` lets an
 // unrelated bootstrap release silently turn this e2e fixture red. Bump
@@ -144,6 +149,23 @@ function patchPackageJson(stubDir: string): void {
         './screens/*': `./tinycld/${STUB_SLUG}/screens/*.tsx`,
     }
     writeFileSync(path, `${JSON.stringify(pkg, null, 4)}\n`)
+}
+
+/**
+ * Repoint the template's vitest config at the app shell's real location.
+ *
+ * The pinned bootstrap still emits `import appConfig from '../app/vitest.config'`
+ * from when the shell lived in app/; it is now tinycld/. Left alone, the stub
+ * cannot resolve its config and `tinycld-pkg check --all` fails on it — on a
+ * stale template, with nothing to do with whatever is being tested. Drop this
+ * once BOOTSTRAP_VERSION moves past the rename.
+ */
+function patchVitestConfig(stubDir: string): void {
+    const path = join(stubDir, 'vitest.config.ts')
+    if (!existsSync(path)) return
+    const contents = readFileSync(path, 'utf8')
+    const patched = contents.replace("'../app/vitest.config'", "'../tinycld/vitest.config'")
+    if (patched !== contents) writeFileSync(path, patched)
 }
 
 function writeScreens(stubDir: string): void {
@@ -268,6 +290,7 @@ function main(): void {
     const stubDir = join(wsRoot, STUB_SLUG)
     patchManifest(stubDir)
     patchPackageJson(stubDir)
+    patchVitestConfig(stubDir)
     writeScreens(stubDir)
 
     ensureMember(wsRoot)


### PR DESCRIPTION
Adds a `/`-triggered search palette that searches across every installed package, plus the shared search engine it runs on.

**Note on scope:** this branch also carries pre-existing haptics, drawer edge-swipe, and shortcut-scope commits that predate the search work. The search feature is `9595155..6dd4743`.

## How it works

Packages contribute a `search` manifest block naming an endpoint and an adapter module (`toRow` pure + `useSearchActions` hook). The generator emits a **bare lazy thunk**, not `React.lazy` — an adapter is a module of two non-component exports, so `lazy()` cannot wrap it.

Query grammar: `pkg:` makes a scope chip, `-term` excludes, boolean operators are stripped. A package name *without* a colon stays literal search text, so an email titled "mail server migration" is still findable.

Results are scored client-side by match quality rather than FTS5 rank: BM25 weights terms by frequency within a single table's corpus, so scores from two packages are in different units and a perfect filename match can sort below a marginal one.

## Shared engine (`core/server/fts`)

- `MemberScope` — membership-table scoping, emitted as a live subquery so revoking access takes effect on the next search
- `ExcludeField` — for bool columns, deliberately distinct from `SoftDeleteField` (which splits on `field = ''`, correct for text timestamps but wrong against a bool under SQLite's loose typing)
- A disabled-user check inside `Search`, so every caller is covered including the JS binding. Search is raw SQL behind an auth check, so PocketBase's collection rules never run on this path — without it a disabled account kept reading until its token expired
- Term exclusion, gated on a positive term: FTS5 errors on a NOT-only MATCH expression

`Search`/`isDisabled` now take `core.App` rather than the concrete `*pocketbase.PocketBase`, which is what makes the security path testable against `tests.NewTestApp` (matching drive's existing pattern).

## Verification

- 864 unit tests, biome + tsc clean
- Go: `core/server/fts` suite green, including fail-closed tests for nil scope and disabled/missing users
- E2E: 13/13 Playwright specs against a real running stack

## Known follow-up (not in this PR)

`allowInInputs: true` is dead code for react-native-web `TextInput`s: `TextInput.handleKeyDown` calls `stopPropagation()` unconditionally and the shortcuts provider binds tinykeys on `window` in the bubble phase, so no shortcut fires while an RN input has focus. The palette sidesteps this with a capture-phase listener, but `core.closeHelp` (Escape) would silently not fire with a help-overlay field focused. Pre-existing and unrelated to search.
