### PR TITLE
fix(core): clear a departing peer's presence avatar

### DIFF
--- a/core/lib/realtime/client.ts
+++ b/core/lib/realtime/client.ts
@@ -19,6 +19,11 @@ const MSG_SYNC_REPLY = 0x04
 const MSG_ASSIGN_ID = 0x05
 const MSG_SERVER_HELLO = 0x06
 const MSG_SERVER_SLOT = 0x07
+// Announces this connection's y-protocols awareness clientID to the
+// broker, so it can name our slot in the synthetic leave frame it sends
+// on our behalf when the connection drops ungracefully. Bookkeeping
+// only — the broker never fans it out.
+const MSG_AWARENESS_HELLO = 0x08
 
 // Reconnect backoff: start small, cap so a long-down server doesn't
 // hammer us. The backoff resets on a successful connect.
@@ -226,6 +231,18 @@ export class RealtimeClient {
                 id.set(frame.subarray(0, CLIENT_ID_LEN))
                 this.clientID = id
 
+                // Announce our y-protocols awareness clientID so the
+                // broker can name our slot in the leave frame it
+                // synthesizes when this connection drops. Without it a
+                // killed tab or TCP reset leaves an avatar behind on
+                // every peer until y-protocols' 30s reaper clears it,
+                // because the broker's own 16-byte routing id shares no
+                // id space with awareness.
+                //
+                // Sent before the queue flush so the broker knows the
+                // slot before any awareness state that references it.
+                this.sendNow(MSG_AWARENESS_HELLO, encodeVarUint(this.opts.awareness.clientID))
+
                 const queued = this.pendingFrames
                 this.pendingFrames = []
                 for (const q of queued) {
@@ -258,13 +275,16 @@ export class RealtimeClient {
 
             case MSG_AWARENESS_UPDATE:
                 if (payload.length === 0) {
-                    // Synthetic leave frame: a peer's connection
-                    // closed. The server emits these so we can drop
-                    // remote awareness slots even on ungraceful
-                    // disconnect. We don't know which slot was theirs
-                    // from the frame alone — the awareness layer will
-                    // age it out via heartbeat absence, or the next
-                    // refresh of their state will re-populate.
+                    // Legacy synthetic leave frame, from a broker that
+                    // predates MSG_AWARENESS_HELLO. It names the
+                    // departing BROKER id, which shares no id space
+                    // with y-protocols awareness, so there is no slot
+                    // we can map it to. Nothing to do but let
+                    // y-protocols' own outdated-state reaper drop the
+                    // slot after 30s — it runs unconditionally from the
+                    // Awareness constructor. A current broker sends a
+                    // real removal payload here instead and the avatar
+                    // goes immediately.
                     break
                 }
                 applyAwarenessUpdate(this.opts.awareness, payload, REMOTE_ORIGIN)
@@ -318,6 +338,16 @@ export class RealtimeClient {
             }
         }
     }
+}
+
+// encodeVarUint writes a single lib0 varuint — the payload shape of
+// MSG_AWARENESS_HELLO. Goes through lib0 rather than a hand-rolled loop
+// so the bytes stay identical to what the rest of the y-protocols stack
+// emits, and to what the Go side's readVarUint expects.
+function encodeVarUint(n: number): Uint8Array {
+    const enc = encoding.createEncoder()
+    encoding.writeVarUint(enc, n)
+    return encoding.toUint8Array(enc)
 }
 
 // REMOTE_ORIGIN tags routine updates received from the network (peer

--- a/core/lib/realtime/use-realtime-room.ts
+++ b/core/lib/realtime/use-realtime-room.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { useFocusEffect } from 'expo-router'
+import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { Awareness } from 'y-protocols/awareness'
 import * as Y from 'yjs'
 import { PB_SERVER_ADDR } from '../config'
@@ -221,6 +222,26 @@ export function useRealtimeRoom({
         }
     }, [roomKind, roomID])
 
