### PR TITLE
ci: run on every PR, not only those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+  # Every PR, whatever it targets — NOT `branches: [main]`.
+  #
+  # Core work here stacks deep: a PR usually targets the unmerged branch below
+  # it rather than main. A `branches: [main]` filter silently skips those, so a
+  # stacked PR reports "no checks reported" — which reads as passing-at-a-glance
+  # rather than never-run. That is how #171, #172, #174 and #176 came to sit on
+  # top of each other with zero CI between them, in the repo every package in
+  # the ecosystem builds against.
+  #
+  # A stacked PR is tested as a merge into ITS OWN base, which is the right
+  # increment: each PR verifies what it adds, and the branch below it is
+  # verified by its own run. The `push: [main]` trigger above still covers
+  # post-merge trunk.
   pull_request:
-    branches: [main]
 
 env:
   TEST_USER_LOGIN: user@tinycld.org


### PR DESCRIPTION
`pull_request: branches: [main]` silently skips any PR that targets the unmerged branch below it, so stacked PRs report "no checks reported" — which reads as passing-at-a-glance rather than never-run.

Currently unverified as a result: #171, #172, #174, #176 — ~34 commits of core changes with zero CI runs between them, in the repo every package builds against. #170 and #173 are green only because they happen to target main.

Dropping the base filter means a stacked PR is tested as a merge into its own base, which is the right increment: each PR verifies what it adds, the branch below is verified by its own run. The `push: [main]` trigger still covers post-merge trunk.

One line plus a comment; no job or step changes. `cards/` has the same fix.