### PR TITLE
Share the file uploader, and fix a Thumbnail that ate its row

### DIFF
--- a/core/components/DropZone.tsx
+++ b/core/components/DropZone.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { Platform, Text, View } from 'react-native'
+import { useThemeColor } from '../lib/use-app-theme'
+
+interface DropZoneProps {
+    children: ReactNode
+    /** Called with the dropped files. Directories are ignored — see below. */
+    onDrop: (files: File[]) => void
+    isEnabled: boolean
+    /** Overlay copy while a drag is over the zone. */
+    label?: string
+}
+
+/**
+ * Wraps a surface so files can be dragged onto it.
+ *
+ * Web only in effect: on native it renders its children in a plain flex View
+ * and nothing else, so callers need no platform branch of their own.
+ *
+ * This handles FILES only. Dropping a folder yields no files here — drive
+ * keeps the `webkitGetAsEntry` recursion for that, because it is the only
+ * package with a folder model to put a tree into.
+ */
+export function DropZone({
+    children,
+    onDrop,
+    isEnabled,
+    label = 'Drop files to upload',
+}: DropZoneProps) {
+    const [isDragging, setIsDragging] = useState(false)
+    const accentColor = useThemeColor('primary')
+
+    if (Platform.OS !== 'web') {
+        return <View className="flex-1">{children}</View>
+    }
+
+    const handleDragEnter = (e: React.DragEvent) => {
+        if (!isEnabled) return
+        e.preventDefault()
+        e.stopPropagation()
+        if (e.dataTransfer.types.includes('Files')) {
+            setIsDragging(true)
+        }
+    }
+
+    const handleDragOver = (e: React.DragEvent) => {
+        if (!isEnabled) return
+        e.preventDefault()
+        e.stopPropagation()
+    }
+
+    const handleDragLeave = (e: React.DragEvent) => {
+        if (!isEnabled) return
+        e.preventDefault()
+        e.stopPropagation()
+        // dragleave also fires when the pointer crosses onto a CHILD element,
+        // so the overlay may only be dismissed once the pointer is genuinely
+        // outside the zone's own box.
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+        const { clientX, clientY } = e
+        if (
+            clientX <= rect.left ||
+            clientX >= rect.right ||
+            clientY <= rect.top ||
+            clientY >= rect.bottom
+        ) {
+            setIsDragging(false)
+        }
+    }
+
+    const handleDrop = (e: React.DragEvent) => {
+        if (!isEnabled) return
+        e.preventDefault()
+        e.stopPropagation()
+        setIsDragging(false)
+
+        const files = Array.from(e.dataTransfer.files)
+        if (files.length > 0) {
+            onDrop(files)
+        }
+    }
+
+    return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop zone requires native DOM events
+        <div
+            role="presentation"
+            style={{
+                flex: 1,
+                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
+                minHeight: 0,
+            }}
+            onDragEnter={handleDragEnter}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+        >
+            {children}
+            {isDragging && isEnabled && (
+                <View
+                    className="absolute top-0 left-0 right-0 bottom-0 items-center justify-center rounded-xl bg-accent/10"
+                    style={{
+                        borderWidth: 2,
+                        borderStyle: 'dashed',
+                        borderColor: accentColor,
+                        zIndex: 100,
+                    }}
+                    pointerEvents="none"
+                >
+                    <Text className="text-accent" style={{ fontSize: 20, fontWeight: '600' }}>
+                        {label}
+                    </Text>
+                </View>
+            )}
+        </div>
+    )
+}

