### PR TITLE
Authorize cards collections for OAuth callers

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,8 @@
             "!third_party/**/*",
             "!**/server",
             "!**/server/**/*",
+            "!**/cli",
+            "!**/cli/**/*",
             "!**/pb-migrations",
             "!**/pb-migrations/**/*",
             "!**/pb-hooks",

--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -101,6 +101,36 @@ var collectionScopes = map[string]collectionAccess{
 	"label_assignments": {read: scopeRule{ScopeMailRead, ScopeContactsRead}, write: scopeRule{ScopeMailSend, ScopeContactsWrite}},
 
 	"drive_item_versions": {read: scopeRule{ScopeDriveRead}, write: scopeRule{ScopeDriveWrite}},
+
+	// Cards' board content. Every one of these carries a `project` relation
+	// (denormalized onto the content rows precisely so a rule can reach it),
+	// and the access rules resolve membership through cards_project_members —
+	// so a grant here widens WHICH ROWS a token may touch not at all. It only
+	// decides whether an OAuth caller may use the collection at all, on top of
+	// the membership the rules already demand.
+	"cards_projects":        {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_lists":           {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_cards":           {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_labels":          {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_checklist_items": {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_comments":        {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_attachments":     {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+
+	// READ-ONLY for OAuth callers, deliberately, and NOT because the rules are
+	// weak — they already confine both to owners. These two are the SHARING
+	// surface: a write to cards_project_members adds a person to a board, and a
+	// write to cards_share_links mints a URL that opens the board to anyone
+	// holding it. That is a categorically larger grant than editing cards, and
+	// `cards:write` reads to a user consenting on the OAuth screen as "change my
+	// cards" — not "give other people my boards".
+	//
+	// So a leaked or over-broad CLI token cannot reshare a board or publish a
+	// public link; those stay in the app, where the Share dialog shows exactly
+	// who gains access. Relaxing this later is one line and is backward
+	// compatible; the reverse would silently revoke a capability integrations
+	// had already built on, so start closed.
+	"cards_project_members": {read: scopeRule{ScopeCardsRead}},
+	"cards_share_links":     {read: scopeRule{ScopeCardsRead}},
 }
 
 // endpointScopes maps a bespoke Go endpoint to its required scope.

--- a/core/server/oauth/route_classification_test.go
+++ b/core/server/oauth/route_classification_test.go
@@ -150,3 +150,71 @@ func TestCardsSearchIsClassified(t *testing.T) {
 		t.Error("an unrelated package's scope must not admit cards search")
 	}
 }
+
+// The board-content collections the cards CLI drives. Every one of these was
+// default-denied until the cards commands needed them, which is the failure
+// mode TestEveryRegisteredRouteIsClassified exists to catch one layer up: the
+// rules admit the caller, the handler runs in tests, and only a real OAuth
+// client sees the 403.
+func TestCardsContentCollectionsAreReadWrite(t *testing.T) {
+	// One representative verb per side. The table is per-collection, so a
+	// missing entry fails read and write together.
+	for _, collection := range []string{
+		"cards_projects", "cards_lists", "cards_cards", "cards_labels",
+		"cards_checklist_items", "cards_comments", "cards_attachments",
+	} {
+		path := "/api/collections/" + collection + "/records"
+		read := ScopeForRoute("GET", path)
+		if !read.satisfiedBy([]string{ScopeCardsRead}) {
+			t.Errorf("GET %s: cards:read must admit a read (got %q)", path, read)
+		}
+		write := ScopeForRoute("POST", path)
+		if !write.satisfiedBy([]string{ScopeCardsWrite}) {
+			t.Errorf("POST %s: cards:write must admit a write (got %q)", path, write)
+		}
+		// Read must not carry write. A token consented to read-only cards
+		// access that could still POST would make the consent screen a lie.
+		if read.satisfiedBy([]string{ScopeCardsWrite}) && !read.satisfiedBy([]string{ScopeCardsRead}) {
+			t.Errorf("GET %s admits cards:write but not cards:read", path)
+		}
+		if write.satisfiedBy([]string{ScopeCardsRead}) {
+			t.Errorf("POST %s: cards:read alone must NOT admit a write", path)
+		}
+		if read.satisfiedBy([]string{ScopeMailRead}) {
+			t.Errorf("GET %s: an unrelated package's scope must not admit it", path)
+		}
+	}
+}
+
+// The sharing surface is deliberately READ-ONLY for OAuth callers. A write to
+// cards_project_members adds a person to a board; a write to cards_share_links
+// mints a URL that opens the board to anyone holding it. Both are a
+// categorically larger grant than editing cards, and "cards:write" on the
+// consent screen does not read as "give other people my boards".
+//
+// Asserted positively so relaxing it is a deliberate edit to this test rather
+// than an unnoticed side effect of touching the table.
+func TestCardsSharingSurfaceIsReadOnlyForOAuth(t *testing.T) {
+	for _, collection := range []string{"cards_project_members", "cards_share_links"} {
+		path := "/api/collections/" + collection + "/records"
+		if !ScopeForRoute("GET", path).satisfiedBy([]string{ScopeCardsRead}) {
+			t.Errorf("GET %s: cards:read must still admit reading the roster/links", path)
+		}
+		// Every write verb, not just POST: revoking a link is a DELETE and
+		// changing a member's role is a PATCH, so a table entry that only
+		// blocked creates would leave both open.
+		for _, method := range []string{"POST", "PATCH", "PUT", "DELETE"} {
+			p := path
+			if method != "POST" {
+				p += "/abc123"
+			}
+			for _, scope := range []string{ScopeCardsWrite, ScopeCardsRead} {
+				if ScopeForRoute(method, p).satisfiedBy([]string{scope}) {
+					t.Errorf("%s %s must not be reachable with %q — an OAuth token "+
+						"must not be able to reshare a board or mint a public link",
+						method, p, scope)
+				}
+			}
+		}
+	}
+}

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -262,7 +262,33 @@ function Trigger({ children, disableClick }: TriggerProps) {
         measureWeb()
     }, [disableClick, measureWeb])
 
+    type PressableChildProps = {
+        onPress?: (e: unknown) => void
+        ref?: React.Ref<View>
+    }
+    const child = children as React.ReactElement<PressableChildProps>
+    const childOnPress = child.props.onPress
+
     if (Platform.OS === 'web') {
+        // The wrapper div stays — it is what measures the trigger rect and
+        // catches hover — but the child is ALSO cloned with an onPress.
+        //
+        // Not cosmetic: a trigger child may branch on `onPress` to decide
+        // whether it is interactive at all (cards' assignee/label/due values
+        // render bare, unpressable text when it is absent, which is how a
+        // read-only card is drawn). Passing children straight through left
+        // that prop undefined on web only, so an OWNER'S card properties
+        // rendered as inert "None" text with no way to open the picker, while
+        // native was fine. The clone makes the contract the same on both
+        // platforms: a Menu.Trigger child always receives an onPress.
+        //
+        // The div keeps `onClickCapture`, which runs BEFORE the child's own
+        // handler and already toggles the menu, so the injected onPress only
+        // forwards the child's original — toggling here too would open and
+        // immediately re-close.
+        const webChild = React.cloneElement(child, {
+            onPress: childOnPress ?? (() => {}),
+        })
         return (
             // biome-ignore lint/a11y/noStaticElementInteractions: wrapper div augments the interactive child (Pressable) with click/hover measurement; the child carries the button role and keyboard semantics.
             <div
@@ -274,18 +300,12 @@ function Trigger({ children, disableClick }: TriggerProps) {
                 onClickCapture={handleClick}
                 onMouseEnter={handleMouseEnter}
             >
-                {children}
+                {webChild}
             </div>
         )
     }
 
     // Wrapping a Pressable child in another Pressable swallows touches on native — the inner responder wins. Clone the child to inject onPress + ref.
-    type PressableChildProps = {
-        onPress?: (e: unknown) => void
-        ref?: React.Ref<View>
-    }
-    const child = children as React.ReactElement<PressableChildProps>
-    const childOnPress = child.props.onPress
     const composedOnPress = (e: unknown) => {
         childOnPress?.(e)
         handleClick()


### PR DESCRIPTION
Cards' CLI (tinycld/cards#18) needs these before a single command works.

Every `cards_*` collection was absent from `collectionScopes`, whose default is
deny. `cards:read`/`cards:write` already existed and `/api/cards/search` was
already classified, but no board row was reachable — so the CLI's record REST
calls would 403 against a real server while its own tests passed, since a fake
test server runs no scope middleware.

Board content maps read to `cards:read` and write to `cards:write`. The access
rules already confine a caller to their own memberships, so this decides only
whether an OAuth caller may use the collection at all.

**The sharing surface is read-only.** `cards_project_members` and
`cards_share_links` get read access only. A write there adds a person to a
board or mints a URL that opens it to anyone holding it — categorically larger
than editing cards, and not what "cards:write" reads as on the consent screen.
Relaxing it later is one line; the reverse would revoke a capability
integrations had already built on.

Tests cover every write verb, not just POST — revoking a link is a DELETE and a
role change is a PATCH. Both new tests are mutation-checked.

Also excludes `cli/` from biome the way `server/` already is: a CLI module is
Go, but its testdata is JSON, and biome would reformat golden vectors whose
value is being a faithful capture. No `cli/` directory in the workspace holds
any `.ts`/`.tsx`.

Stacked on #173.