### PR TITLE
Event-source contribution kind: packages feed read-only events to a host grid

### DIFF
--- a/core/lib/event-sources/__tests__/registry.test.ts
+++ b/core/lib/event-sources/__tests__/registry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createEventSourceLoader, deriveEventSources } from '../registry'
+import type { EventSourceModule } from '../types'
+
+const load = () => Promise.resolve({})
+
+describe('deriveEventSources', () => {
+    it('groups by target, sorted by order then contributor slug', () => {
+        const derived = deriveEventSources([
+            {
+                manifest: { slug: 'tasks' },
+                eventSources: [
+                    { target: 'calendar', id: 'tasks-due', label: 'Tasks', order: 0, load },
+                ],
+            },
+            {
+                manifest: { slug: 'cards' },
+                eventSources: [
+                    { target: 'calendar', id: 'cards-due', label: 'Cards', order: 0, load },
+                    { target: 'timeline', id: 'cards-activity', label: 'Cards', order: 5, load },
+                ],
+            },
+            { manifest: { slug: 'contacts' } },
+        ])
+        expect(Object.keys(derived).sort()).toEqual(['calendar', 'timeline'])
+        expect(derived.calendar.map(s => s.id)).toEqual(['cards-due', 'tasks-due'])
+        expect(derived.timeline[0]).toMatchObject({
+            contributorSlug: 'cards',
+            id: 'cards-activity',
+            order: 5,
+        })
+    })
+
+    it('sorts by order before contributor slug', () => {
+        const derived = deriveEventSources([
+            {
+                manifest: { slug: 'aaa' },
+                eventSources: [{ target: 'calendar', id: 'late', label: 'L', order: 9, load }],
+            },
+            {
+                manifest: { slug: 'zzz' },
+                eventSources: [{ target: 'calendar', id: 'early', label: 'E', order: 1, load }],
+            },
+        ])
+        expect(derived.calendar.map(s => s.id)).toEqual(['early', 'late'])
+    })
+})
+
+describe('createEventSourceLoader', () => {
+    const module: EventSourceModule = {
+        useEventSource: () => ({ items: [], isLoading: false }),
+    }
+
+    it('loads a registered module once and caches it', async () => {
+        const loadSpy = vi.fn().mockResolvedValue(module)
+        const loader = createEventSourceLoader({
+            calendar: [
+                { contributorSlug: 'cards', id: 'cards-due', label: 'C', order: 0, load: loadSpy },
+            ],
+        })
+        const first = await loader('calendar', 'cards-due')
+        const second = await loader('calendar', 'cards-due')
+        expect(first).toBe(module)
+        expect(second).toBe(module)
+        expect(loadSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns null for an unregistered source', async () => {
+        const loader = createEventSourceLoader({})
+        expect(await loader('calendar', 'cards-due')).toBeNull()
+    })
+
+    it('returns null when the module lacks a useEventSource function', async () => {
+        const loader = createEventSourceLoader({
+            calendar: [
+                {
+                    contributorSlug: 'cards',
+                    id: 'cards-due',
+                    label: 'C',
+                    order: 0,
+                    load: () => Promise.resolve({ somethingElse: true }),
+                },
+            ],
+        })
+        expect(await loader('calendar', 'cards-due')).toBeNull()
+    })
+})

--- a/core/lib/event-sources/registry.ts
+++ b/core/lib/event-sources/registry.ts
@@ -1,0 +1,84 @@
+import { tinycldConfig } from '@tinycld/app-generated/tinycld-config'
+import type { EventSourceModule } from './types'
+
+type EventSourceEntryLike = {
+    manifest: { slug: string }
+    eventSources?: {
+        target: string
+        id: string
+        label: string
+        color?: string
+        order: number
+        load: () => Promise<unknown>
+    }[]
+}
+
+export interface RegisteredEventSource {
+    contributorSlug: string
+    id: string
+    label: string
+    color?: string
+    order: number
+    load: () => Promise<unknown>
+}
+
+/** target slug → sources sorted by order, ties broken by contributor slug. */
+export function deriveEventSources(
+    entries: readonly EventSourceEntryLike[]
+): Record<string, RegisteredEventSource[]> {
+    const byTarget: Record<string, RegisteredEventSource[]> = {}
+    for (const e of entries) {
+        for (const s of e.eventSources ?? []) {
+            byTarget[s.target] ??= []
+            byTarget[s.target].push({
+                contributorSlug: e.manifest.slug,
+                id: s.id,
+                label: s.label,
+                ...(s.color ? { color: s.color } : {}),
+                order: s.order,
+                load: s.load,
+            })
+        }
+    }
+    for (const list of Object.values(byTarget)) {
+        list.sort((a, b) => a.order - b.order || a.contributorSlug.localeCompare(b.contributorSlug))
+    }
+    return byTarget
+}
+
+export const packageEventSources = deriveEventSources(
+    tinycldConfig as readonly EventSourceEntryLike[]
+)
+
+/**
+ * Build a module loader over a source table. Split from the module-level
+ * binding so tests can exercise caching and the malformed-module path with
+ * fake loaders.
+ */
+export function createEventSourceLoader(sources: Record<string, RegisteredEventSource[]>) {
+    // Modules are cached after first load so a host re-mounting its collectors
+    // (every screen visit) does not re-import per mount.
+    const cache = new Map<string, EventSourceModule>()
+    /**
+     * Resolve a registered source's module. Returns null when no such source
+     * is registered for the target or the module does not export a
+     * `useEventSource` function — the host treats null as "source inactive",
+     * never an error.
+     */
+    return async function loadEventSourceModule(
+        target: string,
+        id: string
+    ): Promise<EventSourceModule | null> {
+        const key = `${target}:${id}`
+        const cached = cache.get(key)
+        if (cached) return cached
+        const source = sources[target]?.find(s => s.id === id)
+        if (!source) return null
+        const mod = (await source.load()) as EventSourceModule
+        if (typeof mod?.useEventSource !== 'function') return null
+        cache.set(key, mod)
+        return mod
+    }
+}
+
+export const loadEventSourceModule = createEventSourceLoader(packageEventSources)

--- a/core/lib/event-sources/types.ts
+++ b/core/lib/event-sources/types.ts
@@ -1,0 +1,37 @@
+import type { Href } from 'expo-router'
+
+export interface EventSourceRange {
+    start: Date
+    end: Date
+}
+
+/** One read-only item a source contributes to a host's event grid. */
+export interface EventSourceItem {
+    /** Unique within the source — typically the backing record's id. */
+    id: string
+    title: string
+    /** ISO datetime. For allDay items: local midnight of the day. */
+    start: string
+    /** ISO datetime. For allDay items: local end of the day. */
+    end: string
+    allDay: boolean
+    /** Where a press navigates — already org-scoped (built with useOrgHref). */
+    href: Href
+}
+
+/**
+ * The shape an `eventSources` manifest entry's `module` must export.
+ *
+ * The host mounts one collector component per source and calls this hook
+ * unconditionally on every render of that collector, so it must obey the
+ * rules of hooks — a live query (useOrgLiveQuery) is the expected
+ * implementation. Items are read-only on the host grid: no drag, no edit;
+ * a press navigates to `href`. The hook must import only @tinycld/core and
+ * its own package (lean shell: the host may be absent).
+ */
+export interface EventSourceModule {
+    useEventSource: (range: EventSourceRange) => {
+        items: EventSourceItem[]
+        isLoading: boolean
+    }
+}

--- a/core/lib/event-sources/use-event-source-module.ts
+++ b/core/lib/event-sources/use-event-source-module.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+import { loadEventSourceModule } from './registry'
+import type { EventSourceModule } from './types'
+
+/**
+ * Resolve a registered event source's module for rendering. Null while the
+ * dynamic import is pending and forever when the source is unregistered or
+ * malformed. Hosts must NOT call `module.useEventSource` conditionally on
+ * this settling — mount a child component once the module is non-null, so
+ * the hook call is unconditional for that component's entire lifetime
+ * (see SearchPalette's PackageActions for the pattern and the crash it avoids).
+ */
+export function useEventSourceModule(target: string, id: string): EventSourceModule | null {
+    const { data } = useQuery({
+        queryKey: ['event-source-module', target, id],
+        queryFn: () => loadEventSourceModule(target, id),
+        staleTime: Number.POSITIVE_INFINITY,
+    })
+    return data ?? null
+}

--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -36,6 +36,17 @@ export interface SidebarContribution {
     order: number
     Component: ComponentType | LazyExoticComponent<ComponentType>
 }
+// A read-only event feed contributed to another package's event grid. `load`
+// is a bare thunk (not React.lazy) because the module exports a HOOK
+// (`useEventSource`) — see core/lib/event-sources/types.ts for the contract.
+export interface PackageEventSource {
+    target: string
+    id: string
+    label: string
+    color?: string
+    order: number
+    load: () => Promise<unknown>
+}
 export interface SeedContext {
     // Single-org: package seeds own data by the user id directly (the former
     // org/userOrg junction is gone; the `role` enum lives on the user record).
@@ -81,6 +92,7 @@ export interface PackageEntry<S extends SchemaDeclaration, R> {
         label?: string
         load: () => Promise<unknown>
     }
+    eventSources?: PackageEventSource[]
     seed?: (pb: PocketBase, ctx: SeedContext) => Promise<void>
 }
 
@@ -104,6 +116,7 @@ export function definePackageEntry<S extends SchemaDeclaration>() {
         systemSettings?: PackageEntry<S, R>['systemSettings']
         sidebarContributions?: PackageEntry<S, R>['sidebarContributions']
         search?: PackageEntry<S, R>['search']
+        eventSources?: PackageEntry<S, R>['eventSources']
         seed?: PackageEntry<S, R>['seed']
     }): PackageEntry<S, R> => entry as unknown as PackageEntry<S, R>
 }