--- a/core/file-viewer/Thumbnail.tsx
+++ b/core/file-viewer/Thumbnail.tsx
@@ -13,11 +13,15 @@ export function Thumbnail({ source, size = 120 }: ThumbnailProps) {
 
     if (!url) {
         return (
+            // Square, like the image branch — NOT `w-full`. A thumbnail that
+            // fills its parent works in drive's fixed-width grid cell and
+            // silently eats the whole row anywhere else: in a flex row it
+            // takes every pixel and collapses the filename beside it to zero
+            // width. `size` is a request for a box, and both branches owe the
+            // caller the same one.
             <View
-                className="items-center justify-center w-full"
-                style={{
-                    height: size,
-                }}
+                className="items-center justify-center shrink-0"
+                style={{ width: size, height: size }}
             >
                 <FileIcon size={size * 0.33} color={iconColor} />
             </View>

--- a/core/file-viewer/file-naming.ts
+++ b/core/file-viewer/file-naming.ts
@@ -1,0 +1,68 @@
+/**
+ * Filename → mime, and PocketBase's stored name → a human one.
+ *
+ * Both are needed by any surface that lists PB `file` fields: PocketBase
+ * stores no mime alongside the blob and mangles the name on the way in, so a
+ * client holding only a record has to recover both. Mail derived these first;
+ * they live here so cards is not a second copy.
+ */
+
+const EXTENSION_TO_MIME: Record<string, string> = {
+    // images
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    svg: 'image/svg+xml',
+    bmp: 'image/bmp',
+    heic: 'image/heic',
+    // documents
+    pdf: 'application/pdf',
+    txt: 'text/plain',
+    md: 'text/plain',
+    csv: 'text/csv',
+    json: 'application/json',
+    html: 'text/html',
+    htm: 'text/html',
+    css: 'text/css',
+    js: 'text/javascript',
+    xml: 'application/xml',
+    // office
+    doc: 'application/msword',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    xls: 'application/vnd.ms-excel',
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ppt: 'application/vnd.ms-powerpoint',
+    pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    // archives
+    zip: 'application/zip',
+    gz: 'application/gzip',
+    tar: 'application/x-tar',
+    // media
+    mp3: 'audio/mpeg',
+    wav: 'audio/wav',
+    mp4: 'video/mp4',
+    mov: 'video/quicktime',
+    webm: 'video/webm',
+}
+
+export function mimeFromFilename(filename: string): string {
+    const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+    return EXTENSION_TO_MIME[ext] ?? 'application/octet-stream'
+}
+
+/**
+ * PocketBase stores an upload as `{name}_{random10}.{ext}`. Strip the suffix
+ * for display — but only when it matches exactly, so a file the user really
+ * did name `report_2024final.pdf` is left alone.
+ */
+export function cleanFilename(filename: string): string {
+    const match = filename.match(/^(.+)_[a-zA-Z0-9]{10}(\.\w+)$/)
+    return match ? match[1] + match[2] : filename
+}
+
+/** Whether this name is something the preview layer can draw inline. */
+export function isImageFilename(filename: string): boolean {
+    return mimeFromFilename(filename).startsWith('image/')
+}

--- a/core/file-viewer/upload-file.ts
+++ b/core/file-viewer/upload-file.ts
@@ -1,0 +1,141 @@
+import { pb } from '../lib/pocketbase'
+import type { PickedFile } from './picked-file'
+
+/**
+ * Multipart upload with progress, for callers that need a progress bar.
+ *
+ * This is deliberately XMLHttpRequest rather than `fetch`: only XHR exposes
+ * `upload.onprogress`, and the PocketBase SDK is built on fetch — so a
+ * `collection.create()` with a file field cannot report how far a large upload
+ * has got. React Native's XHR polyfill supports upload progress too, so the
+ * one code path serves web and native.
+ *
+ * Bypassing the SDK for file BYTES is the sanctioned exception to the
+ * never-bypass-pbtsdb rule; every other read and write stays on pbtsdb. Drive
+ * established the exception, and cards and mail now share this implementation
+ * rather than each keeping a copy.
+ */
+export function uploadFormDataWithProgress(params: {
+    url: string
+    formData: FormData
+    authToken: string
+    /** Defaults to POST. PATCH is what an update-with-file needs. */
+    method?: string
+    onProgress?: (loaded: number, total: number) => void
+    signal?: AbortSignal
+}): Promise<unknown> {
+    const { url, formData, authToken, method = 'POST', onProgress, signal } = params
+
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new DOMException('Aborted', 'AbortError'))
+            return
+        }
+
+        const xhr = new XMLHttpRequest()
+        xhr.open(method, url, true)
+        if (authToken) {
+            xhr.setRequestHeader('Authorization', authToken)
+        }
+
+        if (onProgress) {
+            xhr.upload.onprogress = e => {
+                if (e.lengthComputable) onProgress(e.loaded, e.total)
+            }
+        }
+
+        xhr.onload = () => {
+            const text = typeof xhr.response === 'string' ? xhr.response : xhr.responseText
+            let parsed: unknown = null
+            try {
+                parsed = text ? JSON.parse(text) : null
+            } catch {
+                // Non-JSON response — treat as an empty success body.
+                parsed = null
+            }
+            if (xhr.status >= 200 && xhr.status < 300) {
+                resolve(parsed)
+            } else {
+                const message =
+                    parsed &&
+                    typeof parsed === 'object' &&
+                    'message' in parsed &&
+                    typeof parsed.message === 'string'
+                        ? parsed.message
+                        : `Upload failed (${xhr.status})`
+                reject(new Error(message))
+            }
+        }
+        xhr.onerror = () => reject(new TypeError('Network request failed'))
+        xhr.onabort = () => reject(new DOMException('Aborted', 'AbortError'))
+
+        signal?.addEventListener('abort', () => xhr.abort(), { once: true })
+
+        xhr.send(formData)
+    })
+}
+
+export interface UploadRecordParams {
+    /** Collection name, e.g. 'cards_attachments'. */
+    collection: string
+    /**
+     * Scalar fields for the record. Pre-generate the id with `newRecordId()`
+     * so optimistic UI can reference the row before the response lands.
+     */
+    fields: Record<string, string>
+    file: PickedFile
+    /** The file field's name on the collection. Defaults to 'file'. */
+    fileField?: string
+    onProgress?: (loaded: number, total: number) => void
+    signal?: AbortSignal
+}
+
+/**
+ * Creates one record carrying one file.
+ *
+ * `PickedFile.file` is only a real `File` on web — on native it is a
+ * `{ uri, name, type, size }` shape that RN's FormData polyfill understands.
+ * It is therefore appended straight into FormData and never inspected.
+ */
+export function uploadRecordWithFile(params: UploadRecordParams): Promise<unknown> {
+    const { collection, fields, file, fileField = 'file', onProgress, signal } = params
+
+    const formData = new FormData()
+    for (const [key, value] of Object.entries(fields)) {
+        formData.append(key, value)
+    }
+    formData.append(fileField, file.file, file.name)
+
+    return uploadFormDataWithProgress({
+        url: pb.buildURL(`/api/collections/${encodeURIComponent(collection)}/records`),
+        formData,
+        authToken: pb.authStore.token ?? '',
+        onProgress,
+        signal,
+    })
+}
+
+/**
+ * At most one progress write per `intervalMs`, plus an unconditional final
+ * one when the last byte lands. Without the final flush a throttled bar
+ * stalls a few percent short and never visibly completes; without the
+ * throttle a large upload re-renders the surface on every network chunk.
+ */
+export function throttleProgress(
+    write: (loaded: number, total: number) => void,
+    intervalMs = 60
+): (loaded: number, total: number) => void {
+    // Null rather than 0: seeding with 0 makes the FIRST event look like it
+    // arrived `Date.now()` ms after a previous one, which is true against a
+    // real clock but false at t=0 — and either way the first progress event
+    // is the one that turns a bar from empty into moving, so it must never
+    // be throttled away.
+    let lastUpdate: number | null = null
+    return (loaded, total) => {
+        const now = Date.now()
+        const isFinal = total > 0 && loaded >= total
+        if (!isFinal && lastUpdate !== null && now - lastUpdate < intervalMs) return
+        lastUpdate = now
+        write(loaded, total)
+    }
+}

