### PR TITLE
feat(automation): workflow rules declaration pipeline (phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ server/pb_test_releases/
 /server/bundled-packages.json
 /server/pb_migrations_owner.json
 /server/pb_migrations/
+/server/automation_defs.json
 /server/pb_hooks/
 /server/tinycld
 /server/app

--- a/core/lib/automation/__tests__/core-defs.test.ts
+++ b/core/lib/automation/__tests__/core-defs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { CORE_AUTOMATION, CORE_PKG_SLUG } from '../core-defs'
+import { validateDefinitions } from '../schemas'
+
+describe('CORE_AUTOMATION', () => {
+    it('is a valid definition set (synthetic triggers allowed for core)', () => {
+        expect(
+            validateDefinitions(CORE_PKG_SLUG, CORE_AUTOMATION, { allowSynthetic: true })
+        ).toEqual([])
+    })
+
+    it('declares the built-in triggers and actions from the spec', () => {
+        const triggerIds = (CORE_AUTOMATION.triggers ?? []).map(t => t.id)
+        const actionIds = (CORE_AUTOMATION.actions ?? []).map(a => a.id)
+        expect(triggerIds).toEqual(['schedule', 'manual'])
+        expect(actionIds).toEqual(['apply-label', 'notify'])
+    })
+
+    it('apply-label writes a polymorphic label_assignments record from context', () => {
+        const applyLabel = (CORE_AUTOMATION.actions ?? []).find(a => a.id === 'apply-label')
+        expect(applyLabel).toMatchObject({
+            kind: 'record-op',
+            collection: 'label_assignments',
+            op: {
+                type: 'create',
+                set: {
+                    label: { param: 'label' },
+                    record_id: { context: 'record-id' },
+                    collection: { context: 'collection' },
+                    user: { context: 'owner' },
+                },
+            },
+        })
+    })
+})

--- a/core/lib/automation/__tests__/helpers.test.ts
+++ b/core/lib/automation/__tests__/helpers.test.ts
@@ -39,10 +39,10 @@ describe('operator sets', () => {
         ])
     })
 