+    // Publish a clean leave whenever this screen stops being visible, and
+    // republish on the way back.
+    //
+    // Keyed on FOCUS and on pagehide, NOT on unmount alone. The effect
+    // cleanup above only runs when the component actually unmounts, and for
+    // package-to-package navigation it never does: the package tabs render
+    // with `freezeOnBlur` (core/components/workspace/PackageTabs.tsx), which
+    // leaves a departed screen mounted-but-frozen so returning to it is
+    // instant. Its socket therefore stays open and its awareness slot stays
+    // populated, so remote peers kept showing an avatar for someone who had
+    // left the package — the bug cards/tests/e2e/board-presence.spec.ts
+    // catches. core/lib/shortcuts/scopes.ts solves the same freeze the same
+    // way, for the same reason.
+    //
+    // A tab close is the other half: it never unmounts anything either, and
+    // `pagehide` is the one event that fires reliably on mobile Safari and
+    // also covers bfcache eviction. Web-only, hence the typeof guard — this
+    // module is imported by React Native.
+    useLeaveOnBlur(handleRef)
+
     if (!handleRef.current) return null
     return {
         doc: handleRef.current.doc,
@@ -230,6 +251,62 @@ export function useRealtimeRoom({
         serverHello,
         serverSlot,
     }
+}
+
+// useLeaveOnBlur publishes an awareness removal when the owning route
+// blurs or the page hides, and restores the slot on refocus.
+//
+// The saved slot is what makes this reversible: `setLocalState(null)`
+// deletes the local state outright, so without stashing it first a
+// refocus would restore an empty slot and the user would be invisible
+// to peers until something else happened to republish. Consumers that
+// keep their own publish effect (cards' useBoardPresence) would recover
+// eventually; ones that publish only via `initialAwareness` would not,
+// since that is captured on the room's first effect run only.
+function useLeaveOnBlur(
+    handleRef: RefObject<{ doc: Y.Doc; awareness: Awareness; client: RealtimeClient } | null>
+) {
+    const savedSlot = useRef<Record<string, unknown> | null>(null)
+
+    const leave = useCallback(() => {
+        const awareness = handleRef.current?.awareness
+        if (awareness == null) return
+        const current = awareness.getLocalState()
+        // Don't clobber a good saved slot with the null we just wrote —
+        // pagehide and blur can both fire for one departure.
+        if (current != null) savedSlot.current = current as Record<string, unknown>
+        try {
+            awareness.setLocalState(null)
+        } catch {
+            // best effort — a destroyed awareness is already "left"
+        }
+    }, [handleRef])
+
+    const rejoin = useCallback(() => {
+        const awareness = handleRef.current?.awareness
+        if (awareness == null || savedSlot.current == null) return
+        try {
+            awareness.setLocalState(savedSlot.current)
+        } catch {
+            // best effort
+        }
+        savedSlot.current = null
+    }, [handleRef])
+
+    useFocusEffect(
+        useCallback(() => {
+            // Refocusing a frozen screen remounts nothing, so the slot has
+            // to be restored here rather than by the room effect.
+            rejoin()
+            return leave
+        }, [leave, rejoin])
+    )
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return
+        window.addEventListener('pagehide', leave)
+        return () => window.removeEventListener('pagehide', leave)
+    }, [leave])
 }
 
 // defaultIsEmpty considers a Y.Doc empty when no top-level shared

--- a/core/lib/realtime/use-realtime-room.ts
+++ b/core/lib/realtime/use-realtime-room.ts
@@ -303,7 +303,13 @@ function useLeaveOnBlur(
     )
 
     useEffect(() => {
-        if (typeof window === 'undefined') return
+        // Feature-detect the METHOD, not the object. React Native defines a
+        // global `window` with no DOM event API, so a `typeof window` check
+        // passes there and then throws "addEventListener is not a function",
+        // taking the whole screen down. There is no pagehide on native
+        // anyway — the app is backgrounded, not unloaded, and blur already
+        // covers navigating away.
+        if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return
         window.addEventListener('pagehide', leave)
         return () => window.removeEventListener('pagehide', leave)
     }, [leave])

--- a/core/server/realtime/realtime.go
+++ b/core/server/realtime/realtime.go
@@ -66,6 +66,21 @@ const (
 	// the room kind defines; clients route it via onServerSlot, never
 	// applying it to doc/awareness. See Room.PublishServerSlot.
 	MsgServerSlot MessageType = 0x07
+	// MsgAwarenessHello is sent by a client once per connection, right
+	// after MsgAssignID, to announce its numeric y-protocols awareness
+	// clientID. The payload is that id as a lib0 varuint. Consumed by
+	// the broker as bookkeeping — never fanned out.
+	//
+	// It exists so broadcastLeave can name the departing awareness slot.
+	// The broker's routing id is an opaque 16 bytes and shares no id
+	// space with y-protocols awareness, so without this a peer receiving
+	// a leave frame cannot tell WHICH avatar to drop, and an ungraceful
+	// disconnect (killed tab, TCP reset) leaves a ghost until
+	// y-protocols' own 30s reaper clears it.
+	//
+	// Optional: a client that never sends it still gets the legacy
+	// zero-length leave frame, so older builds keep working unchanged.
+	MsgAwarenessHello MessageType = 0x08
 )
 
 // clientIDLen is the fixed 16-byte UUID prefix on every wire frame.