--- a/core/lib/packages/types.ts
+++ b/core/lib/packages/types.ts
@@ -84,6 +84,35 @@ export interface PackageManifest {
         order?: number
     }[]
 
+    /**
+     * Read-only event feeds this package contributes to another package's
+     * event grid (today: the calendar). `target` is the host package slug —
+     * the host must declare `eventSourceHost: true` or generation fails;
+     * an absent host leaves the source silently inactive (lean shell).
+     * `id` is unique per target and restricted to `[a-z0-9-]` (the host embeds
+     * it in `:`-delimited synthetic event ids). `module` is a package-exports
+     * subpath to a module exporting `useEventSource` — see
+     * `core/lib/event-sources/types.ts` for the contract. Items are read-only
+     * on the host grid: no drag, no edit; a press navigates to the item's
+     * `href`. `color` names a calendar color key the host resolves.
+     */
+    eventSources?: {
+        target: string
+        id: string
+        label: string
+        module: string
+        color?: string
+        order?: number
+    }[]
+
+    /**
+     * Declares this package hosts event-source contributions: it mounts the
+     * collectors, merges contributed items into its grid, and renders the
+     * per-source visibility toggles. Contributions targeting a package
+     * without this flag fail generation.
+     */
+    eventSourceHost?: boolean
+
     seed?: {
         script: string
     }