-    it('every operator appears in ALL_OPS exactly once', () => {
-        const flattened = Object.values(OPERATORS_BY_TYPE).flat()
-        expect(new Set(flattened).size).toBe(flattened.length)
-        expect([...flattened].sort()).toEqual([...ALL_OPS].sort())
+    it('ALL_OPS is the deduplicated union of every type operator set', () => {
+        const unique = [...new Set(Object.values(OPERATORS_BY_TYPE).flat())]
+        expect([...ALL_OPS].sort()).toEqual(unique.sort())
+        expect(new Set(ALL_OPS).size).toBe(ALL_OPS.length)
     })
 
     it('value-less operators are exactly the is_true/is_false/is_empty set', () => {

--- a/core/lib/automation/__tests__/helpers.test.ts
+++ b/core/lib/automation/__tests__/helpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+    ALL_OPS,
+    humanizeFieldKey,
+    NO_VALUE_OPS,
+    OPERATORS_BY_TYPE,
+    parseRef,
+    qualifyRef,
+} from '../helpers'
+
+describe('humanizeFieldKey', () => {
+    it('replaces underscores and capitalizes the first letter only', () => {
+        expect(humanizeFieldKey('has_attachments')).toBe('Has attachments')
+        expect(humanizeFieldKey('subject')).toBe('Subject')
+        expect(humanizeFieldKey('sender_email')).toBe('Sender email')
+    })
+})
+
+describe('refs', () => {
+    it('round-trips a qualified ref', () => {
+        expect(qualifyRef('mail', 'message-received')).toBe('mail:message-received')
+        expect(parseRef('mail:message-received')).toEqual({ pkg: 'mail', id: 'message-received' })
+    })
+
+    it('throws on a malformed ref', () => {
+        expect(() => parseRef('no-colon')).toThrow(/malformed automation ref/)
+    })
+})
+
+describe('operator sets', () => {
+    it('covers every field type', () => {
+        expect(Object.keys(OPERATORS_BY_TYPE).sort()).toEqual([
+            'boolean',
+            'date',
+            'number',
+            'relation',
+            'select',
+            'text',
+        ])
+    })
+
+    it('every operator appears in ALL_OPS exactly once', () => {
+        const flattened = Object.values(OPERATORS_BY_TYPE).flat()
+        expect(new Set(flattened).size).toBe(flattened.length)
+        expect([...flattened].sort()).toEqual([...ALL_OPS].sort())
+    })
+
+    it('value-less operators are exactly the is_true/is_false/is_empty set', () => {
+        expect([...NO_VALUE_OPS].sort()).toEqual(['is_empty', 'is_false', 'is_true'])
+    })
+})

--- a/core/lib/automation/__tests__/schemas.test.ts
+++ b/core/lib/automation/__tests__/schemas.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { conditionsAstSchema, ruleActionsSchema, validateDefinitions } from '../schemas'
+import type { AutomationDefinitions } from '../types'
+
+const validAst = {
+    match: 'all',
+    groups: [
+        {
+            match: 'any',
+            conditions: [
+                { field: 'sender_email', op: 'contains', value: '@acme.com' },
+                { field: 'sender_email', op: 'contains', value: '@example.com' },
+            ],
+        },
+        { match: 'all', conditions: [{ field: 'has_attachments', op: 'is_true' }] },
+    ],
+}
+
+describe('conditionsAstSchema', () => {
+    it('accepts the spec example AST', () => {
+        expect(conditionsAstSchema.safeParse(validAst).success).toBe(true)
+    })
+
+    it('accepts an empty groups array (rule with no conditions)', () => {
+        expect(conditionsAstSchema.safeParse({ match: 'all', groups: [] }).success).toBe(true)
+    })
+
+    it('rejects an unknown operator', () => {
+        const bad = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'regex', value: 'y' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+
+    it('rejects a value-carrying op with no value', () => {
+        const bad = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'contains' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+
+    it('accepts a value-less op with no value', () => {
+        const ok = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'is_empty' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(ok).success).toBe(true)
+    })
+
+    it('rejects a group with zero conditions', () => {
+        const bad = { match: 'all', groups: [{ match: 'any', conditions: [] }] }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+})
+
+describe('ruleActionsSchema', () => {
+    it('accepts an ordered action list with qualified refs', () => {
+        const ok = [
+            { ref: 'mail:move-to-folder', params: { folder: 'abc123def456ghi' } },
+            { ref: 'core:apply-label', params: { label: 'abc123def456ghi' } },
+        ]
+        expect(ruleActionsSchema.safeParse(ok).success).toBe(true)
+    })
+
+    it('rejects an unqualified ref and an empty list', () => {
+        expect(ruleActionsSchema.safeParse([{ ref: 'move-to-folder', params: {} }]).success).toBe(
+            false
+        )
+        expect(ruleActionsSchema.safeParse([]).success).toBe(false)
+    })
+
+    it('defaults params to an empty object', () => {
+        const parsed = ruleActionsSchema.parse([{ ref: 'core:notify' }])
+        expect(parsed[0].params).toEqual({})
+    })
+})
+
+describe('validateDefinitions', () => {
+    const good: AutomationDefinitions = {
+        triggers: [
+            {
+                id: 'message-received',
+                label: 'A message arrives',
+                collection: 'mail_messages',
+                on: 'create',
+            },
+        ],
+        actions: [
+            {
+                id: 'move-to-folder',
+                label: 'Move to folder',
+                kind: 'record-op',
+                collection: 'mail_messages',
+                op: {
+                    type: 'update',
+                    target: 'trigger-record',
+                    set: { alias: { param: 'alias' } },
+                },
+                params: [{ key: 'alias', field: 'alias' }],
+            },
+        ],
+    }
+
+    it('returns no errors for a valid definition set', () => {
+        expect(validateDefinitions('mail', good)).toEqual([])
+    })
+
+    it('rejects malformed and duplicate ids', () => {
+        const dup: AutomationDefinitions = {
+            triggers: [
+                { id: 'Same_Id', label: 'x', collection: 'c', on: 'create' },
+                { id: 'Same_Id', label: 'y', collection: 'c', on: 'create' },
+            ],
+        }
+        const errors = validateDefinitions('mail', dup)
+        expect(errors.some(e => e.includes('kebab-case'))).toBe(true)
+        expect(errors.some(e => e.includes('duplicate'))).toBe(true)
+    })
+
+    it('rejects synthetic triggers outside core', () => {
+        const synthetic: AutomationDefinitions = {
+            triggers: [{ id: 'schedule', label: 'On a schedule', synthetic: 'schedule' }],
+        }
+        expect(validateDefinitions('mail', synthetic).some(e => e.includes('synthetic'))).toBe(true)
+        expect(validateDefinitions('core', synthetic, { allowSynthetic: true })).toEqual([])
+    })
+
+    it('rejects a record-op whose set references an undeclared param', () => {
+        const bad: AutomationDefinitions = {
+            actions: [
+                {
+                    id: 'move',
+                    label: 'Move',
+                    kind: 'record-op',
+                    collection: 'c',
+                    op: {
+                        type: 'update',
+                        target: 'trigger-record',
+                        set: { folder: { param: 'missing' } },
+                    },
+                    params: [],
+                },
+            ],
+        }
+        expect(validateDefinitions('mail', bad).some(e => e.includes('missing'))).toBe(true)
+    })
+})

--- a/core/lib/automation/__tests__/schemas.test.ts
+++ b/core/lib/automation/__tests__/schemas.test.ts
@@ -49,6 +49,14 @@ describe('conditionsAstSchema', () => {
         expect(conditionsAstSchema.safeParse(ok).success).toBe(true)
     })
 
+    it('rejects a value-less op that carries a stray value', () => {
+        const bad = {
+            match: 'all',
+            groups: [{ match: 'any', conditions: [{ field: 'x', op: 'is_empty', value: 'junk' }] }],
+        }
+        expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
+    })
+
     it('rejects a group with zero conditions', () => {
         const bad = { match: 'all', groups: [{ match: 'any', conditions: [] }] }
         expect(conditionsAstSchema.safeParse(bad).success).toBe(false)
@@ -125,6 +133,38 @@ describe('validateDefinitions', () => {
         }
         expect(validateDefinitions('mail', synthetic).some(e => e.includes('synthetic'))).toBe(true)
         expect(validateDefinitions('core', synthetic, { allowSynthetic: true })).toEqual([])
+    })
+
+    it('rejects a watch clause on a non-update trigger', () => {
+        const bad: AutomationDefinitions = {
+            triggers: [
+                {
+                    id: 'thing-created',
+                    label: 'A thing is created',
+                    collection: 'things',
+                    on: 'create',
+                    watch: ['status'],
+                },
+            ],
+        }
+        expect(validateDefinitions('mail', bad).some(e => e.includes('declares watch'))).toBe(true)
+    })
+
+    it('rejects an empty fields list on a trigger', () => {
+        const bad: AutomationDefinitions = {
+            triggers: [
+                {
+                    id: 'message-received',
+                    label: 'A message arrives',
+                    collection: 'mail_messages',
+                    on: 'create',
+                    fields: [],
+                },
+            ],
+        }
+        expect(validateDefinitions('mail', bad).some(e => e.includes('empty fields list'))).toBe(
+            true
+        )
     })
 
     it('rejects a record-op whose set references an undeclared param', () => {

--- a/core/lib/automation/core-defs.ts
+++ b/core/lib/automation/core-defs.ts
@@ -1,0 +1,41 @@
+import type { AutomationDefinitions } from './types'
+
+export const CORE_PKG_SLUG = 'core'
+
+// Core's own trigger/action catalog. Typed loosely (no schema generic): core's
+// collections are part of the base Schema, and this module must not import the
+// generated pbSchema to stay usable in the generator's node context.
+export const CORE_AUTOMATION: AutomationDefinitions = {
+    triggers: [
+        { id: 'schedule', label: 'On a schedule', synthetic: 'schedule' },
+        { id: 'manual', label: 'Run manually', synthetic: 'manual' },
+    ],
+    actions: [
+        {
+            id: 'apply-label',
+            label: 'Apply label',
+            kind: 'record-op',
+            collection: 'label_assignments',
+            op: {
+                type: 'create',
+                set: {
+                    label: { param: 'label' },
+                    record_id: { context: 'record-id' },
+                    collection: { context: 'collection' },
+                    user: { context: 'owner' },
+                },
+            },
+            params: [{ key: 'label', field: 'label' }],
+        },
+        {
+            id: 'notify',
+            label: 'Send me a notification',
+            kind: 'native',
+            params: [
+                { key: 'title', type: 'text' },
+                { key: 'body', type: 'text' },
+                { key: 'url', type: 'text', label: 'Link (optional)' },
+            ],
+        },
+    ],
+}

--- a/core/lib/automation/helpers.ts
+++ b/core/lib/automation/helpers.ts
@@ -6,10 +6,10 @@ export const OPERATORS_BY_TYPE: Record<FieldType, readonly ConditionOp[]> = {
     boolean: ['is_true', 'is_false'],
     date: ['before', 'after', 'within_last_days'],
     relation: ['is', 'is_not', 'is_empty'],
-    select: [],
+    select: ['is', 'is_not'],
 }
 
-export const ALL_OPS: readonly ConditionOp[] = Object.values(OPERATORS_BY_TYPE).flat()
+export const ALL_OPS: readonly ConditionOp[] = [...new Set(Object.values(OPERATORS_BY_TYPE).flat())]
 
 export const NO_VALUE_OPS: ReadonlySet<ConditionOp> = new Set(['is_true', 'is_false', 'is_empty'])
 

--- a/core/lib/automation/helpers.ts
+++ b/core/lib/automation/helpers.ts
@@ -1,0 +1,31 @@
+import type { ConditionOp, FieldType } from './types'
+
+export const OPERATORS_BY_TYPE: Record<FieldType, readonly ConditionOp[]> = {
+    text: ['contains', 'not_contains', 'equals', 'starts_with'],
+    number: ['eq', 'neq', 'gt', 'lt'],
+    boolean: ['is_true', 'is_false'],
+    date: ['before', 'after', 'within_last_days'],
+    relation: ['is', 'is_not', 'is_empty'],
+    select: [],
+}
+
+export const ALL_OPS: readonly ConditionOp[] = Object.values(OPERATORS_BY_TYPE).flat()
+
+export const NO_VALUE_OPS: ReadonlySet<ConditionOp> = new Set(['is_true', 'is_false', 'is_empty'])
+
+export function humanizeFieldKey(key: string): string {
+    const spaced = key.replace(/_/g, ' ')
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+export function qualifyRef(pkgSlug: string, id: string): string {
+    return `${pkgSlug}:${id}`
+}
+
+export function parseRef(ref: string): { pkg: string; id: string } {
+    const idx = ref.indexOf(':')
+    if (idx <= 0 || idx === ref.length - 1) {
+        throw new Error(`malformed automation ref: '${ref}'`)
+    }
+    return { pkg: ref.slice(0, idx), id: ref.slice(idx + 1) }
+}

--- a/core/lib/automation/schemas.ts
+++ b/core/lib/automation/schemas.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod'
+import { ALL_OPS, NO_VALUE_OPS } from './helpers'
+import type { AutomationDefinitions, ConditionOp } from './types'
+
+const ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+const REF_RE = /^[a-z0-9-]+:[a-z0-9-]+$/
+
+export const conditionSchema = z
+    .object({
+        field: z.string().min(1),
+        op: z.enum(ALL_OPS as [ConditionOp, ...ConditionOp[]]),
+        value: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    })
+    .superRefine((c, ctx) => {
+        if (!NO_VALUE_OPS.has(c.op) && c.value === undefined) {
+            ctx.addIssue({ code: 'custom', message: `operator '${c.op}' requires a value` })
+        }
+    })
+
+export const conditionGroupSchema = z.object({
+    match: z.enum(['all', 'any']),
+    conditions: z.array(conditionSchema).min(1),
+})
+
+// One level of grouping by construction: groups contain conditions, never
+// other groups (spec: condition AST).
+export const conditionsAstSchema = z.object({
+    match: z.enum(['all', 'any']),
+    groups: z.array(conditionGroupSchema),
+})
+
+export const ruleActionSchema = z.object({
+    ref: z.string().regex(REF_RE, 'action ref must be qualified as <pkg>:<id>'),
+    params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).default({}),
+})
+
+export const ruleActionsSchema = z.array(ruleActionSchema).min(1)
+
+function checkId(errors: string[], pkgSlug: string, what: string, id: string, seen: Set<string>) {
+    if (!ID_RE.test(id)) {
+        errors.push(`${pkgSlug}: ${what} id '${id}' must be kebab-case ([a-z0-9-])`)
+    }
+    if (seen.has(id)) errors.push(`${pkgSlug}: duplicate ${what} id '${id}'`)
+    seen.add(id)
+}
+
+/**
+ * Structural validation of a package's automation definitions. Collection and
+ * column EXISTENCE is not checked here — the package's own typecheck enforces
+ * it at compile time, and Phase 2's Go resolution re-checks at runtime.
+ */
+export function validateDefinitions(
+    pkgSlug: string,
+    defs: AutomationDefinitions,
+    opts: { allowSynthetic?: boolean } = {}
+): string[] {
+    const errors: string[] = []
+    const triggerIds = new Set<string>()
+    for (const t of defs.triggers ?? []) {
+        checkId(errors, pkgSlug, 'trigger', t.id, triggerIds)
+        if ('synthetic' in t) {
+            if (!opts.allowSynthetic) {
+                errors.push(
+                    `${pkgSlug}: trigger '${t.id}' is synthetic — only core may declare synthetic triggers`
+                )
+            }
+        } else if (!t.collection) {
+            errors.push(`${pkgSlug}: trigger '${t.id}' has no collection`)
+        }
+    }
+    const actionIds = new Set<string>()
+    for (const a of defs.actions ?? []) {
+        checkId(errors, pkgSlug, 'action', a.id, actionIds)
+        const paramKeys = new Set<string>()
+        for (const p of a.params ?? []) {
+            if (paramKeys.has(p.key))
+                errors.push(`${pkgSlug}: action '${a.id}' duplicate param '${p.key}'`)
+            paramKeys.add(p.key)
+        }
+        if (a.kind === 'record-op') {
+            if (!a.collection)
+                errors.push(`${pkgSlug}: record-op action '${a.id}' has no collection`)
+            if (a.op.type !== 'delete') {
+                for (const v of Object.values(a.op.set)) {
+                    if (
+                        typeof v === 'object' &&
+                        v !== null &&
+                        'param' in v &&
+                        !paramKeys.has(v.param)
+                    ) {
+                        errors.push(
+                            `${pkgSlug}: action '${a.id}' set references undeclared param '${v.param}'`
+                        )
+                    }
+                }
+            }
+        }
+    }
+    return errors
+}

--- a/core/lib/automation/schemas.ts
+++ b/core/lib/automation/schemas.ts
@@ -15,6 +15,9 @@ export const conditionSchema = z
         if (!NO_VALUE_OPS.has(c.op) && c.value === undefined) {
             ctx.addIssue({ code: 'custom', message: `operator '${c.op}' requires a value` })
         }
+        if (NO_VALUE_OPS.has(c.op) && c.value !== undefined) {
+            ctx.addIssue({ code: 'custom', message: `operator '${c.op}' takes no value` })
+        }
     })
 
 export const conditionGroupSchema = z.object({
@@ -64,8 +67,20 @@ export function validateDefinitions(
                     `${pkgSlug}: trigger '${t.id}' is synthetic — only core may declare synthetic triggers`
                 )
             }
-        } else if (!t.collection) {
-            errors.push(`${pkgSlug}: trigger '${t.id}' has no collection`)
+        } else {
+            if (!t.collection) {
+                errors.push(`${pkgSlug}: trigger '${t.id}' has no collection`)
+            }
+            if (t.watch && t.on !== 'update') {
+                errors.push(
+                    `${pkgSlug}: trigger '${t.id}' declares watch but is not an update trigger`
+                )
+            }
+            if (t.fields && t.fields.length === 0) {
+                errors.push(
+                    `${pkgSlug}: trigger '${t.id}' has an empty fields list — omit fields to expose all columns`
+                )
+            }
         }
     }
     const actionIds = new Set<string>()

--- a/core/lib/automation/types.ts
+++ b/core/lib/automation/types.ts
@@ -1,0 +1,122 @@
+// Authoring types for a package's automation.ts (pure data, spec:
+// docs/superpowers/specs/2026-08-11-workflow-rules-design.md). The S generic is
+// the package's generated schema map ({ collection: { type, relations } }), so
+// collection and field references are compile-checked in the package.
+
+export type FieldType = 'text' | 'number' | 'boolean' | 'date' | 'select' | 'relation'
+
+export type ConditionOp =
+    | 'contains'
+    | 'not_contains'
+    | 'equals'
+    | 'starts_with'
+    | 'eq'
+    | 'neq'
+    | 'gt'
+    | 'lt'
+    | 'is_true'
+    | 'is_false'
+    | 'before'
+    | 'after'
+    | 'within_last_days'
+    | 'is'
+    | 'is_not'
+    | 'is_empty'
+
+type AnySchema = Record<string, { type: Record<string, unknown> }>
+type CollectionsOf<S> = keyof S & string
+type FieldsOf<S, C extends keyof S> = S[C] extends { type: infer T } ? keyof T & string : string
+
+/** A trigger field entry: bare column key, or key + display-label override. */
+export type FieldRef<F extends string = string> = F | { key: F; label: string }
+
+export interface RecordTriggerDefBase<C extends string, F extends string> {
+    id: string
+    label: string
+    collection: C
+    on: 'create' | 'update' | 'delete'
+    /** update triggers only: fire only when one of these columns changed */
+    watch?: F[]
+    /** omitted = expose every schema column (see spec: contract rules) */
+    fields?: FieldRef<F>[]
+    /** override the auto-detected user/owner/author owner column */
+    ownerField?: F
+}
+
+export type RecordTriggerDef<S = AnySchema> = {
+    [C in CollectionsOf<S>]: RecordTriggerDefBase<C, FieldsOf<S, C>>
+}[CollectionsOf<S>]
+
+/**
+ * Core-only synthetic triggers with no backing record (core:schedule,
+ * core:manual). Declared by core's own catalog; the generator rejects them in
+ * feature packages.
+ */
+export interface SyntheticTriggerDef {
+    id: string
+    label: string
+    synthetic: 'schedule' | 'manual'
+}
+
+export type TriggerDef<S = AnySchema> = RecordTriggerDef<S> | SyntheticTriggerDef
+
+/**
+ * A value written by a record-op `set` entry:
+ * - `{ param }`: the rule author supplies it (static value or template)
+ * - `{ context }`: engine-provided — the trigger record's id, its collection
+ *   name, or the executing rule's owner id
+ * - literal: fixed at declaration time
+ */
+export type SetValue =
+    | { param: string }
+    | { context: 'record-id' | 'collection' | 'owner' }
+    | string
+    | number
+    | boolean
+
+export type RecordOp<F extends string = string> =
+    | { type: 'update'; target: 'trigger-record'; set: Partial<Record<F, SetValue>> }
+    | { type: 'delete'; target: 'trigger-record' }
+    | { type: 'create'; set: Partial<Record<F, SetValue>> }
+
+/** Column-referencing param (type/relation resolved from the column in Phase 2) */
+export interface ColumnParamDef<F extends string = string> {
+    key: string
+    field: F
+    label?: string
+}
+
+/** Novel param (not a DB column) — declares its own type */
+export interface TypedParamDef {
+    key: string
+    type: FieldType
+    label?: string
+    options?: string[]
+}
+
+export type ParamDef<F extends string = string> = ColumnParamDef<F> | TypedParamDef
+
+export type RecordOpActionDef<S = AnySchema> = {
+    [C in CollectionsOf<S>]: {
+        id: string
+        label: string
+        kind: 'record-op'
+        collection: C
+        op: RecordOp<FieldsOf<S, C>>
+        params?: ParamDef<FieldsOf<S, C>>[]
+    }
+}[CollectionsOf<S>]
+
+export interface NativeActionDef {
+    id: string
+    label: string
+    kind: 'native'
+    params?: TypedParamDef[]
+}
+
+export type ActionDef<S = AnySchema> = RecordOpActionDef<S> | NativeActionDef
+
+export interface AutomationDefinitions<S = AnySchema> {
+    triggers?: TriggerDef<S>[]
+    actions?: ActionDef<S>[]
+}

--- a/core/lib/packages/__tests__/derive-automation.test.ts
+++ b/core/lib/packages/__tests__/derive-automation.test.ts
@@ -20,7 +20,7 @@ const plainEntry = { manifest: { name: 'Calc', slug: 'calc' } }
 
 describe('deriveAutomation', () => {
     it('always includes the core catalog, first', () => {
-        const catalog = deriveAutomation([] as never)
+        const catalog = deriveAutomation([])
         expect(catalog.byPackage[0].pkgSlug).toBe('core')
         expect(catalog.triggers['core:schedule']).toBeDefined()
         expect(catalog.triggers['core:manual']).toBeDefined()
@@ -29,7 +29,7 @@ describe('deriveAutomation', () => {
     })
 
     it('keys package declarations by qualified ref and skips packages without automation', () => {
-        const catalog = deriveAutomation([mailEntry, plainEntry] as never)
+        const catalog = deriveAutomation([mailEntry, plainEntry])
         expect(catalog.triggers['mail:message-received']).toMatchObject({
             pkgSlug: 'mail',
             pkgName: 'Mail',
@@ -38,7 +38,7 @@ describe('deriveAutomation', () => {
     })
 })
 
-describe('use-packages automation passthrough', () => {
+describe('PackageManifest automation field shape', () => {
     it('PackageManifest carries the raw automation pointer shape', () => {
         const manifest = {
             name: 'X',

--- a/core/lib/packages/__tests__/derive-automation.test.ts
+++ b/core/lib/packages/__tests__/derive-automation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { deriveAutomation } from '../derive-automation'
+
+const mailEntry = {
+    manifest: { name: 'Mail', slug: 'mail' },
+    automation: {
+        triggers: [
+            {
+                id: 'message-received',
+                label: 'A message arrives',
+                collection: 'mail_messages',
+                on: 'create' as const,
+            },
+        ],
+        actions: [],
+    },
+}
+const plainEntry = { manifest: { name: 'Calc', slug: 'calc' } }
+
+describe('deriveAutomation', () => {
+    it('always includes the core catalog, first', () => {
+        const catalog = deriveAutomation([] as never)
+        expect(catalog.byPackage[0].pkgSlug).toBe('core')
+        expect(catalog.triggers['core:schedule']).toBeDefined()
+        expect(catalog.triggers['core:manual']).toBeDefined()
+        expect(catalog.actions['core:apply-label']).toBeDefined()
+        expect(catalog.actions['core:notify']).toBeDefined()
+    })
+
+    it('keys package declarations by qualified ref and skips packages without automation', () => {
+        const catalog = deriveAutomation([mailEntry, plainEntry] as never)
+        expect(catalog.triggers['mail:message-received']).toMatchObject({
+            pkgSlug: 'mail',
+            pkgName: 'Mail',
+        })
+        expect(catalog.byPackage.map(p => p.pkgSlug)).toEqual(['core', 'mail'])
+    })
+})

--- a/core/lib/packages/__tests__/derive-automation.test.ts
+++ b/core/lib/packages/__tests__/derive-automation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { deriveAutomation } from '../derive-automation'
+import type { PackageManifest } from '../types'
 
 const mailEntry = {
     manifest: { name: 'Mail', slug: 'mail' },
@@ -34,5 +35,18 @@ describe('deriveAutomation', () => {
             pkgName: 'Mail',
         })
         expect(catalog.byPackage.map(p => p.pkgSlug)).toEqual(['core', 'mail'])
+    })
+})
+
+describe('use-packages automation passthrough', () => {
+    it('PackageManifest carries the raw automation pointer shape', () => {
+        const manifest = {
+            name: 'X',
+            slug: 'x',
+            version: '0.0.1',
+            description: 'd',
+            automation: { definitions: 'automation' },
+        } satisfies PackageManifest
+        expect(manifest.automation.definitions).toBe('automation')
     })
 })

--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -3,6 +3,7 @@ import type { Schema } from '@tinycld/core/types/pbSchema'
 import type { createCollection, SchemaDeclaration } from 'pbtsdb/core'
 import type PocketBase from 'pocketbase'
 import type { ComponentType, LazyExoticComponent, ReactNode } from 'react'
+import type { AutomationDefinitions } from '../automation/types'
 import type { PackageManifest } from './types'
 
 // --- Spike-2-proven helpers (see ~/code/tinycld/new/spike2/sim.ts) ----------
@@ -93,6 +94,7 @@ export interface PackageEntry<S extends SchemaDeclaration, R> {
         load: () => Promise<unknown>
     }
     eventSources?: PackageEventSource[]
+    automation?: AutomationDefinitions
     seed?: (pb: PocketBase, ctx: SeedContext) => Promise<void>
 }
 
@@ -117,6 +119,7 @@ export function definePackageEntry<S extends SchemaDeclaration>() {
         sidebarContributions?: PackageEntry<S, R>['sidebarContributions']
         search?: PackageEntry<S, R>['search']
         eventSources?: PackageEntry<S, R>['eventSources']
+        automation?: PackageEntry<S, R>['automation']
         seed?: PackageEntry<S, R>['seed']
     }): PackageEntry<S, R> => entry as unknown as PackageEntry<S, R>
 }

--- a/core/lib/packages/derive-automation.ts
+++ b/core/lib/packages/derive-automation.ts
@@ -1,0 +1,57 @@
+import { tinycldConfig } from '@tinycld/app-generated/tinycld-config'
+import { CORE_AUTOMATION, CORE_PKG_SLUG } from '../automation/core-defs'
+import { qualifyRef } from '../automation/helpers'
+import type { ActionDef, AutomationDefinitions, TriggerDef } from '../automation/types'
+
+export interface CatalogTrigger {
+    pkgSlug: string
+    pkgName: string
+    def: TriggerDef
+}
+export interface CatalogAction {
+    pkgSlug: string
+    pkgName: string
+    def: ActionDef
+}
+export interface AutomationPackageGroup {
+    pkgSlug: string
+    pkgName: string
+    triggers: TriggerDef[]
+    actions: ActionDef[]
+}
+export interface AutomationCatalog {
+    triggers: Record<string, CatalogTrigger>
+    actions: Record<string, CatalogAction>
+    byPackage: AutomationPackageGroup[]
+}
+
+type AutomationEntryLike = {
+    manifest: { name: string; slug: string }
+    automation?: AutomationDefinitions
+}
+
+/** Ref-keyed trigger/action catalogs; core built-ins always present, first. */
+export function deriveAutomation(entries: readonly AutomationEntryLike[]): AutomationCatalog {
+    const catalog: AutomationCatalog = { triggers: {}, actions: {}, byPackage: [] }
+    const sources: { pkgSlug: string; pkgName: string; defs: AutomationDefinitions }[] = [
+        { pkgSlug: CORE_PKG_SLUG, pkgName: 'Core', defs: CORE_AUTOMATION },
+    ]
+    for (const e of entries) {
+        if (!e.automation) continue
+        sources.push({ pkgSlug: e.manifest.slug, pkgName: e.manifest.name, defs: e.automation })
+    }
+    for (const { pkgSlug, pkgName, defs } of sources) {
+        const triggers = defs.triggers ?? []
+        const actions = defs.actions ?? []
+        for (const def of triggers) {
+            catalog.triggers[qualifyRef(pkgSlug, def.id)] = { pkgSlug, pkgName, def }
+        }
+        for (const def of actions) {
+            catalog.actions[qualifyRef(pkgSlug, def.id)] = { pkgSlug, pkgName, def }
+        }
+        catalog.byPackage.push({ pkgSlug, pkgName, triggers, actions })
+    }
+    return catalog
+}
+
+export const packageAutomation: AutomationCatalog = deriveAutomation(tinycldConfig)

--- a/core/lib/packages/types.ts
+++ b/core/lib/packages/types.ts
@@ -273,6 +273,16 @@ export interface PackageManifest {
         label?: string
     }
 
+    /**
+     * Workflow-rules catalog. `definitions` is a package-exports subpath (like
+     * `seed.script`) resolving to a TS module default-exporting an
+     * AutomationDefinitions object — pure data, typed against the package's
+     * schema. See docs/superpowers/specs/2026-08-11-workflow-rules-design.md.
+     */
+    automation?: {
+        definitions: string
+    }
+
     repository?: {
         url: string
         issueTemplate?: string

--- a/core/lib/packages/use-packages.ts
+++ b/core/lib/packages/use-packages.ts
@@ -48,6 +48,12 @@ export function usePackages(): PackageEntry[] {
                 seed: manifest.seed,
                 tests: manifest.tests,
                 server: manifest.server,
+                // Raw manifest pointer ({ definitions: subpath }) — NOT the
+                // resolved AutomationDefinitions that static config entries
+                // carry. deriveAutomation reads only the static config today;
+                // DB-installed packages get resolved defs embedded in
+                // manifest_json in a later phase. Passed through so the field
+                // is not silently dropped (see the automation spec).
                 automation: manifest.automation,
                 repository: manifest.repository,
                 dependencies: manifest.dependencies,

--- a/core/lib/packages/use-packages.ts
+++ b/core/lib/packages/use-packages.ts
@@ -48,6 +48,7 @@ export function usePackages(): PackageEntry[] {
                 seed: manifest.seed,
                 tests: manifest.tests,
                 server: manifest.server,
+                automation: manifest.automation,
                 repository: manifest.repository,
                 dependencies: manifest.dependencies,
                 packageName: record.npm_package ?? manifest.slug,

--- a/core/lib/pocketbase.ts
+++ b/core/lib/pocketbase.ts
@@ -316,6 +316,18 @@ const notifications = newCollection('notifications', {
 })
 export const notificationsCollection = notifications
 
+const rules = newCollection('rules', {
+    omitOnInsert: ['created', 'updated'],
+    expand: { owner: users },
+    ...indexing,
+})
+
+const rule_runs = newCollection('rule_runs', {
+    omitOnInsert: ['created', 'updated'],
+    expand: { rule: rules },
+    ...indexing,
+})
+
 // NOTE: the `comment_mentions` store registration was removed in the new
 // standalone-core layout because the collection is created by a feature
 // package's migration (drive's create_comment_mentions), not core's own — so
@@ -336,6 +348,8 @@ const coreStores = {
     audit_logs,
     pkg_install_log,
     notifications,
+    rules,
+    rule_runs,
     system_settings,
     oauth_grants,
 }

--- a/core/server/pb_migrations/1990000000_create_rules.js
+++ b/core/server/pb_migrations/1990000000_create_rules.js
@@ -1,0 +1,112 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    app => {
+        const rules = new Collection({
+            id: 'pbc_rules_01',
+            name: 'rules',
+            type: 'base',
+            system: false,
+            // Personal rules: owner only. Org rules: readable by every
+            // authenticated user (so people can see why org automation touches
+            // their data) but writable only by admins/owners.
+            listRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
+            viewRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
+            createRule:
+                "@request.auth.id != '' && owner = @request.auth.id && (scope = 'personal' || @request.auth.role = 'admin' || @request.auth.role = 'owner')",
+            updateRule:
+                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            deleteRule:
+                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            fields: [
+                {
+                    id: 'rules_name',
+                    name: 'name',
+                    type: 'text',
+                    required: true,
+                    max: 200,
+                },
+                {
+                    id: 'rules_scope',
+                    name: 'scope',
+                    type: 'select',
+                    required: true,
+                    maxSelect: 1,
+                    values: ['personal', 'org'],
+                },
+                {
+                    id: 'rules_owner',
+                    name: 'owner',
+                    type: 'relation',
+                    required: true,
+                    collectionId: '_pb_users_auth_',
+                    cascadeDelete: true,
+                    maxSelect: 1,
+                },
+                {
+                    id: 'rules_trigger',
+                    name: 'trigger',
+                    type: 'text',
+                    required: true,
+                    max: 200,
+                },
+                {
+                    id: 'rules_trigger_config',
+                    name: 'trigger_config',
+                    type: 'json',
+                },
+                {
+                    id: 'rules_conditions',
+                    name: 'conditions',
+                    type: 'json',
+                },
+                {
+                    id: 'rules_actions',
+                    name: 'actions',
+                    type: 'json',
+                },
+                {
+                    id: 'rules_enabled',
+                    name: 'enabled',
+                    type: 'bool',
+                },
+                {
+                    id: 'rules_order',
+                    name: 'order',
+                    type: 'number',
+                },
+                {
+                    id: 'rules_stop_processing',
+                    name: 'stop_processing',
+                    type: 'bool',
+                },
+                {
+                    id: 'rules_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                },
+                {
+                    id: 'rules_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                },
+            ],
+            indexes: [
+                'CREATE INDEX `idx_rules_owner` ON `rules` (`owner`, `enabled`)',
+                'CREATE INDEX `idx_rules_trigger` ON `rules` (`trigger`, `enabled`)',
+            ],
+        })
+        app.save(rules)
+    },
+    app => {
+        try {
+            const c = app.findCollectionByNameOrId('rules')
+            app.delete(c)
+        } catch (e) {
+            // may not exist
+        }
+    }
+)

--- a/core/server/pb_migrations/1990000000_create_rules.js
+++ b/core/server/pb_migrations/1990000000_create_rules.js
@@ -7,16 +7,27 @@ migrate(
             type: 'base',
             system: false,
             // Personal rules: owner only. Org rules: readable by every
-            // authenticated user (so people can see why org automation touches
-            // their data) but writable only by admins/owners.
-            listRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
-            viewRule: "owner = @request.auth.id || (scope = 'org' && @request.auth.id != '')",
+            // non-guest authenticated user (so people can see why org
+            // automation touches their data) but writable only by
+            // admins/owners. Guests get neither read nor create (matches the
+            // house posture: 1870000000_exclude_guests_from_org_rls.js,
+            // 1960000000_audit_logs_admin_only.js).
+            listRule:
+                'owner = @request.auth.id || (scope = "org" && @request.auth.id != "" && @request.auth.role != "guest")',
+            viewRule:
+                'owner = @request.auth.id || (scope = "org" && @request.auth.id != "" && @request.auth.role != "guest")',
             createRule:
-                "@request.auth.id != '' && owner = @request.auth.id && (scope = 'personal' || @request.auth.role = 'admin' || @request.auth.role = 'owner')",
+                '@request.auth.id != "" && @request.auth.role != "guest" && owner = @request.auth.id && (scope = "personal" || @request.auth.role = "admin" || @request.auth.role = "owner")',
+            // Body-locked: a personal-rule owner may PATCH other fields but
+            // must not smuggle `scope`/`owner` changes into the same request
+            // (the stored-value check alone can't see the body) — otherwise a
+            // personal-rule owner could PATCH { scope: 'org' } or
+            // { owner: <other> } and escalate. Admins/owners are trusted on
+            // the org branch, so no body locks there.
             updateRule:
-                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                '(scope = "personal" && owner = @request.auth.id && (@request.body.scope:isset = false || @request.body.scope = "personal") && (@request.body.owner:isset = false || @request.body.owner = @request.auth.id)) || (scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             deleteRule:
-                "(scope = 'personal' && owner = @request.auth.id) || (scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                '(scope = "personal" && owner = @request.auth.id) || (scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             fields: [
                 {
                     id: 'rules_name',

--- a/core/server/pb_migrations/1990000001_create_rule_runs.js
+++ b/core/server/pb_migrations/1990000001_create_rule_runs.js
@@ -9,9 +9,9 @@ migrate(
             // Readable by whoever can read the rule; written only by the
             // engine (superuser DAO) — no client create/update/delete.
             listRule:
-                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                'rule.owner = @request.auth.id || (rule.scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             viewRule:
-                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+                'rule.owner = @request.auth.id || (rule.scope = "org" && (@request.auth.role = "admin" || @request.auth.role = "owner"))',
             createRule: null,
             updateRule: null,
             deleteRule: null,

--- a/core/server/pb_migrations/1990000001_create_rule_runs.js
+++ b/core/server/pb_migrations/1990000001_create_rule_runs.js
@@ -1,0 +1,89 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    app => {
+        const runs = new Collection({
+            id: 'pbc_rule_runs_01',
+            name: 'rule_runs',
+            type: 'base',
+            system: false,
+            // Readable by whoever can read the rule; written only by the
+            // engine (superuser DAO) — no client create/update/delete.
+            listRule:
+                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            viewRule:
+                "rule.owner = @request.auth.id || (rule.scope = 'org' && (@request.auth.role = 'admin' || @request.auth.role = 'owner'))",
+            createRule: null,
+            updateRule: null,
+            deleteRule: null,
+            fields: [
+                {
+                    id: 'rr_rule',
+                    name: 'rule',
+                    type: 'relation',
+                    required: true,
+                    collectionId: 'pbc_rules_01',
+                    cascadeDelete: true,
+                    maxSelect: 1,
+                },
+                {
+                    id: 'rr_fired_at',
+                    name: 'fired_at',
+                    type: 'date',
+                    required: true,
+                },
+                {
+                    id: 'rr_matched',
+                    name: 'matched',
+                    type: 'bool',
+                },
+                {
+                    id: 'rr_trigger_summary',
+                    name: 'trigger_summary',
+                    type: 'json',
+                },
+                {
+                    id: 'rr_results',
+                    name: 'results',
+                    type: 'json',
+                },
+                {
+                    id: 'rr_error',
+                    name: 'error',
+                    type: 'text',
+                    max: 2000,
+                },
+                {
+                    id: 'rr_duration_ms',
+                    name: 'duration_ms',
+                    type: 'number',
+                },
+                {
+                    id: 'rr_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                },
+                {
+                    id: 'rr_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                },
+            ],
+            indexes: [
+                'CREATE INDEX `idx_rule_runs_rule` ON `rule_runs` (`rule`, `fired_at`)',
+            ],
+        })
+        app.save(runs)
+    },
+    app => {
+        try {
+            const c = app.findCollectionByNameOrId('rule_runs')
+            app.delete(c)
+        } catch (e) {
+            // may not exist
+        }
+    }
+)

--- a/scripts/__tests__/describe-packages.test.ts
+++ b/scripts/__tests__/describe-packages.test.ts
@@ -100,6 +100,27 @@ describe('manifestToConfigPkg', () => {
             })
         ).toThrow(/duplicate slot name 'sidebar\.after-calendars'/)
     })
+
+    it('maps manifest.automation.definitions to ConfigPkg.automation', () => {
+        const pkg = manifestToConfigPkg('@tinycld/contacts', {
+            name: 'Contacts',
+            slug: 'contacts',
+            version: '0.1.0',
+            description: 'd',
+            automation: { definitions: 'automation' },
+        })
+        expect(pkg.automation).toBe('automation')
+    })
+
+    it('leaves ConfigPkg.automation undefined when the manifest has none', () => {
+        const pkg = manifestToConfigPkg('@tinycld/contacts', {
+            name: 'Contacts',
+            slug: 'contacts',
+            version: '0.1.0',
+            description: 'd',
+        })
+        expect(pkg.automation).toBeUndefined()
+    })
 })
 
 describe('validateSidebarContributions', () => {

--- a/scripts/__tests__/gen-automation.test.ts
+++ b/scripts/__tests__/gen-automation.test.ts
@@ -46,6 +46,32 @@ describe('loadAutomationDefs', () => {
             /no '\.\/automation' entry/
         )
     })
+
+    it('throws when the module has no default export', async () => {
+        const dir = makePkg(
+            { './automation': './tinycld/fake/automation.js' },
+            { 'tinycld/fake/automation.js': 'export const x = 1\n' }
+        )
+        await expect(loadAutomationDefs(dir, '@tinycld/fake', 'automation')).rejects.toThrow(
+            /default-export/i
+        )
+    })
+
+    it('throws naming the entry when the exports map value is a conditional-exports object', async () => {
+        const dir = makePkg({}, {})
+        // makePkg only accepts string exports values; overwrite package.json
+        // directly to exercise the conditional-exports (object entry) shape.
+        fs.writeFileSync(
+            path.join(dir, 'package.json'),
+            JSON.stringify({
+                name: '@tinycld/fake',
+                exports: { './automation': { import: './tinycld/fake/automation.js' } },
+            })
+        )
+        await expect(loadAutomationDefs(dir, '@tinycld/fake', 'automation')).rejects.toThrow(
+            /'\.\/automation'.*not a plain string/
+        )
+    })
 })
 
 describe('mergeAutomationDefs', () => {

--- a/scripts/__tests__/gen-automation.test.ts
+++ b/scripts/__tests__/gen-automation.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { loadAutomationDefs, mergeAutomationDefs } from '../gen-automation'
+
+const tmpDirs: string[] = []
+afterEach(() => {
+    for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true })
+})
+
+function makePkg(exportsMap: Record<string, string>, files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gen-automation-'))
+    tmpDirs.push(dir)
+    fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ name: '@tinycld/fake', exports: exportsMap })
+    )
+    for (const [rel, content] of Object.entries(files)) {
+        const abs = path.join(dir, rel)
+        fs.mkdirSync(path.dirname(abs), { recursive: true })
+        fs.writeFileSync(abs, content)
+    }
+    return dir
+}
+
+describe('loadAutomationDefs', () => {
+    it('resolves the subpath through the exports map and imports the module', async () => {
+        // .js fixture on purpose: vitest's transform pipeline doesn't cover a
+        // dynamic import of a bare .ts file in tmpdir. Production targets are
+        // .ts and load fine because the generator runs under tsx.
+        const dir = makePkg(
+            { './automation': './tinycld/fake/automation.js' },
+            {
+                'tinycld/fake/automation.js':
+                    "export default { triggers: [{ id: 'thing-created', label: 'A thing is created', collection: 'fake_things', on: 'create' }] }\n",
+            }
+        )
+        const defs = await loadAutomationDefs(dir, '@tinycld/fake', 'automation')
+        expect(defs.triggers?.[0]?.id).toBe('thing-created')
+    })
+
+    it('throws a clear error when the exports map lacks the subpath', async () => {
+        const dir = makePkg({}, {})
+        await expect(loadAutomationDefs(dir, '@tinycld/fake', 'automation')).rejects.toThrow(
+            /no '\.\/automation' entry/
+        )
+    })
+})
+
+describe('mergeAutomationDefs', () => {
+    it('puts core first and validates every package', () => {
+        const merged = mergeAutomationDefs([
+            {
+                slug: 'mail',
+                defs: {
+                    triggers: [
+                        {
+                            id: 'message-received',
+                            label: 'A message arrives',
+                            collection: 'mail_messages',
+                            on: 'create',
+                        },
+                    ],
+                },
+            },
+        ])
+        expect(merged.packages[0].slug).toBe('core')
+        expect(merged.packages[0].triggers.map(t => t.id)).toEqual(['schedule', 'manual'])
+        expect(merged.packages[1].slug).toBe('mail')
+    })
+
+    it('throws when a feature declares a synthetic trigger', () => {
+        expect(() =>
+            mergeAutomationDefs([
+                {
+                    slug: 'mail',
+                    defs: { triggers: [{ id: 'x', label: 'x', synthetic: 'schedule' }] },
+                },
+            ])
+        ).toThrow(/synthetic/)
+    })
+})

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -246,6 +246,18 @@ describe('buildConfigSource', () => {
         }
         expect(() => buildConfigSource([bad])).toThrow(/unsafe value/)
     })
+
+    it('imports and attaches automation definitions when declared', () => {
+        const withAutomation: ConfigPkg = { ...contacts, automation: 'automation' }
+        const src = buildConfigSource([withAutomation])
+        expect(src).toContain("import contactsAutomation from '@tinycld/contacts/automation'")
+        expect(src).toContain('automation: contactsAutomation,')
+    })
+
+    it('omits automation entirely when not declared', () => {
+        const src = buildConfigSource([contacts])
+        expect(src).not.toContain('automation')
+    })
 })
 
 describe('buildSeedsSource', () => {

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -256,7 +256,8 @@ describe('buildConfigSource', () => {
 
     it('omits automation entirely when not declared', () => {
         const src = buildConfigSource([contacts])
-        expect(src).not.toContain('automation')
+        expect(src).not.toContain('automation:')
+        expect(src).not.toContain('Automation from')
     })
 })
 

--- a/scripts/describe-packages.ts
+++ b/scripts/describe-packages.ts
@@ -44,6 +44,7 @@ export function manifestToConfigPkg(packageName: string, manifest: PackageManife
             order: c.order ?? 0,
         })),
         ...(manifest.search ? { search: manifest.search } : {}),
+        ...(manifest.automation ? { automation: manifest.automation.definitions } : {}),
         eventSources: (manifest.eventSources ?? []).map(s => ({
             target: s.target,
             id: s.id,

--- a/scripts/gen-automation.ts
+++ b/scripts/gen-automation.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { CORE_AUTOMATION, CORE_PKG_SLUG } from '../core/lib/automation/core-defs'
+import { validateDefinitions } from '../core/lib/automation/schemas'
+import type { ActionDef, AutomationDefinitions, TriggerDef } from '../core/lib/automation/types'
+import { SERVER_DIR } from './paths'
+
+export interface MergedAutomation {
+    packages: { slug: string; triggers: TriggerDef[]; actions: ActionDef[] }[]
+}
+
+// Resolve an exports-map subpath to a file and import it, the same way tsx
+// lets loadManifest import member TS directly. We read package.json ourselves
+// (rather than createRequire) so the error names the missing entry precisely.
+export async function loadAutomationDefs(
+    packageDir: string,
+    packageName: string,
+    subpath: string
+): Promise<AutomationDefinitions> {
+    const pkgJsonPath = path.join(packageDir, 'package.json')
+    const exportsMap = (JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).exports ?? {}) as Record<
+        string,
+        string
+    >
+    const rel = exportsMap[`./${subpath}`]
+    if (!rel) {
+        throw new Error(
+            `[generate] ${packageName}: manifest declares automation definitions '${subpath}' but package.json exports has no './${subpath}' entry`
+        )
+    }
+    const mod = await import(pathToFileURL(path.join(packageDir, rel)).href)
+    return mod.default as AutomationDefinitions
+}
+
+export function mergeAutomationDefs(
+    features: { slug: string; defs: AutomationDefinitions }[]
+): MergedAutomation {
+    const errors = [
+        ...validateDefinitions(CORE_PKG_SLUG, CORE_AUTOMATION, { allowSynthetic: true }),
+        ...features.flatMap(f => validateDefinitions(f.slug, f.defs)),
+    ]
+    if (errors.length > 0) {
+        throw new Error(`[generate] invalid automation definitions:\n  ${errors.join('\n  ')}`)
+    }
+    const sorted = [...features].sort((a, b) => a.slug.localeCompare(b.slug))
+    return {
+        packages: [
+            {
+                slug: CORE_PKG_SLUG,
+                triggers: CORE_AUTOMATION.triggers ?? [],
+                actions: CORE_AUTOMATION.actions ?? [],
+            },
+            ...sorted.map(f => ({
+                slug: f.slug,
+                triggers: f.defs.triggers ?? [],
+                actions: f.defs.actions ?? [],
+            })),
+        ],
+    }
+}
+
+// Materialized for the Go engine (Phase 2 input) — same idiom as the caldav
+// manifest block: TS is the authoring format, the server consumes JSON.
+export function emitAutomationDefs(merged: MergedAutomation): void {
+    fs.writeFileSync(
+        path.join(SERVER_DIR, 'automation_defs.json'),
+        `${JSON.stringify(merged, null, 4)}\n`
+    )
+}

--- a/scripts/gen-automation.ts
+++ b/scripts/gen-automation.ts
@@ -21,7 +21,7 @@ export async function loadAutomationDefs(
     const pkgJsonPath = path.join(packageDir, 'package.json')
     const exportsMap = (JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).exports ?? {}) as Record<
         string,
-        string
+        string | Record<string, unknown>
     >
     const rel = exportsMap[`./${subpath}`]
     if (!rel) {
@@ -29,7 +29,17 @@ export async function loadAutomationDefs(
             `[generate] ${packageName}: manifest declares automation definitions '${subpath}' but package.json exports has no './${subpath}' entry`
         )
     }
+    if (typeof rel !== 'string') {
+        throw new Error(
+            `[generate] ${packageName}: exports entry './${subpath}' is not a plain string (conditional exports are unsupported here)`
+        )
+    }
     const mod = await import(pathToFileURL(path.join(packageDir, rel)).href)
+    if (!mod.default) {
+        throw new Error(
+            `[generate] ${packageName}: module '${rel}' must default-export an AutomationDefinitions object`
+        )
+    }
     return mod.default as AutomationDefinitions
 }
 

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -44,6 +44,7 @@ export interface ConfigPkg {
     slots: string[]
     sidebarContributions: ConfigSidebarContribution[]
     search?: ConfigSearch
+    automation?: string // exports subpath to the AutomationDefinitions module
     eventSources: ConfigEventSource[]
     eventSourceHost: boolean
     manifest: { name: string; slug: string; version: string; description: string } & Record<
@@ -78,6 +79,7 @@ function validateConfigPkg(p: ConfigPkg): void {
         assertSafeImportField('sidebarContributions[].component', c.component)
     }
     if (p.search) assertSafeImportField('search.adapter', p.search.adapter)
+    if (p.automation) assertSafeImportField('automation', p.automation)
     for (const s of p.eventSources) assertSafeImportField('eventSources[].module', s.module)
 }
 
@@ -122,6 +124,9 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
                 `import { registerCollections as ${ident(p.slug)}Register } from '${p.packageName}/collections'`
             )
             lines.push(`import type { ${p.schemaType} } from '${p.packageName}/types'`)
+        }
+        if (p.automation) {
+            lines.push(`import ${ident(p.slug)}Automation from '${p.packageName}/${p.automation}'`)
         }
     }
 
@@ -176,6 +181,7 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
             lines.push('        },')
         }
         pushEventSourceLines(lines, p)
+        if (p.automation) lines.push(`        automation: ${ident(p.slug)}Automation,`)
         lines.push('    }),')
     }
     lines.push('] as const')

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -639,7 +639,7 @@ async function main() {
     )
     emitAutomationDefs(mergeAutomationDefs(automationFeatures))
 
-    // --- 1b. @tinycld/app-generated package manifest -----------------------
+    // --- 1c. @tinycld/app-generated package manifest -----------------------
     // Makes lib/generated/ a real, name-resolvable package so `@tinycld/app-generated/*`
     // resolves by name (via the node_modules/@tinycld/app-generated symlink that
     // link-members.ts creates) — no consumer tsconfig `paths` entry required. The

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -8,6 +8,7 @@ import {
     validateNavShortcuts,
     validateSidebarContributions,
 } from './describe-packages'
+import { emitAutomationDefs, loadAutomationDefs, mergeAutomationDefs } from './gen-automation'
 import { type BuildPkg, runPackageBuilds } from './gen-build'
 import {
     buildCliExtensionsSource,
@@ -626,6 +627,17 @@ async function main() {
     validateNavShortcuts(configPkgs)
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.config.ts'), buildConfigSource(configPkgs))
     fs.writeFileSync(path.join(APP_DIR, 'tinycld.seeds.ts'), buildSeedsSource(configPkgs))
+
+    // --- 1b. automation definitions → server/automation_defs.json ----------
+    const automationFeatures = await Promise.all(
+        features
+            .filter(f => f.manifest.automation)
+            .map(async f => ({
+                slug: f.manifest.slug,
+                defs: await loadAutomationDefs(f.dir, f.name, f.manifest.automation!.definitions),
+            }))
+    )
+    emitAutomationDefs(mergeAutomationDefs(automationFeatures))
 
     // --- 1b. @tinycld/app-generated package manifest -----------------------
     // Makes lib/generated/ a real, name-resolvable package so `@tinycld/app-generated/*`

--- a/scripts/load-manifest.ts
+++ b/scripts/load-manifest.ts
@@ -122,6 +122,9 @@ export interface PackageManifest {
     }
     help?: { directory: string }
     search?: { adapter: string; label?: string }
+    // Workflow-rules catalog: exports subpath to the package's
+    // AutomationDefinitions module. See core/lib/packages/types.ts.
+    automation?: { definitions: string }
     // Read-only event feeds this package contributes to another package's
     // event grid (today: the calendar). `module` is a package-exports subpath
     // to a module exporting `useEventSource` — see the PackageManifest doc in


### PR DESCRIPTION
Phase 1 of the workflow-rules feature: packages declare automation triggers/actions as pure typed data; core validates, merges, and stores.

- `core/lib/automation/` — authoring types (schema-generic), operator sets, zod validation for stored rule JSON, core built-in catalog (`core:schedule`, `core:manual`, `core:apply-label`, `core:notify`)
- Manifest gains `automation: { definitions }`; the generator imports each package's `automation.ts`, validates, and materializes merged defs to `server/automation_defs.json` (gitignored) for the phase-2 Go engine
- `derive-automation.ts` exposes ref-keyed catalogs for the future builder UI; `use-packages.ts` passes the manifest field through for DB-installed packages
- New core collections `rules` + `rule_runs` (migrations `1990000000`/`1990000001`): body-locked personal updates, guest-excluded org reads/creates, org-run visibility admin-only

Engine (phase 2) and UI (phase 3) follow. Design: `docs/superpowers/specs/2026-08-11-workflow-rules-design.md` in the workspace repo.