@@ -194,6 +209,33 @@ type Client struct {
 	// to the WebSocket. Buffer size is bounded so a slow client does
 	// not pin memory; if the buffer overflows, the client is dropped.
 	send chan []byte
+
+	// yjsMu guards the awareness-clientID fields below. They are written
+	// once from the read loop (on MsgAwarenessHello) and read from
+	// broadcastLeave, which the transport runs from its own defer — a
+	// different goroutine in the ungraceful-close path, so the mutex is
+	// load-bearing under -race rather than decorative.
+	yjsMu sync.Mutex
+	// yjsClientID is this connection's y-protocols awareness clientID,
+	// announced via MsgAwarenessHello. yjsKnown distinguishes "not yet
+	// announced" from a legitimately-zero id.
+	yjsClientID uint64
+	yjsKnown    bool
+}
+
+// setYjsClientID records the awareness clientID this connection announced.
+func (c *Client) setYjsClientID(id uint64) {
+	c.yjsMu.Lock()
+	defer c.yjsMu.Unlock()
+	c.yjsClientID, c.yjsKnown = id, true
+}
+
+// YjsClientID returns the announced awareness clientID and whether one was
+// ever announced. Used by broadcastLeave to name the departing slot.
+func (c *Client) YjsClientID() (uint64, bool) {
+	c.yjsMu.Lock()
+	defer c.yjsMu.Unlock()
+	return c.yjsClientID, c.yjsKnown
 }
 
 // id of the client. Mostly used in tests; the byte prefix on each wire

--- a/core/server/realtime/realtime_test.go
+++ b/core/server/realtime/realtime_test.go
@@ -361,7 +361,10 @@ func TestRoomCleanup(t *testing.T) {
 	t.Fatalf("room never cleaned up; count=%d", broker.roomCount())
 }
 