--- a/core/file-viewer/upload-store.ts
+++ b/core/file-viewer/upload-store.ts
@@ -1,0 +1,83 @@
+import { create } from '../lib/store'
+
+export type UploadStatus = 'pending' | 'uploading' | 'done' | 'error'
+
+export interface UploadingFile {
+    id: string
+    name: string
+    /**
+     * Whatever the surface groups uploads by — drive would pass a folder id,
+     * cards passes the card id. The store never interprets it; it exists so
+     * one screen's in-flight uploads don't render on another's.
+     */
+    scopeId: string
+    size: number
+    loaded: number
+    status: UploadStatus
+    errorMessage?: string
+    /**
+     * Local URI for an image being uploaded, so the surface can show the
+     * picture itself while the bytes are still in flight. There is no record
+     * and no server URL yet, so this is the only thing there is to draw.
+     */
+    previewUri?: string
+}
+
+interface UploadStoreState {
+    uploadingFiles: UploadingFile[]
+    add: (entries: UploadingFile[]) => void
+    update: (id: string, patch: Partial<UploadingFile>) => void
+    remove: (id: string) => void
+    clearDoneById: (id: string) => void
+}
+
+/**
+ * In-flight uploads, shared across the components that display them.
+ *
+ * A store rather than local state because the surface that starts an upload
+ * is rarely the only one that reports it — a strip, a toolbar and a row can
+ * all need the same list. Read it with a selector narrowed to one scope
+ * (`useUploadsForScope`) so an unrelated upload elsewhere doesn't re-render.
+ */
+export const useUploadStore = create<UploadStoreState>(set => ({
+    uploadingFiles: [],
+    add: entries =>
+        set(s => ({
+            uploadingFiles: [...s.uploadingFiles, ...entries],
+        })),
+    update: (id, patch) =>
+        set(s => ({
+            uploadingFiles: s.uploadingFiles.map(f => (f.id === id ? { ...f, ...patch } : f)),
+        })),
+    remove: id =>
+        set(s => ({
+            uploadingFiles: s.uploadingFiles.filter(f => f.id !== id),
+        })),
+    clearDoneById: id =>
+        set(s => ({
+            uploadingFiles: s.uploadingFiles.filter(f => !(f.id === id && f.status === 'done')),
+        })),
+}))
+
+/** Fraction in [0,1]. A zero-byte or not-yet-sized upload reads as 0. */
+export function uploadProgress(file: UploadingFile): number {
+    if (file.size <= 0) return 0
+    return Math.min(1, file.loaded / file.size)
+}
+
+const EMPTY: UploadingFile[] = []
+
+/**
+ * The in-flight uploads for one scope.
+ *
+ * Filtering inside the selector would allocate a new array on every store
+ * write and defeat zustand's identity check, so this subscribes to the raw
+ * list and narrows outside the selector — and returns a shared constant when
+ * there is nothing in flight, which is almost always.
+ */
+export function useUploadsForScope(scopeId: string): UploadingFile[] {
+    const all = useUploadStore(s => s.uploadingFiles)
+    if (all.length === 0) return EMPTY
+    const mine = all.filter(f => f.scopeId === scopeId)
+    return mine.length === 0 ? EMPTY : mine
+}