--- a/scripts/__tests__/describe-packages.test.ts
+++ b/scripts/__tests__/describe-packages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
     manifestToConfigPkg,
     schemaTypeName,
+    validateEventSources,
     validateNavShortcuts,
     validateSidebarContributions,
 } from '../describe-packages'
@@ -157,6 +158,88 @@ describe('validateSidebarContributions', () => {
         } finally {
             warn.mockRestore()
         }
+    })
+})
+
+describe('validateEventSources', () => {
+    const source = (overrides: Partial<{ target: string; id: string }> = {}) => ({
+        target: 'calendar',
+        id: 'cards-due',
+        label: 'Card due dates',
+        module: 'calendar-source',
+        ...overrides,
+    })
+
+    const contributor = (slug: string, sources = [source()]) =>
+        manifestToConfigPkg(`@tinycld/${slug}`, {
+            name: slug,
+            slug,
+            version: '0.1.0',
+            description: 'd',
+            eventSources: sources,
+        })
+
+    const host = manifestToConfigPkg('@tinycld/calendar', {
+        name: 'Calendar',
+        slug: 'calendar',
+        version: '0.1.0',
+        description: 'd',
+        eventSourceHost: true,
+    })
+
+    it('maps eventSources onto ConfigPkg, defaulting order to 0', () => {
+        const cp = contributor('cards')
+        expect(cp.eventSources).toEqual([
+            {
+                target: 'calendar',
+                id: 'cards-due',
+                label: 'Card due dates',
+                module: 'calendar-source',
+                order: 0,
+            },
+        ])
+        expect(cp.eventSourceHost).toBe(false)
+        expect(host.eventSourceHost).toBe(true)
+    })
+
+    it('accepts a source targeting a present host', () => {
+        expect(() => validateEventSources([host, contributor('cards')])).not.toThrow()
+    })
+
+    it('tolerates a source targeting an absent host (partial checkout)', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        try {
+            expect(() => validateEventSources([contributor('cards')])).not.toThrow()
+            expect(warn).toHaveBeenCalledWith(
+                expect.stringMatching(/not installed in this workspace/)
+            )
+        } finally {
+            warn.mockRestore()
+        }
+    })
+
+    it('rejects a source targeting a present package that is not a host', () => {
+        const nonHost = manifestToConfigPkg('@tinycld/calendar', {
+            name: 'Calendar',
+            slug: 'calendar',
+            version: '0.1.0',
+            description: 'd',
+        })
+        expect(() => validateEventSources([nonHost, contributor('cards')])).toThrow(
+            /does not declare eventSourceHost/
+        )
+    })
+
+    it('rejects an id outside [a-z0-9-]', () => {
+        expect(() =>
+            validateEventSources([host, contributor('cards', [source({ id: 'Cards:Due' })])])
+        ).toThrow(/must match \[a-z0-9-\]\+/)
+    })
+
+    it('rejects a duplicate (target, id) across contributors', () => {
+        expect(() =>
+            validateEventSources([host, contributor('cards'), contributor('tasks')])
+        ).toThrow(/declared by both 'cards' and 'tasks'/)
     })
 })
 

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -13,6 +13,8 @@ const contacts: ConfigPkg = {
     systemSettings: [],
     slots: [],
     sidebarContributions: [],
+    eventSources: [],
+    eventSourceHost: false,
     manifest: { name: 'Contacts', slug: 'contacts', version: '0.1.0', description: 'd' },
 }
 const takeout: ConfigPkg = {
@@ -27,6 +29,8 @@ const takeout: ConfigPkg = {
     systemSettings: [],
     slots: [],
     sidebarContributions: [],
+    eventSources: [],
+    eventSourceHost: false,
     manifest: {
         name: 'Takeout',
         slug: 'google-takeout-import',
@@ -105,6 +109,8 @@ describe('buildConfigSource', () => {
             systemSettings: [],
             slots: [],
             sidebarContributions: [],
+            eventSources: [],
+            eventSourceHost: false,
             manifest: { name: 'Drive', slug: 'drive', version: '0.1.0', description: 'd' },
         }
         const src = buildConfigSource([withProvider])
@@ -126,6 +132,8 @@ describe('buildConfigSource', () => {
             systemSettings: [],
             slots: [],
             sidebarContributions: [],
+            eventSources: [],
+            eventSourceHost: false,
             manifest: { name: 'Mail', slug: 'mail', version: '0.1.0', description: 'd' },
         }
         const src = buildConfigSource([contacts, mail])
@@ -188,6 +196,55 @@ describe('buildConfigSource', () => {
         expect(src).toContain(
             "Component: lazy(() => import('@tinycld/calendar-slots/sidebar-contributions/booking-pages'))"
         )
+    })
+
+    it('emits eventSources with a bare load thunk, never lazy()', () => {
+        const cardsPkg: ConfigPkg = {
+            ...contacts,
+            packageName: '@tinycld/cards',
+            slug: 'cards',
+            schemaType: '',
+            hasRegister: false,
+            hasSidebar: false,
+            hasSeed: false,
+            eventSources: [
+                {
+                    target: 'calendar',
+                    id: 'cards-due',
+                    label: 'Card due dates',
+                    module: 'calendar-source',
+                    color: 'graphite',
+                    order: 0,
+                },
+            ],
+            manifest: { name: 'Cards', slug: 'cards', version: '0.1.0', description: 'd' },
+        }
+        const src = buildConfigSource([cardsPkg])
+        expect(src).toContain('eventSources: [')
+        expect(src).toContain(
+            'target: "calendar", id: "cards-due", label: "Card due dates", color: "graphite", order: 0'
+        )
+        // A bare thunk: the module exports a hook, so React.lazy cannot wrap it.
+        expect(src).toContain("load: () => import('@tinycld/cards/calendar-source')")
+        expect(src).not.toContain("lazy(() => import('@tinycld/cards/calendar-source'))")
+        // An event source alone must not pull in the react lazy import.
+        expect(src).not.toContain("import { lazy } from 'react'")
+    })
+
+    it('rejects an eventSource module subpath containing a quote', () => {
+        const bad: ConfigPkg = {
+            ...takeout,
+            eventSources: [
+                {
+                    target: 'calendar',
+                    id: 'x',
+                    label: 'X',
+                    module: "calendar-source')//",
+                    order: 0,
+                },
+            ],
+        }
+        expect(() => buildConfigSource([bad])).toThrow(/unsafe value/)
     })
 })
 

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -44,6 +44,15 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
             order: c.order ?? 0,
         })),
         ...(manifest.search ? { search: manifest.search } : {}),
