### PR TITLE
Core support for rich comment editing in cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ server/pb_test_releases/
 /server/bundled-packages.json
 /server/pb_migrations_owner.json
 /server/pb_migrations/
+/server/automation_defs.json
 /server/pb_hooks/
 /server/tinycld
 /server/app

--- a/core/components/ResponsiveToolbar.tsx
+++ b/core/components/ResponsiveToolbar.tsx
@@ -107,21 +107,30 @@ function WebToolbar({ items, rightItems, height = 44 }: ResponsiveToolbarProps) 
         const rightWidth = rightRef.current?.offsetWidth ?? 0
         const available = containerWidth - rightWidth - 8
 
+        // Measure EVERY item up front, not lazily inside the fitting loop.
+        // getItemWidth is also what populates the width cache, and the fitting
+        // loop breaks at the first item that doesn't fit — so measuring inside
+        // it left every item past the break uncached. `allCached` below then
+        // could never come true once overflow engaged, and the next re-render
+        // reset visibleCount to null with nothing left to set it again (the
+        // layout effect only re-runs when items change) — a toolbar stuck
+        // invisible in its measuring state. This runs while all items are
+        // still in the DOM, which is the only moment they CAN all be measured.
+        const widths = items.map((item, i) => getItemWidth(i, item))
+
         let usedWidth = 0
         let fitCount = items.length
 
         for (let i = 0; i < items.length; i++) {
-            const w = getItemWidth(i, items[i])
-            const needed = usedWidth + w
+            const needed = usedWidth + widths[i]
 
             if (needed > available) {
                 const availableWithOverflow = available - OVERFLOW_BUTTON_WIDTH
                 let recalcWidth = 0
                 fitCount = 0
                 for (let j = 0; j < i; j++) {
-                    const wJ = getItemWidth(j, items[j])
-                    if (recalcWidth + wJ > availableWithOverflow) break
-                    recalcWidth += wJ
+                    if (recalcWidth + widths[j] > availableWithOverflow) break
+                    recalcWidth += widths[j]
                     fitCount = j + 1
                 }
                 break

--- a/core/components/help/MarkdownRenderer.tsx
+++ b/core/components/help/MarkdownRenderer.tsx
@@ -1,7 +1,8 @@
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import type { ReactNode } from 'react'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
+    Image,
     type ImageStyle,
     Linking,
     Platform,
@@ -40,6 +41,13 @@ interface Props {
      * supply. Pass a stable reference — identity keys the renderer cache.
      */
     transformImageUri?: ImageUriTransform
+    /**
+     * Cap rendered images to this height, letterboxed with `contain`. Exists
+     * for compact surfaces — a card comment shouldn't be dominated by a
+     * full-width screenshot the way a description or help topic can be.
+     * Undefined keeps the library's own sizing.
+     */
+    imageMaxHeight?: number
 }
 
 const HELP_SCHEME = 'help://'
@@ -97,6 +105,45 @@ interface RendererOptions {
     shortcutTables: boolean
     onLinkPress?: LinkPressHandler
     transformImageUri?: ImageUriTransform
+    imageMaxHeight?: number
+}
+
+/**
+ * An image scaled DOWN to fit a height cap, never up past its natural size.
+ * The intrinsic dimensions arrive async (Image.getSize), so until they do the
+ * box reserves the cap square — a brief placeholder beats a layout jump when
+ * the ratio lands. maxWidth keeps a very wide image inside the column, with
+ * `contain` absorbing the difference.
+ */
+function CappedImage({ uri, alt, maxHeight }: { uri: string; alt?: string; maxHeight: number }) {
+    const [size, setSize] = useState<{ width: number; height: number } | null>(null)
+
+    useEffect(() => {
+        let isLive = true
+        Image.getSize(
+            uri,
+            (width, height) => {
+                if (isLive && width > 0 && height > 0) setSize({ width, height })
+            },
+            () => {}
+        )
+        return () => {
+            isLive = false
+        }
+    }, [uri])
+
+    const height = size ? Math.min(size.height, maxHeight) : maxHeight
+    const aspectRatio = size ? size.width / size.height : 1
+
+    return (
+        <Image
+            source={{ uri }}
+            accessibilityRole="image"
+            accessibilityLabel={alt || 'Image'}
+            resizeMode="contain"
+            style={{ height, aspectRatio, maxWidth: '100%', alignSelf: 'flex-start' }}
+        />
+    )
 }
 
 class HelpRenderer extends Renderer {
@@ -108,6 +155,7 @@ class HelpRenderer extends Renderer {
     private readonly shortcutTables: boolean
     private readonly onLinkPress?: LinkPressHandler
     private readonly transformImageUri?: ImageUriTransform
+    private readonly imageMaxHeight?: number
 
     constructor(options: RendererOptions) {
         super()
@@ -115,13 +163,30 @@ class HelpRenderer extends Renderer {
         this.shortcutTables = options.shortcutTables
         this.onLinkPress = options.onLinkPress
         this.transformImageUri = options.transformImageUri
+        this.imageMaxHeight = options.imageMaxHeight
     }
 
     // The default image() fetches the uri as-is, which 404s for a protected
     // PocketBase file whose stored src is deliberately tokenless. The
     // transform runs here — render time — so every draw carries a live token.
+    //
+    // The height cap cannot ride the style param: the library's MDImage
+    // hardcodes `width: '100%'` + the intrinsic aspect ratio on its OUTER
+    // box and applies the passed style only to the inner image — so a
+    // maxHeight there letterboxes the pixels while the layout box stays
+    // full-bleed. A capped surface therefore renders its own image.
     override image(uri: string, alt?: string, style?: ImageStyle, title?: string): ReactNode {
         const resolved = this.transformImageUri ? this.transformImageUri(uri) : uri
+        if (this.imageMaxHeight) {
+            return (
+                <CappedImage
+                    key={this.getKey()}
+                    uri={resolved}
+                    alt={alt || title}
+                    maxHeight={this.imageMaxHeight}
+                />
+            )
+        }
         return super.image(resolved, alt, style, title)
     }
 
@@ -262,7 +327,7 @@ const rendererCache = new Map<string, HelpRenderer>()
 function rendererFor(options: RendererOptions): HelpRenderer {
     // Per-consumer functions can't be stringified, so each gets an identity
     // tag: same function object → same cache slot.
-    const key = `${options.translateKeys}|${options.shortcutTables}|${functionTag(options.onLinkPress)}|${functionTag(options.transformImageUri)}`
+    const key = `${options.translateKeys}|${options.shortcutTables}|${functionTag(options.onLinkPress)}|${functionTag(options.transformImageUri)}|${options.imageMaxHeight ?? 'none'}`
     const cached = rendererCache.get(key)
     if (cached) return cached
     const renderer = new HelpRenderer(options)
@@ -292,6 +357,7 @@ export function MarkdownRenderer({
     translateModifierKeys: shouldTranslateKeys = true,
     shortcutTableHeuristic = true,
     transformImageUri,
+    imageMaxHeight,
 }: Props) {
     // Codespan text uses `primary` (the brand teal — has matching
     // light + dark tokens) rather than `accent`. `accent` in this
@@ -389,6 +455,7 @@ export function MarkdownRenderer({
         shortcutTables: shortcutTableHeuristic,
         onLinkPress,
         transformImageUri,
+        imageMaxHeight,
     })
 
     return (
@@ -400,6 +467,13 @@ export function MarkdownRenderer({
                 initialNumToRender: 8,
                 scrollEnabled: false,
                 contentContainerStyle: { paddingBottom: 8 },
+                // Override the library's hardcoded #fff/#000 scheme background
+                // (its own style loses to flatListProps). An OPAQUE box here
+                // paints over anything a caller's negative margin pulls it
+                // across — cards' comment rows lost the bottom of their
+                // author line to exactly that — and a raw hex never matches
+                // the themed surface it sits on anyway.
+                style: { backgroundColor: 'transparent' },
             }}
         />
     )

--- a/core/lib/automation/__tests__/core-defs.test.ts
+++ b/core/lib/automation/__tests__/core-defs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { CORE_AUTOMATION, CORE_PKG_SLUG } from '../core-defs'
+import { validateDefinitions } from '../schemas'
+
+describe('CORE_AUTOMATION', () => {
+    it('is a valid definition set (synthetic triggers allowed for core)', () => {
+        expect(
+            validateDefinitions(CORE_PKG_SLUG, CORE_AUTOMATION, { allowSynthetic: true })
+        ).toEqual([])
+    })
+
+    it('declares the built-in triggers and actions from the spec', () => {
+        const triggerIds = (CORE_AUTOMATION.triggers ?? []).map(t => t.id)
+        const actionIds = (CORE_AUTOMATION.actions ?? []).map(a => a.id)
+        expect(triggerIds).toEqual(['schedule', 'manual'])
+        expect(actionIds).toEqual(['apply-label', 'notify'])
+    })
+
+    it('apply-label writes a polymorphic label_assignments record from context', () => {
+        const applyLabel = (CORE_AUTOMATION.actions ?? []).find(a => a.id === 'apply-label')
+        expect(applyLabel).toMatchObject({
+            kind: 'record-op',
+            collection: 'label_assignments',
+            op: {
+                type: 'create',
+                set: {
+                    label: { param: 'label' },
+                    record_id: { context: 'record-id' },
+                    collection: { context: 'collection' },
+                    user: { context: 'owner' },
+                },
+            },
+        })
+    })
+})

--- a/core/lib/automation/__tests__/helpers.test.ts
+++ b/core/lib/automation/__tests__/helpers.test.ts
@@ -39,10 +39,10 @@ describe('operator sets', () => {
         ])
     })
 
-    it('every operator appears in ALL_OPS exactly once', () => {
-        const flattened = Object.values(OPERATORS_BY_TYPE).flat()
-        expect(new Set(flattened).size).toBe(flattened.length)
-        expect([...flattened].sort()).toEqual([...ALL_OPS].sort())
+    it('ALL_OPS is the deduplicated union of every type operator set', () => {
+        const unique = [...new Set(Object.values(OPERATORS_BY_TYPE).flat())]
+        expect([...ALL_OPS].sort()).toEqual(unique.sort())
+        expect(new Set(ALL_OPS).size).toBe(ALL_OPS.length)
     })
 
     it('value-less operators are exactly the is_true/is_false/is_empty set', () => {

--- a/core/lib/automation/__tests__/helpers.test.ts
+++ b/core/lib/automation/__tests__/helpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+    ALL_OPS,
+    humanizeFieldKey,
+    NO_VALUE_OPS,
+    OPERATORS_BY_TYPE,
+    parseRef,
+    qualifyRef,
+} from '../helpers'
+
+describe('humanizeFieldKey', () => {
+    it('replaces underscores and capitalizes the first letter only', () => {
+        expect(humanizeFieldKey('has_attachments')).toBe('Has attachments')
+        expect(humanizeFieldKey('subject')).toBe('Subject')
+        expect(humanizeFieldKey('sender_email')).toBe('Sender email')
+    })
+})
+
+describe('refs', () => {
+    it('round-trips a qualified ref', () => {
+        expect(qualifyRef('mail', 'message-received')).toBe('mail:message-received')
+        expect(parseRef('mail:message-received')).toEqual({ pkg: 'mail', id: 'message-received' })
+    })
+
+    it('throws on a malformed ref', () => {
+        expect(() => parseRef('no-colon')).toThrow(/malformed automation ref/)
+    })
+})
+
+describe('operator sets', () => {
+    it('covers every field type', () => {
+        expect(Object.keys(OPERATORS_BY_TYPE).sort()).toEqual([
+            'boolean',
+            'date',
+            'number',
+            'relation',
+            'select',
+            'text',
+        ])
+    })
+
+    it('every operator appears in ALL_OPS exactly once', () => {
+        const flattened = Object.values(OPERATORS_BY_TYPE).flat()
+        expect(new Set(flattened).size).toBe(flattened.length)
+        expect([...flattened].sort()).toEqual([...ALL_OPS].sort())
+    })
+
+    it('value-less operators are exactly the is_true/is_false/is_empty set', () => {
+        expect([...NO_VALUE_OPS].sort()).toEqual(['is_empty', 'is_false', 'is_true'])
+    })
+})

--- a/core/lib/automation/__tests__/schemas.test.ts
+++ b/core/lib/automation/__tests__/schemas.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { conditionsAstSchema, ruleActionsSchema, validateDefinitions } from '../schemas'
+import type { AutomationDefinitions } from '../types'
+
+const validAst = {
+    match: 'all',
+    groups: [
+        {
+            match: 'any',
+            conditions: [
+                { field: 'sender_email', op: 'contains', value: '@acme.com' },
+                { field: 'sender_email', op: 'contains', value: '@example.com' },
+            ],
+        },
+        { match: 'all', conditions: [{ field: 'has_attachments', op: 'is_true' }] },
+    ],
+}
+
+describe('conditionsAstSchema', () => {
+    it('accepts the spec example AST', () => {
+        expect(conditionsAstSchema.safeParse(validAst).success).toBe(true)
+    })
+
+    it('accepts an empty groups array (rule with no conditions)', () => {
+        expect(conditionsAstSchema.safeParse({ match: 'all', groups: [] }).success).toBe(true)
+    })
+
+    it('rejects an unknown operator', () => {
+        const bad = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'regex', value: 'y' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+
+    it('rejects a value-carrying op with no value', () => {
+        const bad = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'contains' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+
+    it('accepts a value-less op with no value', () => {
+        const ok = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'is_empty' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(ok).success).toBe(true)
+    })
+
+    it('rejects a group with zero conditions', () => {
+        const bad = { match: 'all', groups: [{ match: 'any', conditions: [] }] }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+})
+
+describe('ruleActionsSchema', () => {
+    it('accepts an ordered action list with qualified refs', () => {
+        const ok = [
+            { ref: 'mail:move-to-folder', params: { folder: 'abc123def456ghi' } },
+            { ref: 'core:apply-label', params: { label: 'abc123def456ghi' } },
+        ]
+        expect(ruleActionsSchema.safeParse(ok).success).toBe(true)
+    })
+
+    it('rejects an unqualified ref and an empty list', () => {
+        expect(ruleActionsSchema.safeParse([{ ref: 'move-to-folder', params: {} }]).success).toBe(
+            false
+        )
+        expect(ruleActionsSchema.safeParse([]).success).toBe(false)
+    })
+
+    it('defaults params to an empty object', () => {
+        const parsed = ruleActionsSchema.parse([{ ref: 'core:notify' }])
+        expect(parsed[0].params).toEqual({})
+    })
+})
+
+describe('validateDefinitions', () => {
+    const good: AutomationDefinitions = {
+        triggers: [
+            {
+                id: 'message-received',
+                label: 'A message arrives',
+                collection: 'mail_messages',
+                on: 'create',
+            },
+        ],
+        actions: [
+            {
+                id: 'move-to-folder',
+                label: 'Move to folder',
+                kind: 'record-op',
+                collection: 'mail_messages',
+                op: {
+                    type: 'update',
+                    target: 'trigger-record',
+                    set: { alias: { param: 'alias' } },
+                },
+                params: [{ key: 'alias', field: 'alias' }],
+            },
+        ],
+    }
+
+    it('returns no errors for a valid definition set', () => {
+        expect(validateDefinitions('mail', good)).toEqual([])
+    })
+
+    it('rejects malformed and duplicate ids', () => {
+        const dup: AutomationDefinitions = {
+            triggers: [
+                { id: 'Same_Id', label: 'x', collection: 'c', on: 'create' },
+                { id: 'Same_Id', label: 'y', collection: 'c', on: 'create' },
+            ],
+        }
+        const errors = validateDefinitions('mail', dup)
+        expect(errors.some(e => e.includes('kebab-case'))).toBe(true)
+        expect(errors.some(e => e.includes('duplicate'))).toBe(true)
+    })
+
+    it('rejects synthetic triggers outside core', () => {
+        const synthetic: AutomationDefinitions = {
+            triggers: [{ id: 'schedule', label: 'On a schedule', synthetic: 'schedule' }],
+        }
+        expect(validateDefinitions('mail', synthetic).some(e => e.includes('synthetic'))).toBe(true)
+        expect(validateDefinitions('core', synthetic, { allowSynthetic: true })).toEqual([])
+    })
+
+    it('rejects a record-op whose set references an undeclared param', () => {
+        const bad: AutomationDefinitions = {
+            actions: [
+                {
+                    id: 'move',
+                    label: 'Move',
+                    kind: 'record-op',
+                    collection: 'c',
+                    op: {
+                        type: 'update',
+                        target: 'trigger-record',
+                        set: { folder: { param: 'missing' } },
+                    },
+                    params: [],
+                },
+            ],
+        }
+        expect(validateDefinitions('mail', bad).some(e => e.includes('missing'))).toBe(true)
+    })
+})

--- a/core/lib/automation/__tests__/schemas.test.ts
+++ b/core/lib/automation/__tests__/schemas.test.ts
@@ -49,6 +49,14 @@ describe('conditionsAstSchema', () => {
         expect(conditionsAstSchema.safeParse(ok).success).toBe(true)
     })
 
+    it('rejects a value-less op that carries a stray value', () => {
+        const bad = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'is_empty', value: 'junk' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+
     it('rejects a group with zero conditions', () => {
         const bad = { match: 'all', groups: [{ match: 'any', conditions: [] }] }
         expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
@@ -125,6 +133,38 @@ describe('validateDefinitions', () => {
         }
         expect(validateDefinitions('mail', synthetic).some(e => e.includes('synthetic'))).toBe(true)
         expect(validateDefinitions('core', synthetic, { allowSynthetic: true })).toEqual([])
+    })
+
+    it('rejects a watch clause on a non-update trigger', () => {
+        const bad: AutomationDefinitions = {
+            triggers: [
+                {
+                    id: 'thing-created',
+                    label: 'A thing is created',
+                    collection: 'things',
+                    on: 'create',
+                    watch: ['status'],
+                },
+            ],
+        }
+        expect(validateDefinitions('mail', bad).some(e => e.includes('declares watch'))).toBe(true)
+    })
+
+    it('rejects an empty fields list on a trigger', () => {
+        const bad: AutomationDefinitions = {
+            triggers: [
+                {
+                    id: 'message-received',
+                    label: 'A message arrives',
+                    collection: 'mail_messages',
+                    on: 'create',
+                    fields: [],
+                },
+            ],
+        }
+        expect(validateDefinitions('mail', bad).some(e => e.includes('empty fields list'))).toBe(
+            true
+        )
     })
 
     it('rejects a record-op whose set references an undeclared param', () => {

--- a/core/lib/automation/core-defs.ts
+++ b/core/lib/automation/core-defs.ts
@@ -1,0 +1,41 @@
+import type { AutomationDefinitions } from './types'
+
+export const CORE_PKG_SLUG = 'core'
+
+// Core's own trigger/action catalog. Typed loosely (no schema generic): core's
+// collections are part of the base Schema, and this module must not import the
+// generated pbSchema to stay usable in the generator's node context.
+export const CORE_AUTOMATION: AutomationDefinitions = {
+    triggers: [
+        { id: 'schedule', label: 'On a schedule', synthetic: 'schedule' },
+        { id: 'manual', label: 'Run manually', synthetic: 'manual' },
+    ],
+    actions: [
+        {
+            id: 'apply-label',
+            label: 'Apply label',
+            kind: 'record-op',
+            collection: 'label_assignments',
+            op: {
+                type: 'create',
+                set: {
+                    label: { param: 'label' },
+                    record_id: { context: 'record-id' },
+                    collection: { context: 'collection' },
+                    user: { context: 'owner' },
+                },
+            },
+            params: [{ key: 'label', field: 'label' }],
+        },
+        {
+            id: 'notify',
+            label: 'Send me a notification',
+            kind: 'native',
+            params: [
+                { key: 'title', type: 'text' },
+                { key: 'body', type: 'text' },
+                { key: 'url', type: 'text', label: 'Link (optional)' },
+            ],
+        },
+    ],
+}

--- a/core/lib/automation/helpers.ts
+++ b/core/lib/automation/helpers.ts
@@ -6,10 +6,10 @@ export const OPERATORS_BY_TYPE: Record<FieldType, readonly ConditionOp[]> = {
     boolean: ['is_true', 'is_false'],
     date: ['before', 'after', 'within_last_days'],
     relation: ['is', 'is_not', 'is_empty'],
-    select: [],
+    select: ['is', 'is_not'],
 }
 
-export const ALL_OPS: readonly ConditionOp[] = Object.values(OPERATORS_BY_TYPE).flat()
+export const ALL_OPS: readonly ConditionOp[] = [...new Set(Object.values(OPERATORS_BY_TYPE).flat())]
 
 export const NO_VALUE_OPS: ReadonlySet<ConditionOp> = new Set(['is_true', 'is_false', 'is_empty'])
 

--- a/core/lib/automation/helpers.ts
+++ b/core/lib/automation/helpers.ts
@@ -1,0 +1,31 @@
+import type { ConditionOp, FieldType } from './types'
+
+export const OPERATORS_BY_TYPE: Record<FieldType, readonly ConditionOp[]> = {
+    text: ['contains', 'not_contains', 'equals', 'starts_with'],
+    number: ['eq', 'neq', 'gt', 'lt'],
+    boolean: ['is_true', 'is_false'],
+    date: ['before', 'after', 'within_last_days'],
+    relation: ['is', 'is_not', 'is_empty'],
+    select: [],
+}
+
+export const ALL_OPS: readonly ConditionOp[] = Object.values(OPERATORS_BY_TYPE).flat()
+
+export const NO_VALUE_OPS: ReadonlySet<ConditionOp> = new Set(['is_true', 'is_false', 'is_empty'])
+
+export function humanizeFieldKey(key: string): string {
+    const spaced = key.replace(/_/g, ' ')
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+export function qualifyRef(pkgSlug: string, id: string): string {
+    return `${pkgSlug}:${id}`
+}
+
+export function parseRef(ref: string): { pkg: string; id: string } {
+    const idx = ref.indexOf(':')
+    if (idx <= 0 || idx === ref.length - 1) {
+        throw new Error(`malformed automation ref: '${ref}'`)
+    }
+    return { pkg: ref.slice(0, idx), id: ref.slice(idx + 1) }
+}

--- a/core/lib/automation/schemas.ts
+++ b/core/lib/automation/schemas.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod'
+import { ALL_OPS, NO_VALUE_OPS } from './helpers'
+import type { AutomationDefinitions, ConditionOp } from './types'
+
+const ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+const REF_RE = /^[a-z0-9-]+:[a-z0-9-]+$/
+
+export const conditionSchema = z
+    .object({
+        field: z.string().min(1),
+        op: z.enum(ALL_OPS as [ConditionOp, ...ConditionOp[]]),
+        value: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    })
+    .superRefine((c, ctx) => {
+        if (!NO_VALUE_OPS.has(c.op) && c.value === undefined) {
+            ctx.addIssue({ code: 'custom', message: `operator '${c.op}' requires a value` })
+        }
+    })
+
+export const conditionGroupSchema = z.object({
+    match: z.enum(['all', 'any']),
+    conditions: z.array(conditionSchema).min(1),
+})
+
+// One level of grouping by construction: groups contain conditions, never
+// other groups (spec: condition AST).
+export const conditionsAstSchema = z.object({
+    match: z.enum(['all', 'any']),
+    groups: z.array(conditionGroupSchema),
+})
+
+export const ruleActionSchema = z.object({
+    ref: z.string().regex(REF_RE, 'action ref must be qualified as <pkg>:<id>'),
+    params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).default({}),
+})
+
+export const ruleActionsSchema = z.array(ruleActionSchema).min(1)
+
+function checkId(errors: string[], pkgSlug: string, what: string, id: string, seen: Set<string>) {
+    if (!ID_RE.test(id)) {
+        errors.push(`${pkgSlug}: ${what} id '${id}' must be kebab-case ([a-z0-9-])`)
+    }
+    if (seen.has(id)) errors.push(`${pkgSlug}: duplicate ${what} id '${id}'`)
+    seen.add(id)
+}
+
+/**
+ * Structural validation of a package's automation definitions. Collection and
+ * column EXISTENCE is not checked here — the package's own typecheck enforces
+ * it at compile time, and Phase 2's Go resolution re-checks at runtime.
+ */
+export function validateDefinitions(
+    pkgSlug: string,
+    defs: AutomationDefinitions,
+    opts: { allowSynthetic?: boolean } = {}
+): string[] {
+    const errors: string[] = []
+    const triggerIds = new Set<string>()
+    for (const t of defs.triggers ?? []) {
+        checkId(errors, pkgSlug, 'trigger', t.id, triggerIds)
+        if ('synthetic' in t) {
+            if (!opts.allowSynthetic) {
+                errors.push(
+                    `${pkgSlug}: trigger '${t.id}' is synthetic — only core may declare synthetic triggers`
+                )
+            }
+        } else if (!t.collection) {
+            errors.push(`${pkgSlug}: trigger '${t.id}' has no collection`)
+        }
+    }
+    const actionIds = new Set<string>()
+    for (const a of defs.actions ?? []) {
+        checkId(errors, pkgSlug, 'action', a.id, actionIds)
+        const paramKeys = new Set<string>()
+        for (const p of a.params ?? []) {
+            if (paramKeys.has(p.key))
+                errors.push(`${pkgSlug}: action '${a.id}' duplicate param '${p.key}'`)
+            paramKeys.add(p.key)
+        }
+        if (a.kind === 'record-op') {
+            if (!a.collection)
+                errors.push(`${pkgSlug}: record-op action '${a.id}' has no collection`)
+            if (a.op.type !== 'delete') {
+                for (const v of Object.values(a.op.set)) {
+                    if (
+                        typeof v === 'object' &&
+                        v !== null &&
+                        'param' in v &&
+                        !paramKeys.has(v.param)
+                    ) {
+                        errors.push(
+                            `${pkgSlug}: action '${a.id}' set references undeclared param '${v.param}'`
+                        )
+                    }
+                }
+            }
+        }
+    }
+    return errors
+}

--- a/core/lib/automation/schemas.ts
+++ b/core/lib/automation/schemas.ts
@@ -15,6 +15,9 @@ export const conditionSchema = z
         if (!NO_VALUE_OPS.has(c.op) && c.value === undefined) {
             ctx.addIssue({ code: 'custom', message: `operator '${c.op}' requires a value` })
         }
+        if (NO_VALUE_OPS.has(c.op) && c.value !== undefined) {
+            ctx.addIssue({ code: 'custom', message: `operator '${c.op}' takes no value` })
+        }
     })
 
 export const conditionGroupSchema = z.object({
@@ -64,8 +67,20 @@ export function validateDefinitions(
                     `${pkgSlug}: trigger '${t.id}' is synthetic — only core may declare synthetic triggers`
                 )
             }
-        } else if (!t.collection) {
-            errors.push(`${pkgSlug}: trigger '${t.id}' has no collection`)
+        } else {
+            if (!t.collection) {
+                errors.push(`${pkgSlug}: trigger '${t.id}' has no collection`)
+            }
+            if (t.watch && t.on !== 'update') {
+                errors.push(
+                    `${pkgSlug}: trigger '${t.id}' declares watch but is not an update trigger`
+                )
+            }
+            if (t.fields && t.fields.length === 0) {
+                errors.push(
+                    `${pkgSlug}: trigger '${t.id}' has an empty fields list — omit fields to expose all columns`
+                )
+            }
         }
     }
     const actionIds = new Set<string>()

--- a/core/lib/automation/types.ts
+++ b/core/lib/automation/types.ts
@@ -1,0 +1,122 @@
+// Authoring types for a package's automation.ts (pure data, spec:
+// docs/superpowers/specs/2026-08-11-workflow-rules-design.md). The S generic is
+// the package's generated schema map ({ collection: { type, relations } }), so
+// collection and field references are compile-checked in the package.
+
+export type FieldType = 'text' | 'number' | 'boolean' | 'date' | 'select' | 'relation'
+
+export type ConditionOp =
+    | 'contains'
+    | 'not_contains'
+    | 'equals'
+    | 'starts_with'
+    | 'eq'
+    | 'neq'
+    | 'gt'
+    | 'lt'
+    | 'is_true'
+    | 'is_false'
+    | 'before'
+    | 'after'
+    | 'within_last_days'
+    | 'is'
+    | 'is_not'
+    | 'is_empty'
+
+type AnySchema = Record<string, { type: Record<string, unknown> }>
+type CollectionsOf<S> = keyof S & string
+type FieldsOf<S, C extends keyof S> = S[C] extends { type: infer T } ? keyof T & string : string
+
+/** A trigger field entry: bare column key, or key + display-label override. */
+export type FieldRef<F extends string = string> = F | { key: F; label: string }
+
+export interface RecordTriggerDefBase<C extends string, F extends string> {
+    id: string
+    label: string
+    collection: C
+    on: 'create' | 'update' | 'delete'
+    /** update triggers only: fire only when one of these columns changed */
+    watch?: F[]
+    /** omitted = expose every schema column (see spec: contract rules) */
+    fields?: FieldRef<F>[]
+    /** override the auto-detected user/owner/author owner column */
+    ownerField?: F
+}
+
+export type RecordTriggerDef<S = AnySchema> = {
+    [C in CollectionsOf<S>]: RecordTriggerDefBase<C, FieldsOf<S, C>>
+}[CollectionsOf<S>]
+
+/**
+ * Core-only synthetic triggers with no backing record (core:schedule,
+ * core:manual). Declared by core's own catalog; the generator rejects them in
+ * feature packages.
+ */
+export interface SyntheticTriggerDef {
+    id: string
+    label: string
+    synthetic: 'schedule' | 'manual'
+}
+
+export type TriggerDef<S = AnySchema> = RecordTriggerDef<S> | SyntheticTriggerDef
+
+/**
+ * A value written by a record-op `set` entry:
+ * - `{ param }`: the rule author supplies it (static value or template)
+ * - `{ context }`: engine-provided — the trigger record's id, its collection
+ *   name, or the executing rule's owner id
+ * - literal: fixed at declaration time
+ */
+export type SetValue =
+    | { param: string }
+    | { context: 'record-id' | 'collection' | 'owner' }
+    | string
+    | number
+    | boolean
+
+export type RecordOp<F extends string = string> =
+    | { type: 'update'; target: 'trigger-record'; set: Partial<Record<F, SetValue>> }
+    | { type: 'delete'; target: 'trigger-record' }
+    | { type: 'create'; set: Partial<Record<F, SetValue>> }
+
+/** Column-referencing param (type/relation resolved from the column in Phase 2) */
+export interface ColumnParamDef<F extends string = string> {
+    key: string
+    field: F
+    label?: string
+}
+
+/** Novel param (not a DB column) — declares its own type */
+export interface TypedParamDef {
+    key: string
+    type: FieldType
+    label?: string
+    options?: string[]
+}
+
+export type ParamDef<F extends string = string> = ColumnParamDef<F> | TypedParamDef
+
+export type RecordOpActionDef<S = AnySchema> = {
+    [C in CollectionsOf<S>]: {
+        id: string
+        label: string
+        kind: 'record-op'
+        collection: C
+        op: RecordOp<FieldsOf<S, C>>
+        params?: ParamDef<FieldsOf<S, C>>[]
+    }
+}[CollectionsOf<S>]
+
+export interface NativeActionDef {
+    id: string
+    label: string
+    kind: 'native'
+    params?: TypedParamDef[]
+}
+
+export type ActionDef<S = AnySchema> = RecordOpActionDef<S> | NativeActionDef
+
+export interface AutomationDefinitions<S = AnySchema> {
+    triggers?: TriggerDef<S>[]
+    actions?: ActionDef<S>[]
+}

--- a/core/lib/editor/__tests__/derive-toolbar-state.test.ts
+++ b/core/lib/editor/__tests__/derive-toolbar-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { deriveToolbarState } from '../derive-toolbar-state'
+
+/**
+ * The narrowing contract: every field requires its exact runtime type and
+ * collapses to the documented default otherwise. `isEmpty` is the field
+ * composers gate a Send button on, so its tri-state matters — `undefined`
+ * (no stateUpdate yet) must stay distinguishable from `false` (has content),
+ * because a consumer reads `isEmpty ?? true` to keep Send disabled until the
+ * page has actually spoken.
+ */
+describe('deriveToolbarState', () => {
+    it('maps isEmpty through when the wire value is a boolean', () => {
+        expect(deriveToolbarState({ isEmpty: true }).isEmpty).toBe(true)
+        expect(deriveToolbarState({ isEmpty: false }).isEmpty).toBe(false)
+    })
+
+    it('leaves isEmpty undefined before the first stateUpdate', () => {
+        expect(deriveToolbarState({}).isEmpty).toBeUndefined()
+    })
+
+    it('collapses a malformed wire value to undefined rather than a truthy guess', () => {
+        expect(deriveToolbarState({ isEmpty: 'yes' }).isEmpty).toBeUndefined()
+        expect(deriveToolbarState({ isEmpty: 1 }).isEmpty).toBeUndefined()
+        expect(deriveToolbarState({ isEmpty: null }).isEmpty).toBeUndefined()
+    })
+
+    it('applies the strict defaults for the other fields', () => {
+        const state = deriveToolbarState({ isBoldActive: 'yes', activeHeadingLevel: '2' })
+        expect(state.isBoldActive).toBe(false)
+        expect(state.activeHeadingLevel).toBeNull()
+        expect(state.selectionEmpty).toBe(true)
+        expect(state.wordCount).toBeUndefined()
+    })
+})

--- a/core/lib/editor/derive-toolbar-state.ts
+++ b/core/lib/editor/derive-toolbar-state.ts
@@ -72,5 +72,10 @@ export function deriveToolbarState(bridgeState: Record<string, unknown>): Editor
         // it, or before the initial stateUpdate arrives). The
         // WordCountBadge renders nothing in that case.
         wordCount: typeof bridgeState.wordCount === 'number' ? bridgeState.wordCount : undefined,
+        // Undefined until the page's first stateUpdate arrives, so a
+        // consumer gating a Send button must read `isEmpty ?? true` —
+        // "briefly disabled" is the acceptable failure mode, "sends an
+        // empty body" is not.
+        isEmpty: typeof bridgeState.isEmpty === 'boolean' ? bridgeState.isEmpty : undefined,
     }
 }

--- a/core/lib/event-sources/__tests__/registry.test.ts
+++ b/core/lib/event-sources/__tests__/registry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createEventSourceLoader, deriveEventSources } from '../registry'
+import type { EventSourceModule } from '../types'
+
+const load = () => Promise.resolve({})
+
+describe('deriveEventSources', () => {
+    it('groups by target, sorted by order then contributor slug', () => {
+        const derived = deriveEventSources([
+            {
+                manifest: { slug: 'tasks' },
+                eventSources: [
+                    { target: 'calendar', id: 'tasks-due', label: 'Tasks', order: 0, load },
+                ],
+            },
+            {
+                manifest: { slug: 'cards' },
+                eventSources: [
+                    { target: 'calendar', id: 'cards-due', label: 'Cards', order: 0, load },
+                    { target: 'timeline', id: 'cards-activity', label: 'Cards', order: 5, load },
+                ],
+            },
+            { manifest: { slug: 'contacts' } },
+        ])
+        expect(Object.keys(derived).sort()).toEqual(['calendar', 'timeline'])
+        expect(derived.calendar.map(s => s.id)).toEqual(['cards-due', 'tasks-due'])
+        expect(derived.timeline[0]).toMatchObject({
+            contributorSlug: 'cards',
+            id: 'cards-activity',
+            order: 5,
+        })
+    })
+
+    it('sorts by order before contributor slug', () => {
+        const derived = deriveEventSources([
+            {
+                manifest: { slug: 'aaa' },
+                eventSources: [{ target: 'calendar', id: 'late', label: 'L', order: 9, load }],
+            },
+            {
+                manifest: { slug: 'zzz' },
+                eventSources: [{ target: 'calendar', id: 'early', label: 'E', order: 1, load }],
+            },
+        ])
+        expect(derived.calendar.map(s => s.id)).toEqual(['early', 'late'])
+    })
+})
+
+describe('createEventSourceLoader', () => {
+    const module: EventSourceModule = {
+        useEventSource: () => ({ items: [], isLoading: false }),
+    }
+
+    it('loads a registered module once and caches it', async () => {
+        const loadSpy = vi.fn().mockResolvedValue(module)
+        const loader = createEventSourceLoader({
+            calendar: [
+                { contributorSlug: 'cards', id: 'cards-due', label: 'C', order: 0, load: loadSpy },
+            ],
+        })
+        const first = await loader('calendar', 'cards-due')
+        const second = await loader('calendar', 'cards-due')
+        expect(first).toBe(module)
+        expect(second).toBe(module)
+        expect(loadSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns null for an unregistered source', async () => {
+        const loader = createEventSourceLoader({})
+        expect(await loader('calendar', 'cards-due')).toBeNull()
+    })
+
+    it('returns null when the module lacks a useEventSource function', async () => {
+        const loader = createEventSourceLoader({
+            calendar: [
+                {
+                    contributorSlug: 'cards',
+                    id: 'cards-due',
+                    label: 'C',
+                    order: 0,
+                    load: () => Promise.resolve({ somethingElse: true }),
+                },
+            ],
+        })
+        expect(await loader('calendar', 'cards-due')).toBeNull()
+    })
+})

--- a/core/lib/event-sources/registry.ts
+++ b/core/lib/event-sources/registry.ts
@@ -1,0 +1,84 @@
+import { tinycldConfig } from '@tinycld/app-generated/tinycld-config'
+import type { EventSourceModule } from './types'
+
+type EventSourceEntryLike = {
+    manifest: { slug: string }
+    eventSources?: {
+        target: string
+        id: string
+        label: string
+        color?: string
+        order: number
+        load: () => Promise<unknown>
+    }[]
+}
+
+export interface RegisteredEventSource {
+    contributorSlug: string
+    id: string
+    label: string
+    color?: string
+    order: number
+    load: () => Promise<unknown>
+}
+
+/** target slug → sources sorted by order, ties broken by contributor slug. */
+export function deriveEventSources(
+    entries: readonly EventSourceEntryLike[]
+): Record<string, RegisteredEventSource[]> {
+    const byTarget: Record<string, RegisteredEventSource[]> = {}
+    for (const e of entries) {
+        for (const s of e.eventSources ?? []) {
+            byTarget[s.target] ??= []
+            byTarget[s.target].push({
+                contributorSlug: e.manifest.slug,
+                id: s.id,
+                label: s.label,
+                ...(s.color ? { color: s.color } : {}),
+                order: s.order,
+                load: s.load,
+            })
+        }
+    }
+    for (const list of Object.values(byTarget)) {
+        list.sort((a, b) => a.order - b.order || a.contributorSlug.localeCompare(b.contributorSlug))
+    }
+    return byTarget
+}
+
+export const packageEventSources = deriveEventSources(
+    tinycldConfig as readonly EventSourceEntryLike[]
+)
+
+/**
+ * Build a module loader over a source table. Split from the module-level
+ * binding so tests can exercise caching and the malformed-module path with
+ * fake loaders.
+ */
+export function createEventSourceLoader(sources: Record<string, RegisteredEventSource[]>) {
+    // Modules are cached after first load so a host re-mounting its collectors
+    // (every screen visit) does not re-import per mount.
+    const cache = new Map<string, EventSourceModule>()
+    /**
+     * Resolve a registered source's module. Returns null when no such source
+     * is registered for the target or the module does not export a
+     * `useEventSource` function — the host treats null as "source inactive",
+     * never an error.
+     */
+    return async function loadEventSourceModule(
+        target: string,
+        id: string
+    ): Promise<EventSourceModule | null> {
+        const key = `${target}:${id}`
+        const cached = cache.get(key)
+        if (cached) return cached
+        const source = sources[target]?.find(s => s.id === id)
+        if (!source) return null
+        const mod = (await source.load()) as EventSourceModule
+        if (typeof mod?.useEventSource !== 'function') return null
+        cache.set(key, mod)
+        return mod
+    }
+}
+
+export const loadEventSourceModule = createEventSourceLoader(packageEventSources)

--- a/core/lib/event-sources/types.ts
+++ b/core/lib/event-sources/types.ts
@@ -1,0 +1,37 @@
+import type { Href } from 'expo-router'
+
+export interface EventSourceRange {
+    start: Date
+    end: Date
+}
+
+/** One read-only item a source contributes to a host's event grid. */
+export interface EventSourceItem {
+    /** Unique within the source — typically the backing record's id. */
+    id: string
+    title: string
+    /** ISO datetime. For allDay items: local midnight of the day. */
+    start: string
+    /** ISO datetime. For allDay items: local end of the day. */
+    end: string
+    allDay: boolean
+    /** Where a press navigates — already org-scoped (built with useOrgHref). */
+    href: Href
+}
+
+/**
+ * The shape an `eventSources` manifest entry's `module` must export.
+ *
+ * The host mounts one collector component per source and calls this hook
+ * unconditionally on every render of that collector, so it must obey the
+ * rules of hooks — a live query (useOrgLiveQuery) is the expected
+ * implementation. Items are read-only on the host grid: no drag, no edit;
+ * a press navigates to `href`. The hook must import only @tinycld/core and
+ * its own package (lean shell: the host may be absent).
+ */
+export interface EventSourceModule {
+    useEventSource: (range: EventSourceRange) => {
+        items: EventSourceItem[]
+        isLoading: boolean
+    }
+}

--- a/core/lib/event-sources/use-event-source-module.ts
+++ b/core/lib/event-sources/use-event-source-module.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+import { loadEventSourceModule } from './registry'
+import type { EventSourceModule } from './types'
+
+/**
+ * Resolve a registered event source's module for rendering. Null while the
+ * dynamic import is pending and forever when the source is unregistered or
+ * malformed. Hosts must NOT call `module.useEventSource` conditionally on
+ * this settling — mount a child component once the module is non-null, so
+ * the hook call is unconditional for that component's entire lifetime
+ * (see SearchPalette's PackageActions for the pattern and the crash it avoids).
+ */
+export function useEventSourceModule(target: string, id: string): EventSourceModule | null {
+    const { data } = useQuery({
+        queryKey: ['event-source-module', target, id],
+        queryFn: () => loadEventSourceModule(target, id),
+        staleTime: Number.POSITIVE_INFINITY,
+    })
+    return data ?? null
+}

--- a/core/lib/packages/__tests__/derive-automation.test.ts
+++ b/core/lib/packages/__tests__/derive-automation.test.ts
@@ -20,7 +20,7 @@ const plainEntry = { manifest: { name: 'Calc', slug: 'calc' } }
 
 describe('deriveAutomation', () => {
     it('always includes the core catalog, first', () => {
-        const catalog = deriveAutomation([] as never)
+        const catalog = deriveAutomation([])
         expect(catalog.byPackage[0].pkgSlug).toBe('core')
         expect(catalog.triggers['core:schedule']).toBeDefined()
         expect(catalog.triggers['core:manual']).toBeDefined()
@@ -29,7 +29,7 @@ describe('deriveAutomation', () => {
     })
 
     it('keys package declarations by qualified ref and skips packages without automation', () => {
-        const catalog = deriveAutomation([mailEntry, plainEntry] as never)
+        const catalog = deriveAutomation([mailEntry, plainEntry])
         expect(catalog.triggers['mail:message-received']).toMatchObject({
             pkgSlug: 'mail',
             pkgName: 'Mail',
@@ -38,7 +38,7 @@ describe('deriveAutomation', () => {
     })
 })
 
-describe('use-packages automation passthrough', () => {
+describe('PackageManifest automation field shape', () => {
     it('PackageManifest carries the raw automation pointer shape', () => {
         const manifest = {
             name: 'X',

--- a/core/lib/packages/__tests__/derive-automation.test.ts
+++ b/core/lib/packages/__tests__/derive-automation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { deriveAutomation } from '../derive-automation'
+
+const mailEntry = {
+    manifest: { name: 'Mail', slug: 'mail' },
+    automation: {
+        triggers: [
+            {
+                id: 'message-received',
+                label: 'A message arrives',
+                collection: 'mail_messages',
+                on: 'create' as const,
+            },
+        ],
+        actions: [],
+    },
+}
+const plainEntry = { manifest: { name: 'Calc', slug: 'calc' } }
+
+describe('deriveAutomation', () => {
+    it('always includes the core catalog, first', () => {
+        const catalog = deriveAutomation([] as never)
+        expect(catalog.byPackage[0].pkgSlug).toBe('core')
+        expect(catalog.triggers['core:schedule']).toBeDefined()
+        expect(catalog.triggers['core:manual']).toBeDefined()
+        expect(catalog.actions['core:apply-label']).toBeDefined()
+        expect(catalog.actions['core:notify']).toBeDefined()
+    })
+
+    it('keys package declarations by qualified ref and skips packages without automation', () => {
+        const catalog = deriveAutomation([mailEntry, plainEntry] as never)
+        expect(catalog.triggers['mail:message-received']).toMatchObject({
+            pkgSlug: 'mail',
+            pkgName: 'Mail',
+        })
+        expect(catalog.byPackage.map(p => p.pkgSlug)).toEqual(['core', 'mail'])
+    })
+})

--- a/core/lib/packages/__tests__/derive-automation.test.ts
+++ b/core/lib/packages/__tests__/derive-automation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { deriveAutomation } from '../derive-automation'
+import type { PackageManifest } from '../types'
 
 const mailEntry = {
     manifest: { name: 'Mail', slug: 'mail' },
@@ -34,5 +35,18 @@ describe('deriveAutomation', () => {
             pkgName: 'Mail',
         })
         expect(catalog.byPackage.map(p => p.pkgSlug)).toEqual(['core', 'mail'])
+    })
+})
+
+describe('use-packages automation passthrough', () => {
+    it('PackageManifest carries the raw automation pointer shape', () => {
+        const manifest = {
+            name: 'X',
+            slug: 'x',
+            version: '0.0.1',
+            description: 'd',
+            automation: { definitions: 'automation' },
+        } satisfies PackageManifest
+        expect(manifest.automation.definitions).toBe('automation')
     })
 })

--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -36,6 +36,17 @@ export interface SidebarContribution {
     order: number
     Component: ComponentType | LazyExoticComponent<ComponentType>
 }
+// A read-only event feed contributed to another package's event grid. `load`
+// is a bare thunk (not React.lazy) because the module exports a HOOK
+// (`useEventSource`) — see core/lib/event-sources/types.ts for the contract.
+export interface PackageEventSource {
+    target: string
+    id: string
+    label: string
+    color?: string
+    order: number
+    load: () => Promise<unknown>
+}
 export interface SeedContext {
     // Single-org: package seeds own data by the user id directly (the former
     // org/userOrg junction is gone; the `role` enum lives on the user record).
@@ -81,6 +92,7 @@ export interface PackageEntry<S extends SchemaDeclaration, R> {
         label?: string
         load: () => Promise<unknown>
     }
+    eventSources?: PackageEventSource[]
     seed?: (pb: PocketBase, ctx: SeedContext) => Promise<void>
 }
 
@@ -104,6 +116,7 @@ export function definePackageEntry<S extends SchemaDeclaration>() {
         systemSettings?: PackageEntry<S, R>['systemSettings']
         sidebarContributions?: PackageEntry<S, R>['sidebarContributions']
         search?: PackageEntry<S, R>['search']
+        eventSources?: PackageEntry<S, R>['eventSources']
         seed?: PackageEntry<S, R>['seed']
     }): PackageEntry<S, R> => entry as unknown as PackageEntry<S, R>
 }

--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -3,6 +3,7 @@ import type { Schema } from '@tinycld/core/types/pbSchema'
 import type { createCollection, SchemaDeclaration } from 'pbtsdb/core'
 import type PocketBase from 'pocketbase'
 import type { ComponentType, LazyExoticComponent, ReactNode } from 'react'
+import type { AutomationDefinitions } from '../automation/types'
 import type { PackageManifest } from './types'
 
 // --- Spike-2-proven helpers (see ~/code/tinycld/new/spike2/sim.ts) ----------
@@ -93,6 +94,7 @@ export interface PackageEntry<S extends SchemaDeclaration, R> {
         load: () => Promise<unknown>
     }
     eventSources?: PackageEventSource[]
+    automation?: AutomationDefinitions
     seed?: (pb: PocketBase, ctx: SeedContext) => Promise<void>
 }
 
@@ -117,6 +119,7 @@ export function definePackageEntry<S extends SchemaDeclaration>() {
         sidebarContributions?: PackageEntry<S, R>['sidebarContributions']
         search?: PackageEntry<S, R>['search']
         eventSources?: PackageEntry<S, R>['eventSources']
+        automation?: PackageEntry<S, R>['automation']
         seed?: PackageEntry<S, R>['seed']
     }): PackageEntry<S, R> => entry as unknown as PackageEntry<S, R>
 }

--- a/core/lib/packages/derive-automation.ts
+++ b/core/lib/packages/derive-automation.ts
@@ -1,0 +1,57 @@
+import { tinycldConfig } from '@tinycld/app-generated/tinycld-config'
+import { CORE_AUTOMATION, CORE_PKG_SLUG } from '../automation/core-defs'
+import { qualifyRef } from '../automation/helpers'
+import type { ActionDef, AutomationDefinitions, TriggerDef } from '../automation/types'
+
+export interface CatalogTrigger {
+    pkgSlug: string
+    pkgName: string
+    def: TriggerDef
+}
+export interface CatalogAction {
+    pkgSlug: string
+    pkgName: string
+    def: ActionDef
+}
+export interface AutomationPackageGroup {
+    pkgSlug: string
+    pkgName: string
+    triggers: TriggerDef[]
+    actions: ActionDef[]
+}
+export interface AutomationCatalog {
+    triggers: Record<string, CatalogTrigger>
+    actions: Record<string, CatalogAction>
+    byPackage: AutomationPackageGroup[]
+}
+
+type AutomationEntryLike = {
+    manifest: { name: string; slug: string }
+    automation?: AutomationDefinitions
+}
+
+/** Ref-keyed trigger/action catalogs; core built-ins always present, first. */
+export function deriveAutomation(entries: readonly AutomationEntryLike[]): AutomationCatalog {
+    const catalog: AutomationCatalog = { triggers: {}, actions: {}, byPackage: [] }
+    const sources: { pkgSlug: string; pkgName: string; defs: AutomationDefinitions }[] = [
+        { pkgSlug: CORE_PKG_SLUG, pkgName: 'Core', defs: CORE_AUTOMATION },
+    ]
+    for (const e of entries) {
+        if (!e.automation) continue
+        sources.push({ pkgSlug: e.manifest.slug, pkgName: e.manifest.name, defs: e.automation })
+    }
+    for (const { pkgSlug, pkgName, defs } of sources) {
+        const triggers = defs.triggers ?? []
+        const actions = defs.actions ?? []
+        for (const def of triggers) {
+            catalog.triggers[qualifyRef(pkgSlug, def.id)] = { pkgSlug, pkgName, def }
+        }
+        for (const def of actions) {
+            catalog.actions[qualifyRef(pkgSlug, def.id)] = { pkgSlug, pkgName, def }
+        }
+        catalog.byPackage.push({ pkgSlug, pkgName, triggers, actions })
+    }
+    return catalog
+}
+
+export const packageAutomation: AutomationCatalog = deriveAutomation(tinycldConfig)

--- a/core/lib/packages/types.ts
+++ b/core/lib/packages/types.ts
@@ -273,6 +273,16 @@ export interface PackageManifest {
         label?: string
     }
 
+    /**
+     * Workflow-rules catalog. `definitions` is a package-exports subpath (like
+     * `seed.script`) resolving to a TS module default-exporting an
+     * AutomationDefinitions object — pure data, typed against the package's
+     * schema. See docs/superpowers/specs/2026-08-11-workflow-rules-design.md.
+     */
+    automation?: {
+        definitions: string
+    }
+
     repository?: {
         url: string
         issueTemplate?: string

--- a/core/lib/packages/types.ts
+++ b/core/lib/packages/types.ts
@@ -84,6 +84,35 @@ export interface PackageManifest {
         order?: number
     }[]
 
+    /**
+     * Read-only event feeds this package contributes to another package's
+     * event grid (today: the calendar). `target` is the host package slug —
+     * the host must declare `eventSourceHost: true` or generation fails;
+     * an absent host leaves the source silently inactive (lean shell).
+     * `id` is unique per target and restricted to `[a-z0-9-]` (the host embeds
+     * it in `:`-delimited synthetic event ids). `module` is a package-exports
+     * subpath to a module exporting `useEventSource` — see
+     * `core/lib/event-sources/types.ts` for the contract. Items are read-only
+     * on the host grid: no drag, no edit; a press navigates to the item's
+     * `href`. `color` names a calendar color key the host resolves.
+     */
+    eventSources?: {
+        target: string
+        id: string
+        label: string
+        module: string
+        color?: string
+        order?: number
+    }[]
+
+    /**
+     * Declares this package hosts event-source contributions: it mounts the
+     * collectors, merges contributed items into its grid, and renders the
+     * per-source visibility toggles. Contributions targeting a package
+     * without this flag fail generation.
+     */
+    eventSourceHost?: boolean
+
     seed?: {
         script: string
     }

--- a/core/lib/packages/use-packages.ts
+++ b/core/lib/packages/use-packages.ts
@@ -48,6 +48,12 @@ export function usePackages(): PackageEntry[] {
                 seed: manifest.seed,
                 tests: manifest.tests,
                 server: manifest.server,
+                // Raw manifest pointer ({ definitions: subpath }) — NOT the
+                // resolved AutomationDefinitions that static config entries
+                // carry. deriveAutomation reads only the static config today;
+                // DB-installed packages get resolved defs embedded in
+                // manifest_json in a later phase. Passed through so the field
+                // is not silently dropped (see the automation spec).
                 automation: manifest.automation,
                 repository: manifest.repository,
                 dependencies: manifest.dependencies,

--- a/core/lib/packages/use-packages.ts
+++ b/core/lib/packages/use-packages.ts
@@ -48,6 +48,7 @@ export function usePackages(): PackageEntry[] {
                 seed: manifest.seed,
                 tests: manifest.tests,
                 server: manifest.server,
+                automation: manifest.automation,
                 repository: manifest.repository,
                 dependencies: manifest.dependencies,
                 packageName: record.npm_package ?? manifest.slug,

--- a/core/lib/pocketbase.ts
+++ b/core/lib/pocketbase.ts
@@ -316,6 +316,18 @@ const notifications = newCollection('notifications', {
 })
 export const notificationsCollection = notifications
 
+const rules = newCollection('rules', {
+    omitOnInsert: ['created', 'updated'],
+    expand: { owner: users },
+    ...indexing,
+})
+
+const rule_runs = newCollection('rule_runs', {
+    omitOnInsert: ['created', 'updated'],
+    expand: { rule: rules },
+    ...indexing,
+})
+
 // NOTE: the `comment_mentions` store registration was removed in the new
 // standalone-core layout because the collection is created by a feature
 // package's migration (drive's create_comment_mentions), not core's own — so
@@ -336,6 +348,8 @@ const coreStores = {
     audit_logs,
     pkg_install_log,
     notifications,
+    rules,
+    rule_runs,
     system_settings,
     oauth_grants,
 }

--- a/core/lib/shortcuts/provider.web.tsx
+++ b/core/lib/shortcuts/provider.web.tsx
@@ -8,16 +8,33 @@ export interface ShortcutsProviderProps {
 }
 
 /**
- * Is the currently-focused element a text input? The matcher skips most
- * shortcuts when this is true (unless `allowInInputs` is set on the shortcut).
+ * Did this key event come from a text input? The matcher skips most shortcuts
+ * when it did (unless `allowInInputs` is set on the shortcut).
+ *
+ * Decided from the event TARGET, not `document.activeElement`. The two
+ * disagree in exactly the case that matters: an editor whose Escape handler
+ * blurs or unmounts it. React flushes discrete-event updates synchronously
+ * while the event is still bubbling, so by the time it reaches this window
+ * listener the editor is gone and `activeElement` is BODY — and a shortcut
+ * like the card peek's Escape would fire on the very keystroke the editor
+ * already handled, closing the panel on the FIRST Escape instead of the
+ * second. The target is immutable for the dispatch, so it still names the
+ * input the key was actually typed into. (`isContentEditable` is computed
+ * from layout and reads false on a node React has already detached, hence the
+ * attribute fallback beside it.)
  */
-function isFocusInInput(): boolean {
-    const el = document.activeElement as HTMLElement | null
-    if (!el) return false
-    const tag = el.tagName
-    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
-    if (el.isContentEditable) return true
-    if (el.closest?.('.ProseMirror')) return true
+export function isInputKeyEvent(event: KeyboardEvent): boolean {
+    const targets = [
+        event.target as HTMLElement | null,
+        document.activeElement as HTMLElement | null,
+    ]
+    for (const el of targets) {
+        if (!el || typeof el.closest !== 'function') continue
+        const tag = el.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+        if (el.isContentEditable) return true
+        if (el.closest('[contenteditable="true"], [contenteditable=""], .ProseMirror')) return true
+    }
     return false
 }
 
@@ -39,7 +56,7 @@ export function ShortcutsProvider({ children }: ShortcutsProviderProps) {
         for (const atom of atoms) {
             bindings[atom] = event => {
                 const consumed = matcherRef.current.feedAtom(atom, {
-                    inInput: isFocusInInput(),
+                    inInput: isInputKeyEvent(event),
                 })
                 if (consumed) event.preventDefault()
             }

--- a/core/server/automation/actions.go
+++ b/core/server/automation/actions.go
@@ -1,0 +1,155 @@
+// tinycld/core/server/automation/actions.go
+package automation
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/pkgaccess"
+)
+
+type engineWrite struct {
+	RuleID string
+	Depth  int
+}
+
+// engineWrites carries provenance from an engine-performed Save/Delete to the
+// record hook it fires — the recentlyIndexed sentinel shape from mail. Entries
+// are consumed by the dispatcher (Task 6); stale entries are harmless.
+var engineWrites sync.Map
+
+func markEngineWrite(recordID, ruleID string, depth int) {
+	engineWrites.Store(recordID, engineWrite{RuleID: ruleID, Depth: depth})
+}
+
+func takeEngineWrite(recordID string) (engineWrite, bool) {
+	v, ok := engineWrites.LoadAndDelete(recordID)
+	if !ok {
+		return engineWrite{}, false
+	}
+	return v.(engineWrite), true
+}
+
+func substituteParams(defs ActionDef, raw map[string]any, record *core.Record, trigger TriggerDef) map[string]string {
+	out := map[string]string{}
+	for _, p := range defs.Params {
+		v, ok := raw[p.Key]
+		if !ok {
+			continue
+		}
+		s := normalize(v)
+		out[p.Key] = SubstituteTemplates(s, record, trigger)
+	}
+	return out
+}
+
+func resolveSetValue(sv SetValue, params map[string]string, record *core.Record, ownerID string) (any, error) {
+	switch {
+	case sv.Param != "":
+		return params[sv.Param], nil
+	case sv.Context != "":
+		switch sv.Context {
+		case "record-id":
+			if record == nil {
+				return nil, fmt.Errorf("context record-id with no trigger record")
+			}
+			return record.Id, nil
+		case "collection":
+			if record == nil {
+				return nil, fmt.Errorf("context collection with no trigger record")
+			}
+			return record.Collection().Name, nil
+		case "owner":
+			return ownerID, nil
+		default:
+			return nil, fmt.Errorf("unknown set context %q", sv.Context)
+		}
+	default:
+		return sv.Literal, nil
+	}
+}
+
+// checkPersonalAccess applies pkgaccess to personal-rule record-ops. The
+// engine writes with superuser Save, which bypasses the REST guard entirely
+// (pkgaccess binds request hooks only) — so the engine re-applies the check
+// itself. Org rules run with system authority: admin-authored, documented in
+// the spec. Core-owned collections (pkg "core") are not package-gated.
+func checkPersonalAccess(app core.App, rule *core.Record, pkg string) error {
+	if rule.GetString("scope") != "personal" || pkg == "core" {
+		return nil
+	}
+	owner, err := app.FindRecordById("users", rule.GetString("owner"))
+	if err != nil {
+		return fmt.Errorf("rule owner lookup: %w", err)
+	}
+	return pkgaccess.WriteError(app, owner, pkg)
+}
+
+// ExecuteAction runs one rule action against one trigger event. depth is the
+// chain depth to stamp onto any resulting engine write.
+func ExecuteAction(app core.App, defs *Defs, ref string, rawParams map[string]any, rule *core.Record, trigger TriggerDef, record *core.Record, depth int) error {
+	action, pkg, ok := defs.Action(ref)
+	if !ok {
+		return fmt.Errorf("unknown action %q (package uninstalled?)", ref)
+	}
+	ownerID := rule.GetString("owner")
+	params := substituteParams(action, rawParams, record, trigger)
+
+	if action.Kind == "native" {
+		h, ok := actionHandler(ref)
+		if !ok {
+			return fmt.Errorf("native action %q has no registered handler (package Go not linked?)", ref)
+		}
+		return h(app, ActionRequest{Rule: rule, OwnerID: ownerID, Params: params, Record: record})
+	}
+
+	if err := checkPersonalAccess(app, rule, pkg); err != nil {
+		return err
+	}
+
+	switch action.Op.Type {
+	case "create":
+		col, err := app.FindCollectionByNameOrId(action.Collection)
+		if err != nil {
+			return fmt.Errorf("action collection %q: %w", action.Collection, err)
+		}
+		made := core.NewRecord(col)
+		made.Set("id", core.GenerateDefaultRandomId())
+		for field, sv := range action.Op.Set {
+			v, err := resolveSetValue(sv, params, record, ownerID)
+			if err != nil {
+				return err
+			}
+			made.Set(field, v)
+		}
+		markEngineWrite(made.Id, rule.Id, depth)
+		return app.Save(made)
+	case "update", "delete":
+		if action.Op.Target != "trigger-record" {
+			return fmt.Errorf("record-op %q: unsupported target %q", ref, action.Op.Target)
+		}
+		if record == nil {
+			return fmt.Errorf("record-op %q targets the trigger record but the trigger has none", ref)
+		}
+		if record.Collection().Name != action.Collection {
+			return fmt.Errorf("record-op %q: trigger record is %q, action declares %q", ref, record.Collection().Name, action.Collection)
+		}
+		if action.Op.Type == "delete" {
+			markEngineWrite(record.Id, rule.Id, depth)
+			return app.Delete(record)
+		}
+		for field, sv := range action.Op.Set {
+			v, err := resolveSetValue(sv, params, record, ownerID)
+			if err != nil {
+				return err
+			}
+			record.Set(field, v)
+		}
+		markEngineWrite(record.Id, rule.Id, depth)
+		return app.Save(record)
+	default:
+		return fmt.Errorf("record-op %q: unknown op type %q", ref, action.Op.Type)
+	}
+}

--- a/core/server/automation/actions.go
+++ b/core/server/automation/actions.go
@@ -124,8 +124,17 @@ func ExecuteAction(app core.App, defs *Defs, ref string, rawParams map[string]an
 			}
 			made.Set(field, v)
 		}
-		markEngineWrite(made.Id, rule.Id, depth)
-		return app.Save(made)
+		marked := defsHaveTrigger(defs, action.Collection, "create")
+		if marked {
+			markEngineWrite(made.Id, rule.Id, depth)
+		}
+		if err := app.Save(made); err != nil {
+			if marked {
+				takeEngineWrite(made.Id)
+			}
+			return err
+		}
+		return nil
 	case "update", "delete":
 		if action.Op.Target != "trigger-record" {
 			return fmt.Errorf("record-op %q: unsupported target %q", ref, action.Op.Target)
@@ -137,8 +146,17 @@ func ExecuteAction(app core.App, defs *Defs, ref string, rawParams map[string]an
 			return fmt.Errorf("record-op %q: trigger record is %q, action declares %q", ref, record.Collection().Name, action.Collection)
 		}
 		if action.Op.Type == "delete" {
-			markEngineWrite(record.Id, rule.Id, depth)
-			return app.Delete(record)
+			marked := defsHaveTrigger(defs, action.Collection, "delete")
+			if marked {
+				markEngineWrite(record.Id, rule.Id, depth)
+			}
+			if err := app.Delete(record); err != nil {
+				if marked {
+					takeEngineWrite(record.Id)
+				}
+				return err
+			}
+			return nil
 		}
 		for field, sv := range action.Op.Set {
 			v, err := resolveSetValue(sv, params, record, ownerID)
@@ -147,9 +165,26 @@ func ExecuteAction(app core.App, defs *Defs, ref string, rawParams map[string]an
 			}
 			record.Set(field, v)
 		}
-		markEngineWrite(record.Id, rule.Id, depth)
-		return app.Save(record)
+		marked := defsHaveTrigger(defs, action.Collection, "update")
+		if marked {
+			markEngineWrite(record.Id, rule.Id, depth)
+		}
+		if err := app.Save(record); err != nil {
+			if marked {
+				takeEngineWrite(record.Id)
+			}
+			return err
+		}
+		return nil
 	default:
 		return fmt.Errorf("record-op %q: unknown op type %q", ref, action.Op.Type)
 	}
+}
+
+// defsHaveTrigger reports whether any package declares a (collection, op)
+// trigger — i.e. whether some hook is actually bound for this write. Marking
+// a sentinel for a write nothing will ever consume (e.g. core:apply-label →
+// label_assignments has no bound hook) leaks the sync.Map entry forever.
+func defsHaveTrigger(defs *Defs, collection, op string) bool {
+	return len(defs.TriggersFor(collection, op)) > 0
 }

--- a/core/server/automation/actions_test.go
+++ b/core/server/automation/actions_test.go
@@ -1,0 +1,149 @@
+// tinycld/core/server/automation/actions_test.go
+package automation
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// actionApp builds: users (fixture), label_assignments-like target collection,
+// a source collection, one user, one source record, and a personal rule record
+// shape (plain base collection standing in for `rules` — executor only reads
+// scope/owner via GetString).
+func actionApp(t *testing.T) (*tests.TestApp, *core.Record, *core.Record, *Defs) {
+	t.Helper()
+	t.Cleanup(ResetRegistriesForTest)
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+	users, _ := app.FindCollectionByNameOrId("users")
+
+	src := core.NewBaseCollection("things")
+	src.Fields.Add(&core.TextField{Name: "title"})
+	src.Fields.Add(&core.TextField{Name: "status"})
+	if err := app.Save(src); err != nil {
+		t.Fatal(err)
+	}
+	tgt := core.NewBaseCollection("thing_labels")
+	tgt.Fields.Add(&core.TextField{Name: "label"})
+	tgt.Fields.Add(&core.TextField{Name: "record_id"})
+	tgt.Fields.Add(&core.TextField{Name: "collection"})
+	tgt.Fields.Add(&core.RelationField{Name: "user", CollectionId: users.Id, MaxSelect: 1})
+	if err := app.Save(tgt); err != nil {
+		t.Fatal(err)
+	}
+	rulesCol := core.NewBaseCollection("fake_rules")
+	rulesCol.Fields.Add(&core.TextField{Name: "scope"})
+	rulesCol.Fields.Add(&core.TextField{Name: "owner"})
+	if err := app.Save(rulesCol); err != nil {
+		t.Fatal(err)
+	}
+
+	u, _ := app.FindFirstRecordByFilter("users", "id != ''")
+	rec := core.NewRecord(src)
+	rec.Set("title", "Invoice #7")
+	rec.Set("status", "new")
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+	rule := core.NewRecord(rulesCol)
+	rule.Set("scope", "org")
+	rule.Set("owner", u.Id)
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+
+	defs := &Defs{Packages: []PackageDefs{{
+		Slug: "core",
+		Actions: []ActionDef{
+			{
+				ID: "apply-label", Kind: "record-op", Collection: "thing_labels",
+				Op: RecordOp{Type: "create", Set: map[string]SetValue{
+					"label":      {Param: "label"},
+					"record_id":  {Context: "record-id"},
+					"collection": {Context: "collection"},
+					"user":       {Context: "owner"},
+				}},
+				Params: []ParamDef{{Key: "label", Field: "label"}},
+			},
+			{ID: "notify", Kind: "native", Params: []ParamDef{{Key: "title", Type: "text"}}},
+		},
+	}, {
+		Slug: "things",
+		Actions: []ActionDef{{
+			ID: "set-status", Kind: "record-op", Collection: "things",
+			Op:     RecordOp{Type: "update", Target: "trigger-record", Set: map[string]SetValue{"status": {Param: "status"}}},
+			Params: []ParamDef{{Key: "status", Field: "status"}},
+		}},
+	}}}
+	return app, rec, rule, defs
+}
+
+var openTrigger = TriggerDef{Collection: "things", On: "create"}
+
+func TestRecordOpCreateWithContext(t *testing.T) {
+	app, rec, rule, defs := actionApp(t)
+	err := ExecuteAction(app, defs, "core:apply-label", map[string]any{"label": "Finance {{title}}"}, rule, openTrigger, rec, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	made, err := app.FindFirstRecordByFilter("thing_labels", "record_id = {:id}", map[string]any{"id": rec.Id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if made.GetString("label") != "Finance Invoice #7" {
+		t.Fatalf("template param: %q", made.GetString("label"))
+	}
+	if made.GetString("collection") != "things" || made.GetString("user") != rule.GetString("owner") {
+		t.Fatalf("context values: %+v", made.PublicExport())
+	}
+	if _, ok := takeEngineWrite(made.Id); !ok {
+		t.Fatal("engine create must carry provenance")
+	}
+}
+
+func TestRecordOpUpdateTriggerRecord(t *testing.T) {
+	app, rec, rule, defs := actionApp(t)
+	if err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 1); err != nil {
+		t.Fatal(err)
+	}
+	fresh, _ := app.FindRecordById("things", rec.Id)
+	if fresh.GetString("status") != "filed" {
+		t.Fatal("update did not apply")
+	}
+	w, ok := takeEngineWrite(rec.Id)
+	if !ok || w.Depth != 1 || w.RuleID != rule.Id {
+		t.Fatalf("provenance: %+v %v", w, ok)
+	}
+}
+
+func TestNativeDispatchAndMissingHandler(t *testing.T) {
+	app, rec, rule, defs := actionApp(t)
+	var got ActionRequest
+	RegisterAction("core:notify", func(a core.App, req ActionRequest) error {
+		got = req
+		return nil
+	})
+	err := ExecuteAction(app, defs, "core:notify", map[string]any{"title": "Got {{title}}"}, rule, openTrigger, rec, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Params["title"] != "Got Invoice #7" {
+		t.Fatalf("substituted params must reach handler: %+v", got.Params)
+	}
+	ResetRegistriesForTest()
+	if err := ExecuteAction(app, defs, "core:notify", nil, rule, openTrigger, rec, 0); err == nil {
+		t.Fatal("missing native handler must error")
+	}
+}
+
+func TestTriggerRecordOpNeedsMatchingCollection(t *testing.T) {
+	app, _, rule, defs := actionApp(t)
+	if err := ExecuteAction(app, defs, "things:set-status", nil, rule, openTrigger, nil, 0); err == nil {
+		t.Fatal("trigger-record op with nil record must error")
+	}
+}

--- a/core/server/automation/actions_test.go
+++ b/core/server/automation/actions_test.go
@@ -78,6 +78,10 @@ func actionApp(t *testing.T) (*tests.TestApp, *core.Record, *core.Record, *Defs)
 		},
 	}, {
 		Slug: "things",
+		// An update trigger IS declared here (unlike thing_labels above) so
+		// TestRecordOpUpdateTriggerRecord exercises the positive sentinel-marking
+		// path: a hook is actually bound for (things, update).
+		Triggers: []TriggerDef{{ID: "updated", Collection: "things", On: "update"}},
 		Actions: []ActionDef{{
 			ID: "set-status", Kind: "record-op", Collection: "things",
 			Op:     RecordOp{Type: "update", Target: "trigger-record", Set: map[string]SetValue{"status": {Param: "status"}}},
@@ -105,8 +109,11 @@ func TestRecordOpCreateWithContext(t *testing.T) {
 	if made.GetString("collection") != "things" || made.GetString("user") != rule.GetString("owner") {
 		t.Fatalf("context values: %+v", made.PublicExport())
 	}
-	if _, ok := takeEngineWrite(made.Id); !ok {
-		t.Fatal("engine create must carry provenance")
+	// thing_labels has no bound hook in this defs set (core:apply-label-style
+	// write with nothing declared to trigger on it) — marking a sentinel here
+	// would leak the sync.Map entry forever since nothing will ever consume it.
+	if _, ok := takeEngineWrite(made.Id); ok {
+		t.Fatal("create into a collection with no trigger must not leave a sentinel")
 	}
 }
 
@@ -122,6 +129,41 @@ func TestRecordOpUpdateTriggerRecord(t *testing.T) {
 	w, ok := takeEngineWrite(rec.Id)
 	if !ok || w.Depth != 1 || w.RuleID != rule.Id {
 		t.Fatalf("provenance: %+v %v", w, ok)
+	}
+}
+
+// TestFailedSaveLeavesNoSentinel proves the mark-before-write ordering
+// doesn't strand a sentinel on a real record id when the write itself fails:
+// a stranded sentinel would mis-attribute provenance (depth/source rule) to
+// whatever legitimate save of that same id happens next, wrongly suppressing
+// a rule that should fire.
+func TestFailedSaveLeavesNoSentinel(t *testing.T) {
+	app, rec, rule, defs := actionApp(t)
+
+	// Add a required field to "things" with no default and nothing in the
+	// action's Set map — Save must fail validation.
+	col, err := app.FindCollectionByNameOrId("things")
+	if err != nil {
+		t.Fatal(err)
+	}
+	col.Fields.Add(&core.TextField{Name: "must_have", Required: true})
+	if err := app.Save(col); err != nil {
+		t.Fatal(err)
+	}
+	// Re-fetch: rec was constructed against the pre-migration collection
+	// schema, so its captured Collection() wouldn't see the new required
+	// field and validation would silently pass it by.
+	rec, err = app.FindRecordById("things", rec.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// things:update already has a trigger declared in actionApp's defs, so
+	// this write would be marked absent the fix under test.
+	if err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0); err == nil {
+		t.Fatal("save must fail: required field unset")
+	}
+	if _, ok := takeEngineWrite(rec.Id); ok {
+		t.Fatal("a failed save must not strand a sentinel on the record id")
 	}
 }
 

--- a/core/server/automation/actions_test.go
+++ b/core/server/automation/actions_test.go
@@ -2,10 +2,14 @@
 package automation
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/types"
+
+	"tinycld.org/core/rlstest"
 )
 
 // actionApp builds: users (fixture), label_assignments-like target collection,
@@ -145,5 +149,170 @@ func TestTriggerRecordOpNeedsMatchingCollection(t *testing.T) {
 	app, _, rule, defs := actionApp(t)
 	if err := ExecuteAction(app, defs, "things:set-status", nil, rule, openTrigger, nil, 0); err == nil {
 		t.Fatal("trigger-record op with nil record must error")
+	}
+}
+
+// pkgaccessApp applies core's REAL shipped migrations (rlstest), so
+// checkPersonalAccess is exercised against the actual pkg_registry /
+// org_pkg_access / rules schema rather than the fake_rules stand-in the other
+// tests use. It creates the same "things" source collection as actionApp,
+// registers it in pkg_registry as an installed package (pkgaccess derives
+// ownership from the collection name matching an installed slug), and
+// returns (app, trigger record, member user, personal rule, Defs) for
+// things:set-status.
+func pkgaccessApp(t *testing.T) (*tests.TestApp, *core.Record, *core.Record, *core.Record, *Defs) {
+	t.Helper()
+	t.Cleanup(ResetRegistriesForTest)
+	app := rlstest.NewApp(t)
+
+	// Same fixture reconciliation as coreserver's RLS suites: drop the
+	// bundled username index so 1820000000 (users_username_required) applies
+	// the way it does against a real DB.
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kept types.JSONArray[string]
+	for _, idx := range users.Indexes {
+		if !strings.Contains(idx, "username") {
+			kept = append(kept, idx)
+		}
+	}
+	users.Indexes = kept
+	users.PasswordAuth.IdentityFields = []string{"email"}
+	if err := app.Save(users); err != nil {
+		t.Fatalf("drop fixture username index: %v", err)
+	}
+
+	rlstest.Apply(t, app, rlstest.MigrationsDir(t, "../pb_migrations"))
+
+	src := core.NewBaseCollection("things")
+	src.Fields.Add(&core.TextField{Name: "title"})
+	src.Fields.Add(&core.TextField{Name: "status"})
+	if err := app.Save(src); err != nil {
+		t.Fatal(err)
+	}
+
+	registry, err := app.FindCollectionByNameOrId("pkg_registry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg := core.NewRecord(registry)
+	reg.Set("name", "Things")
+	reg.Set("slug", "things")
+	reg.Set("status", "installed")
+	if err := app.Save(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	member := pkgaccessTestUser(t, app, "member@test.local", "member")
+
+	rulesCol, err := app.FindCollectionByNameOrId("rules")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rule := core.NewRecord(rulesCol)
+	rule.Set("name", "file it")
+	rule.Set("scope", "personal")
+	rule.Set("owner", member.Id)
+	rule.Set("trigger", "things:create")
+	rule.Set("actions", `[]`)
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := core.NewRecord(src)
+	rec.Set("title", "Invoice #7")
+	rec.Set("status", "new")
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	defs := &Defs{Packages: []PackageDefs{{
+		Slug: "things",
+		Actions: []ActionDef{{
+			ID: "set-status", Kind: "record-op", Collection: "things",
+			Op:     RecordOp{Type: "update", Target: "trigger-record", Set: map[string]SetValue{"status": {Param: "status"}}},
+			Params: []ParamDef{{Key: "status", Field: "status"}},
+		}},
+	}}}
+	return app, rec, member, rule, defs
+}
+
+func pkgaccessTestUser(t *testing.T, app core.App, email, role string) *core.Record {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := core.NewRecord(col)
+	r.SetEmail(email)
+	r.Set("username", strings.SplitN(email, "@", 2)[0])
+	r.Set("name", "Test")
+	r.Set("role", role)
+	r.SetVerified(true)
+	r.SetPassword("Password123!")
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func denyOrgPkgAccess(t *testing.T, app core.App, userID, pkg, access string) {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("org_pkg_access")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := core.NewRecord(col)
+	r.Set("user", userID)
+	r.Set("pkg", pkg)
+	r.Set("access", access)
+	if err := app.Save(r); err != nil {
+		t.Fatalf("seed org_pkg_access: %v", err)
+	}
+}
+
+// TestPersonalScopePkgaccess proves ExecuteAction's checkPersonalAccess is
+// wired to the REAL pkgaccess package against the shipped schema: a personal
+// rule owned by a member with no write access to the "things" package is
+// denied; the identical action under an org-scope rule bypasses the check
+// (system authority, spec-documented); and a personal rule succeeds once the
+// member is granted "full" access.
+func TestPersonalScopePkgaccess(t *testing.T) {
+	app, rec, member, rule, defs := pkgaccessApp(t)
+
+	// No org_pkg_access row would default to LevelFull (see LevelFor), so
+	// deny explicitly to exercise the readonly branch of WriteError.
+	denyOrgPkgAccess(t, app, member.Id, "things", "readonly")
+
+	if err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0); err == nil {
+		t.Fatal("personal rule with readonly pkgaccess must be denied")
+	}
+
+	rule.Set("scope", "org")
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+	if err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0); err != nil {
+		t.Fatalf("org rule must bypass pkgaccess (system authority): %v", err)
+	}
+
+	rule.Set("scope", "personal")
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+	existing, err := app.FindFirstRecordByFilter("org_pkg_access",
+		"user = {:user} && pkg = {:pkg}",
+		map[string]any{"user": member.Id, "pkg": "things"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing.Set("access", "full")
+	if err := app.Save(existing); err != nil {
+		t.Fatal(err)
+	}
+	if err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0); err != nil {
+		t.Fatalf("personal rule with full pkgaccess must succeed: %v", err)
 	}
 }

--- a/core/server/automation/defs.go
+++ b/core/server/automation/defs.go
@@ -1,0 +1,181 @@
+// tinycld/core/server/automation/defs.go
+//
+// Wire types for server/automation_defs.json, the generator's materialization
+// of every package's automation.ts (plus core's built-ins). JSON-tagged
+// mirrors, same rationale as tenantcfg's DAV mirrors: the TS side owns the
+// authoring format, Go consumes a stable wire shape.
+package automation
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// FieldRef decodes both wire forms: "subject" and {"key":..., "label":...}.
+type FieldRef struct {
+	Key   string
+	Label string
+}
+
+func (f *FieldRef) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		return json.Unmarshal(b, &f.Key)
+	}
+	var obj struct {
+		Key   string `json:"key"`
+		Label string `json:"label"`
+	}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return err
+	}
+	f.Key, f.Label = obj.Key, obj.Label
+	return nil
+}
+
+// SetValue decodes {param}, {context}, or a bare literal.
+type SetValue struct {
+	Param   string
+	Context string
+	Literal any
+}
+
+func (s *SetValue) UnmarshalJSON(b []byte) error {
+	var obj map[string]any
+	if err := json.Unmarshal(b, &obj); err == nil {
+		if p, ok := obj["param"].(string); ok {
+			s.Param = p
+			return nil
+		}
+		if c, ok := obj["context"].(string); ok {
+			s.Context = c
+			return nil
+		}
+	}
+	return json.Unmarshal(b, &s.Literal)
+}
+
+type TriggerDef struct {
+	ID         string     `json:"id"`
+	Label      string     `json:"label"`
+	Collection string     `json:"collection"`
+	On         string     `json:"on"`
+	Watch      []string   `json:"watch"`
+	Fields     []FieldRef `json:"fields"`
+	OwnerField string     `json:"ownerField"`
+	Synthetic  string     `json:"synthetic"`
+}
+
+type RecordOp struct {
+	Type   string              `json:"type"`
+	Target string              `json:"target"`
+	Set    map[string]SetValue `json:"set"`
+}
+
+type ParamDef struct {
+	Key     string   `json:"key"`
+	Field   string   `json:"field"`
+	Type    string   `json:"type"`
+	Label   string   `json:"label"`
+	Options []string `json:"options"`
+}
+
+type ActionDef struct {
+	ID         string     `json:"id"`
+	Label      string     `json:"label"`
+	Kind       string     `json:"kind"`
+	Collection string     `json:"collection"`
+	Op         RecordOp   `json:"op"`
+	Params     []ParamDef `json:"params"`
+}
+
+type PackageDefs struct {
+	Slug     string       `json:"slug"`
+	Triggers []TriggerDef `json:"triggers"`
+	Actions  []ActionDef  `json:"actions"`
+}
+
+type Defs struct {
+	Packages []PackageDefs `json:"packages"`
+}
+
+type QualifiedTrigger struct {
+	Ref string
+	Pkg string
+	Def TriggerDef
+}
+
+// LoadDefs reads the materialized defs. A missing file is an inert engine,
+// not an error — matches tenantcfg.loadJSON: a workspace with no automation
+// packages simply has nothing to do.
+func LoadDefs(path string) (*Defs, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Defs{}, nil
+		}
+		return nil, fmt.Errorf("automation: read defs: %w", err)
+	}
+	var defs Defs
+	if err := json.Unmarshal(raw, &defs); err != nil {
+		return nil, fmt.Errorf("automation: parse defs %s: %w", path, err)
+	}
+	return &defs, nil
+}
+
+func splitRef(ref string) (pkg, id string, ok bool) {
+	i := strings.IndexByte(ref, ':')
+	if i <= 0 || i == len(ref)-1 {
+		return "", "", false
+	}
+	return ref[:i], ref[i+1:], true
+}
+
+func (d *Defs) Trigger(ref string) (TriggerDef, string, bool) {
+	pkg, id, ok := splitRef(ref)
+	if !ok {
+		return TriggerDef{}, "", false
+	}
+	for _, p := range d.Packages {
+		if p.Slug != pkg {
+			continue
+		}
+		for _, t := range p.Triggers {
+			if t.ID == id {
+				return t, p.Slug, true
+			}
+		}
+	}
+	return TriggerDef{}, "", false
+}
+
+func (d *Defs) Action(ref string) (ActionDef, string, bool) {
+	pkg, id, ok := splitRef(ref)
+	if !ok {
+		return ActionDef{}, "", false
+	}
+	for _, p := range d.Packages {
+		if p.Slug != pkg {
+			continue
+		}
+		for _, a := range p.Actions {
+			if a.ID == id {
+				return a, p.Slug, true
+			}
+		}
+	}
+	return ActionDef{}, "", false
+}
+
+func (d *Defs) TriggersFor(collection, op string) []QualifiedTrigger {
+	var out []QualifiedTrigger
+	for _, p := range d.Packages {
+		for _, t := range p.Triggers {
+			if t.Synthetic == "" && t.Collection == collection && t.On == op {
+				out = append(out, QualifiedTrigger{Ref: p.Slug + ":" + t.ID, Pkg: p.Slug, Def: t})
+			}
+		}
+	}
+	return out
+}

--- a/core/server/automation/defs_test.go
+++ b/core/server/automation/defs_test.go
@@ -1,0 +1,98 @@
+package automation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const fixtureJSON = `{
+    "packages": [
+        {
+            "slug": "core",
+            "triggers": [
+                { "id": "schedule", "label": "On a schedule", "synthetic": "schedule" },
+                { "id": "manual", "label": "Run manually", "synthetic": "manual" }
+            ],
+            "actions": [
+                {
+                    "id": "apply-label", "label": "Apply label", "kind": "record-op",
+                    "collection": "label_assignments",
+                    "op": { "type": "create", "set": {
+                        "label": { "param": "label" },
+                        "record_id": { "context": "record-id" },
+                        "collection": { "context": "collection" },
+                        "user": { "context": "owner" }
+                    } },
+                    "params": [{ "key": "label", "field": "label" }]
+                },
+                { "id": "notify", "label": "Send me a notification", "kind": "native",
+                  "params": [{ "key": "title", "type": "text" }, { "key": "body", "type": "text" }] }
+            ]
+        },
+        {
+            "slug": "mail",
+            "triggers": [
+                { "id": "message-received", "label": "A message arrives",
+                  "collection": "mail_messages", "on": "create",
+                  "fields": ["subject", { "key": "sender_email", "label": "Sender" }] }
+            ],
+            "actions": []
+        }
+    ]
+}`
+
+func writeFixture(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "automation_defs.json")
+	if err := os.WriteFile(p, []byte(fixtureJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestLoadDefsMissingFileIsInert(t *testing.T) {
+	defs, err := LoadDefs(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("missing file must be inert, got %v", err)
+	}
+	if len(defs.Packages) != 0 {
+		t.Fatalf("expected empty defs, got %d packages", len(defs.Packages))
+	}
+}
+
+func TestLookupByQualifiedRef(t *testing.T) {
+	defs, err := LoadDefs(writeFixture(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	trig, pkg, ok := defs.Trigger("mail:message-received")
+	if !ok || pkg != "mail" || trig.Collection != "mail_messages" || trig.On != "create" {
+		t.Fatalf("trigger lookup failed: %+v %q %v", trig, pkg, ok)
+	}
+	if trig.Fields[1].Key != "sender_email" || trig.Fields[1].Label != "Sender" {
+		t.Fatalf("mixed-form fields not decoded: %+v", trig.Fields)
+	}
+	act, pkg, ok := defs.Action("core:apply-label")
+	if !ok || pkg != "core" || act.Kind != "record-op" || act.Op.Type != "create" {
+		t.Fatalf("action lookup failed: %+v", act)
+	}
+	sv := act.Op.Set["record_id"]
+	if sv.Context != "record-id" {
+		t.Fatalf("context SetValue not decoded: %+v", sv)
+	}
+	if _, _, ok := defs.Trigger("mail:nope"); ok {
+		t.Fatal("unknown ref must miss")
+	}
+}
+
+func TestTriggersForCollectionOp(t *testing.T) {
+	defs, _ := LoadDefs(writeFixture(t))
+	hits := defs.TriggersFor("mail_messages", "create")
+	if len(hits) != 1 || hits[0].Ref != "mail:message-received" {
+		t.Fatalf("TriggersFor: %+v", hits)
+	}
+	if len(defs.TriggersFor("mail_messages", "delete")) != 0 {
+		t.Fatal("op filter failed")
+	}
+}

--- a/core/server/automation/endpoints.go
+++ b/core/server/automation/endpoints.go
@@ -44,6 +44,14 @@ type dryRunResult struct {
 // ownerFilterFor builds the caller-scoping filter for dry runs from the same
 // owner-field detection the dispatcher uses. ok=false when the collection has
 // no resolvable owner field.
+//
+// Known gap (deferred to Phase 3): this only detects a direct user/owner/author
+// relation column via autoOwnerFields/OwnerField. A trigger whose owner is
+// resolved dynamically via RegisterOwnerResolver (e.g. mail's shared-mailbox
+// resolver) has no such column, so dry-run treats it as unscoped/admin-only
+// even though ResolveOwners could, in principle, scope it per caller. Fixing
+// this requires threading a per-record OwnerResolver call into the dry-run
+// filter/query path, not just a static field-name lookup.
 func (e *Engine) ownerFilterFor(trigger TriggerDef) (string, bool) {
 	col, err := e.app.FindCollectionByNameOrId(trigger.Collection)
 	if err != nil {
@@ -87,7 +95,10 @@ func (e *Engine) dryRun(caller *core.Record, triggerRef string, ast ConditionsAS
 	}
 	out.Total = len(records)
 	for _, r := range records {
-		if EvaluateConditions(ast, r) {
+		if !triggerAllowed(e.app, triggerRef, r) {
+			continue
+		}
+		if EvaluateConditions(ast, r, trigger) {
 			out.Matches = append(out.Matches, dryRunMatch{ID: r.Id, Summary: triggerSummary(r, trigger)})
 		}
 	}

--- a/core/server/automation/endpoints.go
+++ b/core/server/automation/endpoints.go
@@ -1,0 +1,136 @@
+// tinycld/core/server/automation/endpoints.go
+package automation
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func isAdmin(user *core.Record) bool {
+	if user == nil {
+		return false
+	}
+	role := user.GetString("role")
+	return role == "owner" || role == "admin"
+}
+
+func validateManualRun(rule *core.Record, caller *core.Record) error {
+	if caller == nil {
+		return fmt.Errorf("authentication required")
+	}
+	if rule.GetString("owner") != caller.Id && !isAdmin(caller) {
+		return fmt.Errorf("not your rule")
+	}
+	switch rule.GetString("trigger") {
+	case "core:manual", "core:schedule":
+		return nil
+	default:
+		return fmt.Errorf("only manual/scheduled rules can be run directly")
+	}
+}
+
+type dryRunMatch struct {
+	ID      string         `json:"id"`
+	Summary map[string]any `json:"summary"`
+}
+
+type dryRunResult struct {
+	Total   int           `json:"total"`
+	Matches []dryRunMatch `json:"matches"`
+}
+
+// ownerFilterFor builds the caller-scoping filter for dry runs from the same
+// owner-field detection the dispatcher uses. ok=false when the collection has
+// no resolvable owner field.
+func (e *Engine) ownerFilterFor(trigger TriggerDef) (string, bool) {
+	col, err := e.app.FindCollectionByNameOrId(trigger.Collection)
+	if err != nil {
+		return "", false
+	}
+	usersCol, err := e.app.FindCachedCollectionByNameOrId("users")
+	if err != nil {
+		return "", false
+	}
+	candidates := autoOwnerFields
+	if trigger.OwnerField != "" {
+		candidates = []string{trigger.OwnerField}
+	}
+	for _, name := range candidates {
+		if rel, ok := col.Fields.GetByName(name).(*core.RelationField); ok && rel.CollectionId == usersCol.Id {
+			return name + " = {:caller}", true
+		}
+	}
+	return "", false
+}
+
+func (e *Engine) dryRun(caller *core.Record, triggerRef string, ast ConditionsAST) (dryRunResult, error) {
+	var out dryRunResult
+	trigger, _, ok := e.defs.Trigger(triggerRef)
+	if !ok || trigger.Synthetic != "" {
+		return out, fmt.Errorf("unknown or synthetic trigger %q", triggerRef)
+	}
+	filter, scoped := e.ownerFilterFor(trigger)
+	params := map[string]any{}
+	if scoped {
+		params["caller"] = caller.Id
+	} else {
+		if !isAdmin(caller) {
+			return out, fmt.Errorf("this trigger's records cannot be scoped to you; ask an admin to test it")
+		}
+		filter = "id != ''"
+	}
+	records, err := e.app.FindRecordsByFilter(trigger.Collection, filter, "-created", 50, 0, params)
+	if err != nil {
+		return out, err
+	}
+	out.Total = len(records)
+	for _, r := range records {
+		if EvaluateConditions(ast, r) {
+			out.Matches = append(out.Matches, dryRunMatch{ID: r.Id, Summary: triggerSummary(r, trigger)})
+		}
+	}
+	return out, nil
+}
+
+func requireAuth(re *core.RequestEvent) error {
+	if re.Auth == nil {
+		return re.UnauthorizedError("Authentication required", nil)
+	}
+	return re.Next()
+}
+
+func registerEndpoints(app core.App, engine *Engine) {
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		se.Router.POST("/api/automation/rules/{id}/run", func(re *core.RequestEvent) error {
+			rule, err := re.App.FindRecordById("rules", re.Request.PathValue("id"))
+			if err != nil {
+				return re.NotFoundError("rule not found", err)
+			}
+			if err := validateManualRun(rule, re.Auth); err != nil {
+				return re.BadRequestError(err.Error(), nil)
+			}
+			trigger, _, _ := engine.defs.Trigger(rule.GetString("trigger"))
+			engine.enqueue(event{TriggerRef: rule.GetString("trigger"), Trigger: trigger, RuleID: rule.Id})
+			return re.JSON(http.StatusOK, map[string]any{"queued": true})
+		}).BindFunc(requireAuth)
+
+		se.Router.POST("/api/automation/dry-run", func(re *core.RequestEvent) error {
+			var body struct {
+				Trigger    string        `json:"trigger"`
+				Conditions ConditionsAST `json:"conditions"`
+			}
+			if err := re.BindBody(&body); err != nil {
+				return re.BadRequestError("invalid body", err)
+			}
+			res, err := engine.dryRun(re.Auth, body.Trigger, body.Conditions)
+			if err != nil {
+				return re.BadRequestError(err.Error(), nil)
+			}
+			return re.JSON(http.StatusOK, res)
+		}).BindFunc(requireAuth)
+
+		return se.Next()
+	})
+}

--- a/core/server/automation/endpoints_test.go
+++ b/core/server/automation/endpoints_test.go
@@ -1,0 +1,74 @@
+// tinycld/core/server/automation/endpoints_test.go
+package automation
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Endpoint auth/validation logic is factored into plain funcs so it tests
+// without HTTP scaffolding; the route bindings are thin.
+func TestRunEndpointValidation(t *testing.T) {
+	app, _, u := scheduleApp(t)
+	manual := scheduleRule(t, app, u.Id, "0 8 * * *", true) // trigger core:schedule → synthetic, runnable
+	col, _ := app.FindCollectionByNameOrId("rules")
+	recordRule := core.NewRecord(col)
+	recordRule.Set("name", "rec")
+	recordRule.Set("scope", "personal")
+	recordRule.Set("owner", u.Id)
+	recordRule.Set("trigger", "tickets:ticket-created")
+	recordRule.Set("enabled", true)
+	if err := app.Save(recordRule); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateManualRun(manual, u); err != nil {
+		t.Fatalf("owner running a synthetic-trigger rule must pass: %v", err)
+	}
+	if err := validateManualRun(recordRule, u); err == nil {
+		t.Fatal("record-trigger rules must be rejected")
+	}
+
+	users, _ := app.FindCollectionByNameOrId("users")
+	stranger := core.NewRecord(users)
+	stranger.Set("email", "s@example.com")
+	stranger.Set("username", "stranger1")
+	stranger.Set("name", "S")
+	stranger.Set("role", "member")
+	stranger.SetPassword("0123456789")
+	if err := app.Save(stranger); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateManualRun(manual, stranger); err == nil {
+		t.Fatal("non-owner non-admin must be rejected")
+	}
+	stranger.Set("role", "admin")
+	if err := validateManualRun(manual, stranger); err != nil {
+		t.Fatalf("admin may run any rule: %v", err)
+	}
+}
+
+func TestDryRunScoping(t *testing.T) {
+	app, eng, u := engineApp(t) // tickets collection + trigger defs from Task 7's helper
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	for _, title := range []string{"urgent: a", "routine b", "URGENT c"} {
+		r := core.NewRecord(col)
+		r.Set("title", title)
+		r.Set("user", u.Id)
+		if err := app.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ast := ConditionsAST{Match: "all", Groups: []ConditionGroup{{
+		Match:      "any",
+		Conditions: []Condition{{Field: "title", Op: "contains", Value: "urgent"}},
+	}}}
+	res, err := eng.dryRun(u, "tickets:ticket-created", ast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Total != 3 || len(res.Matches) != 2 {
+		t.Fatalf("dry run: total=%d matches=%d", res.Total, len(res.Matches))
+	}
+}

--- a/core/server/automation/endpoints_test.go
+++ b/core/server/automation/endpoints_test.go
@@ -76,6 +76,43 @@ func TestDryRunScoping(t *testing.T) {
 	}
 }
 
+// TestDryRunUnscopedRequiresAdmin covers the "collection has no resolvable
+// owner field" branch: ownerFilterFor returns ok=false for "broadcasts" (no
+// user/owner/author relation), so dry-run can't scope results to the caller.
+// A non-admin caller must be rejected outright; an admin caller gets results
+// across every record, unscoped.
+func TestDryRunUnscopedRequiresAdmin(t *testing.T) {
+	app, eng, u := engineApp(t)
+	col, _ := app.FindCollectionByNameOrId("broadcasts")
+	for _, title := range []string{"alert one", "routine note", "ALERT two"} {
+		r := core.NewRecord(col)
+		r.Set("title", title)
+		if err := app.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ast := ConditionsAST{Match: "all", Groups: []ConditionGroup{{
+		Match:      "any",
+		Conditions: []Condition{{Field: "title", Op: "contains", Value: "alert"}},
+	}}}
+
+	if _, err := eng.dryRun(u, "tickets:broadcast-created", ast); err == nil {
+		t.Fatal("non-admin caller against an unscoped collection must be rejected")
+	}
+
+	u.Set("role", "admin")
+	if err := app.Save(u); err != nil {
+		t.Fatal(err)
+	}
+	res, err := eng.dryRun(u, "tickets:broadcast-created", ast)
+	if err != nil {
+		t.Fatalf("admin caller must be allowed against an unscoped collection: %v", err)
+	}
+	if res.Total != 3 || len(res.Matches) != 2 {
+		t.Fatalf("admin dry run: total=%d matches=%d", res.Total, len(res.Matches))
+	}
+}
+
 // TestCoreNotifyHandler exercises the real core:notify handler as Register
 // installs it — not a test-local stub (actions_test.go's
 // TestNativeDispatchAndMissingHandler registers its own) — and asserts it

--- a/core/server/automation/endpoints_test.go
+++ b/core/server/automation/endpoints_test.go
@@ -3,8 +3,11 @@ package automation
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/notify"
 )
 
 // Endpoint auth/validation logic is factored into plain funcs so it tests
@@ -70,5 +73,55 @@ func TestDryRunScoping(t *testing.T) {
 	}
 	if res.Total != 3 || len(res.Matches) != 2 {
 		t.Fatalf("dry run: total=%d matches=%d", res.Total, len(res.Matches))
+	}
+}
+
+// TestCoreNotifyHandler exercises the real core:notify handler as Register
+// installs it — not a test-local stub (actions_test.go's
+// TestNativeDispatchAndMissingHandler registers its own) — and asserts it
+// goes through the notifyUser seam rather than calling notify.NotifyUser
+// directly, so a test can observe it without racing real push I/O.
+func TestCoreNotifyHandler(t *testing.T) {
+	t.Cleanup(ResetRegistriesForTest)
+	registerCoreNativeActions()
+
+	captured := make(chan notify.NotifyParams, 1)
+	original := notifyUser
+	notifyUser = func(app core.App, params notify.NotifyParams) {
+		captured <- params
+	}
+	t.Cleanup(func() { notifyUser = original })
+
+	app, rule := runsApp(t)
+	defs := &Defs{Packages: []PackageDefs{{
+		Slug: "core",
+		Actions: []ActionDef{{
+			ID: "notify", Kind: "native",
+			Params: []ParamDef{{Key: "title"}, {Key: "body"}, {Key: "url"}},
+		}},
+	}}}
+	rawParams := map[string]any{"title": "Hello {{title}}", "body": "a body", "url": "/somewhere"}
+	scratchCol := core.NewBaseCollection("scratch")
+	scratchCol.Fields.Add(&core.TextField{Name: "title"})
+	rec := core.NewRecord(scratchCol)
+	rec.Set("title", "World")
+
+	if err := ExecuteAction(app, defs, "core:notify", rawParams, rule, TriggerDef{}, rec, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case params := <-captured:
+		if params.Type != "automation" || params.Package != "core" {
+			t.Fatalf("notification shape: %+v", params)
+		}
+		if params.Title != "Hello World" {
+			t.Fatalf("substituted title: %q", params.Title)
+		}
+		if params.UserID != rule.GetString("owner") {
+			t.Fatalf("UserID must be the rule owner: got %q want %q", params.UserID, rule.GetString("owner"))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the async core:notify handler")
 	}
 }

--- a/core/server/automation/engine.go
+++ b/core/server/automation/engine.go
@@ -14,6 +14,12 @@ const (
 	maxChainDepth    = 3
 	actionTimeout    = 30 * time.Second
 	dispatchQueueLen = 1024
+	// shutdownDrainWait bounds how long OnTerminate waits for an in-flight
+	// dispatch to finish. Long enough for the common case — a dispatch mid-
+	// flight finishes its current DB call — but a hung action must not hold
+	// up process shutdown, mirroring the abandon-don't-kill design of the
+	// per-action timeout below.
+	shutdownDrainWait = 5 * time.Second
 )
 
 type event struct {
@@ -25,11 +31,12 @@ type event struct {
 }
 
 type Engine struct {
-	app    core.App
-	defs   *Defs
-	queue  chan event
-	cancel context.CancelFunc
-	done   chan struct{}
+	app     core.App
+	defs    *Defs
+	queue   chan event
+	cancel  context.CancelFunc
+	done    chan struct{}
+	started bool
 }
 
 func NewEngine(app core.App, defs *Defs) *Engine {
@@ -41,6 +48,12 @@ func NewEngine(app core.App, defs *Defs) *Engine {
 // Rule execution never runs on the hook goroutine: a slow rule must not block
 // an SMTP delivery.
 func (e *Engine) Start() {
+	if e.started {
+		e.app.Logger().Warn("automation: Start called more than once, ignoring")
+		return
+	}
+	e.started = true
+
 	ctx, cancel := context.WithCancel(context.Background())
 	e.cancel = cancel
 	e.app.OnTerminate().BindFunc(func(te *core.TerminateEvent) error {
@@ -49,7 +62,15 @@ func (e *Engine) Start() {
 		// proceed: cancelling only stops it from picking up the NEXT event —
 		// a dispatch already in flight is still touching the DB, and a test
 		// app's Cleanup() tears the DB down right after this hook returns.
-		<-e.done
+		// Bounded rather than unconditional: a dispatch can run N rules × M
+		// actions × a 30s per-action timeout plus prune I/O, and a hung
+		// action must not hold up process shutdown — same abandon-don't-kill
+		// tradeoff as the per-action timeout itself.
+		select {
+		case <-e.done:
+		case <-time.After(shutdownDrainWait):
+			e.app.Logger().Warn("automation: worker did not drain before terminate; abandoning in-flight dispatch")
+		}
 		return te.Next()
 	})
 	go e.worker(ctx)
@@ -79,6 +100,13 @@ func (e *Engine) Start() {
 	}
 
 	reload := func(ev *core.RecordEvent) error {
+		// The auto-disable path (recordRunResult) marks an engine-write
+		// sentinel before saving the rule it just disabled. Nothing else
+		// ever consumes that sentinel for the "rules" collection itself, so
+		// drain it here — otherwise it lingers and misattributes provenance
+		// (depth/source rule) to whatever later legitimate save of the same
+		// rule row happens to land next.
+		takeEngineWrite(ev.Record.Id)
 		e.reloadScheduleFor(ev.Record)
 		return ev.Next()
 	}

--- a/core/server/automation/engine.go
+++ b/core/server/automation/engine.go
@@ -28,6 +28,10 @@ type event struct {
 	Record     *core.Record
 	Depth      int
 	SourceRule string
+	// RuleID targets one specific rule (scheduled dispatch — each cron job
+	// has its own cadence, so a firing must hit exactly its rule). Empty
+	// means all enabled rules on the trigger, the record-hook path's behavior.
+	RuleID string
 }
 
 type Engine struct {
@@ -112,12 +116,43 @@ func (e *Engine) Start() {
 	}
 	e.app.OnRecordAfterCreateSuccess("rules").BindFunc(reload)
 	e.app.OnRecordAfterUpdateSuccess("rules").BindFunc(reload)
-	e.app.OnRecordAfterDeleteSuccess("rules").BindFunc(reload)
+	e.app.OnRecordAfterDeleteSuccess("rules").BindFunc(func(ev *core.RecordEvent) error {
+		// A deleted record's fields still read as they were pre-delete (e.g.
+		// enabled=true), so routing through reloadScheduleFor's field check
+		// would re-Add instead of Remove. The row is gone either way — just
+		// drop the job unconditionally.
+		takeEngineWrite(ev.Record.Id)
+		e.app.Cron().Remove(scheduleJobID(ev.Record.Id))
+		return ev.Next()
+	})
+
+	e.syncSchedules()
 }
 
-// reloadScheduleFor is completed in the schedule task; the hook binding above
-// must exist from the start so no rules write is missed between tasks.
-func (e *Engine) reloadScheduleFor(rule *core.Record) {}
+// reloadScheduleFor reconciles one rule's cron registration after any rules
+// write — the base_backup.go loadJob shape: Add replaces by id, Remove is a
+// no-op for unknown ids, so this is idempotent for every transition
+// (create/enable/disable/delete/edit-expression).
+func (e *Engine) reloadScheduleFor(rule *core.Record) {
+	jobID := scheduleJobID(rule.Id)
+	if rule.GetString("trigger") != "core:schedule" || !rule.GetBool("enabled") {
+		e.app.Cron().Remove(jobID)
+		return
+	}
+	cfg := decodeScheduleConfig(rule.Get("trigger_config"))
+	trigger, _, _ := e.defs.Trigger("core:schedule")
+	ruleID := rule.Id
+	err := e.app.Cron().Add(jobID, cfg.Cron, func() {
+		if !appIsLive(e.app) {
+			return
+		}
+		e.enqueue(event{TriggerRef: "core:schedule", Trigger: trigger, Record: nil, RuleID: ruleID})
+	})
+	if err != nil {
+		e.app.Logger().Warn("automation: invalid schedule", "rule", rule.Id, "cron", cfg.Cron, "err", err)
+		WriteRun(e.app, rule, nil, TriggerDef{}, RunOutcome{Err: "invalid schedule: " + cfg.Cron})
+	}
+}
 
 func (e *Engine) recordHookHandler(col, op string) func(*core.RecordEvent) error {
 	return func(ev *core.RecordEvent) error {
@@ -202,6 +237,18 @@ func (e *Engine) dispatch(ev event) {
 	if err != nil || len(rules) == 0 {
 		return
 	}
+	if ev.RuleID != "" {
+		filtered := rules[:0]
+		for _, r := range rules {
+			if r.Id == ev.RuleID {
+				filtered = append(filtered, r)
+			}
+		}
+		rules = filtered
+		if len(rules) == 0 {
+			return
+		}
+	}
 	// Org rules first, then personal — order preserved within each tier.
 	sort.SliceStable(rules, func(i, j int) bool {
 		si, sj := rules[i].GetString("scope"), rules[j].GetString("scope")
@@ -225,7 +272,10 @@ func (e *Engine) dispatch(ev event) {
 		if rule.Id == ev.SourceRule {
 			continue // a rule never re-fires on its own write
 		}
-		if rule.GetString("scope") == "personal" && !ownerSet[rule.GetString("owner")] {
+		// No record → no owner to resolve (ResolveOwners returns nil); the
+		// rule firing IS the owner's context (e.g. a scheduled rule), so the
+		// personal-owner filter doesn't apply.
+		if ev.Record != nil && rule.GetString("scope") == "personal" && !ownerSet[rule.GetString("owner")] {
 			continue
 		}
 		start := time.Now()

--- a/core/server/automation/engine.go
+++ b/core/server/automation/engine.go
@@ -166,7 +166,13 @@ func (e *Engine) recordHookHandler(col, op string) func(*core.RecordEvent) error
 			e.app.Logger().Warn("automation: chain depth exceeded", "collection", col, "record", ev.Record.Id, "sourceRule", source)
 			if source != "" {
 				if rule, err := e.app.FindRecordById("rules", source); err == nil {
-					WriteRun(e.app, rule, ev.Record, TriggerDef{}, RunOutcome{Err: "chain-depth-exceeded"})
+					// nil record, not ev.Record: an empty TriggerDef has no
+					// declared field allowlist, so triggerSummary would fall
+					// into the "open trigger" branch and snapshot EVERY column
+					// of the record — including curated-away/hidden fields.
+					// The error string is the payload here; the record adds
+					// nothing but a leak.
+					WriteRun(e.app, rule, nil, TriggerDef{}, RunOutcome{Err: "chain-depth-exceeded"})
 				}
 			}
 			return ev.Next()
@@ -233,24 +239,29 @@ func decodeActions(raw any) ([]storedAction, error) {
 }
 
 func (e *Engine) dispatch(ev event) {
-	rules, err := e.app.FindRecordsByFilter(
-		"rules", "trigger = {:ref} && enabled = true", "order", 0, 0,
-		map[string]any{"ref": ev.TriggerRef},
-	)
-	if err != nil || len(rules) == 0 {
-		return
-	}
+	var rules []*core.Record
 	if ev.RuleID != "" {
-		filtered := rules[:0]
-		for _, r := range rules {
-			if r.Id == ev.RuleID {
-				filtered = append(filtered, r)
-			}
-		}
-		rules = filtered
-		if len(rules) == 0 {
+		// Manual-run/scheduled-run targets one specific rule directly, bypassing
+		// the enabled filter: the endpoint already replied {"queued": true}
+		// regardless of enabled, so a disabled rule must still run here or the
+		// dispatch silently no-ops after promising the caller it was queued.
+		rule, err := e.app.FindRecordById("rules", ev.RuleID)
+		if err != nil {
 			return
 		}
+		if rule.GetString("trigger") != ev.TriggerRef {
+			return
+		}
+		rules = []*core.Record{rule}
+	} else {
+		found, err := e.app.FindRecordsByFilter(
+			"rules", "trigger = {:ref} && enabled = true", "order", 0, 0,
+			map[string]any{"ref": ev.TriggerRef},
+		)
+		if err != nil || len(found) == 0 {
+			return
+		}
+		rules = found
 	}
 	// Org rules first, then personal — order preserved within each tier.
 	sort.SliceStable(rules, func(i, j int) bool {
@@ -288,7 +299,7 @@ func (e *Engine) dispatch(ev event) {
 			WriteRun(e.app, rule, ev.Record, ev.Trigger, RunOutcome{Err: "invalid conditions: " + err.Error(), Duration: time.Since(start)})
 			continue
 		}
-		if !EvaluateConditions(ast, ev.Record) {
+		if !EvaluateConditions(ast, ev.Record, ev.Trigger) {
 			WriteRun(e.app, rule, ev.Record, ev.Trigger, RunOutcome{Matched: false, Duration: time.Since(start)})
 			continue
 		}
@@ -328,7 +339,12 @@ func (timeoutErr) Error() string { return "action timed out" }
 
 // runActionWithTimeout abandons (does not kill) an overrunning action: the PB
 // SDK has no context-cancellable Save, so the goroutine finishes on its own
-// while the run is recorded as timed out.
+// while the run is recorded as timed out. Abandoned means exactly that — the
+// goroutine keeps running against ev.Record (and whatever else ExecuteAction
+// touches) after this function has returned and the dispatch loop has moved
+// on to the next rule/event using that same *core.Record. A hung Save that
+// eventually completes (e.g. a 30s+ stall) can still mutate the record out
+// from under later code that assumed the timeout meant nothing happened.
 func (e *Engine) runActionWithTimeout(a storedAction, rule *core.Record, ev event) error {
 	done := make(chan error, 1)
 	go func() {

--- a/core/server/automation/engine.go
+++ b/core/server/automation/engine.go
@@ -1,0 +1,262 @@
+// tinycld/core/server/automation/engine.go
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const (
+	maxChainDepth    = 3
+	actionTimeout    = 30 * time.Second
+	dispatchQueueLen = 1024
+)
+
+type event struct {
+	TriggerRef string
+	Trigger    TriggerDef
+	Record     *core.Record
+	Depth      int
+	SourceRule string
+}
+
+type Engine struct {
+	app    core.App
+	defs   *Defs
+	queue  chan event
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func NewEngine(app core.App, defs *Defs) *Engine {
+	return &Engine{app: app, defs: defs, queue: make(chan event, dispatchQueueLen), done: make(chan struct{})}
+}
+
+// Start binds one hook per distinct (collection, op) named by the defs, plus
+// the rules-change hooks for schedule reconciliation, and launches the worker.
+// Rule execution never runs on the hook goroutine: a slow rule must not block
+// an SMTP delivery.
+func (e *Engine) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	e.cancel = cancel
+	e.app.OnTerminate().BindFunc(func(te *core.TerminateEvent) error {
+		cancel()
+		// Wait for the worker to actually exit before letting teardown
+		// proceed: cancelling only stops it from picking up the NEXT event —
+		// a dispatch already in flight is still touching the DB, and a test
+		// app's Cleanup() tears the DB down right after this hook returns.
+		<-e.done
+		return te.Next()
+	})
+	go e.worker(ctx)
+
+	type colOp struct{ col, op string }
+	seen := map[colOp]bool{}
+	for _, p := range e.defs.Packages {
+		for _, t := range p.Triggers {
+			if t.Synthetic != "" {
+				continue
+			}
+			key := colOp{t.Collection, t.On}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			handler := e.recordHookHandler(key.col, key.op)
+			switch key.op {
+			case "create":
+				e.app.OnRecordAfterCreateSuccess(key.col).BindFunc(handler)
+			case "update":
+				e.app.OnRecordAfterUpdateSuccess(key.col).BindFunc(handler)
+			case "delete":
+				e.app.OnRecordAfterDeleteSuccess(key.col).BindFunc(handler)
+			}
+		}
+	}
+
+	reload := func(ev *core.RecordEvent) error {
+		e.reloadScheduleFor(ev.Record)
+		return ev.Next()
+	}
+	e.app.OnRecordAfterCreateSuccess("rules").BindFunc(reload)
+	e.app.OnRecordAfterUpdateSuccess("rules").BindFunc(reload)
+	e.app.OnRecordAfterDeleteSuccess("rules").BindFunc(reload)
+}
+
+// reloadScheduleFor is completed in the schedule task; the hook binding above
+// must exist from the start so no rules write is missed between tasks.
+func (e *Engine) reloadScheduleFor(rule *core.Record) {}
+
+func (e *Engine) recordHookHandler(col, op string) func(*core.RecordEvent) error {
+	return func(ev *core.RecordEvent) error {
+		depth := 0
+		source := ""
+		if w, ok := takeEngineWrite(ev.Record.Id); ok {
+			depth = w.Depth + 1
+			source = w.RuleID
+		}
+		if depth > maxChainDepth {
+			e.app.Logger().Warn("automation: chain depth exceeded", "collection", col, "record", ev.Record.Id, "sourceRule", source)
+			if source != "" {
+				if rule, err := e.app.FindRecordById("rules", source); err == nil {
+					WriteRun(e.app, rule, ev.Record, TriggerDef{}, RunOutcome{Err: "chain-depth-exceeded"})
+				}
+			}
+			return ev.Next()
+		}
+		for _, qt := range e.defs.TriggersFor(col, op) {
+			if op == "update" && !WatchChanged(ev.Record, qt.Def.Watch) {
+				continue
+			}
+			e.enqueue(event{TriggerRef: qt.Ref, Trigger: qt.Def, Record: ev.Record, Depth: depth, SourceRule: source})
+		}
+		return ev.Next()
+	}
+}
+
+func (e *Engine) enqueue(ev event) {
+	select {
+	case e.queue <- ev:
+	default:
+		// A dropped dispatch is recoverable (the data is in the DB); a blocked
+		// write path is not. Log loudly and move on.
+		e.app.Logger().Error("automation: dispatch queue full, dropping event", "trigger", ev.TriggerRef)
+	}
+}
+
+func (e *Engine) worker(ctx context.Context) {
+	defer close(e.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-e.queue:
+			if !appIsLive(e.app) {
+				return
+			}
+			e.dispatch(ev)
+		}
+	}
+}
+
+// DispatchForTest runs one event synchronously.
+func (e *Engine) DispatchForTest(ev event) { e.dispatch(ev) }
+
+type storedAction struct {
+	Ref    string         `json:"ref"`
+	Params map[string]any `json:"params"`
+}
+
+func decodeActions(raw any) ([]storedAction, error) {
+	var out []storedAction
+	if raw == nil {
+		return out, nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 || string(b) == "null" || string(b) == `""` {
+		return out, nil
+	}
+	return out, json.Unmarshal(b, &out)
+}
+
+func (e *Engine) dispatch(ev event) {
+	rules, err := e.app.FindRecordsByFilter(
+		"rules", "trigger = {:ref} && enabled = true", "order", 0, 0,
+		map[string]any{"ref": ev.TriggerRef},
+	)
+	if err != nil || len(rules) == 0 {
+		return
+	}
+	// Org rules first, then personal — order preserved within each tier.
+	sort.SliceStable(rules, func(i, j int) bool {
+		si, sj := rules[i].GetString("scope"), rules[j].GetString("scope")
+		if si != sj {
+			return si == "org"
+		}
+		return false
+	})
+
+	owners := ResolveOwners(e.app, ev.TriggerRef, ev.Trigger, ev.Record)
+	ownerSet := map[string]bool{}
+	for _, id := range owners {
+		ownerSet[id] = true
+	}
+
+	stopped := false
+	for _, rule := range rules {
+		if stopped {
+			break
+		}
+		if rule.Id == ev.SourceRule {
+			continue // a rule never re-fires on its own write
+		}
+		if rule.GetString("scope") == "personal" && !ownerSet[rule.GetString("owner")] {
+			continue
+		}
+		start := time.Now()
+
+		ast, err := DecodeConditions(rule.Get("conditions"))
+		if err != nil {
+			WriteRun(e.app, rule, ev.Record, ev.Trigger, RunOutcome{Err: "invalid conditions: " + err.Error(), Duration: time.Since(start)})
+			continue
+		}
+		if !EvaluateConditions(ast, ev.Record) {
+			WriteRun(e.app, rule, ev.Record, ev.Trigger, RunOutcome{Matched: false, Duration: time.Since(start)})
+			continue
+		}
+
+		actions, err := decodeActions(rule.Get("actions"))
+		if err != nil {
+			WriteRun(e.app, rule, ev.Record, ev.Trigger, RunOutcome{Matched: true, Err: "invalid actions: " + err.Error(), Duration: time.Since(start)})
+			continue
+		}
+		results := make([]ActionResult, 0, len(actions))
+		failed := 0
+		for _, a := range actions {
+			res := ActionResult{Ref: a.Ref, Status: "ok"}
+			if err := e.runActionWithTimeout(a, rule, ev); err != nil {
+				res.Status = "error"
+				res.Message = err.Error()
+				failed++
+			}
+			results = append(results, res)
+		}
+		WriteRun(e.app, rule, ev.Record, ev.Trigger, RunOutcome{Matched: true, Results: results, Duration: time.Since(start)})
+		recordRunResult(e.app, rule, len(actions) > 0 && failed == len(actions))
+
+		if rule.GetBool("stop_processing") {
+			if rule.GetString("scope") == "org" {
+				stopped = true // org stop halts everything downstream
+			} else {
+				stopped = true // personal stop halts later personal rules — org already ran (org-first ordering)
+			}
+		}
+	}
+}
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string { return "action timed out" }
+
+// runActionWithTimeout abandons (does not kill) an overrunning action: the PB
+// SDK has no context-cancellable Save, so the goroutine finishes on its own
+// while the run is recorded as timed out.
+func (e *Engine) runActionWithTimeout(a storedAction, rule *core.Record, ev event) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- ExecuteAction(e.app, e.defs, a.Ref, a.Params, rule, ev.Trigger, ev.Record, ev.Depth)
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(actionTimeout):
+		return timeoutErr{}
+	}
+}

--- a/core/server/automation/engine.go
+++ b/core/server/automation/engine.go
@@ -175,6 +175,9 @@ func (e *Engine) recordHookHandler(col, op string) func(*core.RecordEvent) error
 			if op == "update" && !WatchChanged(ev.Record, qt.Def.Watch) {
 				continue
 			}
+			if !triggerAllowed(e.app, qt.Ref, ev.Record) {
+				continue
+			}
 			e.enqueue(event{TriggerRef: qt.Ref, Trigger: qt.Def, Record: ev.Record, Depth: depth, SourceRule: source})
 		}
 		return ev.Next()

--- a/core/server/automation/engine_test.go
+++ b/core/server/automation/engine_test.go
@@ -206,6 +206,26 @@ func TestStopProcessingAndOrdering(t *testing.T) {
 	}
 }
 
+func TestStartIsIdempotent(t *testing.T) {
+	app, eng, _ := engineApp(t)
+
+	before := rlstest.HookHandlerCounts(t, app)
+
+	// Must not panic (e.g. double-close of the done channel) and must not
+	// spawn a second worker or rebind hooks.
+	eng.Start()
+
+	after := rlstest.HookHandlerCounts(t, app)
+	for name, count := range before {
+		if after[name] != count {
+			t.Fatalf("second Start() must be a no-op: hook %s went from %d to %d handlers", name, count, after[name])
+		}
+	}
+	if !eng.started {
+		t.Fatal("started flag must remain set")
+	}
+}
+
 func TestSelfRetriggerAndChainDepth(t *testing.T) {
 	app, _, u := engineApp(t)
 	// set-status writes the trigger record → refires the update hook. There is

--- a/core/server/automation/engine_test.go
+++ b/core/server/automation/engine_test.go
@@ -1,0 +1,230 @@
+// tinycld/core/server/automation/engine_test.go
+package automation
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/types"
+
+	"tinycld.org/core/rlstest"
+)
+
+// engineApp: real rules/rule_runs migrations + a "tickets" collection with an
+// owner relation + defs declaring a create trigger and a set-status action.
+func engineApp(t *testing.T) (core.App, *Engine, *core.Record) {
+	t.Helper()
+	t.Cleanup(ResetRegistriesForTest)
+	t.Cleanup(ResetRunStateForTest)
+	app := rlstest.NewApp(t)
+
+	// Same fixture reconciliation as actions_test.go's pkgaccessApp: drop the
+	// bundled username index so 1820000000 (users_username_required) applies
+	// the way it does against a real DB.
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kept types.JSONArray[string]
+	for _, idx := range users.Indexes {
+		if !strings.Contains(idx, "username") {
+			kept = append(kept, idx)
+		}
+	}
+	users.Indexes = kept
+	users.PasswordAuth.IdentityFields = []string{"email"}
+	if err := app.Save(users); err != nil {
+		t.Fatalf("drop fixture username index: %v", err)
+	}
+
+	rlstest.Apply(t, app, rlstest.MigrationsDir(t, "../pb_migrations"))
+
+	col := core.NewBaseCollection("tickets")
+	col.Fields.Add(&core.TextField{Name: "title"})
+	col.Fields.Add(&core.TextField{Name: "status"})
+	col.Fields.Add(&core.RelationField{Name: "user", CollectionId: users.Id, MaxSelect: 1})
+	if err := app.Save(col); err != nil {
+		t.Fatal(err)
+	}
+
+	defs := &Defs{Packages: []PackageDefs{{
+		Slug:     "tickets",
+		Triggers: []TriggerDef{{ID: "ticket-created", Label: "created", Collection: "tickets", On: "create"}},
+		Actions: []ActionDef{{
+			ID: "set-status", Label: "set", Kind: "record-op", Collection: "tickets",
+			Op:     RecordOp{Type: "update", Target: "trigger-record", Set: map[string]SetValue{"status": {Param: "status"}}},
+			Params: []ParamDef{{Key: "status", Field: "status"}},
+		}},
+	}}}
+	eng := NewEngine(app, defs)
+	eng.Start()
+
+	u, _ := app.FindFirstRecordByFilter("users", "id != ''")
+	return app, eng, u
+}
+
+func makeRule(t *testing.T, app core.App, owner, scope string, conditions, actions any, order int, stop bool) *core.Record {
+	t.Helper()
+	col, _ := app.FindCollectionByNameOrId("rules")
+	r := core.NewRecord(col)
+	r.Set("name", "r")
+	r.Set("scope", scope)
+	r.Set("owner", owner)
+	r.Set("trigger", "tickets:ticket-created")
+	r.Set("conditions", conditions)
+	r.Set("actions", actions)
+	r.Set("enabled", true)
+	r.Set("order", order)
+	r.Set("stop_processing", stop)
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func waitForRuns(t *testing.T, app core.App, ruleID string, want int) []*core.Record {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "-fired_at", 0, 0, map[string]any{"id": ruleID})
+		if len(runs) >= want {
+			return runs
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d runs of %s", want, ruleID)
+	return nil
+}
+
+func TestEndToEndMatchAndAction(t *testing.T) {
+	app, _, u := engineApp(t)
+	rule := makeRule(t, app, u.Id, "personal",
+		map[string]any{"match": "all", "groups": []any{map[string]any{
+			"match": "any", "conditions": []any{map[string]any{"field": "title", "op": "contains", "value": "urgent"}},
+		}}},
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "triaged"}}},
+		0, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "URGENT: disk full")
+	rec.Set("user", u.Id)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	runs := waitForRuns(t, app, rule.Id, 1)
+	if !runs[0].GetBool("matched") {
+		t.Fatal("rule must match")
+	}
+	fresh, _ := app.FindRecordById("tickets", rec.Id)
+	if fresh.GetString("status") != "triaged" {
+		t.Fatalf("action must apply: %q", fresh.GetString("status"))
+	}
+}
+
+func TestNonMatchIsLogged(t *testing.T) {
+	app, _, u := engineApp(t)
+	rule := makeRule(t, app, u.Id, "personal",
+		map[string]any{"match": "all", "groups": []any{map[string]any{
+			"match": "any", "conditions": []any{map[string]any{"field": "title", "op": "contains", "value": "nope"}},
+		}}},
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "x"}}},
+		0, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "routine")
+	rec.Set("user", u.Id)
+	app.Save(rec)
+
+	runs := waitForRuns(t, app, rule.Id, 1)
+	if runs[0].GetBool("matched") {
+		t.Fatal("non-match must log matched=false")
+	}
+	fresh, _ := app.FindRecordById("tickets", rec.Id)
+	if fresh.GetString("status") != "" {
+		t.Fatal("no action on non-match")
+	}
+}
+
+func TestPersonalScopeFiltering(t *testing.T) {
+	app, _, u := engineApp(t)
+	// Rule owned by u, but the ticket belongs to a second user → must not fire.
+	users, _ := app.FindCollectionByNameOrId("users")
+	other := core.NewRecord(users)
+	other.Set("email", "other@example.com")
+	other.Set("username", "otheruser")
+	other.Set("name", "Other")
+	other.Set("role", "member")
+	other.SetPassword("0123456789")
+	if err := app.Save(other); err != nil {
+		t.Fatal(err)
+	}
+	rule := makeRule(t, app, u.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "x"}}}, 0, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "anything")
+	rec.Set("user", other.Id)
+	app.Save(rec)
+
+	// Give the worker a beat, then assert NO run row exists.
+	time.Sleep(300 * time.Millisecond)
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": rule.Id})
+	if len(runs) != 0 {
+		t.Fatalf("personal rule must not fire on another user's record: %d runs", len(runs))
+	}
+	_ = rule
+}
+
+func TestStopProcessingAndOrdering(t *testing.T) {
+	app, _, u := engineApp(t)
+	first := makeRule(t, app, u.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "from-first"}}}, 0, true)
+	second := makeRule(t, app, u.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "from-second"}}}, 1, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "t")
+	rec.Set("user", u.Id)
+	app.Save(rec)
+
+	waitForRuns(t, app, first.Id, 1)
+	time.Sleep(300 * time.Millisecond)
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": second.Id})
+	if len(runs) != 0 {
+		t.Fatal("stop_processing must skip later personal rules")
+	}
+	fresh, _ := app.FindRecordById("tickets", rec.Id)
+	if fresh.GetString("status") != "from-first" {
+		t.Fatalf("first rule's action must have applied: %q", fresh.GetString("status"))
+	}
+}
+
+func TestSelfRetriggerAndChainDepth(t *testing.T) {
+	app, _, u := engineApp(t)
+	// set-status writes the trigger record → refires the update hook. There is
+	// no update trigger declared, so the direct loop risk is create-only here;
+	// assert the self-retrigger guard via provenance: rule fires once, and the
+	// engine-write sentinel was consumed (no unbounded growth).
+	rule := makeRule(t, app, u.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "done"}}}, 0, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "t")
+	rec.Set("user", u.Id)
+	app.Save(rec)
+
+	waitForRuns(t, app, rule.Id, 1)
+	time.Sleep(300 * time.Millisecond)
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": rule.Id})
+	if len(runs) != 1 {
+		t.Fatalf("rule must fire exactly once, got %d", len(runs))
+	}
+}

--- a/core/server/automation/engine_test.go
+++ b/core/server/automation/engine_test.go
@@ -186,6 +186,40 @@ func TestPersonalScopeFiltering(t *testing.T) {
 	_ = rule
 }
 
+func TestTriggerFilterGatesEnqueue(t *testing.T) {
+	app, _, u := engineApp(t)
+	RegisterTriggerFilter("tickets:ticket-created", func(app core.App, record *core.Record) bool {
+		return record.GetString("status") != "draft"
+	})
+	rule := makeRule(t, app, u.Id, "org", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "x"}}}, 0, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	filtered := core.NewRecord(col)
+	filtered.Set("title", "filtered out")
+	filtered.Set("status", "draft")
+	filtered.Set("user", u.Id)
+	if err := app.Save(filtered); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give the worker a beat, then assert the filtered-out create produced NO run row.
+	time.Sleep(300 * time.Millisecond)
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": rule.Id})
+	if len(runs) != 0 {
+		t.Fatalf("a trigger filtered out must not enqueue: %d runs", len(runs))
+	}
+
+	allowed := core.NewRecord(col)
+	allowed.Set("title", "allowed through")
+	allowed.Set("status", "ready")
+	allowed.Set("user", u.Id)
+	if err := app.Save(allowed); err != nil {
+		t.Fatal(err)
+	}
+	waitForRuns(t, app, rule.Id, 1)
+}
+
 func TestStopProcessingAndOrdering(t *testing.T) {
 	app, _, u := engineApp(t)
 	first := makeRule(t, app, u.Id, "personal", nil,

--- a/core/server/automation/engine_test.go
+++ b/core/server/automation/engine_test.go
@@ -54,13 +54,38 @@ func engineApp(t *testing.T) (core.App, *Engine, *core.Record) {
 		t.Fatal(err)
 	}
 
+	// broadcasts: no user/owner/author relation at all — exercises the
+	// unscoped dry-run path (TestDryRunUnscopedRequiresAdmin), which
+	// ownerFilterFor can't resolve to a per-caller filter.
+	broadcasts := core.NewBaseCollection("broadcasts")
+	broadcasts.Fields.Add(&core.TextField{Name: "title"})
+	broadcasts.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	broadcasts.Fields.Add(&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true})
+	if err := app.Save(broadcasts); err != nil {
+		t.Fatal(err)
+	}
+
 	defs := &Defs{Packages: []PackageDefs{{
-		Slug:     "tickets",
-		Triggers: []TriggerDef{{ID: "ticket-created", Label: "created", Collection: "tickets", On: "create"}},
+		Slug: "tickets",
+		Triggers: []TriggerDef{
+			{ID: "ticket-created", Label: "created", Collection: "tickets", On: "create"},
+			{ID: "broadcast-created", Label: "broadcast", Collection: "broadcasts", On: "create"},
+		},
 		Actions: []ActionDef{{
 			ID: "set-status", Label: "set", Kind: "record-op", Collection: "tickets",
 			Op:     RecordOp{Type: "update", Target: "trigger-record", Set: map[string]SetValue{"status": {Param: "status"}}},
 			Params: []ParamDef{{Key: "status", Field: "status"}},
+		}, {
+			// clone-ticket lets a test build a self-triggering chain: each
+			// created ticket's rule creates another ticket owned by the same
+			// user (so a personal rule keeps matching each generation),
+			// re-firing the create hook — used to exercise the
+			// chain-depth-exceeded path.
+			ID: "clone-ticket", Label: "clone", Kind: "record-op", Collection: "tickets",
+			Op: RecordOp{Type: "create", Set: map[string]SetValue{
+				"title": {Literal: "clone"},
+				"user":  {Context: "owner"},
+			}},
 		}},
 	}}}
 	eng := NewEngine(app, defs)
@@ -285,5 +310,98 @@ func TestSelfRetriggerAndChainDepth(t *testing.T) {
 	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": rule.Id})
 	if len(runs) != 1 {
 		t.Fatalf("rule must fire exactly once, got %d", len(runs))
+	}
+}
+
+// TestChainDepthExceededRunRow drives a genuine chain of ticket creates past
+// maxChainDepth, then asserts the resulting run row: written with an error,
+// and — the fix under test — trigger_summary is empty rather than a snapshot
+// of every column, because the chain-depth-exceeded WriteRun call passes a
+// nil record instead of the real one under an empty TriggerDef (which would
+// otherwise fall into the "expose everything" branch).
+func TestChainDepthExceededRunRow(t *testing.T) {
+	app, _, u := engineApp(t)
+	// A single rule can't chain past depth 1: the "a rule never re-fires on
+	// its own write" guard (dispatch's rule.Id == ev.SourceRule check) blocks
+	// it. Two rules that both clone on every ticket-created ping-pong past
+	// each other's sentinel instead, so depth keeps climbing past
+	// maxChainDepth.
+	makeRule(t, app, u.Id, "org", nil,
+		[]any{map[string]any{"ref": "tickets:clone-ticket"}}, 0, false)
+	makeRule(t, app, u.Id, "org", nil,
+		[]any{map[string]any{"ref": "tickets:clone-ticket"}}, 1, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "seed")
+	rec.Set("user", u.Id)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each generation's rule run enqueues another create from the OTHER
+	// rule's next hop; wait for the chain to run past maxChainDepth (3) and
+	// produce the depth-exceeded run row — distinguished from ordinary
+	// matched runs by having a non-empty error. Either rule can end up as the
+	// row's owner depending on ping-pong parity, so query across both.
+	deadline := time.Now().Add(5 * time.Second)
+	var errRun *core.Record
+	for time.Now().Before(deadline) {
+		runs, _ := app.FindRecordsByFilter("rule_runs", "error != ''", "", 0, 0, nil)
+		if len(runs) > 0 {
+			errRun = runs[0]
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if errRun == nil {
+		t.Fatal("timed out waiting for the chain-depth-exceeded run row")
+	}
+	if errRun.GetString("error") != "chain-depth-exceeded" {
+		t.Fatalf("error string: %q", errRun.GetString("error"))
+	}
+	summary, _ := errRun.Get("trigger_summary").(map[string]any)
+	if len(summary) != 0 {
+		t.Fatalf("chain-depth-exceeded row must have an empty trigger_summary, got %+v", summary)
+	}
+}
+
+// TestManualRunOfDisabledRuleStillExecutes proves the manual-run endpoint's
+// promise: it replies {"queued": true} regardless of the rule's enabled
+// state, so dispatch must honor that for a RuleID-targeted event even though
+// the rule is disabled — the auto-disable scenario being the motivating case.
+// Before the fix, dispatch loaded only `enabled = true` rules and then
+// filtered by RuleID, so a disabled rule silently vanished and no run row
+// was ever written.
+func TestManualRunOfDisabledRuleStillExecutes(t *testing.T) {
+	app, eng, u := engineApp(t)
+	rule := makeRule(t, app, u.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "ran-anyway"}}}, 0, false)
+	rule.Set("enabled", false) // auto-disable-style: the rule a manual run is meant to bypass
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "t")
+	rec.Set("user", u.Id)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	trigger, _, _ := eng.defs.Trigger("tickets:ticket-created")
+	eng.DispatchForTest(event{TriggerRef: "tickets:ticket-created", Trigger: trigger, Record: rec, RuleID: rule.Id})
+
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": rule.Id})
+	if len(runs) != 1 {
+		t.Fatalf("manual-run of a disabled rule must still write a run row: got %d", len(runs))
+	}
+	if !runs[0].GetBool("matched") {
+		t.Fatal("disabled rule targeted by RuleID must still evaluate and match")
+	}
+	fresh, _ := app.FindRecordById("tickets", rec.Id)
+	if fresh.GetString("status") != "ran-anyway" {
+		t.Fatalf("disabled rule's action must still execute: %q", fresh.GetString("status"))
 	}
 }

--- a/core/server/automation/engine_test.go
+++ b/core/server/automation/engine_test.go
@@ -45,6 +45,11 @@ func engineApp(t *testing.T) (core.App, *Engine, *core.Record) {
 	col.Fields.Add(&core.TextField{Name: "title"})
 	col.Fields.Add(&core.TextField{Name: "status"})
 	col.Fields.Add(&core.RelationField{Name: "user", CollectionId: users.Id, MaxSelect: 1})
+	// Every real generated collection carries autodate created/updated fields
+	// (see pb_migrations/1990000000_create_rules.js); dry-run's "-created"
+	// sort relies on that, same as it would against any feature collection.
+	col.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	col.Fields.Add(&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true})
 	if err := app.Save(col); err != nil {
 		t.Fatal(err)
 	}

--- a/core/server/automation/eval.go
+++ b/core/server/automation/eval.go
@@ -3,6 +3,7 @@ package automation
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -71,8 +72,10 @@ func toFloat(v any) (float64, bool) {
 		f, err := t.Float64()
 		return f, err == nil
 	case string:
-		var f float64
-		_, err := fmt.Sscanf(t, "%g", &f)
+		// ParseFloat rejects trailing garbage (e.g. "1500abc"); Sscanf with
+		// "%g" would happily accept it and silently drop the suffix, letting
+		// a malformed rule value match on a truncated number. Fail closed.
+		f, err := strconv.ParseFloat(t, 64)
 		return f, err == nil
 	default:
 		return 0, false
@@ -142,9 +145,15 @@ func evalCondition(c Condition, record *core.Record) bool {
 		if err != nil {
 			// Date-only form from the builder ("2026-08-11")
 			want, err = time.Parse("2006-01-02", normalize(c.Value))
-			if err != nil {
-				return false
-			}
+		}
+		if err != nil {
+			// RFC3339 ("2026-08-11T15:04:05Z"): the Phase 3 condition builder
+			// may emit either this or the PB DB format above depending on
+			// which UI control produced the value.
+			want, err = time.Parse(time.RFC3339, normalize(c.Value))
+		}
+		if err != nil {
+			return false
 		}
 		if c.Op == "before" {
 			return have.Before(want)
@@ -171,12 +180,12 @@ func evalCondition(c Condition, record *core.Record) bool {
 	return false
 }
 
-func evalGroup(g ConditionGroup, record *core.Record) bool {
+func evalGroup(g ConditionGroup, record *core.Record, exposed map[string]bool, gate bool) bool {
 	if len(g.Conditions) == 0 {
 		return true
 	}
 	for _, c := range g.Conditions {
-		hit := evalCondition(c, record)
+		hit := (!gate || exposed[c.Field]) && evalCondition(c, record)
 		if g.Match == "any" && hit {
 			return true
 		}
@@ -188,12 +197,29 @@ func evalGroup(g ConditionGroup, record *core.Record) bool {
 }
 
 // EvaluateConditions applies the one-level AND/OR AST. No conditions = match.
-func EvaluateConditions(ast ConditionsAST, record *core.Record) bool {
+//
+// record != nil: a condition whose Field isn't in this trigger's
+// exposedFields evaluates to false regardless of operator — fail closed, the
+// same convention as an unknown operator. Without this gate, evalCondition
+// would happily read any record.Get(field), letting a rule author or dry-run
+// caller probe curated-away/hidden columns via match/no-match (e.g.
+// starts_with as a binary-search oracle over a hidden field's value).
+//
+// record == nil (scheduled trigger): unchanged from pre-fix behavior — there
+// is no record whose fields could leak, so the exposure gate doesn't apply;
+// an empty AST still matches, a non-empty AST falls through to evalCondition
+// exactly as before this fix.
+func EvaluateConditions(ast ConditionsAST, record *core.Record, trigger TriggerDef) bool {
 	if len(ast.Groups) == 0 {
 		return true
 	}
+	gate := record != nil
+	var exposed map[string]bool
+	if gate {
+		exposed = exposedFields(record, trigger)
+	}
 	for _, g := range ast.Groups {
-		hit := evalGroup(g, record)
+		hit := evalGroup(g, record, exposed, gate)
 		if ast.Match == "any" && hit {
 			return true
 		}

--- a/core/server/automation/eval.go
+++ b/core/server/automation/eval.go
@@ -1,0 +1,220 @@
+package automation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+type Condition struct {
+	Field string `json:"field"`
+	Op    string `json:"op"`
+	Value any    `json:"value"`
+}
+
+type ConditionGroup struct {
+	Match      string      `json:"match"`
+	Conditions []Condition `json:"conditions"`
+}
+
+type ConditionsAST struct {
+	Match  string           `json:"match"`
+	Groups []ConditionGroup `json:"groups"`
+}
+
+// DecodeConditions round-trips through JSON because Record.Get on a json
+// column yields types.JSONRaw (see notify_batcher.go's hard-won comment) and
+// the client stores plain objects — one path handles both.
+func DecodeConditions(raw any) (ConditionsAST, error) {
+	var ast ConditionsAST
+	if raw == nil {
+		return ast, nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return ast, err
+	}
+	if len(b) == 0 || string(b) == "null" || string(b) == `""` {
+		return ast, nil
+	}
+	return ast, json.Unmarshal(b, &ast)
+}
+
+// normalize mirrors audit.fieldToString: one canonical string per value.
+func normalize(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []string:
+		return strings.Join(t, ",")
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+func toFloat(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case float32:
+		return float64(t), true
+	case int:
+		return float64(t), true
+	case int64:
+		return float64(t), true
+	case json.Number:
+		f, err := t.Float64()
+		return f, err == nil
+	case string:
+		var f float64
+		_, err := fmt.Sscanf(t, "%g", &f)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func stringValues(record *core.Record, field string) []string {
+	if vs := record.GetStringSlice(field); len(vs) > 0 {
+		return vs
+	}
+	if s := record.GetString(field); s != "" {
+		return []string{s}
+	}
+	return nil
+}
+
+func evalCondition(c Condition, record *core.Record) bool {
+	switch c.Op {
+	case "contains", "not_contains", "equals", "starts_with":
+		field := strings.ToLower(normalize(record.Get(c.Field)))
+		want := strings.ToLower(normalize(c.Value))
+		var hit bool
+		switch c.Op {
+		case "contains":
+			hit = strings.Contains(field, want)
+		case "not_contains":
+			return !strings.Contains(field, want)
+		case "equals":
+			hit = field == want
+		case "starts_with":
+			hit = strings.HasPrefix(field, want)
+		}
+		return hit
+	case "eq", "neq", "gt", "lt":
+		have := record.GetFloat(c.Field)
+		want, ok := toFloat(c.Value)
+		if !ok {
+			return false
+		}
+		switch c.Op {
+		case "eq":
+			return have == want
+		case "neq":
+			return have != want
+		case "gt":
+			return have > want
+		case "lt":
+			return have < want
+		}
+	case "is_true":
+		return record.GetBool(c.Field)
+	case "is_false":
+		return !record.GetBool(c.Field)
+	case "before", "after", "within_last_days":
+		have := record.GetDateTime(c.Field).Time()
+		if have.IsZero() {
+			return false
+		}
+		if c.Op == "within_last_days" {
+			days, ok := toFloat(c.Value)
+			if !ok {
+				return false
+			}
+			return have.After(time.Now().Add(-time.Duration(days*24) * time.Hour))
+		}
+		want, err := time.Parse("2006-01-02 15:04:05.000Z", normalize(c.Value))
+		if err != nil {
+			// Date-only form from the builder ("2026-08-11")
+			want, err = time.Parse("2006-01-02", normalize(c.Value))
+			if err != nil {
+				return false
+			}
+		}
+		if c.Op == "before" {
+			return have.Before(want)
+		}
+		return have.After(want)
+	case "is", "is_not":
+		want := normalize(c.Value)
+		hit := false
+		for _, v := range stringValues(record, c.Field) {
+			if v == want {
+				hit = true
+				break
+			}
+		}
+		if c.Op == "is" {
+			return hit
+		}
+		return !hit
+	case "is_empty":
+		return len(stringValues(record, c.Field)) == 0 && normalize(record.Get(c.Field)) == ""
+	}
+	// Unknown operator: a rule authored against a newer core than this one.
+	// Fail closed (no match) rather than erroring the whole dispatch.
+	return false
+}
+
+func evalGroup(g ConditionGroup, record *core.Record) bool {
+	if len(g.Conditions) == 0 {
+		return true
+	}
+	for _, c := range g.Conditions {
+		hit := evalCondition(c, record)
+		if g.Match == "any" && hit {
+			return true
+		}
+		if g.Match != "any" && !hit {
+			return false
+		}
+	}
+	return g.Match != "any"
+}
+
+// EvaluateConditions applies the one-level AND/OR AST. No conditions = match.
+func EvaluateConditions(ast ConditionsAST, record *core.Record) bool {
+	if len(ast.Groups) == 0 {
+		return true
+	}
+	for _, g := range ast.Groups {
+		hit := evalGroup(g, record)
+		if ast.Match == "any" && hit {
+			return true
+		}
+		if ast.Match != "any" && !hit {
+			return false
+		}
+	}
+	return ast.Match != "any"
+}
+
+// WatchChanged reports whether any watched field differs from the record's
+// original values. Empty watch = fire on every update.
+func WatchChanged(record *core.Record, watch []string) bool {
+	if len(watch) == 0 {
+		return true
+	}
+	original := record.Original()
+	for _, f := range watch {
+		if normalize(record.Get(f)) != normalize(original.Get(f)) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/server/automation/eval_test.go
+++ b/core/server/automation/eval_test.go
@@ -24,6 +24,9 @@ func evalRecord(t *testing.T) (*tests.TestApp, *core.Record) {
 	col.Fields.Add(&core.NumberField{Name: "size"})
 	col.Fields.Add(&core.DateField{Name: "happened"})
 	col.Fields.Add(&core.SelectField{Name: "tags", Values: []string{"a", "b", "c"}, MaxSelect: 3})
+	// tokenKey stands in for a curated-away/hidden secret column: rule
+	// conditions must never be able to probe it via match/no-match.
+	col.Fields.Add(&core.TextField{Name: "tokenKey", Hidden: true})
 	if err := app.Save(col); err != nil {
 		t.Fatal(err)
 	}
@@ -34,6 +37,7 @@ func evalRecord(t *testing.T) (*tests.TestApp, *core.Record) {
 	r.Set("size", 1500)
 	r.Set("happened", time.Now().Add(-48*time.Hour).UTC().Format("2006-01-02 15:04:05.000Z"))
 	r.Set("tags", []string{"a", "c"})
+	r.Set("tokenKey", "super-secret-value")
 	if err := app.Save(r); err != nil {
 		t.Fatal(err)
 	}
@@ -48,6 +52,11 @@ func one(c Condition) ConditionsAST {
 	return ConditionsAST{Match: "all", Groups: []ConditionGroup{{Match: "all", Conditions: []Condition{c}}}}
 }
 
+// openEvalTrigger declares no Fields allowlist, so exposedFields exposes every
+// non-system, non-hidden column of eval_things — the pre-existing behavior
+// TestOperatorTable/TestGroupSemantics rely on.
+var openEvalTrigger = TriggerDef{}
+
 func TestOperatorTable(t *testing.T) {
 	_, r := evalRecord(t)
 	cases := []struct {
@@ -61,6 +70,7 @@ func TestOperatorTable(t *testing.T) {
 		{"equals ci", cond("sender", "equals", "Billing@acme.com"), true},
 		{"starts_with", cond("subject", "starts_with", "invoice #"), true},
 		{"eq", cond("size", "eq", 1500), true},
+		{"eq partial-parse string rejected", cond("size", "eq", "1500abc"), false},
 		{"neq", cond("size", "neq", 1500), false},
 		{"gt", cond("size", "gt", 1000), true},
 		{"lt", cond("size", "lt", 1000), false},
@@ -76,7 +86,7 @@ func TestOperatorTable(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := EvaluateConditions(one(tc.c), r); got != tc.want {
+			if got := EvaluateConditions(one(tc.c), r, openEvalTrigger); got != tc.want {
 				t.Fatalf("%s: got %v want %v", tc.name, got, tc.want)
 			}
 		})
@@ -91,17 +101,52 @@ func TestGroupSemantics(t *testing.T) {
 	anyGroup := ConditionGroup{Match: "any", Conditions: []Condition{miss, hit}}
 	allGroup := ConditionGroup{Match: "all", Conditions: []Condition{hit, miss}}
 
-	if !EvaluateConditions(ConditionsAST{Match: "all", Groups: []ConditionGroup{anyGroup}}, r) {
+	if !EvaluateConditions(ConditionsAST{Match: "all", Groups: []ConditionGroup{anyGroup}}, r, openEvalTrigger) {
 		t.Fatal("any-group with one hit must pass")
 	}
-	if EvaluateConditions(ConditionsAST{Match: "all", Groups: []ConditionGroup{anyGroup, allGroup}}, r) {
+	if EvaluateConditions(ConditionsAST{Match: "all", Groups: []ConditionGroup{anyGroup, allGroup}}, r, openEvalTrigger) {
 		t.Fatal("all-of-groups with a failing group must fail")
 	}
-	if !EvaluateConditions(ConditionsAST{Match: "any", Groups: []ConditionGroup{anyGroup, allGroup}}, r) {
+	if !EvaluateConditions(ConditionsAST{Match: "any", Groups: []ConditionGroup{anyGroup, allGroup}}, r, openEvalTrigger) {
 		t.Fatal("any-of-groups with a passing group must pass")
 	}
-	if !EvaluateConditions(ConditionsAST{}, r) {
+	if !EvaluateConditions(ConditionsAST{}, r, openEvalTrigger) {
 		t.Fatal("empty AST must pass (no conditions = always match)")
+	}
+}
+
+// TestConditionsFailClosedOnNonExposedFields proves a rule condition can't be
+// used as a match/no-match oracle to probe a field the trigger doesn't expose
+// — hidden columns, and columns curated away by an explicit Fields allowlist.
+func TestConditionsFailClosedOnNonExposedFields(t *testing.T) {
+	_, r := evalRecord(t)
+
+	// Hidden field: even under the open trigger (no Fields declared, so every
+	// non-hidden column is exposed), tokenKey is hidden and must never match —
+	// regardless of the actual value or operator outcome.
+	hiddenHit := cond("tokenKey", "equals", "super-secret-value")
+	if EvaluateConditions(one(hiddenHit), r, openEvalTrigger) {
+		t.Fatal("condition on a hidden field must evaluate false even when the value would otherwise match")
+	}
+	hiddenMiss := cond("tokenKey", "equals", "definitely-not-it")
+	if EvaluateConditions(one(hiddenMiss), r, openEvalTrigger) {
+		t.Fatal("condition on a hidden field must stay false on the non-matching branch too (no oracle either direction)")
+	}
+
+	// Curated-away field: an allowlisted trigger that only exposes "subject"
+	// must reject a condition on "sender", a real, non-hidden column that
+	// simply isn't in the allowlist.
+	curatedTrigger := TriggerDef{Fields: []FieldRef{{Key: "subject"}}}
+	curatedAwayHit := cond("sender", "equals", "billing@acme.com")
+	if EvaluateConditions(one(curatedAwayHit), r, curatedTrigger) {
+		t.Fatal("condition on a field curated away by the trigger's allowlist must evaluate false")
+	}
+
+	// Exposed field: behavior for an allowlisted, actually-exposed field is
+	// unchanged.
+	exposedHit := cond("subject", "contains", "invoice")
+	if !EvaluateConditions(one(exposedHit), r, curatedTrigger) {
+		t.Fatal("condition on an exposed, allowlisted field must evaluate normally")
 	}
 }
 

--- a/core/server/automation/eval_test.go
+++ b/core/server/automation/eval_test.go
@@ -1,0 +1,150 @@
+// tinycld/core/server/automation/eval_test.go
+package automation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+func evalRecord(t *testing.T) (*tests.TestApp, *core.Record) {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+
+	col := core.NewBaseCollection("eval_things")
+	col.Fields.Add(&core.TextField{Name: "subject"})
+	col.Fields.Add(&core.TextField{Name: "sender"})
+	col.Fields.Add(&core.BoolField{Name: "flagged"})
+	col.Fields.Add(&core.NumberField{Name: "size"})
+	col.Fields.Add(&core.DateField{Name: "happened"})
+	col.Fields.Add(&core.SelectField{Name: "tags", Values: []string{"a", "b", "c"}, MaxSelect: 3})
+	if err := app.Save(col); err != nil {
+		t.Fatal(err)
+	}
+	r := core.NewRecord(col)
+	r.Set("subject", "Invoice #42 attached")
+	r.Set("sender", "billing@ACME.com")
+	r.Set("flagged", true)
+	r.Set("size", 1500)
+	r.Set("happened", time.Now().Add(-48*time.Hour).UTC().Format("2006-01-02 15:04:05.000Z"))
+	r.Set("tags", []string{"a", "c"})
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+	return app, r
+}
+
+func cond(field, op string, value any) Condition {
+	return Condition{Field: field, Op: op, Value: value}
+}
+
+func one(c Condition) ConditionsAST {
+	return ConditionsAST{Match: "all", Groups: []ConditionGroup{{Match: "all", Conditions: []Condition{c}}}}
+}
+
+func TestOperatorTable(t *testing.T) {
+	_, r := evalRecord(t)
+	cases := []struct {
+		name string
+		c    Condition
+		want bool
+	}{
+		{"contains ci", cond("subject", "contains", "invoice"), true},
+		{"contains miss", cond("subject", "contains", "receipt"), false},
+		{"not_contains", cond("subject", "not_contains", "receipt"), true},
+		{"equals ci", cond("sender", "equals", "Billing@acme.com"), true},
+		{"starts_with", cond("subject", "starts_with", "invoice #"), true},
+		{"eq", cond("size", "eq", 1500), true},
+		{"neq", cond("size", "neq", 1500), false},
+		{"gt", cond("size", "gt", 1000), true},
+		{"lt", cond("size", "lt", 1000), false},
+		{"is_true", cond("flagged", "is_true", nil), true},
+		{"is_false", cond("flagged", "is_false", nil), false},
+		{"within_last_days hit", cond("happened", "within_last_days", 7), true},
+		{"within_last_days miss", cond("happened", "within_last_days", 1), false},
+		{"is multi-match", cond("tags", "is", "c"), true},
+		{"is multi-miss", cond("tags", "is", "b"), false},
+		{"is_not", cond("tags", "is_not", "b"), true},
+		{"is_empty miss", cond("subject", "is_empty", nil), false},
+		{"unknown op", cond("subject", "regex", ".*"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EvaluateConditions(one(tc.c), r); got != tc.want {
+				t.Fatalf("%s: got %v want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGroupSemantics(t *testing.T) {
+	_, r := evalRecord(t)
+	hit := cond("subject", "contains", "invoice")
+	miss := cond("subject", "contains", "receipt")
+
+	anyGroup := ConditionGroup{Match: "any", Conditions: []Condition{miss, hit}}
+	allGroup := ConditionGroup{Match: "all", Conditions: []Condition{hit, miss}}
+
+	if !EvaluateConditions(ConditionsAST{Match: "all", Groups: []ConditionGroup{anyGroup}}, r) {
+		t.Fatal("any-group with one hit must pass")
+	}
+	if EvaluateConditions(ConditionsAST{Match: "all", Groups: []ConditionGroup{anyGroup, allGroup}}, r) {
+		t.Fatal("all-of-groups with a failing group must fail")
+	}
+	if !EvaluateConditions(ConditionsAST{Match: "any", Groups: []ConditionGroup{anyGroup, allGroup}}, r) {
+		t.Fatal("any-of-groups with a passing group must pass")
+	}
+	if !EvaluateConditions(ConditionsAST{}, r) {
+		t.Fatal("empty AST must pass (no conditions = always match)")
+	}
+}
+
+func TestWatchChanged(t *testing.T) {
+	app, r := evalRecord(t)
+	r.Set("subject", "Changed subject")
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+	// After Save, Original() reflects pre-save state only inside hooks; emulate
+	// by building the comparison directly: load fresh, mutate in memory.
+	fresh, err := app.FindRecordById("eval_things", r.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fresh.Set("sender", "other@acme.com")
+	if !WatchChanged(fresh, []string{"sender"}) {
+		t.Fatal("watched field changed → true")
+	}
+	if WatchChanged(fresh, []string{"subject"}) {
+		t.Fatal("unwatched-change only → false")
+	}
+	if !WatchChanged(fresh, nil) {
+		t.Fatal("empty watch → always true")
+	}
+}
+
+func TestDecodeConditions(t *testing.T) {
+	ast, err := DecodeConditions(map[string]any{
+		"match": "all",
+		"groups": []any{map[string]any{
+			"match":      "any",
+			"conditions": []any{map[string]any{"field": "subject", "op": "contains", "value": "x"}},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ast.Groups[0].Conditions[0].Field != "subject" {
+		t.Fatalf("decode failed: %+v", ast)
+	}
+	empty, err := DecodeConditions(nil)
+	if err != nil || len(empty.Groups) != 0 {
+		t.Fatalf("nil decodes to empty AST: %+v %v", empty, err)
+	}
+}

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -26,12 +26,30 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 		return
 	}
 
+	registerCoreNativeActions()
+
+	engine := NewEngine(app, defs)
+	registerEndpoints(app, engine)
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		engine.Start()
+		return se.Next()
+	})
+}
+
+// registerCoreNativeActions installs the Go handlers for core's own native
+// action refs. Factored out of Register so a test can install them without
+// the full app-bootstrap path (LoadDefs + OnServe binding).
+func registerCoreNativeActions() {
 	RegisterAction("core:notify", func(a core.App, req ActionRequest) error {
 		go func() {
 			if !appIsLive(a) {
 				return
 			}
-			notify.NotifyUser(a, notify.NotifyParams{
+			// notifyUser is runs.go's package-level seam over notify.NotifyUser —
+			// tests intercept it to assert on the notification without racing the
+			// real push I/O against app teardown (same rationale as the
+			// auto-disable notification's use of the seam).
+			notifyUser(a, notify.NotifyParams{
 				UserID:  req.OwnerID,
 				Type:    "automation",
 				Package: "core",
@@ -41,12 +59,5 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 			})
 		}()
 		return nil
-	})
-
-	engine := NewEngine(app, defs)
-	registerEndpoints(app, engine)
-	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
-		engine.Start()
-		return se.Next()
 	})
 }

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -1,0 +1,52 @@
+// tinycld/core/server/automation/register.go
+package automation
+
+import (
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/notify"
+)
+
+type Options struct {
+	DefsPath string
+}
+
+// Register wires the rules engine into an app. With no materialized defs the
+// engine is inert: no hooks bound, no endpoints — a workspace without
+// automation packages pays one file-stat.
+func Register(app *pocketbase.PocketBase, opts Options) {
+	defs, err := LoadDefs(opts.DefsPath)
+	if err != nil {
+		app.Logger().Error("automation: defs unreadable, engine disabled", "err", err)
+		return
+	}
+	if len(defs.Packages) == 0 {
+		app.Logger().Info("automation: no definitions, engine inert")
+		return
+	}
+
+	RegisterAction("core:notify", func(a core.App, req ActionRequest) error {
+		go func() {
+			if !appIsLive(a) {
+				return
+			}
+			notify.NotifyUser(a, notify.NotifyParams{
+				UserID:  req.OwnerID,
+				Type:    "automation",
+				Package: "core",
+				Title:   req.Params["title"],
+				Body:    req.Params["body"],
+				URL:     req.Params["url"],
+			})
+		}()
+		return nil
+	})
+
+	engine := NewEngine(app, defs)
+	registerEndpoints(app, engine)
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		engine.Start()
+		return se.Next()
+	})
+}

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -40,6 +40,11 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 // action refs. Factored out of Register so a test can install them without
 // the full app-bootstrap path (LoadDefs + OnServe binding).
 func registerCoreNativeActions() {
+	// core:notify is fire-and-forget: the handler returns nil immediately and
+	// the actual push happens on a detached goroutine. The engine records this
+	// action's ActionResult as "ok" the instant the handler returns, before
+	// notifyUser has run (or even before its liveness check) — a delivery
+	// failure inside the goroutine is invisible to rule_runs.results.
 	RegisterAction("core:notify", func(a core.App, req ActionRequest) error {
 		go func() {
 			if !appIsLive(a) {

--- a/core/server/automation/registry.go
+++ b/core/server/automation/registry.go
@@ -1,3 +1,10 @@
+// Package automation's registries (actionHandlers, ownerResolvers,
+// triggerFilters below) are process-global vars, not per-app state. In
+// multi-org mode one process hosts many tenant apps, each with its own
+// Engine — all of them share these same maps. That's fine in practice: refs
+// are package-qualified ("mail:send", "core:notify", …) and collide only on a
+// 15-char random id, which random-id generation makes negligible. Do not
+// assume a registered handler/resolver/filter is scoped to one tenant.
 package automation
 
 import (
@@ -8,6 +15,11 @@ import (
 
 // ActionRequest is what a native action handler receives. Params are already
 // template-substituted strings; Record is nil for synthetic triggers.
+//
+// Native handlers run outside the record-op/pkgaccess path (see
+// checkPersonalAccess in actions.go, which only re-applies pkgaccess to
+// record-op actions): a native handler must self-enforce any access control
+// it needs, the engine does not gate it for you.
 type ActionRequest struct {
 	Rule    *core.Record
 	OwnerID string
@@ -15,6 +27,9 @@ type ActionRequest struct {
 	Record  *core.Record
 }
 
+// ActionHandler is the function shape RegisterAction installs. See
+// ActionRequest's doc for the access-control implication: nothing upstream of
+// the handler enforces pkgaccess for native actions.
 type ActionHandler func(app core.App, req ActionRequest) error
 
 // OwnerResolver maps a trigger record to the user ids the event belongs to,
@@ -38,6 +53,9 @@ var (
 
 // RegisterAction installs the Go handler for a native action ref. Packages
 // call this from their Register(app), mirroring $-binding registration.
+// pkgaccess is NOT applied to native actions (only to record-ops, via
+// checkPersonalAccess) — the handler itself must enforce any access control
+// it needs.
 func RegisterAction(ref string, h ActionHandler) {
 	registryMu.Lock()
 	defer registryMu.Unlock()

--- a/core/server/automation/registry.go
+++ b/core/server/automation/registry.go
@@ -1,0 +1,93 @@
+package automation
+
+import (
+	"sync"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// ActionRequest is what a native action handler receives. Params are already
+// template-substituted strings; Record is nil for synthetic triggers.
+type ActionRequest struct {
+	Rule    *core.Record
+	OwnerID string
+	Params  map[string]string
+	Record  *core.Record
+}
+
+type ActionHandler func(app core.App, req ActionRequest) error
+
+// OwnerResolver maps a trigger record to the user ids the event belongs to,
+// for triggers whose collection has no direct user FK (e.g. mail's shared
+// mailboxes). Empty result = the event has no personal scope.
+type OwnerResolver func(app core.App, record *core.Record) []string
+
+var (
+	registryMu     sync.RWMutex
+	actionHandlers = map[string]ActionHandler{}
+	ownerResolvers = map[string]OwnerResolver{}
+)
+
+// RegisterAction installs the Go handler for a native action ref. Packages
+// call this from their Register(app), mirroring $-binding registration.
+func RegisterAction(ref string, h ActionHandler) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	actionHandlers[ref] = h
+}
+
+func actionHandler(ref string) (ActionHandler, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	h, ok := actionHandlers[ref]
+	return h, ok
+}
+
+// RegisterOwnerResolver overrides owner auto-detection for one trigger ref.
+func RegisterOwnerResolver(triggerRef string, r OwnerResolver) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	ownerResolvers[triggerRef] = r
+}
+
+func ResetRegistriesForTest() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	actionHandlers = map[string]ActionHandler{}
+	ownerResolvers = map[string]OwnerResolver{}
+}
+
+var autoOwnerFields = []string{"user", "owner", "author"}
+
+// ResolveOwners: registered resolver > declared ownerField > auto-detected
+// user/owner/author relation → users. Empty = personal rules never match
+// this event (locked Phase 2 decision — org rules still fire).
+func ResolveOwners(app core.App, triggerRef string, trigger TriggerDef, record *core.Record) []string {
+	if record == nil {
+		return nil
+	}
+	registryMu.RLock()
+	resolver, hasResolver := ownerResolvers[triggerRef]
+	registryMu.RUnlock()
+	if hasResolver {
+		return resolver(app, record)
+	}
+
+	candidates := autoOwnerFields
+	if trigger.OwnerField != "" {
+		candidates = []string{trigger.OwnerField}
+	}
+	usersCol, err := app.FindCachedCollectionByNameOrId("users")
+	if err != nil {
+		return nil
+	}
+	for _, name := range candidates {
+		field := record.Collection().Fields.GetByName(name)
+		rel, ok := field.(*core.RelationField)
+		if !ok || rel.CollectionId != usersCol.Id {
+			continue
+		}
+		return stringValues(record, name)
+	}
+	return nil
+}

--- a/core/server/automation/registry.go
+++ b/core/server/automation/registry.go
@@ -22,10 +22,18 @@ type ActionHandler func(app core.App, req ActionRequest) error
 // mailboxes). Empty result = the event has no personal scope.
 type OwnerResolver func(app core.App, record *core.Record) []string
 
+// TriggerFilter gates whether a record event counts as this trigger at all —
+// for triggers whose collection carries rows the trigger's semantics exclude
+// (e.g. mail's "message-received" must not fire on drafts or outbound sends).
+// Applies to ALL rule scopes, unlike OwnerResolver which only scopes personal
+// rules.
+type TriggerFilter func(app core.App, record *core.Record) bool
+
 var (
 	registryMu     sync.RWMutex
 	actionHandlers = map[string]ActionHandler{}
 	ownerResolvers = map[string]OwnerResolver{}
+	triggerFilters = map[string]TriggerFilter{}
 )
 
 // RegisterAction installs the Go handler for a native action ref. Packages
@@ -50,11 +58,33 @@ func RegisterOwnerResolver(triggerRef string, r OwnerResolver) {
 	ownerResolvers[triggerRef] = r
 }
 
+// RegisterTriggerFilter installs a gate for one trigger ref: a record event
+// is only treated as that trigger when the filter returns true. Applies
+// before owner resolution and to org-scoped rules alike.
+func RegisterTriggerFilter(triggerRef string, f TriggerFilter) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	triggerFilters[triggerRef] = f
+}
+
+// triggerAllowed reports whether record counts as triggerRef. No registered
+// filter = always allowed.
+func triggerAllowed(app core.App, triggerRef string, record *core.Record) bool {
+	registryMu.RLock()
+	filter, ok := triggerFilters[triggerRef]
+	registryMu.RUnlock()
+	if !ok {
+		return true
+	}
+	return filter(app, record)
+}
+
 func ResetRegistriesForTest() {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	actionHandlers = map[string]ActionHandler{}
 	ownerResolvers = map[string]OwnerResolver{}
+	triggerFilters = map[string]TriggerFilter{}
 }
 
 var autoOwnerFields = []string{"user", "owner", "author"}

--- a/core/server/automation/registry_test.go
+++ b/core/server/automation/registry_test.go
@@ -84,3 +84,35 @@ func TestOwnerAutoDetect(t *testing.T) {
 		t.Fatalf("resolver must win: %v", owners)
 	}
 }
+
+func TestTriggerFilterRegistry(t *testing.T) {
+	t.Cleanup(ResetRegistriesForTest)
+
+	// No registered filter = always allowed.
+	if !triggerAllowed(nil, "pkg:unfiltered", nil) {
+		t.Fatal("a trigger ref with no registered filter must default to allowed")
+	}
+
+	RegisterTriggerFilter("pkg:gated", func(app core.App, record *core.Record) bool {
+		return record != nil && record.GetString("status") == "ready"
+	})
+
+	col := core.NewBaseCollection("gated_things")
+	col.Fields.Add(&core.TextField{Name: "status"})
+	ready := core.NewRecord(col)
+	ready.Set("status", "ready")
+	notReady := core.NewRecord(col)
+	notReady.Set("status", "draft")
+
+	if !triggerAllowed(nil, "pkg:gated", ready) {
+		t.Fatal("record satisfying the filter must be allowed")
+	}
+	if triggerAllowed(nil, "pkg:gated", notReady) {
+		t.Fatal("record failing the filter must be rejected")
+	}
+
+	ResetRegistriesForTest()
+	if !triggerAllowed(nil, "pkg:gated", notReady) {
+		t.Fatal("reset must clear registered filters back to default-allow")
+	}
+}

--- a/core/server/automation/registry_test.go
+++ b/core/server/automation/registry_test.go
@@ -1,0 +1,86 @@
+package automation
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+func TestActionRegistry(t *testing.T) {
+	t.Cleanup(ResetRegistriesForTest)
+	called := false
+	RegisterAction("mail:send-message", func(app core.App, req ActionRequest) error {
+		called = true
+		return nil
+	})
+	h, ok := actionHandler("mail:send-message")
+	if !ok {
+		t.Fatal("registered handler must resolve")
+	}
+	if err := h(nil, ActionRequest{}); err != nil || !called {
+		t.Fatal("handler must be invocable")
+	}
+	if _, ok := actionHandler("mail:unregistered"); ok {
+		t.Fatal("unknown ref must miss")
+	}
+}
+
+func TestOwnerAutoDetect(t *testing.T) {
+	t.Cleanup(ResetRegistriesForTest)
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	col := core.NewBaseCollection("owned_things")
+	col.Fields.Add(&core.TextField{Name: "title"})
+	col.Fields.Add(&core.RelationField{Name: "owner", CollectionId: users.Id, MaxSelect: 1})
+	if err := app.Save(col); err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := app.FindFirstRecordByFilter("users", "id != ''")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := core.NewRecord(col)
+	r.Set("title", "x")
+	r.Set("owner", u.Id)
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+
+	owners := ResolveOwners(app, "pkg:thing-created", TriggerDef{Collection: "owned_things", On: "create"}, r)
+	if len(owners) != 1 || owners[0] != u.Id {
+		t.Fatalf("auto-detect via 'owner' relation: %v", owners)
+	}
+
+	// No user-relation field → no personal scope.
+	bare := core.NewBaseCollection("bare_things")
+	bare.Fields.Add(&core.TextField{Name: "title"})
+	if err := app.Save(bare); err != nil {
+		t.Fatal(err)
+	}
+	br := core.NewRecord(bare)
+	br.Set("title", "y")
+	if err := app.Save(br); err != nil {
+		t.Fatal(err)
+	}
+	if owners := ResolveOwners(app, "pkg:bare", TriggerDef{Collection: "bare_things"}, br); len(owners) != 0 {
+		t.Fatalf("unresolvable owner must be empty, got %v", owners)
+	}
+
+	// A registered resolver wins over auto-detection.
+	RegisterOwnerResolver("pkg:bare", func(app core.App, record *core.Record) []string {
+		return []string{"custom-user-id"}
+	})
+	if owners := ResolveOwners(app, "pkg:bare", TriggerDef{Collection: "bare_things"}, br); len(owners) != 1 || owners[0] != "custom-user-id" {
+		t.Fatalf("resolver must win: %v", owners)
+	}
+}

--- a/core/server/automation/runs.go
+++ b/core/server/automation/runs.go
@@ -16,6 +16,19 @@ const (
 	autoDisableAfter = 20
 )
 
+// notifyUser is an indirection so tests can intercept the auto-disable
+// notification without racing the real push I/O against app teardown.
+var notifyUser = notify.NotifyUser
+
+// appIsLive reports whether app still has a usable DB connection pool. The
+// auto-disable notification fires from a background goroutine that can
+// outlive the request/test that triggered it; checking this before touching
+// app avoids a nil-pointer panic against a torn-down app. engine.go's worker
+// (Task 7) reuses this same helper rather than redefining it.
+func appIsLive(app core.App) bool {
+	return app != nil && app.ConcurrentDB() != nil
+}
+
 type ActionResult struct {
 	Ref     string `json:"ref"`
 	Status  string `json:"status"`
@@ -116,16 +129,17 @@ func recordRunResult(app core.App, rule *core.Record, fullyFailed bool) {
 		app.Logger().Error("automation: auto-disable", "rule", rule.Id, "err", err)
 		return
 	}
-	// Synchronous, matching invite.go's call site: NotifyUser does its own
-	// I/O quickly, and firing it via `go` here raced app teardown in tests
-	// (the goroutine could still be running against app after t.Cleanup
-	// closed it) with nothing upstream to wait on it.
-	notify.NotifyUser(app, notify.NotifyParams{
-		UserID:  rule.GetString("owner"),
-		Type:    "automation_disabled",
-		Package: "core",
-		Title:   "Automation rule disabled",
-		Body:    "\"" + rule.GetString("name") + "\" failed repeatedly and was turned off.",
-		URL:     "/",
-	})
+	go func() {
+		if !appIsLive(app) {
+			return
+		}
+		notifyUser(app, notify.NotifyParams{
+			UserID:  rule.GetString("owner"),
+			Type:    "automation_disabled",
+			Package: "core",
+			Title:   "Automation rule disabled",
+			Body:    "\"" + rule.GetString("name") + "\" failed repeatedly and was turned off.",
+			URL:     "/",
+		})
+	}()
 }

--- a/core/server/automation/runs.go
+++ b/core/server/automation/runs.go
@@ -1,0 +1,131 @@
+// tinycld/core/server/automation/runs.go
+package automation
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/notify"
+)
+
+const (
+	keepRunsPerRule  = 200
+	autoDisableAfter = 20
+)
+
+type ActionResult struct {
+	Ref     string `json:"ref"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+type RunOutcome struct {
+	Matched  bool
+	Results  []ActionResult
+	Err      string
+	Duration time.Duration
+}
+
+func triggerSummary(record *core.Record, trigger TriggerDef) map[string]any {
+	if record == nil {
+		return nil
+	}
+	out := map[string]any{}
+	for key := range exposedFields(record, trigger) {
+		out[key] = normalize(record.Get(key))
+	}
+	return out
+}
+
+// WriteRun logs one engine run — matched or not: "why didn't it fire" is
+// debugged from non-match rows. Failures to log are reported to the app
+// logger, never propagated: the run already happened.
+func WriteRun(app core.App, rule *core.Record, record *core.Record, trigger TriggerDef, outcome RunOutcome) {
+	col, err := app.FindCollectionByNameOrId("rule_runs")
+	if err != nil {
+		app.Logger().Error("automation: rule_runs collection missing", "err", err)
+		return
+	}
+	run := core.NewRecord(col)
+	run.Set("rule", rule.Id)
+	run.Set("fired_at", time.Now().UTC().Format("2006-01-02 15:04:05.000Z"))
+	run.Set("matched", outcome.Matched)
+	run.Set("trigger_summary", triggerSummary(record, trigger))
+	if len(outcome.Results) > 0 {
+		b, _ := json.Marshal(outcome.Results)
+		run.Set("results", json.RawMessage(b))
+	}
+	run.Set("error", outcome.Err)
+	run.Set("duration_ms", outcome.Duration.Milliseconds())
+	if err := app.Save(run); err != nil {
+		app.Logger().Error("automation: write rule_run", "rule", rule.Id, "err", err)
+		return
+	}
+	pruneRuns(app, rule.Id)
+}
+
+func pruneRuns(app core.App, ruleID string) {
+	for {
+		extra, err := app.FindRecordsByFilter(
+			"rule_runs", "rule = {:id}", "-fired_at", 50, keepRunsPerRule,
+			map[string]any{"id": ruleID},
+		)
+		if err != nil || len(extra) == 0 {
+			return
+		}
+		for _, r := range extra {
+			if err := app.Delete(r); err != nil {
+				app.Logger().Error("automation: prune rule_run", "err", err)
+				return
+			}
+		}
+		if len(extra) < 50 {
+			return
+		}
+	}
+}
+
+// failureStreaks is in-memory by design: a restart resets the streak, and
+// rule_runs is the durable record. Good enough to stop a hot broken rule.
+var failureStreaks sync.Map
+
+func ResetRunStateForTest() {
+	failureStreaks = sync.Map{}
+}
+
+func recordRunResult(app core.App, rule *core.Record, fullyFailed bool) {
+	if !fullyFailed {
+		failureStreaks.Delete(rule.Id)
+		return
+	}
+	n := 1
+	if v, ok := failureStreaks.Load(rule.Id); ok {
+		n = v.(int) + 1
+	}
+	failureStreaks.Store(rule.Id, n)
+	if n < autoDisableAfter {
+		return
+	}
+	failureStreaks.Delete(rule.Id)
+	rule.Set("enabled", false)
+	markEngineWrite(rule.Id, rule.Id, 0)
+	if err := app.Save(rule); err != nil {
+		app.Logger().Error("automation: auto-disable", "rule", rule.Id, "err", err)
+		return
+	}
+	// Synchronous, matching invite.go's call site: NotifyUser does its own
+	// I/O quickly, and firing it via `go` here raced app teardown in tests
+	// (the goroutine could still be running against app after t.Cleanup
+	// closed it) with nothing upstream to wait on it.
+	notify.NotifyUser(app, notify.NotifyParams{
+		UserID:  rule.GetString("owner"),
+		Type:    "automation_disabled",
+		Package: "core",
+		Title:   "Automation rule disabled",
+		Body:    "\"" + rule.GetString("name") + "\" failed repeatedly and was turned off.",
+		URL:     "/",
+	})
+}

--- a/core/server/automation/runs_test.go
+++ b/core/server/automation/runs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tools/types"
 
+	"tinycld.org/core/notify"
 	"tinycld.org/core/rlstest"
 )
 
@@ -97,6 +98,17 @@ func TestPruneKeeps200(t *testing.T) {
 
 func TestAutoDisableAfterConsecutiveFailures(t *testing.T) {
 	app, rule := runsApp(t)
+
+	notified := make(chan notify.NotifyParams, 1)
+	orig := notifyUser
+	notifyUser = func(app core.App, p notify.NotifyParams) {
+		select {
+		case notified <- p:
+		default:
+		}
+	}
+	t.Cleanup(func() { notifyUser = orig })
+
 	for i := 0; i < autoDisableAfter-1; i++ {
 		recordRunResult(app, rule, true)
 	}
@@ -111,5 +123,17 @@ func TestAutoDisableAfterConsecutiveFailures(t *testing.T) {
 	fresh, _ = app.FindRecordById("rules", rule.Id)
 	if fresh.GetBool("enabled") {
 		t.Fatal(fmt.Sprintf("must disable after %d consecutive failures", autoDisableAfter))
+	}
+
+	select {
+	case p := <-notified:
+		if p.Type != "automation_disabled" {
+			t.Fatalf("notification type: %q", p.Type)
+		}
+		if p.UserID != rule.GetString("owner") {
+			t.Fatalf("notification UserID: got %q want %q", p.UserID, rule.GetString("owner"))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("auto-disable notification was not sent")
 	}
 }

--- a/core/server/automation/runs_test.go
+++ b/core/server/automation/runs_test.go
@@ -1,0 +1,115 @@
+// tinycld/core/server/automation/runs_test.go
+package automation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/types"
+
+	"tinycld.org/core/rlstest"
+)
+
+func runsApp(t *testing.T) (core.App, *core.Record) {
+	t.Helper()
+	t.Cleanup(ResetRunStateForTest)
+	app := rlstest.NewApp(t)
+
+	// Same fixture reconciliation as actions_test.go's pkgaccessApp: drop the
+	// bundled username index so 1820000000 (users_username_required) applies
+	// the way it does against a real DB.
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kept types.JSONArray[string]
+	for _, idx := range users.Indexes {
+		if !strings.Contains(idx, "username") {
+			kept = append(kept, idx)
+		}
+	}
+	users.Indexes = kept
+	users.PasswordAuth.IdentityFields = []string{"email"}
+	if err := app.Save(users); err != nil {
+		t.Fatalf("drop fixture username index: %v", err)
+	}
+
+	rlstest.Apply(t, app, rlstest.MigrationsDir(t, "../pb_migrations"))
+
+	u, err := app.FindFirstRecordByFilter("users", "id != ''")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rulesCol, err := app.FindCollectionByNameOrId("rules")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rule := core.NewRecord(rulesCol)
+	rule.Set("name", "Test rule")
+	rule.Set("scope", "personal")
+	rule.Set("owner", u.Id)
+	rule.Set("trigger", "core:manual")
+	rule.Set("enabled", true)
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+	return app, rule
+}
+
+func TestWriteRunAndPrune(t *testing.T) {
+	app, rule := runsApp(t)
+	outcome := RunOutcome{
+		Matched:  true,
+		Results:  []ActionResult{{Ref: "core:notify", Status: "ok"}},
+		Duration: 12 * time.Millisecond,
+	}
+	WriteRun(app, rule, nil, TriggerDef{}, outcome)
+
+	runs, err := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "-fired_at", 0, 0, map[string]any{"id": rule.Id})
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("expected 1 run: %v %v", len(runs), err)
+	}
+	if !runs[0].GetBool("matched") || runs[0].GetInt("duration_ms") != 12 {
+		t.Fatalf("run fields: %+v", runs[0].PublicExport())
+	}
+}
+
+func TestPruneKeeps200(t *testing.T) {
+	app, rule := runsApp(t)
+	col, _ := app.FindCollectionByNameOrId("rule_runs")
+	for i := 0; i < 205; i++ {
+		r := core.NewRecord(col)
+		r.Set("rule", rule.Id)
+		r.Set("fired_at", time.Now().Add(-time.Duration(i)*time.Minute).UTC().Format("2006-01-02 15:04:05.000Z"))
+		if err := app.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	WriteRun(app, rule, nil, TriggerDef{}, RunOutcome{Matched: false})
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": rule.Id})
+	if len(runs) != keepRunsPerRule {
+		t.Fatalf("prune: got %d want %d", len(runs), keepRunsPerRule)
+	}
+}
+
+func TestAutoDisableAfterConsecutiveFailures(t *testing.T) {
+	app, rule := runsApp(t)
+	for i := 0; i < autoDisableAfter-1; i++ {
+		recordRunResult(app, rule, true)
+	}
+	fresh, _ := app.FindRecordById("rules", rule.Id)
+	if !fresh.GetBool("enabled") {
+		t.Fatal("must not disable before the threshold")
+	}
+	recordRunResult(app, rule, false) // success resets the streak
+	for i := 0; i < autoDisableAfter; i++ {
+		recordRunResult(app, rule, true)
+	}
+	fresh, _ = app.FindRecordById("rules", rule.Id)
+	if fresh.GetBool("enabled") {
+		t.Fatal(fmt.Sprintf("must disable after %d consecutive failures", autoDisableAfter))
+	}
+}

--- a/core/server/automation/schedule.go
+++ b/core/server/automation/schedule.go
@@ -1,0 +1,40 @@
+// tinycld/core/server/automation/schedule.go
+package automation
+
+import (
+	"encoding/json"
+)
+
+type scheduleConfig struct {
+	Cron string `json:"cron"`
+}
+
+func decodeScheduleConfig(raw any) scheduleConfig {
+	var cfg scheduleConfig
+	if raw == nil {
+		return cfg
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return cfg
+	}
+	_ = json.Unmarshal(b, &cfg)
+	return cfg
+}
+
+func scheduleJobID(ruleID string) string { return "automation:" + ruleID }
+
+// syncSchedules registers cron jobs for every enabled core:schedule rule.
+// Called once from Start; per-rule changes reconcile via reloadScheduleFor.
+func (e *Engine) syncSchedules() {
+	rules, err := e.app.FindRecordsByFilter(
+		"rules", "trigger = 'core:schedule' && enabled = true", "", 0, 0,
+	)
+	if err != nil {
+		e.app.Logger().Error("automation: load schedule rules", "err", err)
+		return
+	}
+	for _, r := range rules {
+		e.reloadScheduleFor(r)
+	}
+}

--- a/core/server/automation/schedule_test.go
+++ b/core/server/automation/schedule_test.go
@@ -1,0 +1,146 @@
+// tinycld/core/server/automation/schedule_test.go
+package automation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/types"
+
+	"tinycld.org/core/rlstest"
+)
+
+func scheduleApp(t *testing.T) (core.App, *Engine, *core.Record) {
+	t.Helper()
+	t.Cleanup(ResetRegistriesForTest)
+	t.Cleanup(ResetRunStateForTest)
+	app := rlstest.NewApp(t)
+
+	// Same fixture reconciliation as engineApp/pkgaccessApp: drop the bundled
+	// username index so 1820000000 (users_username_required) applies the way
+	// it does against a real DB.
+	users, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kept types.JSONArray[string]
+	for _, idx := range users.Indexes {
+		if !strings.Contains(idx, "username") {
+			kept = append(kept, idx)
+		}
+	}
+	users.Indexes = kept
+	users.PasswordAuth.IdentityFields = []string{"email"}
+	if err := app.Save(users); err != nil {
+		t.Fatalf("drop fixture username index: %v", err)
+	}
+
+	rlstest.Apply(t, app, rlstest.MigrationsDir(t, "../pb_migrations"))
+	defs := &Defs{Packages: []PackageDefs{{
+		Slug:     "core",
+		Triggers: []TriggerDef{{ID: "schedule", Synthetic: "schedule"}, {ID: "manual", Synthetic: "manual"}},
+	}}}
+	eng := NewEngine(app, defs)
+	eng.Start()
+	u, _ := app.FindFirstRecordByFilter("users", "id != ''")
+	return app, eng, u
+}
+
+func scheduleRule(t *testing.T, app core.App, owner, cron string, enabled bool) *core.Record {
+	t.Helper()
+	col, _ := app.FindCollectionByNameOrId("rules")
+	r := core.NewRecord(col)
+	r.Set("name", "sched")
+	r.Set("scope", "personal")
+	r.Set("owner", owner)
+	r.Set("trigger", "core:schedule")
+	r.Set("trigger_config", map[string]any{"cron": cron})
+	r.Set("enabled", enabled)
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func hasJob(app core.App, ruleID string) bool {
+	for _, j := range app.Cron().Jobs() {
+		if j.Id() == "automation:"+ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScheduleReconcile(t *testing.T) {
+	app, _, u := scheduleApp(t)
+	rule := scheduleRule(t, app, u.Id, "0 8 * * *", true)
+	if !hasJob(app, rule.Id) {
+		t.Fatal("enabled schedule rule must register a cron job")
+	}
+
+	rule.Set("enabled", false)
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+	if hasJob(app, rule.Id) {
+		t.Fatal("disabling must remove the job")
+	}
+
+	rule.Set("enabled", true)
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !hasJob(app, rule.Id) {
+		t.Fatal("re-enabling must re-add the job")
+	}
+
+	if err := app.Delete(rule); err != nil {
+		t.Fatal(err)
+	}
+	if hasJob(app, rule.Id) {
+		t.Fatal("deleting must remove the job")
+	}
+}
+
+func TestSyncSchedulesOnBoot(t *testing.T) {
+	app, _, u := scheduleApp(t)
+	// Rule created while "engine offline": simulate by removing the job, then sync.
+	rule := scheduleRule(t, app, u.Id, "*/5 * * * *", true)
+	app.Cron().Remove("automation:" + rule.Id)
+	eng2 := NewEngine(app, &Defs{})
+	eng2.syncSchedules()
+	if !hasJob(app, rule.Id) {
+		t.Fatal("syncSchedules must pick up existing enabled rules")
+	}
+}
+
+func TestInvalidCronIsSurfaced(t *testing.T) {
+	app, _, u := scheduleApp(t)
+	rule := scheduleRule(t, app, u.Id, "not a cron", true)
+	if hasJob(app, rule.Id) {
+		t.Fatal("invalid cron must not register")
+	}
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": rule.Id})
+	if len(runs) != 1 || runs[0].GetString("error") == "" {
+		t.Fatalf("invalid cron must write an explanatory run row: %d", len(runs))
+	}
+}
+
+func TestScheduledDispatchTargetsOneRule(t *testing.T) {
+	app, eng, u := scheduleApp(t)
+	a := scheduleRule(t, app, u.Id, "0 8 * * *", true)
+	b := scheduleRule(t, app, u.Id, "0 9 * * *", true)
+
+	trigger, _, _ := eng.defs.Trigger("core:schedule")
+	eng.DispatchForTest(event{TriggerRef: "core:schedule", Trigger: trigger, RuleID: a.Id})
+
+	runsA, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": a.Id})
+	runsB, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0, map[string]any{"id": b.Id})
+	if len(runsA) != 1 || len(runsB) != 0 {
+		t.Fatalf("scheduled dispatch must hit exactly its rule: a=%d b=%d", len(runsA), len(runsB))
+	}
+	if !runsA[0].GetBool("matched") {
+		t.Fatal("nil-record dispatch with empty conditions must match (personal owner filter skipped)")
+	}
+}

--- a/core/server/automation/template.go
+++ b/core/server/automation/template.go
@@ -1,0 +1,50 @@
+// tinycld/core/server/automation/template.go
+package automation
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+var placeholderRe = regexp.MustCompile(`\{\{\s*([a-zA-Z0-9_]+)\s*\}\}`)
+
+// exposedFields returns the set of field keys rule templates/conditions may
+// see for this trigger: the declared allowlist, or (when the declaration
+// omitted fields) every non-system column plus created/updated — mirroring
+// the Phase 1 contract ("fields omitted = expose every schema column").
+func exposedFields(record *core.Record, trigger TriggerDef) map[string]bool {
+	out := map[string]bool{}
+	if len(trigger.Fields) > 0 {
+		for _, f := range trigger.Fields {
+			out[f.Key] = true
+		}
+		return out
+	}
+	for _, field := range record.Collection().Fields {
+		name := field.GetName()
+		if name == "id" || strings.HasPrefix(name, "_") {
+			continue
+		}
+		out[name] = true
+	}
+	return out
+}
+
+// SubstituteTemplates fills {{field}} placeholders from the trigger record.
+// Non-exposed and unknown fields become empty strings: a template must never
+// leak a column the trigger's declaration curated away.
+func SubstituteTemplates(s string, record *core.Record, trigger TriggerDef) string {
+	if record == nil || !strings.Contains(s, "{{") {
+		return s
+	}
+	exposed := exposedFields(record, trigger)
+	return placeholderRe.ReplaceAllStringFunc(s, func(m string) string {
+		key := placeholderRe.FindStringSubmatch(m)[1]
+		if !exposed[key] {
+			return ""
+		}
+		return normalize(record.Get(key))
+	})
+}

--- a/core/server/automation/template.go
+++ b/core/server/automation/template.go
@@ -14,25 +14,41 @@ var placeholderRe = regexp.MustCompile(`\{\{\s*([a-zA-Z0-9_]+)\s*\}\}`)
 // see for this trigger: the declared allowlist, or (when the declaration
 // omitted fields) every non-system column plus created/updated — mirroring
 // the Phase 1 contract ("fields omitted = expose every schema column").
-// System and hidden fields are never exposed, even if explicitly named.
+// System and hidden fields are never exposed, except autodate timestamps
+// (created/updated) which are always safe to expose.
 func exposedFields(record *core.Record, trigger TriggerDef) map[string]bool {
 	out := map[string]bool{}
 	col := record.Collection()
 	if len(trigger.Fields) > 0 {
-		// Curated allowlist: filter out system/hidden fields even if explicitly named.
+		// Curated allowlist: filter out system/hidden fields even if explicitly named,
+		// but allow autodate timestamps.
 		for _, f := range trigger.Fields {
 			field := col.Fields.GetByName(f.Key)
-			if field != nil && !field.GetSystem() && !field.GetHidden() {
-				out[f.Key] = true
+			if field == nil {
+				continue
 			}
+			if field.GetHidden() {
+				continue
+			}
+			if field.GetSystem() {
+				if _, isAutodate := field.(*core.AutodateField); !isAutodate {
+					continue
+				}
+			}
+			out[f.Key] = true
 		}
 		return out
 	}
-	// Open trigger: expose all non-system, non-hidden columns.
+	// Open trigger: expose all non-system, non-hidden columns, plus autodate timestamps.
 	for _, field := range col.Fields {
 		name := field.GetName()
-		if name == "id" || strings.HasPrefix(name, "_") || field.GetSystem() || field.GetHidden() {
+		if name == "id" || strings.HasPrefix(name, "_") || field.GetHidden() {
 			continue
+		}
+		if field.GetSystem() {
+			if _, isAutodate := field.(*core.AutodateField); !isAutodate {
+				continue
+			}
 		}
 		out[name] = true
 	}

--- a/core/server/automation/template.go
+++ b/core/server/automation/template.go
@@ -14,17 +14,24 @@ var placeholderRe = regexp.MustCompile(`\{\{\s*([a-zA-Z0-9_]+)\s*\}\}`)
 // see for this trigger: the declared allowlist, or (when the declaration
 // omitted fields) every non-system column plus created/updated — mirroring
 // the Phase 1 contract ("fields omitted = expose every schema column").
+// System and hidden fields are never exposed, even if explicitly named.
 func exposedFields(record *core.Record, trigger TriggerDef) map[string]bool {
 	out := map[string]bool{}
+	col := record.Collection()
 	if len(trigger.Fields) > 0 {
+		// Curated allowlist: filter out system/hidden fields even if explicitly named.
 		for _, f := range trigger.Fields {
-			out[f.Key] = true
+			field := col.Fields.GetByName(f.Key)
+			if field != nil && !field.GetSystem() && !field.GetHidden() {
+				out[f.Key] = true
+			}
 		}
 		return out
 	}
-	for _, field := range record.Collection().Fields {
+	// Open trigger: expose all non-system, non-hidden columns.
+	for _, field := range col.Fields {
 		name := field.GetName()
-		if name == "id" || strings.HasPrefix(name, "_") {
+		if name == "id" || strings.HasPrefix(name, "_") || field.GetSystem() || field.GetHidden() {
 			continue
 		}
 		out[name] = true

--- a/core/server/automation/template_test.go
+++ b/core/server/automation/template_test.go
@@ -1,7 +1,12 @@
 // tinycld/core/server/automation/template_test.go
 package automation
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/tests"
+)
 
 func TestSubstituteTemplates(t *testing.T) {
 	_, r := evalRecord(t)
@@ -28,5 +33,35 @@ func TestSubstituteTemplates(t *testing.T) {
 	}
 	if got := SubstituteTemplates("{{subject}}", nil, trig); got != "{{subject}}" {
 		t.Fatalf("nil record leaves input unchanged, got %q", got)
+	}
+}
+
+func TestSystemAndHiddenFieldsNeverSubstitute(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { app.Cleanup() })
+	u, err := app.FindFirstRecordByFilter("users", "id != ''")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Open trigger (all columns): hidden/system auth fields must never substitute,
+	// even if they have values. They should become empty strings.
+	got := SubstituteTemplates("{{tokenKey}}x{{password}}", u, TriggerDef{})
+	if got != "x" {
+		t.Fatalf("system/hidden fields must not substitute, got %q want 'x'", got)
+	}
+	// Even an explicit allowlist naming system/hidden fields must not leak.
+	curated := TriggerDef{Fields: []FieldRef{{Key: "tokenKey"}, {Key: "name"}}}
+	gotAllowlist := SubstituteTemplates("{{tokenKey}}|{{name}}", u, curated)
+	// tokenKey should have been filtered out (it's system/hidden), so it becomes empty.
+	if !strings.HasPrefix(gotAllowlist, "|") {
+		t.Fatalf("tokenKey (system field) must not substitute in curated allowlist, got %q", gotAllowlist)
+	}
+	// The name field should still substitute (it's a regular field).
+	expectedName := u.GetString("name")
+	if !strings.Contains(gotAllowlist, expectedName) {
+		t.Fatalf("name field should substitute in allowlist, got %q", gotAllowlist)
 	}
 }

--- a/core/server/automation/template_test.go
+++ b/core/server/automation/template_test.go
@@ -64,4 +64,15 @@ func TestSystemAndHiddenFieldsNeverSubstitute(t *testing.T) {
 	if !strings.Contains(gotAllowlist, expectedName) {
 		t.Fatalf("name field should substitute in allowlist, got %q", gotAllowlist)
 	}
+
+	// Autodate timestamps must still work on open triggers.
+	created := SubstituteTemplates("{{created}}", u, TriggerDef{})
+	if created == "" || created == "{{created}}" {
+		t.Fatalf("created (autodate) must substitute on open trigger, got %q", created)
+	}
+	// And on curated allowlists that explicitly name them.
+	curatedCreated := TriggerDef{Fields: []FieldRef{{Key: "created"}}}
+	if got := SubstituteTemplates("{{created}}", u, curatedCreated); got == "" || got == "{{created}}" {
+		t.Fatalf("created (autodate) must substitute when explicitly allowlisted, got %q", got)
+	}
 }

--- a/core/server/automation/template_test.go
+++ b/core/server/automation/template_test.go
@@ -1,0 +1,32 @@
+// tinycld/core/server/automation/template_test.go
+package automation
+
+import "testing"
+
+func TestSubstituteTemplates(t *testing.T) {
+	_, r := evalRecord(t)
+	trig := TriggerDef{Fields: []FieldRef{{Key: "subject"}, {Key: "sender"}}}
+
+	cases := []struct{ in, want string }{
+		{"Re: {{subject}}", "Re: Invoice #42 attached"},
+		{"{{ subject }} from {{sender}}", "Invoice #42 attached from billing@ACME.com"},
+		{"{{size}}", ""},        // not exposed by the trigger's allowlist
+		{"{{nonexistent}}", ""}, // unknown field
+		{"no placeholders", "no placeholders"},
+		{"{{subject", "{{subject"}, // unterminated stays verbatim
+	}
+	for _, tc := range cases {
+		if got := SubstituteTemplates(tc.in, r, trig); got != tc.want {
+			t.Fatalf("%q: got %q want %q", tc.in, got, tc.want)
+		}
+	}
+
+	// Empty Fields = all non-system columns exposed.
+	open := TriggerDef{}
+	if got := SubstituteTemplates("{{size}}", r, open); got != "1500" {
+		t.Fatalf("open trigger exposes all columns, got %q", got)
+	}
+	if got := SubstituteTemplates("{{subject}}", nil, trig); got != "{{subject}}" {
+		t.Fatalf("nil record leaves input unchanged, got %q", got)
+	}
+}

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pocketbase/pocketbase/plugins/migratecmd"
 	"github.com/pocketbase/pocketbase/tools/hook"
 
+	"tinycld.org/core/automation"
 	"tinycld.org/core/notify"
 	"tinycld.org/core/oauth"
 	"tinycld.org/core/offboard"
@@ -302,6 +303,15 @@ func registerSharedCore(app *pocketbase.PocketBase) {
 	// package Register, so with no packages linked this serves an empty result
 	// rather than failing.
 	search.Register(app)
+
+	// Workflow rules engine: record-hook + scheduled dispatch, manual-run and
+	// dry-run endpoints. Shared for the same reason as OAuth/search above — a
+	// tenant's rules fire exactly as a self-hosted deployment's do. Inert with
+	// no materialized defs (a workspace with no automation-contributing
+	// packages), so this is a no-op call in that case.
+	automation.Register(app, automation.Options{
+		DefsPath: filepath.Join(resolveServerDir(), "automation_defs.json"),
+	})
 
 	// Keep the /carddav (and /caldav, /dav) CORS bypass here even though core no
 	// longer serves a protocol handler itself: a package's own Go server (e.g.

--- a/core/server/driveshare/driveshare.go
+++ b/core/server/driveshare/driveshare.go
@@ -246,4 +246,3 @@ func CheckDelete(app core.App, userID, itemID string) error {
 func IsOwner(app core.App, userID, itemID string) bool {
 	return CheckDelete(app, userID, itemID) == nil
 }
-

--- a/core/server/pb_migrations/1990000000_create_rules.js
+++ b/core/server/pb_migrations/1990000000_create_rules.js
@@ -1,0 +1,112 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    app => {
+        const rules = new Collection({
+            id: 'pbc_rules_01',
+            name: 'rules',
+            type: 'base',
+            system: false,
+            // Personal rules: owner only. Org rules: readable by every
+            // authenticated user (so people can see why org automation touches
+            // their data) but writable only by admins/owners.
+            listRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
+            viewRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
+            createRule:
+                "@request.auth.id != '' && owner = @request.auth.id && (scope = 'personal' || @request.auth.role = 'admin' || @request.auth.role = 'owner')",
+            updateRule:
+                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            deleteRule:
+                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            fields: [
+                {
+                    id: 'rules_name',
+                    name: 'name',
+                    type: 'text',
+                    required: true,
+                    max: 200,
+                },
+                {
+                    id: 'rules_scope',
+                    name: 'scope',
+                    type: 'select',
+                    required: true,
+                    maxSelect: 1,
+                    values: ['personal', 'org'],
+                },
+                {
+                    id: 'rules_owner',
+                    name: 'owner',
+                    type: 'relation',
+                    required: true,
+                    collectionId: '_pb_users_auth_',
+                    cascadeDelete: true,
+                    maxSelect: 1,
+                },
+                {
+                    id: 'rules_trigger',
+                    name: 'trigger',
+                    type: 'text',
+                    required: true,
+                    max: 200,
+                },
+                {
+                    id: 'rules_trigger_config',
+                    name: 'trigger_config',
+                    type: 'json',
+                },
+                {
+                    id: 'rules_conditions',
+                    name: 'conditions',
+                    type: 'json',
+                },
+                {
+                    id: 'rules_actions',
+                    name: 'actions',
+                    type: 'json',
+                },
+                {
+                    id: 'rules_enabled',
+                    name: 'enabled',
+                    type: 'bool',
+                },
+                {
+                    id: 'rules_order',
+                    name: 'order',
+                    type: 'number',
+                },
+                {
+                    id: 'rules_stop_processing',
+                    name: 'stop_processing',
+                    type: 'bool',
+                },
+                {
+                    id: 'rules_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                },
+                {
+                    id: 'rules_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                },
+            ],
+            indexes: [
+                'CREATE INDEX `idx_rules_owner` ON `rules` (`owner`, `enabled`)',
+                'CREATE INDEX `idx_rules_trigger` ON `rules` (`trigger`, `enabled`)',
+            ],
+        })
+        app.save(rules)
+    },
+    app => {
+        try {
+            const c = app.findCollectionByNameOrId('rules')
+            app.delete(c)
+        } catch (e) {
+            // may not exist
+        }
+    }
+)

--- a/core/server/pb_migrations/1990000000_create_rules.js
+++ b/core/server/pb_migrations/1990000000_create_rules.js
@@ -7,16 +7,27 @@ migrate(
             type: 'base',
             system: false,
             // Personal rules: owner only. Org rules: readable by every
-            // authenticated user (so people can see why org automation touches
-            // their data) but writable only by admins/owners.
-            listRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
-            viewRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
+            // non-guest authenticated user (so people can see why org
+            // automation touches their data) but writable only by
+            // admins/owners. Guests get neither read nor create (matches the
+            // house posture: 1870000000_exclude_guests_from_org_rls.js,
+            // 1960000000_audit_logs_admin_only.js).
+            listRule:
+                'owner = @request.auth.id || (scope = "org" && @request.auth.id != "" && @request.auth.role != "guest")',
+            viewRule:
+                'owner = @request.auth.id || (scope = "org" && @request.auth.id != "" && @request.auth.role != "guest")',
             createRule:
-                "@request.auth.id != '' && owner = @request.auth.id && (scope = 'personal' || @request.auth.role = 'admin' || @request.auth.role = 'owner')",
+                '@request.auth.id != "" && @request.auth.role != "guest" && owner = @request.auth.id && (scope = "personal" || @request.auth.role = "admin" || @request.auth.role = "owner")',
+            // Body-locked: a personal-rule owner may PATCH other fields but
+            // must not smuggle `scope`/`owner` changes into the same request
+            // (the stored-value check alone can't see the body) — otherwise a
+            // personal-rule owner could PATCH { scope: 'org' } or
+            // { owner: <other> } and escalate. Admins/owners are trusted on
+            // the org branch, so no body locks there.
             updateRule:
-                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                '(scope = "personal" && owner = @request.auth.id && (@request.body.scope:isset = false || @request.body.scope = "personal") && (@request.body.owner:isset = false || @request.body.owner = @request.auth.id)) || (scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             deleteRule:
-                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                '(scope = "personal" && owner = @request.auth.id) || (scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             fields: [
                 {
                     id: 'rules_name',

--- a/core/server/pb_migrations/1990000001_create_rule_runs.js
+++ b/core/server/pb_migrations/1990000001_create_rule_runs.js
@@ -9,9 +9,9 @@ migrate(
             // Readable by whoever can read the rule; written only by the
             // engine (superuser DAO) — no client create/update/delete.
             listRule:
-                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                'rule.owner = @request.auth.id || (rule.scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             viewRule:
-                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                'rule.owner = @request.auth.id || (rule.scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             createRule: null,
             updateRule: null,
             deleteRule: null,

--- a/core/server/pb_migrations/1990000001_create_rule_runs.js
+++ b/core/server/pb_migrations/1990000001_create_rule_runs.js
@@ -1,0 +1,89 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    app => {
+        const runs = new Collection({
+            id: 'pbc_rule_runs_01',
+            name: 'rule_runs',
+            type: 'base',
+            system: false,
+            // Readable by whoever can read the rule; written only by the
+            // engine (superuser DAO) — no client create/update/delete.
+            listRule:
+                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            viewRule:
+                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            createRule: null,
+            updateRule: null,
+            deleteRule: null,
+            fields: [
+                {
+                    id: 'rr_rule',
+                    name: 'rule',
+                    type: 'relation',
+                    required: true,
+                    collectionId: 'pbc_rules_01',
+                    cascadeDelete: true,
+                    maxSelect: 1,
+                },
+                {
+                    id: 'rr_fired_at',
+                    name: 'fired_at',
+                    type: 'date',
+                    required: true,
+                },
+                {
+                    id: 'rr_matched',
+                    name: 'matched',
+                    type: 'bool',
+                },
+                {
+                    id: 'rr_trigger_summary',
+                    name: 'trigger_summary',
+                    type: 'json',
+                },
+                {
+                    id: 'rr_results',
+                    name: 'results',
+                    type: 'json',
+                },
+                {
+                    id: 'rr_error',
+                    name: 'error',
+                    type: 'text',
+                    max: 2000,
+                },
+                {
+                    id: 'rr_duration_ms',
+                    name: 'duration_ms',
+                    type: 'number',
+                },
+                {
+                    id: 'rr_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                },
+                {
+                    id: 'rr_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                },
+            ],
+            indexes: [
+                'CREATE INDEX `idx_rule_runs_rule` ON `rule_runs` (`rule`, `fired_at`)',
+            ],
+        })
+        app.save(runs)
+    },
+    app => {
+        try {
+            const c = app.findCollectionByNameOrId('rule_runs')
+            app.delete(c)
+        } catch (e) {
+            // may not exist
+        }
+    }
+)

--- a/core/tests/unit/input-key-event.test.ts
+++ b/core/tests/unit/input-key-event.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+//
+// The provider decides `inInput` per key event; a DOM is what it inspects.
+import { isInputKeyEvent } from '@tinycld/core/lib/shortcuts/provider.web'
+import { describe, expect, it } from 'vitest'
+
+function keyEventOn(target: EventTarget, key = 'Escape'): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true })
+    Object.defineProperty(event, 'target', { value: target })
+    return event
+}
+
+describe('isInputKeyEvent', () => {
+    it('is true for a key typed into an input', () => {
+        const input = document.createElement('input')
+        document.body.appendChild(input)
+        expect(isInputKeyEvent(keyEventOn(input))).toBe(true)
+        input.remove()
+    })
+
+    it('is true for a key typed into a ProseMirror surface', () => {
+        const editor = document.createElement('div')
+        editor.className = 'ProseMirror'
+        const inner = document.createElement('p')
+        editor.appendChild(inner)
+        document.body.appendChild(editor)
+        expect(isInputKeyEvent(keyEventOn(inner))).toBe(true)
+        editor.remove()
+    })
+
+    it('stays true when the editor was unmounted before the event reached the window', () => {
+        // The regression: an editor whose Escape handler unmounts (or blurs)
+        // it. React flushes that update while the event is still bubbling, so
+        // at the window listener `document.activeElement` is already BODY —
+        // but the TARGET still names the node the key was typed into, even
+        // detached. Deciding from activeElement made the peek's Escape fire
+        // on the very keystroke the editor had handled.
+        const editor = document.createElement('div')
+        editor.className = 'ProseMirror'
+        const inner = document.createElement('p')
+        editor.appendChild(inner)
+        document.body.appendChild(editor)
+        const event = keyEventOn(inner)
+        editor.remove()
+        expect(document.activeElement?.tagName).toBe('BODY')
+        expect(isInputKeyEvent(event)).toBe(true)
+    })
+
+    it('is true for a detached contenteditable, where isContentEditable reads false', () => {
+        const editable = document.createElement('div')
+        editable.setAttribute('contenteditable', 'true')
+        const event = keyEventOn(editable)
+        expect(isInputKeyEvent(event)).toBe(true)
+    })
+
+    it('is false for a key pressed over plain content', () => {
+        const div = document.createElement('div')
+        document.body.appendChild(div)
+        expect(isInputKeyEvent(keyEventOn(div))).toBe(false)
+        div.remove()
+    })
+
+    it('falls back to the focused element when the target is not an input', () => {
+        const input = document.createElement('input')
+        document.body.appendChild(input)
+        input.focus()
+        expect(isInputKeyEvent(keyEventOn(document.body))).toBe(true)
+        input.remove()
+    })
+})

--- a/scripts/__tests__/describe-packages.test.ts
+++ b/scripts/__tests__/describe-packages.test.ts
@@ -100,6 +100,27 @@ describe('manifestToConfigPkg', () => {
             })
         ).toThrow(/duplicate slot name 'sidebar\.after-calendars'/)
     })
+
+    it('maps manifest.automation.definitions to ConfigPkg.automation', () => {
+        const pkg = manifestToConfigPkg('@tinycld/contacts', {
+            name: 'Contacts',
+            slug: 'contacts',
+            version: '0.1.0',
+            description: 'd',
+            automation: { definitions: 'automation' },
+        })
+        expect(pkg.automation).toBe('automation')
+    })
+
+    it('leaves ConfigPkg.automation undefined when the manifest has none', () => {
+        const pkg = manifestToConfigPkg('@tinycld/contacts', {
+            name: 'Contacts',
+            slug: 'contacts',
+            version: '0.1.0',
+            description: 'd',
+        })
+        expect(pkg.automation).toBeUndefined()
+    })
 })
 
 describe('validateSidebarContributions', () => {

--- a/scripts/__tests__/describe-packages.test.ts
+++ b/scripts/__tests__/describe-packages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
     manifestToConfigPkg,
     schemaTypeName,
+    validateEventSources,
     validateNavShortcuts,
     validateSidebarContributions,
 } from '../describe-packages'
@@ -157,6 +158,88 @@ describe('validateSidebarContributions', () => {
         } finally {
             warn.mockRestore()
         }
+    })
+})
+
+describe('validateEventSources', () => {
+    const source = (overrides: Partial<{ target: string; id: string }> = {}) => ({
+        target: 'calendar',
+        id: 'cards-due',
+        label: 'Card due dates',
+        module: 'calendar-source',
+        ...overrides,
+    })
+
+    const contributor = (slug: string, sources = [source()]) =>
+        manifestToConfigPkg(`@tinycld/${slug}`, {
+            name: slug,
+            slug,
+            version: '0.1.0',
+            description: 'd',
+            eventSources: sources,
+        })
+
+    const host = manifestToConfigPkg('@tinycld/calendar', {
+        name: 'Calendar',
+        slug: 'calendar',
+        version: '0.1.0',
+        description: 'd',
+        eventSourceHost: true,
+    })
+
+    it('maps eventSources onto ConfigPkg, defaulting order to 0', () => {
+        const cp = contributor('cards')
+        expect(cp.eventSources).toEqual([
+            {
+                target: 'calendar',
+                id: 'cards-due',
+                label: 'Card due dates',
+                module: 'calendar-source',
+                order: 0,
+            },
+        ])
+        expect(cp.eventSourceHost).toBe(false)
+        expect(host.eventSourceHost).toBe(true)
+    })
+
+    it('accepts a source targeting a present host', () => {
+        expect(() => validateEventSources([host, contributor('cards')])).not.toThrow()
+    })
+
+    it('tolerates a source targeting an absent host (partial checkout)', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        try {
+            expect(() => validateEventSources([contributor('cards')])).not.toThrow()
+            expect(warn).toHaveBeenCalledWith(
+                expect.stringMatching(/not installed in this workspace/)
+            )
+        } finally {
+            warn.mockRestore()
+        }
+    })
+
+    it('rejects a source targeting a present package that is not a host', () => {
+        const nonHost = manifestToConfigPkg('@tinycld/calendar', {
+            name: 'Calendar',
+            slug: 'calendar',
+            version: '0.1.0',
+            description: 'd',
+        })
+        expect(() => validateEventSources([nonHost, contributor('cards')])).toThrow(
+            /does not declare eventSourceHost/
+        )
+    })
+
+    it('rejects an id outside [a-z0-9-]', () => {
+        expect(() =>
+            validateEventSources([host, contributor('cards', [source({ id: 'Cards:Due' })])])
+        ).toThrow(/must match \[a-z0-9-\]\+/)
+    })
+
+    it('rejects a duplicate (target, id) across contributors', () => {
+        expect(() =>
+            validateEventSources([host, contributor('cards'), contributor('tasks')])
+        ).toThrow(/declared by both 'cards' and 'tasks'/)
     })
 })
 

--- a/scripts/__tests__/gen-automation.test.ts
+++ b/scripts/__tests__/gen-automation.test.ts
@@ -46,6 +46,32 @@ describe('loadAutomationDefs', () => {
             /no '\.\/automation' entry/
         )
     })
+
+    it('throws when the module has no default export', async () => {
+        const dir = makePkg(
+            { './automation': './tinycld/fake/automation.js' },
+            { 'tinycld/fake/automation.js': 'export const x = 1\n' }
+        )
+        await expect(loadAutomationDefs(dir, '@tinycld/fake', 'automation')).rejects.toThrow(
+            /default-export/i
+        )
+    })
+
+    it('throws naming the entry when the exports map value is a conditional-exports object', async () => {
+        const dir = makePkg({}, {})
+        // makePkg only accepts string exports values; overwrite package.json
+        // directly to exercise the conditional-exports (object entry) shape.
+        fs.writeFileSync(
+            path.join(dir, 'package.json'),
+            JSON.stringify({
+                name: '@tinycld/fake',
+                exports: { './automation': { import: './tinycld/fake/automation.js' } },
+            })
+        )
+        await expect(loadAutomationDefs(dir, '@tinycld/fake', 'automation')).rejects.toThrow(
+            /'\.\/automation'.*not a plain string/
+        )
+    })
 })
 
 describe('mergeAutomationDefs', () => {

--- a/scripts/__tests__/gen-automation.test.ts
+++ b/scripts/__tests__/gen-automation.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { loadAutomationDefs, mergeAutomationDefs } from '../gen-automation'
+
+const tmpDirs: string[] = []
+afterEach(() => {
+    for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true })
+})
+
+function makePkg(exportsMap: Record<string, string>, files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gen-automation-'))
+    tmpDirs.push(dir)
+    fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ name: '@tinycld/fake', exports: exportsMap })
+    )
+    for (const [rel, content] of Object.entries(files)) {
+        const abs = path.join(dir, rel)
+        fs.mkdirSync(path.dirname(abs), { recursive: true })
+        fs.writeFileSync(abs, content)
+    }
+    return dir
+}
+
+describe('loadAutomationDefs', () => {
+    it('resolves the subpath through the exports map and imports the module', async () => {
+        // .js fixture on purpose: vitest's transform pipeline doesn't cover a
+        // dynamic import of a bare .ts file in tmpdir. Production targets are
+        // .ts and load fine because the generator runs under tsx.
+        const dir = makePkg(
+            { './automation': './tinycld/fake/automation.js' },
+            {
+                'tinycld/fake/automation.js':
+                    "export default { triggers: [{ id: 'thing-created', label: 'A thing is created', collection: 'fake_things', on: 'create' }] }\n",
+            }
+        )
+        const defs = await loadAutomationDefs(dir, '@tinycld/fake', 'automation')
+        expect(defs.triggers?.[0]?.id).toBe('thing-created')
+    })
+
+    it('throws a clear error when the exports map lacks the subpath', async () => {
+        const dir = makePkg({}, {})
+        await expect(loadAutomationDefs(dir, '@tinycld/fake', 'automation')).rejects.toThrow(
+            /no '\.\/automation' entry/
+        )
+    })
+})
+
+describe('mergeAutomationDefs', () => {
+    it('puts core first and validates every package', () => {
+        const merged = mergeAutomationDefs([
+            {
+                slug: 'mail',
+                defs: {
+                    triggers: [
+                        {
+                            id: 'message-received',
+                            label: 'A message arrives',
+                            collection: 'mail_messages',
+                            on: 'create',
+                        },
+                    ],
+                },
+            },
+        ])
+        expect(merged.packages[0].slug).toBe('core')
+        expect(merged.packages[0].triggers.map(t => t.id)).toEqual(['schedule', 'manual'])
+        expect(merged.packages[1].slug).toBe('mail')
+    })
+
+    it('throws when a feature declares a synthetic trigger', () => {
+        expect(() =>
+            mergeAutomationDefs([
+                {
+                    slug: 'mail',
+                    defs: { triggers: [{ id: 'x', label: 'x', synthetic: 'schedule' }] },
+                },
+            ])
+        ).toThrow(/synthetic/)
+    })
+})

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -13,6 +13,8 @@ const contacts: ConfigPkg = {
     systemSettings: [],
     slots: [],
     sidebarContributions: [],
+    eventSources: [],
+    eventSourceHost: false,
     manifest: { name: 'Contacts', slug: 'contacts', version: '0.1.0', description: 'd' },
 }
 const takeout: ConfigPkg = {
@@ -27,6 +29,8 @@ const takeout: ConfigPkg = {
     systemSettings: [],
     slots: [],
     sidebarContributions: [],
+    eventSources: [],
+    eventSourceHost: false,
     manifest: {
         name: 'Takeout',
         slug: 'google-takeout-import',
@@ -105,6 +109,8 @@ describe('buildConfigSource', () => {
             systemSettings: [],
             slots: [],
             sidebarContributions: [],
+            eventSources: [],
+            eventSourceHost: false,
             manifest: { name: 'Drive', slug: 'drive', version: '0.1.0', description: 'd' },
         }
         const src = buildConfigSource([withProvider])
@@ -126,6 +132,8 @@ describe('buildConfigSource', () => {
             systemSettings: [],
             slots: [],
             sidebarContributions: [],
+            eventSources: [],
+            eventSourceHost: false,
             manifest: { name: 'Mail', slug: 'mail', version: '0.1.0', description: 'd' },
         }
         const src = buildConfigSource([contacts, mail])
@@ -188,6 +196,55 @@ describe('buildConfigSource', () => {
         expect(src).toContain(
             "Component: lazy(() => import('@tinycld/calendar-slots/sidebar-contributions/booking-pages'))"
         )
+    })
+
+    it('emits eventSources with a bare load thunk, never lazy()', () => {
+        const cardsPkg: ConfigPkg = {
+            ...contacts,
+            packageName: '@tinycld/cards',
+            slug: 'cards',
+            schemaType: '',
+            hasRegister: false,
+            hasSidebar: false,
+            hasSeed: false,
+            eventSources: [
+                {
+                    target: 'calendar',
+                    id: 'cards-due',
+                    label: 'Card due dates',
+                    module: 'calendar-source',
+                    color: 'graphite',
+                    order: 0,
+                },
+            ],
+            manifest: { name: 'Cards', slug: 'cards', version: '0.1.0', description: 'd' },
+        }
+        const src = buildConfigSource([cardsPkg])
+        expect(src).toContain('eventSources: [')
+        expect(src).toContain(
+            'target: "calendar", id: "cards-due", label: "Card due dates", color: "graphite", order: 0'
+        )
+        // A bare thunk: the module exports a hook, so React.lazy cannot wrap it.
+        expect(src).toContain("load: () => import('@tinycld/cards/calendar-source')")
+        expect(src).not.toContain("lazy(() => import('@tinycld/cards/calendar-source'))")
+        // An event source alone must not pull in the react lazy import.
+        expect(src).not.toContain("import { lazy } from 'react'")
+    })
+
+    it('rejects an eventSource module subpath containing a quote', () => {
+        const bad: ConfigPkg = {
+            ...takeout,
+            eventSources: [
+                {
+                    target: 'calendar',
+                    id: 'x',
+                    label: 'X',
+                    module: "calendar-source')//",
+                    order: 0,
+                },
+            ],
+        }
+        expect(() => buildConfigSource([bad])).toThrow(/unsafe value/)
     })
 })
 

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -246,6 +246,18 @@ describe('buildConfigSource', () => {
         }
         expect(() => buildConfigSource([bad])).toThrow(/unsafe value/)
     })
+
+    it('imports and attaches automation definitions when declared', () => {
+        const withAutomation: ConfigPkg = { ...contacts, automation: 'automation' }
+        const src = buildConfigSource([withAutomation])
+        expect(src).toContain("import contactsAutomation from '@tinycld/contacts/automation'")
+        expect(src).toContain('automation: contactsAutomation,')
+    })
+
+    it('omits automation entirely when not declared', () => {
+        const src = buildConfigSource([contacts])
+        expect(src).not.toContain('automation')
+    })
 })
 
 describe('buildSeedsSource', () => {

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -256,7 +256,8 @@ describe('buildConfigSource', () => {
 
     it('omits automation entirely when not declared', () => {
         const src = buildConfigSource([contacts])
-        expect(src).not.toContain('automation')
+        expect(src).not.toContain('automation:')
+        expect(src).not.toContain('Automation from')
     })
 })
 

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -44,6 +44,15 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
             order: c.order ?? 0,
         })),
         ...(manifest.search ? { search: manifest.search } : {}),
+        eventSources: (manifest.eventSources ?? []).map(s => ({
+            target: s.target,
+            id: s.id,
+            label: s.label,
+            module: s.module,
+            ...(s.color ? { color: s.color } : {}),
+            order: s.order ?? 0,
+        })),
+        eventSourceHost: Boolean(manifest.eventSourceHost),
         manifest: {
             name: manifest.name,
             slug: manifest.slug,
@@ -92,6 +101,52 @@ export function validateNavShortcuts(pkgs: ConfigPkg[]): void {
  * (normal for a partial checkout — the contribution just won't appear). A
  * contribution targeting a present package's UNKNOWN slot is a build error.
  */
+/**
+ * Cross-package validation for event-source contributions. An absent target is
+ * tolerated with a warning (partial checkout — the source is silently
+ * inactive); a PRESENT target that does not declare `eventSourceHost: true` is
+ * a build error (version drift should fail fast, not render nothing). Source
+ * ids are embedded in `:`-delimited synthetic event ids by the host, so they
+ * are restricted to [a-z0-9-], and (target, id) must be unique across the
+ * workspace or two sources' items would collide.
+ */
+export function validateEventSources(pkgs: ConfigPkg[]): void {
+    const hostBySlug = new Map<string, boolean>()
+    for (const p of pkgs) {
+        hostBySlug.set(p.slug, p.eventSourceHost)
+    }
+    const seen = new Map<string, string>()
+    for (const p of pkgs) {
+        for (const s of p.eventSources) {
+            if (!/^[a-z0-9-]+$/.test(s.id)) {
+                throw new Error(
+                    `[generate] ${p.slug}: eventSource id '${s.id}' is invalid — ids are embedded in synthetic event ids and must match [a-z0-9-]+`
+                )
+            }
+            const key = `${s.target}:${s.id}`
+            const existing = seen.get(key)
+            if (existing) {
+                throw new Error(
+                    `[generate] eventSource id '${s.id}' targeting '${s.target}' is declared by both '${existing}' and '${p.slug}' — (target, id) must be unique`
+                )
+            }
+            seen.set(key, p.slug)
+            const host = hostBySlug.get(s.target)
+            if (host === undefined) {
+                console.warn(
+                    `[generate] ${p.slug}: eventSource targets '${s.target}' which is not installed in this workspace — source will be silently inactive`
+                )
+                continue
+            }
+            if (!host) {
+                throw new Error(
+                    `[generate] ${p.slug}: eventSource targets '${s.target}', which does not declare eventSourceHost: true. Upgrade '${s.target}' to a version that hosts event sources or drop the contribution.`
+                )
+            }
+        }
+    }
+}
+
 export function validateSidebarContributions(pkgs: ConfigPkg[]): void {
     const slotsByTarget = new Map<string, Set<string>>()
     for (const p of pkgs) {

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -44,6 +44,7 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
             order: c.order ?? 0,
         })),
         ...(manifest.search ? { search: manifest.search } : {}),
+        ...(manifest.automation ? { automation: manifest.automation.definitions } : {}),
         eventSources: (manifest.eventSources ?? []).map(s => ({
             target: s.target,
             id: s.id,

--- a/scripts/gen-automation.ts
+++ b/scripts/gen-automation.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { CORE_AUTOMATION, CORE_PKG_SLUG } from '../core/lib/automation/core-defs'
+import { validateDefinitions } from '../core/lib/automation/schemas'
+import type { ActionDef, AutomationDefinitions, TriggerDef } from '../core/lib/automation/types'
+import { SERVER_DIR } from './paths'
+
+export interface MergedAutomation {
+    packages: { slug: string; triggers: TriggerDef[]; actions: ActionDef[] }[]
+}
+
+// Resolve an exports-map subpath to a file and import it, the same way tsx
+// lets loadManifest import member TS directly. We read package.json ourselves
+// (rather than createRequire) so the error names the missing entry precisely.
+export async function loadAutomationDefs(
+    packageDir: string,
+    packageName: string,
+    subpath: string
+): Promise<AutomationDefinitions> {
+    const pkgJsonPath = path.join(packageDir, 'package.json')
+    const exportsMap = (JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).exports ?? {}) as Record<
+        string,
+        string
+    >
+    const rel = exportsMap[`./${subpath}`]
+    if (!rel) {
+        throw new Error(
+            `[generate] ${packageName}: manifest declares automation definitions '${subpath}' but package.json exports has no './${subpath}' entry`
+        )
+    }
+    const mod = await import(pathToFileURL(path.join(packageDir, rel)).href)
+    return mod.default as AutomationDefinitions
+}
+
+export function mergeAutomationDefs(
+    features: { slug: string; defs: AutomationDefinitions }[]
+): MergedAutomation {
+    const errors = [
+        ...validateDefinitions(CORE_PKG_SLUG, CORE_AUTOMATION, { allowSynthetic: true }),
+        ...features.flatMap(f => validateDefinitions(f.slug, f.defs)),
+    ]
+    if (errors.length > 0) {
+        throw new Error(`[generate] invalid automation definitions:\n  ${errors.join('\n  ')}`)
+    }
+    const sorted = [...features].sort((a, b) => a.slug.localeCompare(b.slug))
+    return {
+        packages: [
+            {
+                slug: CORE_PKG_SLUG,
+                triggers: CORE_AUTOMATION.triggers ?? [],
+                actions: CORE_AUTOMATION.actions ?? [],
+            },
+            ...sorted.map(f => ({
+                slug: f.slug,
+                triggers: f.defs.triggers ?? [],
+                actions: f.defs.actions ?? [],
+            })),
+        ],
+    }
+}
+
+// Materialized for the Go engine (Phase 2 input) — same idiom as the caldav
+// manifest block: TS is the authoring format, the server consumes JSON.
+export function emitAutomationDefs(merged: MergedAutomation): void {
+    fs.writeFileSync(
+        path.join(SERVER_DIR, 'automation_defs.json'),
+        `${JSON.stringify(merged, null, 4)}\n`
+    )
+}

--- a/scripts/gen-automation.ts
+++ b/scripts/gen-automation.ts
@@ -21,7 +21,7 @@ export async function loadAutomationDefs(
     const pkgJsonPath = path.join(packageDir, 'package.json')
     const exportsMap = (JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).exports ?? {}) as Record<
         string,
-        string
+        string | Record<string, unknown>
     >
     const rel = exportsMap[`./${subpath}`]
     if (!rel) {
@@ -29,7 +29,17 @@ export async function loadAutomationDefs(
             `[generate] ${packageName}: manifest declares automation definitions '${subpath}' but package.json exports has no './${subpath}' entry`
         )
     }
+    if (typeof rel !== 'string') {
+        throw new Error(
+            `[generate] ${packageName}: exports entry './${subpath}' is not a plain string (conditional exports are unsupported here)`
+        )
+    }
     const mod = await import(pathToFileURL(path.join(packageDir, rel)).href)
+    if (!mod.default) {
+        throw new Error(
+            `[generate] ${packageName}: module '${rel}' must default-export an AutomationDefinitions object`
+        )
+    }
     return mod.default as AutomationDefinitions
 }
 

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -44,6 +44,7 @@ export interface ConfigPkg {
     slots: string[]
     sidebarContributions: ConfigSidebarContribution[]
     search?: ConfigSearch
+    automation?: string // exports subpath to the AutomationDefinitions module
     eventSources: ConfigEventSource[]
     eventSourceHost: boolean
     manifest: { name: string; slug: string; version: string; description: string } & Record<
@@ -78,6 +79,7 @@ function validateConfigPkg(p: ConfigPkg): void {
         assertSafeImportField('sidebarContributions[].component', c.component)
     }
     if (p.search) assertSafeImportField('search.adapter', p.search.adapter)
+    if (p.automation) assertSafeImportField('automation', p.automation)
     for (const s of p.eventSources) assertSafeImportField('eventSources[].module', s.module)
 }
 
@@ -122,6 +124,9 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
                 `import { registerCollections as ${ident(p.slug)}Register } from '${p.packageName}/collections'`
             )
             lines.push(`import type { ${p.schemaType} } from '${p.packageName}/types'`)
+        }
+        if (p.automation) {
+            lines.push(`import ${ident(p.slug)}Automation from '${p.packageName}/${p.automation}'`)
         }
     }
 
@@ -176,6 +181,7 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
             lines.push('        },')
         }
         pushEventSourceLines(lines, p)
+        if (p.automation) lines.push(`        automation: ${ident(p.slug)}Automation,`)
         lines.push('    }),')
     }
     lines.push('] as const')

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -22,6 +22,15 @@ export interface ConfigSearch {
     label?: string
 }
 
+export interface ConfigEventSource {
+    target: string
+    id: string
+    label: string
+    module: string // package-exports subpath e.g. 'calendar-source'
+    color?: string
+    order: number
+}
+
 export interface ConfigPkg {
     packageName: string
     slug: string
@@ -35,6 +44,8 @@ export interface ConfigPkg {
     slots: string[]
     sidebarContributions: ConfigSidebarContribution[]
     search?: ConfigSearch
+    eventSources: ConfigEventSource[]
+    eventSourceHost: boolean
     manifest: { name: string; slug: string; version: string; description: string } & Record<
         string,
         unknown
@@ -67,6 +78,20 @@ function validateConfigPkg(p: ConfigPkg): void {
         assertSafeImportField('sidebarContributions[].component', c.component)
     }
     if (p.search) assertSafeImportField('search.adapter', p.search.adapter)
+    for (const s of p.eventSources) assertSafeImportField('eventSources[].module', s.module)
+}
+
+function pushEventSourceLines(lines: string[], p: ConfigPkg): void {
+    if (p.eventSources.length === 0) return
+    lines.push('        eventSources: [')
+    for (const s of p.eventSources) {
+        // Same bare-thunk rationale as search: the module exports a hook.
+        const color = s.color ? ` color: ${jsonLiteral(s.color)},` : ''
+        lines.push(
+            `            { target: ${jsonLiteral(s.target)}, id: ${jsonLiteral(s.id)}, label: ${jsonLiteral(s.label)},${color} order: ${s.order}, load: () => import('${p.packageName}/${s.module}') },`
+        )
+    }
+    lines.push('        ],')
 }
 
 export function buildConfigSource(pkgs: ConfigPkg[]): string {
@@ -150,6 +175,7 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
             lines.push(`            load: () => import('${p.packageName}/${p.search.adapter}'),`)
             lines.push('        },')
         }
+        pushEventSourceLines(lines, p)
         lines.push('    }),')
     }
     lines.push('] as const')

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -639,7 +639,7 @@ async function main() {
     )
     emitAutomationDefs(mergeAutomationDefs(automationFeatures))
 
-    // --- 1b. @tinycld/app-generated package manifest -----------------------
+    // --- 1c. @tinycld/app-generated package manifest -----------------------
     // Makes lib/generated/ a real, name-resolvable package so `@tinycld/app-generated/*`
     // resolves by name (via the node_modules/@tinycld/app-generated symlink that
     // link-members.ts creates) — no consumer tsconfig `paths` entry required. The

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -8,6 +8,7 @@ import {
     validateNavShortcuts,
     validateSidebarContributions,
 } from './describe-packages'
+import { emitAutomationDefs, loadAutomationDefs, mergeAutomationDefs } from './gen-automation'
 import { type BuildPkg, runPackageBuilds } from './gen-build'
 import {
     buildCliExtensionsSource,
@@ -626,6 +627,17 @@ async function main() {
     validateNavShortcuts(configPkgs)
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.config.ts'), buildConfigSource(configPkgs))
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.seeds.ts'), buildSeedsSource(configPkgs))
+
+    // --- 1b. automation definitions → server/automation_defs.json ----------
+    const automationFeatures = await Promise.all(
+        features
+            .filter(f => f.manifest.automation)
+            .map(async f => ({
+                slug: f.manifest.slug,
+                defs: await loadAutomationDefs(f.dir, f.name, f.manifest.automation!.definitions),
+            }))
+    )
+    emitAutomationDefs(mergeAutomationDefs(automationFeatures))
 
     // --- 1b. @tinycld/app-generated package manifest -----------------------
     // Makes lib/generated/ a real, name-resolvable package so `@tinycld/app-generated/*`

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path'
 import { getPackages } from '../../tinycld.packages'
 import {
     manifestToConfigPkg,
+    validateEventSources,
     validateNavShortcuts,
     validateSidebarContributions,
 } from './describe-packages'
@@ -621,6 +622,7 @@ async function main() {
     // --- 1. tinycld.config.ts + tinycld.seeds.ts (at app root) -------------
     const configPkgs: ConfigPkg[] = features.map(f => manifestToConfigPkg(f.name, f.manifest))
     validateSidebarContributions(configPkgs)
+    validateEventSources(configPkgs)
     validateNavShortcuts(configPkgs)
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.config.ts'), buildConfigSource(configPkgs))
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.seeds.ts'), buildSeedsSource(configPkgs))

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -122,6 +122,20 @@ export interface PackageManifest {
     }
     help?: { directory: string }
     search?: { adapter: string; label?: string }
+    // Read-only event feeds this package contributes to another package's
+    // event grid (today: the calendar). `module` is a package-exports subpath
+    // to a module exporting `useEventSource` — see the PackageManifest doc in
+    // core/lib/packages/types.ts.
+    eventSources?: {
+        target: string
+        id: string
+        label: string
+        module: string
+        color?: string
+        order?: number
+    }[]
+    // Declares this package hosts event-source contributions.
+    eventSourceHost?: boolean
     repository?: { url: string; issueTemplate?: string }
     dependencies?: string[]
     // Semver ranges this version requires of other packages / @tinycld/core,

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -122,6 +122,9 @@ export interface PackageManifest {
     }
     help?: { directory: string }
     search?: { adapter: string; label?: string }
+    // Workflow-rules catalog: exports subpath to the package's
+    // AutomationDefinitions module. See core/lib/packages/types.ts.
+    automation?: { definitions: string }
     // Read-only event feeds this package contributes to another package's
     // event grid (today: the calendar). `module` is a package-exports subpath
     // to a module exporting `useEventSource` — see the PackageManifest doc in


### PR DESCRIPTION
Four core changes the cards comment editor needs, stacked on the editor-images branch:

- `deriveToolbarState` now maps `isEmpty` from the WebView bridge (drives Send gating on native; was always `undefined`).
- `MarkdownRenderer`: optional `imageMaxHeight` (scales images down for compact surfaces via a new `CappedImage`), and the library's hardcoded opaque `#fff`/`#000` FlatList background is forced transparent — it painted over anything a caller's negative margin pulled it across.
- Shortcuts provider (web): `inInput` is decided from the key event's target instead of `document.activeElement` — React flushes the editor's blur/unmount while Escape is still bubbling, so the peek closed on the first press an editor had already handled.
- `ResponsiveToolbar`: item widths are measured before the fitting loop; the lazy in-loop measurement left overflowed items uncached and could strand the whole row invisible.

Each fix carries a unit test where the behavior is testable (`derive-toolbar-state.test.ts`, `input-key-event.test.ts`).