--- a/core/server/mailproto/dev_tls_optional_test.go
+++ b/core/server/mailproto/dev_tls_optional_test.go
@@ -1,0 +1,150 @@
+package mailproto
+
+import (
+	"crypto/tls"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-smtp"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// In DEV, the implicit-TLS listener is a convenience and the plain one is what
+// clients actually use. A dev machine commonly has another local server
+// already holding :1993 / :1587 — those two ports are not parameterized the
+// way IMAP_ADDR is — and the old code closed the plain listener and returned
+// an error when the TLS bind failed. The symptom was baffling: the log said
+// "IMAP server listening" and every client still got ECONNREFUSED on a port
+// that HAD just bound. It made all eight mail IMAP e2e specs fail whenever a
+// dev server was running.
+//
+// These call the dev entry points directly: IsDev comes from unexported
+// PocketBase config, so a tests.TestApp cannot be flipped into dev mode.
+
+// listenOnceThenFail hands out `ln` for the first address and refuses every
+// later one — standing in for a TLS port another process already holds.
+func listenOnceThenFail(ln net.Listener) (ListenFunc, *int) {
+	calls := 0
+	return func(addr string) (net.Listener, error) {
+		calls++
+		if calls == 1 {
+			return ln, nil
+		}
+		return nil, &net.OpError{
+			Op:   "listen",
+			Net:  "tcp",
+			Addr: nil,
+			Err:  net.UnknownNetworkError("address already in use"),
+		}
+	}, &calls
+}
+
+func TestStartIMAPDev_KeepsPlainListenerWhenTLSPortIsTaken(t *testing.T) {
+	app := newTestApp(t)
+
+	dir := t.TempDir()
+	certPath, keyPath := dir+"/cert.pem", dir+"/key.pem"
+	writeCertPair(t, certPath, keyPath, "imap.test")
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listen, calls := listenOnceThenFail(ln)
+	shutdown, err := startIMAPDev(app, tlsConfig, IMAPOptions{
+		NewSession: func(_ core.App, _ *imapserver.Conn) imapserver.Session {
+			return &nopIMAPSession{}
+		},
+		Listen: listen,
+	})
+	if err != nil {
+		t.Fatalf("a taken IMAPS port must not fail the whole IMAP server: %v", err)
+	}
+	t.Cleanup(shutdown)
+
+	if *calls != 2 {
+		t.Fatalf("Listen called %d times, want 2 (plain, then the failing TLS port)", *calls)
+	}
+
+	// The plain listener is still serving — this is the assertion the old
+	// code failed, having closed it on the way out.
+	if greeting := dialAndReadLine(t, ln); !strings.HasPrefix(greeting, "* OK") {
+		t.Fatalf("IMAP greeting = %q, want a plain listener still serving", greeting)
+	}
+}
+
+func TestStartSMTPDev_KeepsPlainListenerWhenTLSPortIsTaken(t *testing.T) {
+	app := newTestApp(t)
+	t.Setenv("TEST_SMTP_ADDR", unbindableAddr)
+
+	dir := t.TempDir()
+	certPath, keyPath := dir+"/cert.pem", dir+"/key.pem"
+	writeCertPair(t, certPath, keyPath, "smtp.test")
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listen, calls := listenOnceThenFail(ln)
+	shutdown, err := startSMTPDev(app, tlsConfig, SMTPOptions{
+		Backend:           nopSMTPBackend{},
+		Label:             "test SMTP",
+		AddrEnv:           "TEST_SMTP_ADDR",
+		TLSAddrEnv:        "TEST_SMTPS_ADDR",
+		DefaultAddr:       unbindableAddr,
+		DefaultDevTLSAddr: unbindableAddr,
+		Listen:            listen,
+	})
+	if err != nil {
+		t.Fatalf("a taken submission-TLS port must not fail the whole SMTP server: %v", err)
+	}
+	t.Cleanup(shutdown)
+
+	if *calls != 2 {
+		t.Fatalf("Listen called %d times, want 2 (plain, then the failing TLS port)", *calls)
+	}
+
+	if greeting := dialAndReadLine(t, ln); !strings.HasPrefix(greeting, "220") {
+		t.Fatalf("SMTP greeting = %q, want a plain listener still serving", greeting)
+	}
+}
+
+// Guard rail: the dev leniency above must not leak into production. A missing
+// TLS source there still refuses to boot rather than quietly serving plain.
+func TestStartIMAP_ProductionWithoutTLSStillRefuses(t *testing.T) {
+	app := newTestApp(t) // tests.TestApp is production-mode
+	t.Setenv("IMAP_TLS_CERT", "")
+	t.Setenv("IMAP_TLS_KEY", "")
+
+	_, err := StartIMAP(app, nil, IMAPOptions{
+		NewSession: func(_ core.App, _ *imapserver.Conn) imapserver.Session {
+			return &nopIMAPSession{}
+		},
+		Listen: func(string) (net.Listener, error) {
+			t.Fatal("production without TLS must not reach a listener at all")
+			return nil, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("production without a TLS source must refuse to start IMAP")
+	}
+	if !strings.Contains(err.Error(), "IMAPS") {
+		t.Fatalf("error should name the misconfiguration, got: %v", err)
+	}
+}
+
+var _ = smtp.ErrAuthRequired

--- a/core/server/mailproto/imap.go
+++ b/core/server/mailproto/imap.go
@@ -204,16 +204,30 @@ func startIMAPDev(app core.App, tlsConfig *tls.Config, opts IMAPOptions) (func()
 		}
 		rawLn, err := listenWith(opts.Listen, imapsAddr)
 		if err != nil {
-			plainLn.Close()
-			return nil, fmt.Errorf("failed to listen on %s: %w", imapsAddr, err)
+			// Dev only, and deliberately not fatal: the implicit-TLS listener
+			// is a convenience here, while the PLAIN one on IMAP_ADDR is what
+			// clients and the e2e suite actually use. Tearing the plain
+			// listener down because an optional port is taken is how a dev
+			// server already holding :1993 made every IMAP e2e fail with
+			// ECONNREFUSED on a port that had just bound successfully —
+			// IMAP_ADDR is parameterized per-run, IMAPS_ADDR was not.
+			//
+			// Production never reaches this branch: it returns earlier via
+			// startIMAPTLSOnly, or refuses to boot without a TLS source.
+			app.Logger().Warn(
+				"IMAPS listener unavailable; continuing with plain IMAP only",
+				"addr", imapsAddr,
+				"error", err,
+			)
+		} else {
+			tlsLn = tls.NewListener(rawLn, tlsConfig)
+			app.Logger().Info("IMAPS server listening (implicit TLS)", "addr", imapsAddr)
+			go func() {
+				if err := server.Serve(tlsLn); err != nil {
+					app.Logger().Error("IMAPS server error", "addr", imapsAddr, "error", err)
+				}
+			}()
 		}
-		tlsLn = tls.NewListener(rawLn, tlsConfig)
-		app.Logger().Info("IMAPS server listening (implicit TLS)", "addr", imapsAddr)
-		go func() {
-			if err := server.Serve(tlsLn); err != nil {
-				app.Logger().Error("IMAPS server error", "addr", imapsAddr, "error", err)
-			}
-		}()
 	}
 
 	return func() {

--- a/core/server/mailproto/smtp.go
+++ b/core/server/mailproto/smtp.go
@@ -212,16 +212,24 @@ func startSMTPDev(app core.App, tlsConfig *tls.Config, opts SMTPOptions) (func()
 		}
 		rawLn, err := listenWith(opts.Listen, tlsAddr)
 		if err != nil {
-			plainLn.Close()
-			return nil, fmt.Errorf("failed to listen on %s: %w", tlsAddr, err)
+			// Same reasoning as the IMAPS branch in imap.go: dev only, and the
+			// plain listener above is the one that matters. Closing it because
+			// an optional TLS port is already held by another local server
+			// turns a taken port into a total outage of the protocol.
+			app.Logger().Warn(
+				opts.Label+" implicit-TLS listener unavailable; continuing with plain only",
+				"addr", tlsAddr,
+				"error", err,
+			)
+		} else {
+			tlsLn = tls.NewListener(rawLn, tlsConfig)
+			app.Logger().Info(opts.Label+" server listening (implicit TLS)", "addr", tlsAddr)
+			go func() {
+				if err := server.Serve(tlsLn); err != nil {
+					app.Logger().Error(opts.Label+" server error", "addr", tlsAddr, "error", err)
+				}
+			}()
 		}
-		tlsLn = tls.NewListener(rawLn, tlsConfig)
-		app.Logger().Info(opts.Label+" server listening (implicit TLS)", "addr", tlsAddr)
-		go func() {
-			if err := server.Serve(tlsLn); err != nil {
-				app.Logger().Error(opts.Label+" server error", "addr", tlsAddr, "error", err)
-			}
-		}()
 	}
 
 	return func() {

--- a/core/tests/unit/upload-file.test.ts
+++ b/core/tests/unit/upload-file.test.ts
@@ -1,0 +1,333 @@
+import type { PickedFile } from '@tinycld/core/file-viewer/picked-file'
+import {
+    throttleProgress,
+    uploadFormDataWithProgress,
+    uploadRecordWithFile,
+} from '@tinycld/core/file-viewer/upload-file'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tinycld/core/lib/pocketbase', () => ({
+    pb: {
+        buildURL: (path: string) => `https://example.test${path}`,
+        authStore: { token: 'test-token' },
+    },
+}))
+
+/**
+ * A stand-in for the browser's XMLHttpRequest, capturing what the uploader
+ * sent and letting each test drive the response by hand. Only the surface
+ * upload-file.ts touches is implemented.
+ */
+class FakeXHR {
+    static last: FakeXHR | null = null
+
+    method = ''
+    url = ''
+    headers: Record<string, string> = {}
+    body: unknown = null
+    aborted = false
+
+    status = 200
+    response = ''
+    responseText = ''
+
+    upload: { onprogress: ((e: ProgressEventLike) => void) | null } = { onprogress: null }
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+    onabort: (() => void) | null = null
+
+    constructor() {
+        FakeXHR.last = this
+    }
+
+    open(method: string, url: string) {
+        this.method = method
+        this.url = url
+    }
+
+    setRequestHeader(key: string, value: string) {
+        this.headers[key] = value
+    }
+
+    send(body: unknown) {
+        this.body = body
+    }
+
+    abort() {
+        this.aborted = true
+        this.onabort?.()
+    }
+
+    /** Completes the request with a JSON body. */
+    finish(status: number, payload: unknown) {
+        this.status = status
+        const text = typeof payload === 'string' ? payload : JSON.stringify(payload)
+        this.response = text
+        this.responseText = text
+        this.onload?.()
+    }
+
+    emitProgress(loaded: number, total: number, lengthComputable = true) {
+        this.upload.onprogress?.({ loaded, total, lengthComputable })
+    }
+}
+
+interface ProgressEventLike {
+    loaded: number
+    total: number
+    lengthComputable: boolean
+}
+
+const originalXHR = globalThis.XMLHttpRequest
+
+beforeEach(() => {
+    FakeXHR.last = null
+    globalThis.XMLHttpRequest = FakeXHR as unknown as typeof XMLHttpRequest
+})
+
+afterEach(() => {
+    globalThis.XMLHttpRequest = originalXHR
+    vi.useRealTimers()
+})
+
+function pickedFile(name = 'photo.png', size = 2048): PickedFile {
+    // A real Blob, because jsdom's FormData rejects anything else. On a device
+    // `PickedFile.file` is instead an opaque `{ uri, name, type, size }` that
+    // RN's FormData polyfill accepts — the uploader never inspects it either
+    // way, so a Blob here exercises the same code path.
+    return {
+        name,
+        type: 'image/png',
+        size,
+        file: new Blob(['x'.repeat(size)], { type: 'image/png' }) as unknown as File,
+    }
+}
+
+describe('uploadFormDataWithProgress', () => {
+    it('resolves with the parsed body on success', async () => {
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+        })
+        FakeXHR.last?.finish(200, { id: 'abc' })
+        await expect(promise).resolves.toEqual({ id: 'abc' })
+    })
+
+    it('sends the auth header and defaults to POST', async () => {
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+        })
+        FakeXHR.last?.finish(200, {})
+        await promise
+
+        expect(FakeXHR.last?.method).toBe('POST')
+        expect(FakeXHR.last?.headers.Authorization).toBe('tok')
+    })
+
+    it('honours an explicit method', async () => {
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+            method: 'PATCH',
+        })
+        FakeXHR.last?.finish(200, {})
+        await promise
+
+        expect(FakeXHR.last?.method).toBe('PATCH')
+    })
+
+    it('omits the auth header when there is no token', async () => {
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: '',
+        })
+        FakeXHR.last?.finish(200, {})
+        await promise
+
+        expect(FakeXHR.last?.headers.Authorization).toBeUndefined()
+    })
+
+    it('reports progress only for length-computable events', async () => {
+        const onProgress = vi.fn()
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+            onProgress,
+        })
+
+        FakeXHR.last?.emitProgress(10, 100)
+        FakeXHR.last?.emitProgress(50, 100, false)
+        FakeXHR.last?.finish(200, {})
+        await promise
+
+        expect(onProgress).toHaveBeenCalledTimes(1)
+        expect(onProgress).toHaveBeenCalledWith(10, 100)
+    })
+
+    it('rejects with the server message on an error status', async () => {
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+        })
+        FakeXHR.last?.finish(400, { message: 'Failed to create record.' })
+        await expect(promise).rejects.toThrow('Failed to create record.')
+    })
+
+    it('falls back to the status code when the error body has no message', async () => {
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+        })
+        FakeXHR.last?.finish(503, 'not json at all')
+        await expect(promise).rejects.toThrow('Upload failed (503)')
+    })
+
+    it('rejects on a transport error', async () => {
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+        })
+        FakeXHR.last?.onerror?.()
+        await expect(promise).rejects.toThrow('Network request failed')
+    })
+
+    it('aborts an in-flight request when the signal fires', async () => {
+        const controller = new AbortController()
+        const promise = uploadFormDataWithProgress({
+            url: 'https://example.test/api/x',
+            formData: new FormData(),
+            authToken: 'tok',
+            signal: controller.signal,
+        })
+
+        controller.abort()
+
+        expect(FakeXHR.last?.aborted).toBe(true)
+        await expect(promise).rejects.toThrow('Aborted')
+    })
+
+    it('rejects immediately when handed an already-aborted signal', async () => {
+        const controller = new AbortController()
+        controller.abort()
+
+        await expect(
+            uploadFormDataWithProgress({
+                url: 'https://example.test/api/x',
+                formData: new FormData(),
+                authToken: 'tok',
+                signal: controller.signal,
+            })
+        ).rejects.toThrow('Aborted')
+
+        // Nothing should have been opened at all.
+        expect(FakeXHR.last).toBeNull()
+    })
+})
+
+describe('uploadRecordWithFile', () => {
+    it('posts scalar fields and the file to the collection records endpoint', async () => {
+        const promise = uploadRecordWithFile({
+            collection: 'cards_attachments',
+            fields: { id: 'rec1', card: 'card1', size: '2048' },
+            file: pickedFile(),
+        })
+        FakeXHR.last?.finish(200, { id: 'rec1' })
+        await promise
+
+        expect(FakeXHR.last?.url).toBe(
+            'https://example.test/api/collections/cards_attachments/records'
+        )
+
+        const body = FakeXHR.last?.body as FormData
+        expect(body.get('id')).toBe('rec1')
+        expect(body.get('card')).toBe('card1')
+        expect(body.get('size')).toBe('2048')
+        expect(body.get('file')).toBeTruthy()
+    })
+
+    it('uses a custom file field name when given one', async () => {
+        const promise = uploadRecordWithFile({
+            collection: 'x',
+            fields: {},
+            file: pickedFile(),
+            fileField: 'avatar',
+        })
+        FakeXHR.last?.finish(200, {})
+        await promise
+
+        const body = FakeXHR.last?.body as FormData
+        expect(body.get('avatar')).toBeTruthy()
+        expect(body.get('file')).toBeNull()
+    })
+})
+
+describe('throttleProgress', () => {
+    it('drops intermediate writes inside the interval', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(0)
+
+        const write = vi.fn()
+        const onProgress = throttleProgress(write, 60)
+
+        onProgress(10, 1000)
+        onProgress(20, 1000)
+        vi.setSystemTime(70)
+        onProgress(30, 1000)
+
+        expect(write.mock.calls).toEqual([
+            [10, 1000],
+            [30, 1000],
+        ])
+    })
+
+    it('always writes the final byte, however soon it arrives', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(0)
+
+        const write = vi.fn()
+        const onProgress = throttleProgress(write, 60)
+
+        onProgress(10, 1000)
+        onProgress(1000, 1000)
+
+        // Without the final flush the bar would stop short of 100%.
+        expect(write).toHaveBeenLastCalledWith(1000, 1000)
+    })
+
+    it('always writes the first event, so a bar starts moving at once', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(0)
+
+        const write = vi.fn()
+        const onProgress = throttleProgress(write, 60)
+
+        onProgress(10, 1000)
+
+        expect(write).toHaveBeenCalledWith(10, 1000)
+    })
+
+    it('does not treat an unknown total as final', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(0)
+
+        const write = vi.fn()
+        const onProgress = throttleProgress(write, 60)
+
+        // The first is written unconditionally; the second is inside the
+        // window and `total: 0` must not qualify it as the final byte.
+        onProgress(10, 0)
+        onProgress(20, 0)
+
+        expect(write).toHaveBeenCalledTimes(1)
+        expect(write).toHaveBeenCalledWith(10, 0)
+    })
+})