+        eventSources: (manifest.eventSources ?? []).map(s => ({
+            target: s.target,
+            id: s.id,
+            label: s.label,
+            module: s.module,
+            ...(s.color ? { color: s.color } : {}),
+            order: s.order ?? 0,
+        })),
+        eventSourceHost: Boolean(manifest.eventSourceHost),
         manifest: {
             name: manifest.name,
             slug: manifest.slug,
@@ -92,6 +101,52 @@ export function validateNavShortcuts(pkgs: ConfigPkg[]): void {
  * (normal for a partial checkout — the contribution just won't appear). A
  * contribution targeting a present package's UNKNOWN slot is a build error.
  */
+/**
+ * Cross-package validation for event-source contributions. An absent target is
+ * tolerated with a warning (partial checkout — the source is silently
+ * inactive); a PRESENT target that does not declare `eventSourceHost: true` is
+ * a build error (version drift should fail fast, not render nothing). Source
+ * ids are embedded in `:`-delimited synthetic event ids by the host, so they
+ * are restricted to [a-z0-9-], and (target, id) must be unique across the
+ * workspace or two sources' items would collide.
+ */
+export function validateEventSources(pkgs: ConfigPkg[]): void {
+    const hostBySlug = new Map<string, boolean>()
+    for (const p of pkgs) {
+        hostBySlug.set(p.slug, p.eventSourceHost)
+    }
+    const seen = new Map<string, string>()
+    for (const p of pkgs) {
+        for (const s of p.eventSources) {
+            if (!/^[a-z0-9-]+$/.test(s.id)) {
+                throw new Error(
+                    `[generate] ${p.slug}: eventSource id '${s.id}' is invalid — ids are embedded in synthetic event ids and must match [a-z0-9-]+`
+                )
+            }
+            const key = `${s.target}:${s.id}`
+            const existing = seen.get(key)
+            if (existing) {
+                throw new Error(
+                    `[generate] eventSource id '${s.id}' targeting '${s.target}' is declared by both '${existing}' and '${p.slug}' — (target, id) must be unique`
+                )
+            }
+            seen.set(key, p.slug)
+            const host = hostBySlug.get(s.target)
+            if (host === undefined) {
+                console.warn(
+                    `[generate] ${p.slug}: eventSource targets '${s.target}' which is not installed in this workspace — source will be silently inactive`
+                )
+                continue
+            }
+            if (!host) {
+                throw new Error(
+                    `[generate] ${p.slug}: eventSource targets '${s.target}', which does not declare eventSourceHost: true. Upgrade '${s.target}' to a version that hosts event sources or drop the contribution.`
+                )
+            }
+        }
+    }
+}
+
 export function validateSidebarContributions(pkgs: ConfigPkg[]): void {
     const slotsByTarget = new Map<string, Set<string>>()
     for (const p of pkgs) {

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -22,6 +22,15 @@ export interface ConfigSearch {
     label?: string
 }
 
+export interface ConfigEventSource {
+    target: string
+    id: string
+    label: string
+    module: string // package-exports subpath e.g. 'calendar-source'
+    color?: string
+    order: number
+}
+
 export interface ConfigPkg {
     packageName: string
     slug: string
@@ -35,6 +44,8 @@ export interface ConfigPkg {
     slots: string[]
     sidebarContributions: ConfigSidebarContribution[]
     search?: ConfigSearch
+    eventSources: ConfigEventSource[]
+    eventSourceHost: boolean
     manifest: { name: string; slug: string; version: string; description: string } & Record<
         string,
         unknown
@@ -67,6 +78,20 @@ function validateConfigPkg(p: ConfigPkg): void {
         assertSafeImportField('sidebarContributions[].component', c.component)
     }
     if (p.search) assertSafeImportField('search.adapter', p.search.adapter)
+    for (const s of p.eventSources) assertSafeImportField('eventSources[].module', s.module)
+}
+
+function pushEventSourceLines(lines: string[], p: ConfigPkg): void {
+    if (p.eventSources.length === 0) return
+    lines.push('        eventSources: [')
+    for (const s of p.eventSources) {
+        // Same bare-thunk rationale as search: the module exports a hook.
+        const color = s.color ? ` color: ${jsonLiteral(s.color)},` : ''
+        lines.push(
+            `            { target: ${jsonLiteral(s.target)}, id: ${jsonLiteral(s.id)}, label: ${jsonLiteral(s.label)},${color} order: ${s.order}, load: () => import('${p.packageName}/${s.module}') },`
+        )
+    }
+    lines.push('        ],')
 }
 
 export function buildConfigSource(pkgs: ConfigPkg[]): string {
@@ -150,6 +175,7 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
             lines.push(`            load: () => import('${p.packageName}/${p.search.adapter}'),`)
             lines.push('        },')
         }
+        pushEventSourceLines(lines, p)
         lines.push('    }),')
     }
     lines.push('] as const')

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path'
 import { getPackages } from '../../tinycld.packages'
 import {
     manifestToConfigPkg,
+    validateEventSources,
     validateNavShortcuts,
     validateSidebarContributions,
 } from './describe-packages'
@@ -621,6 +622,7 @@ async function main() {
     // --- 1. tinycld.config.ts + tinycld.seeds.ts (at app root) -------------
     const configPkgs: ConfigPkg[] = features.map(f => manifestToConfigPkg(f.name, f.manifest))
     validateSidebarContributions(configPkgs)
+    validateEventSources(configPkgs)
     validateNavShortcuts(configPkgs)
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.config.ts'), buildConfigSource(configPkgs))
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.seeds.ts'), buildSeedsSource(configPkgs))

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -122,6 +122,20 @@ export interface PackageManifest {
     }
     help?: { directory: string }
     search?: { adapter: string; label?: string }
+    // Read-only event feeds this package contributes to another package's
+    // event grid (today: the calendar). `module` is a package-exports subpath
+    // to a module exporting `useEventSource` — see the PackageManifest doc in
+    // core/lib/packages/types.ts.
+    eventSources?: {
+        target: string
+        id: string
+        label: string
+        module: string
+        color?: string
+        order?: number
+    }[]
+    // Declares this package hosts event-source contributions.
+    eventSourceHost?: boolean
     repository?: { url: string; issueTemplate?: string }
     dependencies?: string[]
     // Semver ranges this version requires of other packages / @tinycld/core,


### PR DESCRIPTION
Adds a generic `eventSources` / `eventSourceHost` manifest contribution kind, wired through the same generator layers as `sidebarContributions`, plus `core/lib/event-sources/` (contract types, registry with cached module loader, `useEventSourceModule`).

- Generated config emits a bare `load` thunk (the module exports a hook — same rationale as the `search` block).
- Generation fails fast on a present-but-non-host target, duplicate `(target, id)`, or an id outside `[a-z0-9-]`; an absent target warns and stays inert (lean shell).
- Covered by describe-packages/gen-config test extensions and a new registry suite.

First host is calendar (event grid), first contributor is cards (due dates) — each lands in its own repo.