-// TestLeaveBroadcast: when A disconnects, B receives a leave frame.
+// TestLeaveBroadcast: a client that never announced an awareness
+// clientID still produces the legacy zero-length leave frame, so an
+// older client build talking to a current broker behaves as it always
+// did.
 func TestLeaveBroadcast(t *testing.T) {
 	broker := NewBroker()
 	opts := startTestServer(t, broker, allowAllAuth)
@@ -379,6 +382,155 @@ func TestLeaveBroadcast(t *testing.T) {
 	}
 	if len(p) != 0 {
 		t.Fatalf("expected empty leave payload, got %d bytes", len(p))
+	}
+}
+
+// TestLeaveBroadcastNamesAwarenessSlot: an UNGRACEFUL disconnect — the
+// transport dies with no chance for the client to send its own removal —
+// still produces a frame naming the departing awareness slot.
+//
+// This is the case the hello frame exists for. A killed tab or TCP reset
+// runs no client-side teardown, so the broker is the only party that can
+// tell peers the client is gone; and without the announced clientID the
+// frame cannot say WHICH avatar to drop.
+func TestLeaveBroadcastNamesAwarenessSlot(t *testing.T) {
+	broker := NewBroker()
+	opts := startTestServer(t, broker, allowAllAuth)
+
+	a := dialClient(t, opts, "leaveroom", "alice")
+	b := dialClient(t, opts, "leaveroom", "bob")
+	time.Sleep(50 * time.Millisecond)
+
+	const aliceYjs uint64 = 3101126589
+	writeFrame(t, a, MsgAwarenessHello, appendVarUint(nil, aliceYjs))
+	time.Sleep(50 * time.Millisecond)
+
+	// CloseNow skips the closing handshake — as close as this harness
+	// gets to a killed tab.
+	_ = a.conn.CloseNow()
+
+	mt, p := readFrame(t, b, 2*time.Second)
+	if mt != MsgAwarenessUpdate {
+		t.Fatalf("B expected AWARENESS_UPDATE leave frame, got 0x%02x", mt)
+	}
+	if len(p) == 0 {
+		t.Fatal("leave payload was empty; peers cannot tell which slot to drop")
+	}
+
+	// Decode the y-protocols shape: count, clientID, clock, varString.
+	rest := p
+	count, ok := readVarUint(rest)
+	if !ok || count != 1 {
+		t.Fatalf("expected exactly 1 awareness entry, got count=%d ok=%v", count, ok)
+	}
+	rest = rest[varUintSize(count):]
+	gotID, ok := readVarUint(rest)
+	if !ok || gotID != aliceYjs {
+		t.Fatalf("leave frame named clientID %d, want %d (ok=%v)", gotID, aliceYjs, ok)
+	}
+	rest = rest[varUintSize(gotID):]
+	clock, ok := readVarUint(rest)
+	if !ok || clock != awarenessRemovalClock {
+		t.Fatalf("leave frame clock=%d, want %d (ok=%v)", clock, uint64(awarenessRemovalClock), ok)
+	}
+	rest = rest[varUintSize(clock):]
+	// The remainder must be varString("null") — the literal that makes
+	// applyAwarenessUpdate delete the slot.
+	strLen, ok := readVarUint(rest)
+	if !ok || strLen != 4 {
+		t.Fatalf("expected varString of len 4, got %d (ok=%v)", strLen, ok)
+	}
+	if got := string(rest[varUintSize(strLen):]); got != "null" {
+		t.Fatalf("expected state %q, got %q", "null", got)
+	}
+}
+
+// TestAwarenessHelloIsNotFannedOut: the announce frame is broker
+// bookkeeping, not presence. If it were fanned out, peers would try to
+// parse it as a y-protocols awareness payload.
+func TestAwarenessHelloIsNotFannedOut(t *testing.T) {
+	broker := NewBroker()
+	opts := startTestServer(t, broker, allowAllAuth)
+
+	a := dialClient(t, opts, "helloroom", "alice")
+	b := dialClient(t, opts, "helloroom", "bob")
+	time.Sleep(50 * time.Millisecond)
+
+	writeFrame(t, a, MsgAwarenessHello, appendVarUint(nil, 42))
+	// A real awareness frame behind it: whatever B reads first must be
+	// this one, proving the hello was consumed rather than relayed.
+	writeFrame(t, a, MsgAwarenessUpdate, []byte{0xAA, 0xBB})
+
+	mt, p := readFrame(t, b, 2*time.Second)
+	if mt != MsgAwarenessUpdate {
+		t.Fatalf("B expected AWARENESS_UPDATE, got 0x%02x", mt)
+	}
+	if len(p) != 2 || p[0] != 0xAA || p[1] != 0xBB {
+		t.Fatalf("B received the wrong frame: %v", p)
+	}
+}
+
+// TestAwarenessHelloMalformedIsIgnored: a truncated varuint must neither
+// panic nor drop the connection — it just falls back to the legacy
+// zero-length leave frame.
+func TestAwarenessHelloMalformedIsIgnored(t *testing.T) {
+	broker := NewBroker()
+	opts := startTestServer(t, broker, allowAllAuth)
+
+	a := dialClient(t, opts, "badhelloroom", "alice")
+	b := dialClient(t, opts, "badhelloroom", "bob")
+	time.Sleep(50 * time.Millisecond)
+
+	// 0xFF sets the continuation bit with no following byte.
+	writeFrame(t, a, MsgAwarenessHello, []byte{0xFF})
+	time.Sleep(50 * time.Millisecond)
+
+	// The connection still works.
+	writeFrame(t, a, MsgAwarenessUpdate, []byte{0x01})
+	mt, p := readFrame(t, b, 2*time.Second)
+	if mt != MsgAwarenessUpdate || len(p) != 1 {
+		t.Fatalf("connection broken after malformed hello: mt=0x%02x p=%v", mt, p)
+	}
+
+	_ = a.conn.CloseNow()
+	mt, p = readFrame(t, b, 2*time.Second)
+	if mt != MsgAwarenessUpdate {
+		t.Fatalf("expected leave frame, got 0x%02x", mt)
+	}
+	if len(p) != 0 {
+		t.Fatalf("malformed hello should leave no recorded id, got %d payload bytes", len(p))
+	}
+}
+
+// TestEncodeAwarenessRemovalGolden pins the encoder against bytes
+// captured from y-protocols' own encodeAwarenessUpdate for a removed
+// slot (clientID 3101126589, clock 2), so a lib0 varuint change or a
+// field-order slip surfaces here rather than as a silent no-op ghost.
+func TestEncodeAwarenessRemovalGolden(t *testing.T) {
+	got := encodeAwarenessRemoval(3101126589, 2)
+	want := []byte{1, 189, 223, 221, 198, 11, 2, 4, 'n', 'u', 'l', 'l'}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("encodeAwarenessRemoval mismatch:\n got %v\nwant %v", got, want)
+	}
+}
+
+// TestReadVarUint covers the decode side, including the malformed inputs
+// the wire can carry.
+func TestReadVarUint(t *testing.T) {
+	for _, n := range []uint64{0, 1, 127, 128, 300, 3101126589, awarenessRemovalClock} {
+		got, ok := readVarUint(appendVarUint(nil, n))
+		if !ok || got != n {
+			t.Fatalf("round-trip %d: got %d ok=%v", n, got, ok)
+		}
+	}
+	if _, ok := readVarUint(nil); ok {
+		t.Fatal("empty input should not decode")
+	}
+	if _, ok := readVarUint([]byte{0xFF}); ok {
+		t.Fatal("truncated varuint should not decode")
+	}
+	if _, ok := readVarUint(bytes.Repeat([]byte{0xFF}, 12)); ok {
+		t.Fatal("over-long varuint should not decode")
 	}
 }
 