--- a/core/tests/unit/upload-store.test.ts
+++ b/core/tests/unit/upload-store.test.ts
@@ -1,0 +1,95 @@
+import {
+    type UploadingFile,
+    uploadProgress,
+    useUploadStore,
+} from '@tinycld/core/file-viewer/upload-store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+function entry(patch: Partial<UploadingFile> = {}): UploadingFile {
+    return {
+        id: 'u1',
+        name: 'photo.png',
+        scopeId: 'card1',
+        size: 1000,
+        loaded: 0,
+        status: 'pending',
+        ...patch,
+    }
+}
+
+beforeEach(() => {
+    useUploadStore.setState({ uploadingFiles: [] })
+})
+
+describe('useUploadStore', () => {
+    it('appends rather than replacing, so two scopes can upload at once', () => {
+        const { add } = useUploadStore.getState()
+        add([entry({ id: 'a', scopeId: 'card1' })])
+        add([entry({ id: 'b', scopeId: 'card2' })])
+
+        expect(useUploadStore.getState().uploadingFiles.map(f => f.id)).toEqual(['a', 'b'])
+    })
+
+    it('patches one row and leaves its siblings alone', () => {
+        const { add, update } = useUploadStore.getState()
+        add([entry({ id: 'a' }), entry({ id: 'b' })])
+
+        update('a', { loaded: 500, status: 'uploading' })
+
+        const [a, b] = useUploadStore.getState().uploadingFiles
+        expect(a).toMatchObject({ id: 'a', loaded: 500, status: 'uploading' })
+        expect(b).toMatchObject({ id: 'b', loaded: 0, status: 'pending' })
+    })
+
+    it('removes a row outright', () => {
+        const { add, remove } = useUploadStore.getState()
+        add([entry({ id: 'a' }), entry({ id: 'b' })])
+
+        remove('a')
+
+        expect(useUploadStore.getState().uploadingFiles.map(f => f.id)).toEqual(['b'])
+    })
+
+    it('clears a finished row by id', () => {
+        const { add, clearDoneById } = useUploadStore.getState()
+        add([entry({ id: 'a', status: 'done' })])
+
+        clearDoneById('a')
+
+        expect(useUploadStore.getState().uploadingFiles).toEqual([])
+    })
+
+    it('leaves a still-running row alone when asked to clear it', () => {
+        const { add, clearDoneById } = useUploadStore.getState()
+        add([entry({ id: 'a', status: 'uploading' })])
+
+        // The auto-clear timer fires on a delay, and the row may have been
+        // retried in the meantime — clearing it then would hide a live upload.
+        clearDoneById('a')
+
+        expect(useUploadStore.getState().uploadingFiles).toHaveLength(1)
+    })
+
+    it('leaves a failed row visible, so the error can be read', () => {
+        const { add, clearDoneById } = useUploadStore.getState()
+        add([entry({ id: 'a', status: 'error', errorMessage: 'too big' })])
+
+        clearDoneById('a')
+
+        expect(useUploadStore.getState().uploadingFiles).toHaveLength(1)
+    })
+})
+
+describe('uploadProgress', () => {
+    it('is the fraction of bytes sent', () => {
+        expect(uploadProgress(entry({ size: 1000, loaded: 250 }))).toBe(0.25)
+    })
+
+    it('never exceeds 1, even if the server counts more bytes than the file', () => {
+        expect(uploadProgress(entry({ size: 1000, loaded: 1200 }))).toBe(1)
+    })
+
+    it('reads as 0 for an unsized upload rather than dividing by zero', () => {
+        expect(uploadProgress(entry({ size: 0, loaded: 10 }))).toBe(0)
+    })
+})