--- a/core/server/realtime/room.go
+++ b/core/server/realtime/room.go
@@ -305,6 +305,20 @@ func (r *Room) route(from *Client, frame []byte) {
 		}
 	case MsgAwarenessUpdate:
 		r.fanOut(from, frame)
+	case MsgAwarenessHello:
+		// Announce-only: record the sender's awareness clientID so
+		// broadcastLeave can name their slot, then stop. Deliberately NOT
+		// fanned out — peers learn each other's slots from the awareness
+		// payloads themselves.
+		//
+		// A malformed varuint is ignored rather than fatal: the only cost
+		// is falling back to the legacy zero-length leave frame for this
+		// connection. Do NOT give this switch a `default:` that closes the
+		// connection — a newer client talking to an older broker relies on
+		// unknown frames being dropped silently.
+		if id, ok := readVarUint(frame[frameOverhead:]); ok {
+			from.setYjsClientID(id)
+		}
 	case MsgSyncRequest:
 		// If a server-side mirror is configured, the server is the
 		// source of truth: build a SyncReply directly from the
@@ -402,16 +416,87 @@ func (r *Room) deliverByID(target [clientIDLen]byte, frame []byte) {
 // and fans it out to remaining members. Called by the transport once the
 // client's read/write loop has finished.
 //
-// Convention: a leave is signaled as an awareness frame from `c` with a
-// zero-byte payload. The y-protocols/awareness encoding for "remove this
-// client" is what clients should send on graceful close, but we send our
-// own zero-length frame as a fallback so that ungraceful disconnects (TCP
-// reset, killed tab) also surface to peers.
+// When the client announced its awareness clientID via MsgAwarenessHello,
+// the frame carries a REAL y-protocols awareness removal payload naming
+// that slot, so peers drop the avatar immediately. This is the whole point
+// of the hello: an ungraceful disconnect (TCP reset, killed tab) never gets
+// to send its own removal, and without a named slot a peer cannot tell
+// which avatar the leave refers to.
+//
+// When it did not (an older client build), we fall back to the legacy
+// zero-length payload. That frame is not actionable by the receiver — it
+// leaves the ghost to y-protocols' own 30s reaper — but emitting it keeps
+// the wire contract unchanged.
 func (r *Room) broadcastLeave(c *Client) {
-	frame := make([]byte, frameOverhead)
+	var payload []byte
+	if yjsID, ok := c.YjsClientID(); ok {
+		payload = encodeAwarenessRemoval(yjsID, awarenessRemovalClock)
+	}
+	frame := make([]byte, frameOverhead+len(payload))
 	copy(frame[:clientIDLen], c.id[:])
 	frame[clientIDLen] = byte(MsgAwarenessUpdate)
+	copy(frame[frameOverhead:], payload)
 	r.fanOut(c, frame)
+}
+
+// awarenessRemovalClock is the clock the broker stamps on a synthesized
+// removal. y-protocols accepts an incoming awareness entry when its clock
+// is GREATER than the one the receiver holds for that slot, or when the
+// clocks are equal and the state is null. The broker does not track
+// per-slot clocks — it never parses the awareness payloads it fans out —
+// so it stamps a value no live session will reach: an awareness clock
+// increments once per local state write, and y-protocols' own renewal
+// ticks at most once every 15s, so 2^31 is unreachable in any real
+// session lifetime.
+//
+// The alternative — having the hello carry the client's current clock —
+// is more precise but makes the hello stateful (it would have to be
+// re-sent on every local state change to stay accurate), which is a worse
+// trade for a frame whose only job is to name a slot.
+const awarenessRemovalClock = 1 << 31
+
+// encodeAwarenessRemoval builds a y-protocols awareness update marking one
+// client's slot as gone. Mirrors encodeAwarenessUpdate in
+// y-protocols/awareness.js for the single-client, null-state case:
+//
+//	varUint(1)          // one entry follows
+//	varUint(clientID)
+//	varUint(clock)
+//	varString("null")   // varUint(len) || utf8 bytes
+//
+// The literal "null" is what JSON.stringify(null) produces, and the
+// receiving applyAwarenessUpdate takes its state===null branch on exactly
+// that, calling states.delete(clientID). Pinned to real y-protocols output
+// by TestEncodeAwarenessRemovalGolden.
+func encodeAwarenessRemoval(clientID, clock uint64) []byte {
+	const nullJSON = "null"
+	out := make([]byte, 0, 16)
+	out = appendVarUint(out, 1)
+	out = appendVarUint(out, clientID)
+	out = appendVarUint(out, clock)
+	out = appendVarUint(out, uint64(len(nullJSON)))
+	return append(out, nullJSON...)
+}
+
+// readVarUint decodes a lib0 varuint from the front of b. Returns false on
+// a truncated or over-long encoding rather than panicking — the input is
+// attacker-controlled.
+func readVarUint(b []byte) (uint64, bool) {
+	var v uint64
+	var shift uint
+	for i, by := range b {
+		// A uint64 varuint is at most 10 bytes; anything longer is
+		// malformed and would overflow the shift.
+		if i >= 10 {
+			return 0, false
+		}
+		v |= uint64(by&0x7F) << shift
+		if by&0x80 == 0 {
+			return v, true
+		}
+		shift += 7
+	}
+	return 0, false
 }
 
 // deliver pushes a frame to a client's send buffer. If the buffer is

--- a/core/tests/unit/realtime-leave-native.test.ts
+++ b/core/tests/unit/realtime-leave-native.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * React Native defines a global `window` object that is NOT a DOM window: it
+ * has no `addEventListener`. A `typeof window === 'undefined'` guard therefore
+ * passes on native and the call throws
+ *
+ *   TypeError: window.addEventListener is not a function
+ *
+ * from a passive effect, which unmounts the whole screen. That shipped and
+ * crashed the cards board on iOS, so the shape is pinned here.
+ *
+ * This tests the GUARD rather than the hook: reaching the hook needs a React
+ * renderer plus expo-router's navigation context, and the bug was never in the
+ * hook's logic — it was in which global it probed.
+ */
+
+/** The guard as written in useLeaveOnBlur. */
+function canListenToPageHide(win: unknown): boolean {
+    if (typeof win === 'undefined' || win === null) return false
+    return typeof (win as { addEventListener?: unknown }).addEventListener === 'function'
+}
+
+describe('pagehide guard', () => {
+    it('declines React Native’s window, which has no addEventListener', () => {
+        // What RN actually provides: a real object, DOM-less.
+        const reactNativeWindow = { navigator: { product: 'ReactNative' } }
+        expect(canListenToPageHide(reactNativeWindow)).toBe(false)
+    })
+
+    it('accepts a real DOM window', () => {
+        const domWindow = { addEventListener() {}, removeEventListener() {} }
+        expect(canListenToPageHide(domWindow)).toBe(true)
+    })
+
+    it('declines when there is no window at all (SSR, unit tests)', () => {
+        expect(canListenToPageHide(undefined)).toBe(false)
+        expect(canListenToPageHide(null)).toBe(false)
+    })
+
+    it('is not satisfied by a non-callable addEventListener', () => {
+        // Guarding on presence rather than callability would pass here and
+        // then throw at the call site — the same class of bug.
+        expect(canListenToPageHide({ addEventListener: 'nope' })).toBe(false)
+    })
+})

--- a/core/tests/unit/realtime-leave.test.ts
+++ b/core/tests/unit/realtime-leave.test.ts
@@ -1,0 +1,195 @@
+import { RealtimeClient } from '@tinycld/core/lib/realtime/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Awareness, applyAwarenessUpdate, encodeAwarenessUpdate } from 'y-protocols/awareness'
+import * as Y from 'yjs'
+
+// Wire constants, mirrored from client.ts (which keeps them private).
+const CLIENT_ID_LEN = 16
+const FRAME_OVERHEAD = CLIENT_ID_LEN + 1
+const MSG_AWARENESS_UPDATE = 0x02
+const MSG_SYNC_REQUEST = 0x03
+const MSG_ASSIGN_ID = 0x05
+const MSG_AWARENESS_HELLO = 0x08
+
+// A stand-in for the browser WebSocket that records what the client
+// sends and lets a test push frames back. readyState must report OPEN or
+// the client's sendNow drops every frame on the floor.
+class FakeSocket {
+    static OPEN = 1
+    readyState = 1
+    sent: Uint8Array[] = []
+    closed = false
+    // Order matters for the teardown test: it asserts the removal frame
+    // was written BEFORE the socket closed.
+    log: string[] = []
+    onopen: (() => void) | null = null
+    onmessage: ((evt: { data: ArrayBuffer }) => void) | null = null
+    onclose: (() => void) | null = null
+    onerror: (() => void) | null = null
+    binaryType = 'arraybuffer'
+
+    send(frame: Uint8Array) {
+        this.sent.push(new Uint8Array(frame))
+        this.log.push('send')
+    }
+    close() {
+        this.closed = true
+        this.log.push('close')
+    }
+    /** Deliver a server frame to the client under test. */
+    deliver(msgType: number, payload: Uint8Array, senderID?: Uint8Array) {
+        const frame = new Uint8Array(FRAME_OVERHEAD + payload.length)
+        if (senderID) frame.set(senderID, 0)
+        frame[CLIENT_ID_LEN] = msgType
+        frame.set(payload, FRAME_OVERHEAD)
+        this.onmessage?.({ data: frame.buffer as ArrayBuffer })
+    }
+}
+
+let sockets: FakeSocket[] = []
+
+beforeEach(() => {
+    sockets = []
+    // A plain function stands in for the WebSocket constructor: `new Fn()`
+    // on a function returning an object yields that object, so each client
+    // gets a FakeSocket we can still reach through `sockets`.
+    const WebSocketStub = function WebSocketStub() {
+        const socket = new FakeSocket()
+        sockets.push(socket)
+        return socket
+    } as unknown as typeof WebSocket
+    ;(WebSocketStub as { OPEN: number }).OPEN = FakeSocket.OPEN
+    vi.stubGlobal('WebSocket', WebSocketStub)
+})
+
+function frameType(frame: Uint8Array): number {
+    return frame[CLIENT_ID_LEN]
+}
+
+function framePayload(frame: Uint8Array): Uint8Array {
+    return frame.subarray(FRAME_OVERHEAD)
+}
+
+/** Decode a lib0 varuint, the payload shape of MSG_AWARENESS_HELLO. */
+function readVarUint(bytes: Uint8Array): number {
+    let value = 0
+    let shift = 0
+    for (const byte of bytes) {
+        value |= (byte & 0x7f) << shift
+        if ((byte & 0x80) === 0) return value >>> 0
+        shift += 7
+    }
+    throw new Error('truncated varuint')
+}
+
+function connected() {
+    const doc = new Y.Doc()
+    const awareness = new Awareness(doc)
+    const client = new RealtimeClient({ url: 'ws://test/room', doc, awareness })
+    client.connect()
+    const ws = sockets[0]
+    ws.onopen?.()
+    // The server assigns an id; its 16-byte prefix IS the assignment.
+    const assigned = new Uint8Array(CLIENT_ID_LEN).fill(7)
+    ws.deliver(MSG_ASSIGN_ID, new Uint8Array(0), assigned)
+    return { doc, awareness, client, ws }
+}
+
+describe('RealtimeClient — awareness hello', () => {
+    it('announces its yjs clientID as soon as the server assigns an id', () => {
+        const { awareness, ws, client } = connected()
+
+        const hello = ws.sent.find(f => frameType(f) === MSG_AWARENESS_HELLO)
+        expect(hello, 'no MSG_AWARENESS_HELLO was sent').toBeDefined()
+        // The broker keys the synthesized leave frame off this value, so a
+        // mismatch means peers would be told to drop the wrong avatar.
+        expect(readVarUint(framePayload(hello as Uint8Array))).toBe(awareness.clientID)
+
+        client.destroy()
+    })
+
+    it('announces before the sync handshake, so the broker knows the slot first', () => {
+        const { ws, client } = connected()
+
+        const helloAt = ws.sent.findIndex(f => frameType(f) === MSG_AWARENESS_HELLO)
+        const syncAt = ws.sent.findIndex(f => frameType(f) === MSG_SYNC_REQUEST)
+        expect(helloAt).toBeGreaterThanOrEqual(0)
+        expect(syncAt).toBeGreaterThanOrEqual(0)
+        expect(helloAt).toBeLessThan(syncAt)
+
+        client.destroy()
+    })
+})
+
+describe('RealtimeClient — leave frames', () => {
+    it('drops a peer slot when the broker synthesizes a real removal', () => {
+        const { awareness, ws, client } = connected()
+
+        // Seed a peer slot the way a real awareness update would.
+        const peerDoc = new Y.Doc()
+        const peer = new Awareness(peerDoc)
+        peer.setLocalState({ user: { id: 'ghost', name: 'Ghost', color: '#fff' } })
+        ws.deliver(MSG_AWARENESS_UPDATE, encodeAwarenessUpdate(peer, [peer.clientID]))
+        expect(awareness.getStates().has(peer.clientID)).toBe(true)
+
+        // The broker's synthesized removal: the peer left ungracefully, so
+        // this frame is the only notice anyone gets.
+        peer.setLocalState(null)
+        ws.deliver(MSG_AWARENESS_UPDATE, encodeAwarenessUpdate(peer, [peer.clientID]))
+
+        expect(awareness.getStates().has(peer.clientID)).toBe(false)
+
+        client.destroy()
+        peer.destroy()
+        peerDoc.destroy()
+    })
+
+    it('ignores a legacy zero-length leave frame without throwing', () => {
+        const { awareness, ws, client } = connected()
+
+        const peerDoc = new Y.Doc()
+        const peer = new Awareness(peerDoc)
+        peer.setLocalState({ user: { id: 'ghost' } })
+        ws.deliver(MSG_AWARENESS_UPDATE, encodeAwarenessUpdate(peer, [peer.clientID]))
+
+        // An older broker names the departing BROKER id, which maps to no
+        // awareness slot. The slot survives here by design — y-protocols'
+        // own reaper is what eventually clears it.
+        expect(() => ws.deliver(MSG_AWARENESS_UPDATE, new Uint8Array(0))).not.toThrow()
+        expect(awareness.getStates().has(peer.clientID)).toBe(true)
+
+        client.destroy()
+        peer.destroy()
+        peerDoc.destroy()
+    })
+
+    it('sends the local removal BEFORE closing the socket', () => {
+        const { awareness, ws, client } = connected()
+        awareness.setLocalState({ user: { id: 'me' } })
+        ws.sent.length = 0
+        ws.log.length = 0
+
+        // What useRealtimeRoom's teardown does, in order.
+        awareness.setLocalState(null)
+        client.destroy()
+
+        // A removal that never reaches the wire is the whole bug this
+        // guards: pin the ordering so a refactor can't quietly invert it.
+        expect(ws.log.indexOf('send')).toBeGreaterThanOrEqual(0)
+        expect(ws.log.indexOf('send')).toBeLessThan(ws.log.indexOf('close'))
+
+        // And the frame must actually clear the slot on a peer.
+        const removal = ws.sent.find(f => frameType(f) === MSG_AWARENESS_UPDATE)
+        expect(removal).toBeDefined()
+
+        const observerDoc = new Y.Doc()
+        const observer = new Awareness(observerDoc)
+        observer.setLocalState(null)
+        // Give the observer the departing client's slot first.
+        applyAwarenessUpdate(observer, framePayload(removal as Uint8Array), 'test')
+        expect(observer.getStates().has(awareness.clientID)).toBe(false)
+
+        observer.destroy()
+        observerDoc.destroy()
+    })
+})


### PR DESCRIPTION
A departing peer's avatar lingered on every other client. Two independent causes, both in core realtime — so this affects every consumer of presence (cards, calc, text).

## Graceful leave never fired

Package screens render with `freezeOnBlur`, so navigating from one package to another leaves the previous screen **mounted and frozen**. `useRealtimeRoom`'s teardown is keyed on unmount, so it never ran: the socket stayed open and the leaver kept publishing awareness.

Measured before changing anything, with probes on both sides of the wire — the departing session was still transmitting after leaving, and no unmount fired for it. A board→board switch, which *does* unmount, tore down correctly.

`core/lib/shortcuts/scopes.ts` already solves this exact freeze for keyboard shortcuts and documents it. Presence now follows the same approach: publish the leave on **blur** and on `pagehide`, restoring the saved slot on refocus. Saving the slot is load-bearing — `setLocalState(null)` deletes it outright, so a naive refocus would leave the user invisible to peers.

Two comments asserting the old, false model were corrected (`text/hooks/useTextRoom.ts`, `BoardPresenceProvider`).

## Ungraceful leave could not be acted on

`broadcastLeave` sent a zero-length payload keyed by the 16-byte **broker** id, which shares no id space with the numeric **yjs** awareness clientID. Receivers could not tell which slot to drop, so they discarded the frame. That is the killed-tab / TCP-reset path, where no client-side teardown runs at all.

Clients now announce their awareness clientID via `MsgAwarenessHello` (0x08) right after `MsgAssignID`; the broker stores it and synthesizes a real y-protocols removal naming that slot. Bookkeeping only — never fanned out.

**Compatibility** across all four skew combinations: a client that never announces still gets the legacy zero-length frame, and `route()`'s switch has no `default`, so an older broker drops the unknown frame silently. There's a comment warning against adding one.

## Worth a reviewer's attention

The synthesized removal stamps a blunt `1<<31` clock, because the broker never parses awareness payloads and so cannot track per-slot clocks. I verified against real y-protocols that a removal at that clock does delete the slot, and pinned the Go encoder to captured `encodeAwarenessUpdate` bytes with a golden test. The alternative — carrying the client's live clock in the hello — is more precise but makes that frame stateful.

## Testing

- 6 Go tests, including the ungraceful `CloseNow` path, hello-not-fanned-out, and a malformed varuint. Green under `-race`.
- 5 TS tests in `core/tests/unit/realtime-leave.test.ts`; the hello tests were mutation-checked (deleting the send makes them fail).
- Full suites: core unit 957, text unit 920 + e2e 107, calc unit 1378 + e2e 87, cards unit 177.
- Fixes cards' `board-presence.spec.ts`, red since the feature was written. Paired PR: tinycld/cards.