### PR DESCRIPTION
Stacked on #171.

Cards needs to upload card attachments (100MB cap, so a progress bar is not optional) and mail's send is a bare `fetch` that reports nothing on a 10MB message. Drive already had a working progress uploader — private to drive. This promotes it instead of making a second and third copy.

### The uploader

Two layers, because the three callers don't agree on shape: drive and cards post one record per file to a PB collection, mail posts one multipart body to `/api/mail/send`. The shared piece is the transport — only XHR exposes `upload.onprogress`, and the PocketBase SDK is built on `fetch`, so `collection.create()` with a file field can never report progress. Bypassing the SDK for file **bytes** stays the sanctioned exception; everything else stays on pbtsdb.

Found a real bug in drive's version while writing the tests: `throttleProgress` seeded its clock at `0`, so the first progress event was dropped whenever it arrived within the throttle window of the epoch. That's the event that turns a bar from empty into moving. Mutation-checked.

### Thumbnail

The icon fallback branch carried `w-full`, so a `Thumbnail` asked for a 56px box returned one as wide as its parent. Drive only ever renders it in a fixed-width grid cell, which hid it; the first flex-row caller got a 413px thumbnail that collapsed the filename beside it to width zero.

Worth noting for anyone debugging layout here: three plausible fixes to the *caller* were tried first and all failed. A DOM probe measuring the actual boxes is what found it.

### Also

- `DropZone` promoted, file-only. Drive keeps the `webkitGetAsEntry` folder recursion, being the only package with a folder model. The overlay gains `pointerEvents="none"` so it can't swallow the drop it invites.
- `file-naming.ts` — mail's filename→mime and PB-suffix-stripping helpers, which cards would otherwise have copied verbatim.
- Drive is deliberately **not** refactored onto any of this. It gains nothing today and rewriting a shipped upload path is unrelated risk; a comment points new callers at core.

25 new unit tests. Full core check green: 1035 tests.