### PR TITLE
feat(editor): character triggers, and the native @-mention bridge

### DIFF
--- a/core/lib/comments/mutations.ts
+++ b/core/lib/comments/mutations.ts
@@ -41,6 +41,14 @@ export interface CommentMentionInsert {
     comment_record: string
     drive_item: string
     mentioned_user: string
+    // The polymorphic target, added when `comment_mentions` stopped being
+    // drive-only (core migration 1985000002). Document packages set it to
+    // ('drive_items', <driveItemId>) — the same thing `drive_item` says, but in
+    // the columns every consumer now reads. The Go notify hook still falls back
+    // to `drive_item`, so an older client mid-rollout keeps working; new writes
+    // should not rely on that.
+    target_collection: string
+    target_record: string
 }
 
 // Optional mentions support. When supplied, the add/reply mutations
@@ -130,6 +138,8 @@ export function useBaseCommentMutations<
                     comment_record: commentId,
                     drive_item: driveItemId,
                     mentioned_user: m.userId,
+                    target_collection: 'drive_items',
+                    target_record: driveItemId,
                 })
             )
         }

--- a/core/lib/editor/message-bus/popover-protocol.ts
+++ b/core/lib/editor/message-bus/popover-protocol.ts
@@ -1,0 +1,111 @@
+/**
+ * The 'ui' namespace's anchored-popover messages, as types.
+ *
+ * These shapes were specified in prose in ./types.ts and constructed by hand on
+ * both sides — the in-WebView bridge that posts them and the host controller
+ * that parses them. Two hand-written spellings of one wire format drift the
+ * moment either side gains a field, and the failure is silent: a popover that
+ * simply never opens, on a platform with no e2e coverage. Naming them once is
+ * what makes that a compile error instead.
+ *
+ * The prose in ./types.ts remains the narrative explanation of WHY the protocol
+ * has this shape; this file is the machine-checkable half.
+ *
+ * Must stay free of DOM and React Native references — the WebView page and the
+ * native host both import it.
+ */
+
+/** WebView → host, request. Open an overlay anchored to a document range. */
+export const UI_SHOW_POPOVER = 'show-popover'
+/** host → WebView, response. Echoes the show-popover's requestId. */
+export const UI_POPOVER_RESULT = 'popover-result'
+/** WebView → host. Re-renders the open overlay's contents. */
+export const UI_POPOVER_UPDATE = 'popover-update'
+/** WebView → host. The in-page driver wound down on its own. */
+export const UI_POPOVER_EXITED = 'popover-exited'
+/**
+ * Host-internal, never crosses the WebView boundary. The native editor
+ * publishes it into its own bus when the document scrolls, because an overlay
+ * anchored to a range that has moved is worse than no overlay.
+ */
+export const UI_POPOVER_DISMISS_ON_SCROLL = 'popover-dismiss-on-scroll'
+
+/**
+ * Where to anchor, in the WebView's viewport coordinates, plus the scroll
+ * snapshot the host needs to translate them to screen coordinates.
+ *
+ * Matches the `ImageSelection.rect` contract the 'ui' namespace already uses.
+ * Deliberately not a DOMRect: that is a live object whose values mutate between
+ * frames, so it must never be held across a message boundary.
+ */
+export interface PopoverRect {
+    top: number
+    left: number
+    width: number
+    height: number
+    scrollX: number
+    scrollY: number
+}
+
+/** Payload of {@link UI_SHOW_POPOVER}. */
+export interface ShowPopoverPayload<TPayload = unknown> {
+    /**
+     * Which overlay to render. The host keys its registry on this, so two
+     * concurrent popover sources must never share a kind.
+     */
+    kind: string
+    rect: PopoverRect
+    /** Kind-specific contents. */
+    payload: TPayload
+    /**
+     * Which editor on the screen posted this.
+     *
+     * Load-bearing wherever more than one editor is mounted at once — a card
+     * detail carries a description editor, a comment composer, and possibly an
+     * inline comment editor simultaneously. Without it every mounted host
+     * controller answers every show-popover, so one `@` opens three overlays,
+     * two of them measured against the wrong WebView.
+     */
+    editorInstanceId?: string
+}
+
+/** Payload of {@link UI_POPOVER_UPDATE} — a show-popover minus kind and rect. */
+export interface PopoverUpdatePayload<TPayload = unknown> {
+    payload: TPayload
+    editorInstanceId?: string
+}
+
+/** Payload of {@link UI_POPOVER_EXITED}. */
+export interface PopoverExitedPayload {
+    editorInstanceId?: string
+}
+
+/** What the host did with the overlay. */
+export type PopoverResultAction = 'select' | 'dismiss'
+
+/** Payload of {@link UI_POPOVER_RESULT}. */
+export interface PopoverResultPayload<TPayload = unknown> {
+    action: PopoverResultAction
+    /** Present on 'select'. Kind-specific. */
+    payload?: TPayload
+}
+
+/**
+ * Contents of a trigger-kind popover — what {@link ShowPopoverPayload.payload}
+ * carries for the `trigger:<id>` kinds the rich editor's autocompletes use.
+ */
+export interface TriggerPopoverPayload {
+    items: { id: string; label: string; secondary?: string }[]
+    query: string
+    selectedIndex: number
+}
+
+/** What a trigger popover's 'select' answers with. */
+export interface TriggerPopoverSelection {
+    itemId: string
+}
+
+/** The overlay kind for a rich-editor trigger. Distinct per trigger id. */
+export function triggerPopoverKind(triggerId: string): string {
+    return `trigger:${triggerId}`
+}

--- a/core/lib/editor/message-bus/types.ts
+++ b/core/lib/editor/message-bus/types.ts
@@ -60,6 +60,10 @@
 //
 // 'ui' namespace message types:
 //
+//   The popover messages below are TYPED in ./popover-protocol.ts, which both
+//   the in-WebView bridge and the host controller import. What follows is the
+//   narrative half — why the protocol has this shape. Change both together.
+//
 //   selection-changed  (WebView -> host, no response)
 //     payload: { kind: 'image' | 'none', image?: ImageSelection }
 //     Already in use since Milestone B.

--- a/core/lib/editor/overlay/anchored-overlay-controller.tsx
+++ b/core/lib/editor/overlay/anchored-overlay-controller.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useReducer, useState } from 'react'
+import { Dimensions, Modal, Platform, Pressable, View } from 'react-native'
+import { UI_POPOVER_RESULT } from '../message-bus/popover-protocol'
+import { makeMessage } from '../message-bus/types'
+import {
+    type AnchoredOverlayAction,
+    type AnchoredOverlayRequest,
+    type AnchoredOverlayResponseAction,
+    anchoredOverlayReducer,
+    decodeUiMessage,
+    initialAnchoredOverlayState,
+    resolvePopoverPosition,
+} from './anchored-overlay-state'
+import { subscribeUiMessage } from './ui-message-bus'
+
+// Vertical gap between the anchor's bottom and the popover. Mirrors the
+// web's POPOVER_GAP_PX so the two platforms feel visually consistent.
+const POPOVER_GAP_PX = 4
+// Estimated popover height for the flip-above-the-caret decision. The
+// web variant uses the same value; we don't try to do a measure-then-
+// reflow pass on native because the flicker would be more disruptive
+// than a slightly-imprecise flip threshold.
+const POPOVER_HEIGHT_ESTIMATE_PX = 320
+const POPOVER_WIDTH_PX = 260
+
+// Minimal duck-typed shape we use off the WebView ref. The TenTap
+// webviewRef points at the underlying react-native-webview instance,
+// which exposes both .measure (a RN View method) and .postMessage
+// (an RN-WebView method). We don't depend on the full type — every
+// callsite narrows on `typeof ... === 'function'` before invoking.
+interface WebViewMeasurable {
+    measure(
+        cb: (
+            x: number,
+            y: number,
+            width: number,
+            height: number,
+            pageX: number,
+            pageY: number
+        ) => void
+    ): void
+    postMessage(message: string): void
+}
+
+// Subset of a WebView ref that the controller needs.
+type WebViewRef = React.RefObject<unknown> | null
+
+// Props accepted by every overlay component the registry knows about.
+// payload comes verbatim from the WebView's show-popover.payload (kind-
+// scoped); respond closes the popover by posting popover-result back.
+//
+// The controller hands the body a `respond` closure rather than
+// surfacing the protocol; each body just calls respond('select', ...)
+// or respond('dismiss') on user input. Future overlay kinds plug in
+// the same way.
+export interface AnchoredOverlayProps {
+    payload: unknown
+    respond: (action: AnchoredOverlayResponseAction, payload?: unknown) => void
+}
+
+export interface AnchoredOverlayRegistry {
+    [kind: string]: (props: AnchoredOverlayProps) => React.ReactNode
+}
+
+export interface AnchoredOverlayControllerProps {
+    webViewRef: WebViewRef
+    registry: AnchoredOverlayRegistry
+    /**
+     * Which editor's popovers this controller answers. Omitted → it answers
+     * every editor's, which is only safe when exactly one is mounted. Pass it
+     * whenever a screen can carry two (a card detail carries three).
+     */
+    editorInstanceId?: string
+}
+
+// Promise wrapper around .measure(). Resolves to null when the ref is
+// missing, the current value isn't a measurable, or measure returns
+// without invoking the callback (the RN runtime can drop measure calls
+// when a view isn't laid out yet). On null the controller fails closed —
+// dismisses the request and posts popover-result so the WebView clears
+// its trigger — rather than rendering the popover at (0, 0) with no
+// relationship to the caret.
+async function measureWebView(
+    ref: WebViewRef
+): Promise<{ pageX: number; pageY: number; width: number; height: number } | null> {
+    const r = ref?.current as Partial<WebViewMeasurable> | null | undefined
+    if (!r || typeof r.measure !== 'function') return null
+    return new Promise(resolve => {
+        let resolved = false
+        const fallback = setTimeout(() => {
+            if (!resolved) {
+                resolved = true
+                resolve(null)
+            }
+        }, 250)
+        try {
+            ;(r as WebViewMeasurable).measure((_x, _y, width, height, pageX, pageY) => {
+                if (resolved) return
+                resolved = true
+                clearTimeout(fallback)
+                resolve({ pageX, pageY, width, height })
+            })
+        } catch {
+            clearTimeout(fallback)
+            resolved = true
+            resolve(null)
+        }
+    })
+}
+
+// Send a 'ui' namespace message into the WebView. Used to deliver
+// popover-result responses (and any future host→WebView UI message).
+// Safe to call when the ref is detached — the message is silently
+// dropped because the WebView is gone, which matches the "fire and
+// forget" semantics of the bus.
+function postUiToWebView(ref: WebViewRef, type: string, payload: unknown, requestId?: string) {
+    const r = ref?.current as Partial<WebViewMeasurable> | null | undefined
+    if (!r || typeof r.postMessage !== 'function') return
+    try {
+        ;(r as WebViewMeasurable).postMessage(
+            JSON.stringify(makeMessage('ui', type, payload, requestId))
+        )
+    } catch {
+        // postMessage throws if the WebView's content world hasn't
+        // initialized yet (very early in the mount, before the bridge
+        // is up). Swallow — the popover protocol is best-effort.
+    }
+}
+
+// AnchoredOverlayController — host-side overlay router. Subscribes to
+// the ui-message-bus, opens an absolutely-positioned Modal with the
+// kind-specific body, and responds back to the WebView. Web mounts of
+// this component are no-ops (we render through a portal there, not a
+// Modal), which keeps screen-level mounting platform-agnostic.
+export function AnchoredOverlayController({
+    webViewRef,
+    registry,
+    editorInstanceId,
+}: AnchoredOverlayControllerProps): React.ReactElement | null {
+    const [state, dispatch] = useReducer(anchoredOverlayReducer, initialAnchoredOverlayState)
+    const [screenPos, setScreenPos] = useState<{ top: number; left: number } | null>(null)
+
+    // Subscribe to the bus so 'show-popover' / 'popover-update' /
+    // 'popover-dismiss-on-scroll' / 'popover-exited' messages get
+    // reduced into state. The native variant of useDocumentEditor is
+    // responsible for publishing every 'ui' message into the bus; we
+    // just consume.
+    // Scoped to this editor: several editors can be mounted at once, and an
+    // unscoped subscription would answer their popovers too — see
+    // ui-message-bus.ts.
+    useEffect(() => {
+        const unsubscribe = subscribeUiMessage(message => {
+            const action: AnchoredOverlayAction | null = decodeUiMessage(message)
+            if (action) dispatch(action)
+        }, editorInstanceId)
+        return unsubscribe
+    }, [editorInstanceId])
+
+    // On show, .measure() the WebView to translate viewport coords to
+    // screen coords, then compute the popover anchor. We re-run only on
+    // a fresh request (requestId change) so popover-update messages
+    // don't trigger a remeasure — the anchor is fixed once the popover
+    // opens, and an in-flight scroll already dismisses.
+    //
+    // webViewRef is intentionally omitted from the dep array: the
+    // useEditorBridge hook returns a stable RefObject whose identity
+    // doesn't change across renders. Including it would invite a
+    // re-measure on a hypothetical ref swap that the surrounding code
+    // doesn't actually perform.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional narrow dep — remeasure only on a fresh requestId (not on popover-update); webViewRef is a stable RefObject (see comment above)
+    useEffect(() => {
+        if (!state.open) {
+            setScreenPos(null)
+            return
+        }
+        let cancelled = false
+        const open = state.open
+        ;(async () => {
+            const m = await measureWebView(webViewRef)
+            if (cancelled) return
+            if (!m) {
+                // Measure failed (no ref, timed out, threw). Falling
+                // back to (0, 0) would render the popover in the
+                // top-left of the screen with no visual relationship
+                // to the caret — worse than showing nothing. Fail
+                // closed: dismiss the request and tell the WebView we
+                // gave up so the suggestion plugin clears its trigger.
+                postUiToWebView(
+                    webViewRef,
+                    'popover-result',
+                    { action: 'dismiss' as AnchoredOverlayResponseAction },
+                    open.requestId
+                )
+                dispatch({ type: 'dismiss-external' })
+                return
+            }
+            const { width: vw, height: vh } = Dimensions.get('window')
+            setScreenPos(
+                resolvePopoverPosition({
+                    rect: open.rect,
+                    webViewOriginX: m.pageX,
+                    webViewOriginY: m.pageY,
+                    viewportWidth: vw,
+                    viewportHeight: vh,
+                    popoverWidth: POPOVER_WIDTH_PX,
+                    popoverHeightEstimate: POPOVER_HEIGHT_ESTIMATE_PX,
+                    gap: POPOVER_GAP_PX,
+                })
+            )
+        })()
+        return () => {
+            cancelled = true
+        }
+    }, [state.open?.requestId])
+
+    if (Platform.OS === 'web') return null
+    if (!state.open || !screenPos) return null
+
+    const open: AnchoredOverlayRequest = state.open
+    const Body = registry[open.kind]
+    if (!Body) return null
+
+    const respond = (action: AnchoredOverlayResponseAction, payload?: unknown) => {
+        postUiToWebView(
+            webViewRef,
+            UI_POPOVER_RESULT,
+            { action, payload: payload ?? undefined },
+            open.requestId
+        )
+        dispatch({ type: 'respond', requestId: open.requestId })
+    }
+
+    const dismissExternal = () => {
+        postUiToWebView(
+            webViewRef,
+            UI_POPOVER_RESULT,
+            { action: 'dismiss' as AnchoredOverlayResponseAction },
+            open.requestId
+        )
+        dispatch({ type: 'dismiss-external' })
+    }
+
+    // Modal is transparent so the absolutely-positioned popover floats
+    // over the WebView at the computed screen coords. The full-screen
+    // Pressable behind it captures backdrop taps for dismiss without
+    // intercepting touches on the popover itself.
+    return (
+        <Modal
+            transparent
+            visible
+            animationType="none"
+            onRequestClose={dismissExternal}
+            // statusBarTranslucent matches our app's other Modals so the
+            // popover anchor math (which uses Dimensions.get('window'))
+            // matches the actual layer the popover renders into.
+            statusBarTranslucent
+        >
+            <Pressable
+                onPress={dismissExternal}
+                accessibilityRole="button"
+                accessibilityLabel="Dismiss popover"
+                style={{ flex: 1 }}
+            >
+                <View
+                    style={{
+                        position: 'absolute',
+                        top: screenPos.top,
+                        left: screenPos.left,
+                        width: POPOVER_WIDTH_PX,
+                        maxHeight: POPOVER_HEIGHT_ESTIMATE_PX,
+                    }}
+                    // onStartShouldSetResponder=true stops backdrop taps
+                    // that originate inside the popover from bubbling up
+                    // to the backdrop Pressable.
+                    onStartShouldSetResponder={() => true}
+                >
+                    <Body payload={open.payload} respond={respond} />
+                </View>
+            </Pressable>
+        </Modal>
+    )
+}

--- a/core/lib/editor/overlay/anchored-overlay-state.ts
+++ b/core/lib/editor/overlay/anchored-overlay-state.ts
@@ -1,0 +1,261 @@
+import {
+    UI_POPOVER_DISMISS_ON_SCROLL,
+    UI_POPOVER_EXITED,
+    UI_POPOVER_UPDATE,
+    UI_SHOW_POPOVER,
+} from '../message-bus/popover-protocol'
+import type { EditorMessage } from '../message-bus/types'
+
+// The rect a show-popover message carries: viewport coords inside the
+// WebView + the WebView's scroll snapshot at capture time. Matches
+// ImageSelection.rect's contract from Milestone B exactly so future
+// 'ui' namespace popovers don't have to invent a second rect shape.
+//
+// scrollX/scrollY are preserved on the wire even though the controller
+// doesn't currently use them — the policy is "dismiss on scroll" so
+// the popover never lives long enough to need re-anchoring. They're
+// here so a future re-anchor-on-scroll behavior change is wire-
+// compatible.
+export interface AnchoredOverlayRect {
+    top: number
+    left: number
+    width: number
+    height: number
+    scrollX: number
+    scrollY: number
+}
+
+// The request the WebView sends on 'show-popover'. The kind discriminates
+// which registry entry renders the body (e.g. 'slash-menu' →
+// SlashMenuPopover); the payload is whatever that kind's body needs.
+//
+// We deliberately leave payload typed as `unknown` here — the controller
+// only routes it; the body component asserts a concrete shape at the
+// render boundary. Erasing the type here keeps the state-machine pure
+// and decoupled from any specific overlay kind.
+export interface AnchoredOverlayRequest {
+    kind: string
+    requestId: string
+    rect: AnchoredOverlayRect
+    payload: unknown
+}
+
+// The state the controller renders against. open=null means no
+// popover; open=non-null means the controller has accepted a
+// show-popover and is awaiting a select/dismiss. The payload field
+// is kept separate so popover-update messages can replace it without
+// disturbing the kind/requestId/rect that opened the popover.
+export interface AnchoredOverlayState {
+    open: AnchoredOverlayRequest | null
+}
+
+// What the host sends back to the WebView. The action drives the
+// suggestion plugin's behavior: 'select' applies the chosen entry
+// and clears the trigger; 'dismiss' aborts.
+export type AnchoredOverlayResponseAction = 'select' | 'dismiss'
+
+// Reducer action types. Pure data — no side effects in the reducer
+// itself; effects (postMessage to the WebView) live in the controller's
+// react layer. This split keeps the state-machine trivially testable
+// in node without booting RN.
+export type AnchoredOverlayAction =
+    | { type: 'show'; request: AnchoredOverlayRequest }
+    | { type: 'update'; requestId: string; payload: unknown }
+    | { type: 'respond'; requestId: string }
+    | { type: 'dismiss-on-scroll' }
+    | { type: 'dismiss-external' }
+    | { type: 'webview-exited'; requestId: string }
+
+export const initialAnchoredOverlayState: AnchoredOverlayState = { open: null }
+
+// Pure reducer. The controller dispatches reducer actions in response
+// to bus messages and user input; this function describes the legal
+// state transitions and nothing else.
+export function anchoredOverlayReducer(
+    state: AnchoredOverlayState,
+    action: AnchoredOverlayAction
+): AnchoredOverlayState {
+    switch (action.type) {
+        case 'show':
+            // Opening over an already-open popover is legal — the
+            // WebView may send a new show-popover (e.g. a stale one
+            // wins the race after a dismiss). The new request wins;
+            // the old one's response-loop is just abandoned. The
+            // controller's effect layer is responsible for sending a
+            // popover-dismissed for the displaced request if the
+            // protocol grows to need it.
+            return { open: action.request }
+
+        case 'update':
+            // Stale updates (requestId mismatch — popover has since
+            // closed, or has been replaced) are silently dropped.
+            // The state-machine guarantees that a popover-update for
+            // a no-longer-open request never modifies state.
+            if (!state.open) return state
+            if (state.open.requestId !== action.requestId) return state
+            return { open: { ...state.open, payload: action.payload } }
+
+        case 'respond':
+            // Respond closes the popover IF the requestId matches.
+            // Stale responds (controller already moved on, or this is
+            // a duplicate) are no-ops.
+            if (!state.open) return state
+            if (state.open.requestId !== action.requestId) return state
+            return { open: null }
+
+        case 'dismiss-on-scroll':
+            // Scroll dismisses any open popover without needing a
+            // requestId match — the scroll event is package-global,
+            // not request-specific.
+            if (!state.open) return state
+            return { open: null }
+
+        case 'dismiss-external':
+            // Backdrop-tap / programmatic dismiss path. Same semantics
+            // as dismiss-on-scroll, but a distinct action so the
+            // controller's effect layer can post the appropriate
+            // popover-result back to the WebView. The reducer treats
+            // them identically.
+            if (!state.open) return state
+            return { open: null }
+
+        case 'webview-exited':
+            // popover-exited from the WebView: the in-editor suggestion
+            // plugin has wound down on its own (item selected, trigger
+            // broken by typing space, Escape pressed). Close the overlay
+            // if the requestId still matches; ignore stale exits for a
+            // request the host has already moved past. No postMessage
+            // needed — the WebView already knows it's done.
+            if (!state.open) return state
+            if (state.open.requestId !== action.requestId) return state
+            return { open: null }
+    }
+}
+
+// Decode an 'ui' namespace message into an action this state-machine
+// understands, or null if the message isn't routable. Lifting the
+// decode out of the reducer keeps the action types untouched by wire-
+// format details and makes them easy to construct in tests.
+export function decodeUiMessage(message: EditorMessage): AnchoredOverlayAction | null {
+    if (message.namespace !== 'ui') return null
+    if (message.type === UI_SHOW_POPOVER) {
+        const payload = message.payload
+        const requestId = message.requestId
+        if (!requestId) return null
+        if (payload === null || typeof payload !== 'object') return null
+        const p = payload as {
+            kind?: unknown
+            rect?: unknown
+            payload?: unknown
+        }
+        if (typeof p.kind !== 'string') return null
+        if (!isValidRect(p.rect)) return null
+        return {
+            type: 'show',
+            request: {
+                kind: p.kind,
+                requestId,
+                rect: p.rect,
+                payload: p.payload ?? null,
+            },
+        }
+    }
+    if (message.type === UI_POPOVER_UPDATE) {
+        const requestId = message.requestId
+        if (!requestId) return null
+        // The wire wraps the body's contents alongside the routing metadata
+        // (`{ payload, editorInstanceId }`), so unwrap one level — handing the
+        // envelope to the body would give it a `payload.payload`.
+        const wrapper = message.payload as { payload?: unknown } | null | undefined
+        return {
+            type: 'update',
+            requestId,
+            payload: wrapper?.payload ?? null,
+        }
+    }
+    if (message.type === UI_POPOVER_DISMISS_ON_SCROLL) {
+        return { type: 'dismiss-on-scroll' }
+    }
+    if (message.type === UI_POPOVER_EXITED) {
+        const requestId = message.requestId
+        if (!requestId) return null
+        return { type: 'webview-exited', requestId }
+    }
+    return null
+}
+
+// Narrow an unknown wire value into a fully-typed AnchoredOverlayRect.
+// Defensive against partial / malformed messages — the WebView side
+// constructs these from window.scrollX / getBoundingClientRect so
+// numeric fields should always be present, but a single bad message
+// shouldn't crash the controller.
+function isValidRect(value: unknown): value is AnchoredOverlayRect {
+    if (value === null || typeof value !== 'object') return false
+    const r = value as Record<string, unknown>
+    return (
+        typeof r.top === 'number' &&
+        typeof r.left === 'number' &&
+        typeof r.width === 'number' &&
+        typeof r.height === 'number' &&
+        typeof r.scrollX === 'number' &&
+        typeof r.scrollY === 'number'
+    )
+}
+
+// Geometry helper used by the React controller — separated here so
+// it's pure and trivially testable. Given the rect from the WebView
+// (viewport coords + scroll snapshot) and the WebView's screen origin
+// from .measure(), plus the viewport dimensions, returns the screen
+// (top, left) where the popover should render.
+//
+// Flips above the caret when the estimated popover height would
+// overflow the bottom of the viewport. Mirrors web's SlashMenu.web.tsx
+// resolvePosition() heuristic so the two platforms feel the same.
+export interface ResolvePositionInput {
+    rect: AnchoredOverlayRect
+    webViewOriginX: number
+    webViewOriginY: number
+    viewportWidth: number
+    viewportHeight: number
+    popoverWidth: number
+    popoverHeightEstimate: number
+    gap: number
+}
+
+export function resolvePopoverPosition(input: ResolvePositionInput): {
+    top: number
+    left: number
+} {
+    const {
+        rect,
+        webViewOriginX,
+        webViewOriginY,
+        viewportWidth,
+        viewportHeight,
+        popoverWidth,
+        popoverHeightEstimate,
+        gap,
+    } = input
+
+    // Anchor is the rect's *bottom* on the visible WebView (viewport
+    // coords) — add the WebView's screen origin to translate to screen
+    // coords. Web's resolvePosition uses bottom directly; here we
+    // compute it from top + height because the wire shape preserves
+    // only top/left + width/height (no separate bottom field).
+    const anchorBottomScreen = webViewOriginY + rect.top + rect.height
+    const anchorTopScreen = webViewOriginY + rect.top
+    const anchorLeftScreen = webViewOriginX + rect.left
+
+    const wouldOverflowBottom = anchorBottomScreen + gap + popoverHeightEstimate > viewportHeight
+
+    const top = wouldOverflowBottom
+        ? Math.max(8, anchorTopScreen - gap - popoverHeightEstimate)
+        : anchorBottomScreen + gap
+
+    const left = Math.min(
+        Math.max(8, anchorLeftScreen),
+        Math.max(8, viewportWidth - popoverWidth - 8)
+    )
+
+    return { top, left }
+}

--- a/core/lib/editor/overlay/editor-overlay-registry.ts
+++ b/core/lib/editor/overlay/editor-overlay-registry.ts
@@ -1,0 +1,68 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
+/**
+ * Where a host overlay finds the editor it must anchor to.
+ *
+ * The problem this solves: an anchored overlay needs the editor's `webViewRef`
+ * to translate the page's viewport coordinates into screen coordinates, but the
+ * popover is rendered as a SIBLING of the editor, not a descendant of it —
+ * often in a different subtree entirely (a dialog host, say). React context
+ * cannot cross that, and moving the popover under the editor would break the
+ * web variant, which deliberately portals to the document body so the card
+ * detail's scroll container cannot clip it.
+ *
+ * So the editor publishes its handle under a caller-supplied key and the
+ * overlay looks it up. The key must be unique PER EDITOR, not per screen or per
+ * document — a card detail mounts a description editor and a comment composer
+ * against the same board, and a shared key would anchor one's popover to the
+ * other's WebView.
+ */
+export interface EditorOverlayHandle {
+    webViewRef: unknown
+    editorInstanceId: string
+}
+
+const handles = new Map<string, EditorOverlayHandle>()
+const listeners = new Set<() => void>()
+
+function emit(): void {
+    for (const listener of listeners) listener()
+}
+
+/** Publish an editor's handle. Returns the deregistration function. */
+export function registerEditorOverlay(key: string, handle: EditorOverlayHandle): () => void {
+    handles.set(key, handle)
+    emit()
+    return () => {
+        // Only clear if this registration is still the live one — a remount can
+        // register the replacement before the outgoing effect cleans up.
+        if (handles.get(key) === handle) {
+            handles.delete(key)
+            emit()
+        }
+    }
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+/**
+ * Read the editor registered under a key, re-rendering when it appears.
+ *
+ * Returns null until the editor mounts, which is the normal first-render state:
+ * the overlay renders nothing, and the editor's registration effect wakes it.
+ */
+export function useEditorOverlay(key: string | undefined): EditorOverlayHandle | null {
+    const getSnapshot = useCallback(() => (key ? (handles.get(key) ?? null) : null), [key])
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/** Test-only. The registry is module-global and would otherwise leak. */
+export function resetEditorOverlayRegistry(): void {
+    handles.clear()
+    listeners.clear()
+}

--- a/core/lib/editor/overlay/index.ts
+++ b/core/lib/editor/overlay/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Host-side anchored overlays for WebView editors.
+ *
+ * The native editor is a WebView, so anything that must be drawn by the host —
+ * an autocomplete popover, a bottom sheet anchored to a selection — cannot be
+ * rendered by the page that decided to show it. The page posts over the 'ui'
+ * namespace; this module routes those messages, measures the WebView, and
+ * renders a native Modal at the right screen coordinates.
+ *
+ * Promoted from the text package, which proved the approach on its slash menu.
+ * It moved here when cards' @-mentions became the second consumer: siblings
+ * cannot import each other, so the alternative was a second copy of a
+ * non-trivial state machine and its geometry.
+ */
+
+export {
+    AnchoredOverlayController,
+    type AnchoredOverlayControllerProps,
+    type AnchoredOverlayProps,
+    type AnchoredOverlayRegistry,
+} from './anchored-overlay-controller'
+export {
+    type AnchoredOverlayAction,
+    type AnchoredOverlayRect,
+    type AnchoredOverlayRequest,
+    type AnchoredOverlayResponseAction,
+    type AnchoredOverlayState,
+    anchoredOverlayReducer,
+    decodeUiMessage,
+    initialAnchoredOverlayState,
+    resolvePopoverPosition,
+} from './anchored-overlay-state'
+export {
+    type EditorOverlayHandle,
+    registerEditorOverlay,
+    resetEditorOverlayRegistry,
+    useEditorOverlay,
+} from './editor-overlay-registry'
+export { publishUiMessage, resetUiMessageBus, subscribeUiMessage } from './ui-message-bus'

--- a/core/lib/editor/overlay/ui-message-bus.ts
+++ b/core/lib/editor/overlay/ui-message-bus.ts
@@ -1,0 +1,88 @@
+import type { EditorMessage } from '../message-bus/types'
+
+/**
+ * A tiny pub/sub routing 'ui' namespace messages from a WebView editor to
+ * whatever host code draws overlays for it. The native editor hook publishes
+ * everything `useWebViewEditor`'s `onUiMessage` hands it; the anchored-overlay
+ * controller subscribes.
+ *
+ * Not a Zustand store: the bus has no state, only routing. A store would force
+ * every subscriber onto a React render path, and this one is also driven from
+ * unit tests with no component in sight.
+ *
+ * SUBSCRIBERS FILTER BY EDITOR INSTANCE, which is the one thing this does that
+ * a naive fan-out must not. More than one editor is routinely mounted at once —
+ * a card detail carries a description editor, a comment composer, and an inline
+ * comment editor while a comment is being edited. Every one of them mounts its
+ * own controller, so an unfiltered bus would have all three answer a single
+ * `@`: three overlays, two of them measured against the wrong WebView. A
+ * message naming no instance is a broadcast (dismiss-on-scroll is screen-wide
+ * by nature) and still reaches everyone.
+ */
+type Handler = (message: EditorMessage) => void
+
+interface Subscription {
+    handler: Handler
+    /** Undefined → receives every message, filtered or not. */
+    instanceId?: string
+}
+
+const subscriptions = new Set<Subscription>()
+
+/**
+ * Read the editor instance a message belongs to, if it names one.
+ *
+ * The id rides inside the payload rather than on the envelope because the
+ * envelope is TenTap's shared shape — widening it would touch every namespace
+ * for the benefit of one.
+ */
+function messageInstanceId(message: EditorMessage): string | undefined {
+    const payload = message.payload as { editorInstanceId?: unknown } | null | undefined
+    const id = payload?.editorInstanceId
+    return typeof id === 'string' ? id : undefined
+}
+
+/**
+ * Add a handler, optionally scoped to one editor instance. The returned
+ * function removes it. Idempotent against double-unsubscribe.
+ */
+export function subscribeUiMessage(handler: Handler, instanceId?: string): () => void {
+    const subscription: Subscription = { handler, instanceId }
+    subscriptions.add(subscription)
+    return () => {
+        subscriptions.delete(subscription)
+    }
+}
+
+/**
+ * Fan a message out to every subscriber it is addressed to.
+ *
+ * A throwing handler does not starve the others — this is a router, not a
+ * chain — but the error is re-raised afterwards so a test or error boundary
+ * still sees it.
+ */
+export function publishUiMessage(message: EditorMessage): void {
+    const target = messageInstanceId(message)
+    let thrown: unknown = null
+    let didThrow = false
+    for (const { handler, instanceId } of subscriptions) {
+        // A scoped subscriber ignores other editors' traffic. An unaddressed
+        // message is a broadcast and reaches everyone.
+        if (target !== undefined && instanceId !== undefined && instanceId !== target) continue
+        try {
+            handler(message)
+        } catch (err) {
+            thrown = err
+            didThrow = true
+        }
+    }
+    if (didThrow) throw thrown
+}
+
+/**
+ * Test-only. The bus is module-global, so a suite that publishes into it leaks
+ * handlers across files without this in a beforeEach.
+ */
+export function resetUiMessageBus(): void {
+    subscriptions.clear()
+}

--- a/core/lib/editor/rich/extensions.ts
+++ b/core/lib/editor/rich/extensions.ts
@@ -11,6 +11,7 @@ import StarterKit from '@tiptap/starter-kit'
 import type { Awareness } from 'y-protocols/awareness'
 import type * as Y from 'yjs'
 import { SubmitShortcut } from './submit-shortcut'
+import { createTriggerExtension, type TriggerConfig } from './triggers'
 
 export interface RichEditorCollabOptions {
     /** The Y.Doc to bind to. Never construct one per editor — pass the room's. */
@@ -38,6 +39,14 @@ export interface BuildRichEditorExtensionsOptions {
      * inside the WebView page) and this builder must stay importable from both.
      */
     imageNodeView?: NodeViewRenderer
+    /**
+     * Character-triggered autocompletes (`@` mentions, and whatever wants the
+     * same shape later). Built here rather than added by the caller so BOTH
+     * platforms get them from the one schema — the native editor is a prebuilt
+     * WebView bundle, so a plugin a package adds at runtime would exist on web
+     * and silently not on native. See triggers.ts.
+     */
+    triggers?: TriggerConfig[]
 }
 
 /**
@@ -58,7 +67,8 @@ export interface BuildRichEditorExtensionsOptions {
 export function buildRichEditorExtensions(
     options: BuildRichEditorExtensionsOptions = {}
 ): Extensions {
-    const { placeholder, characterLimit, onSubmitShortcut, collab, imageNodeView } = options
+    const { placeholder, characterLimit, onSubmitShortcut, collab, imageNodeView, triggers } =
+        options
 
     const extensions: Extensions = [
         StarterKit.configure({
@@ -83,6 +93,9 @@ export function buildRichEditorExtensions(
     }
     if (onSubmitShortcut) {
         extensions.push(SubmitShortcut.configure({ onSubmit: onSubmitShortcut }))
+    }
+    for (const trigger of triggers ?? []) {
+        extensions.push(createTriggerExtension(trigger))
     }
     if (collab) {
         extensions.push(Collaboration.configure({ document: collab.document, field: collab.field }))

--- a/core/lib/editor/rich/index.ts
+++ b/core/lib/editor/rich/index.ts
@@ -14,10 +14,17 @@ export { findDamagedTableRows, repairMarkdown } from './markdown-repair'
 export type { EditorContentFormat, UseRichEditorOptions } from './options'
 export { setContentWhenReady } from './set-content-when-ready'
 export type {
+    SerializableTriggerConfig,
     TriggerAnchor,
     TriggerConfig,
     TriggerItem,
     TriggerState,
 } from './triggers'
-export { CLOSED_TRIGGER_STATE, createTriggerExtension } from './triggers'
+export {
+    CLOSED_TRIGGER_STATE,
+    createTriggerExtension,
+    filterTriggerItems,
+    renderInsertTemplate,
+    triggerPluginKey,
+} from './triggers'
 export { useRichEditor } from './use-rich-editor'

--- a/core/lib/editor/rich/index.ts
+++ b/core/lib/editor/rich/index.ts
@@ -13,4 +13,11 @@ export { buildRichEditorExtensions } from './extensions'
 export { findDamagedTableRows, repairMarkdown } from './markdown-repair'
 export type { EditorContentFormat, UseRichEditorOptions } from './options'
 export { setContentWhenReady } from './set-content-when-ready'
+export type {
+    TriggerAnchor,
+    TriggerConfig,
+    TriggerItem,
+    TriggerState,
+} from './triggers'
+export { CLOSED_TRIGGER_STATE, createTriggerExtension } from './triggers'
 export { useRichEditor } from './use-rich-editor'

--- a/core/lib/editor/rich/options.ts
+++ b/core/lib/editor/rich/options.ts
@@ -62,4 +62,14 @@ export interface UseRichEditorOptions {
      * — see rich/triggers.ts.
      */
     triggers?: TriggerConfig[]
+    /**
+     * Publishes this editor's handle so a host-drawn overlay (a native trigger
+     * popover) can anchor to it. Native-only; web popovers position from the
+     * DOM and ignore it.
+     *
+     * Must be unique PER EDITOR. A card detail mounts a description editor and
+     * a comment composer against the same board, so anything derived from the
+     * board alone would anchor one's popover to the other's WebView.
+     */
+    overlayKey?: string
 }

--- a/core/lib/editor/rich/options.ts
+++ b/core/lib/editor/rich/options.ts
@@ -1,4 +1,5 @@
 import type { RichEditorCollabOptions } from './extensions'
+import type { TriggerConfig } from './triggers'
 
 export type { RichEditorCollabOptions }
 
@@ -55,4 +56,10 @@ export interface UseRichEditorOptions {
     theme?: { backgroundColor?: string }
     /** Binds this editor to a shared document. See RichEditorCollabOptions. */
     collab?: RichEditorCollabOptions
+    /**
+     * Character-triggered autocompletes (e.g. `@` mentions). Handled inside the
+     * shared extension builder so web and the native WebView behave identically
+     * — see rich/triggers.ts.
+     */
+    triggers?: TriggerConfig[]
 }

--- a/core/lib/editor/rich/trigger-items-webview-host.ts
+++ b/core/lib/editor/rich/trigger-items-webview-host.ts
@@ -1,0 +1,56 @@
+import { type EditorMessage, makeMessage } from '../message-bus/types'
+import type { TriggerItem } from './triggers'
+import { APP_TRIGGER_ITEMS, type TriggerItemsPayload } from './webview/source/protocol'
+
+/**
+ * Host side of the trigger-roster channel: pushes each trigger's candidate pool
+ * into the WebView whenever it actually changes.
+ *
+ * The page cannot compute candidates itself — they come from a live database
+ * query on the host, and the page is a prebuilt bundle a closure cannot cross.
+ * So the host pushes and the page filters locally, which keeps typing off the
+ * bridge entirely.
+ *
+ * "Actually changes" is the whole job. The roster arrives from a live query
+ * that re-emits a fresh array on unrelated writes, so posting on every render
+ * would flood the bridge with identical payloads. Comparing the serialized form
+ * is the same identity-skip the find-replace channel uses, and it is cheap
+ * against a roster of tens of members.
+ */
+type PostMessage = (message: EditorMessage) => boolean
+
+export class TriggerItemsWebViewHost {
+    private readonly postMessage: PostMessage
+    /** Last payload sent per trigger id, serialized for comparison. */
+    private readonly sent = new Map<string, string>()
+
+    constructor(options: { postMessage: PostMessage }) {
+        this.postMessage = options.postMessage
+    }
+
+    /**
+     * Push a roster if it differs from the last one sent.
+     *
+     * Returns whether anything went over the wire, which is what makes the
+     * skip observable in a test.
+     */
+    push(triggerId: string, items: TriggerItem[]): boolean {
+        const serialized = JSON.stringify(items)
+        if (this.sent.get(triggerId) === serialized) return false
+        this.sent.set(triggerId, serialized)
+        const payload: TriggerItemsPayload = { triggerId, items }
+        return this.postMessage(makeMessage('app', APP_TRIGGER_ITEMS, payload))
+    }
+
+    /**
+     * Forget what has been sent, so the next push re-sends.
+     *
+     * Called when the page reloads: the new page's store is empty, but the
+     * host's memo of what it sent is not, so without this a roster unchanged
+     * across the reload would never be re-pushed and the popover would offer
+     * nothing.
+     */
+    reset(): void {
+        this.sent.clear()
+    }
+}

--- a/core/lib/editor/rich/triggers.ts
+++ b/core/lib/editor/rich/triggers.ts
@@ -1,0 +1,238 @@
+import { Extension } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
+import Suggestion from '@tiptap/suggestion'
+
+// Character-triggered autocomplete for the shared rich editor.
+//
+// A "trigger" is a character (`@`, `:`, `#`) that opens a picker mid-typing and
+// inserts something when an entry is chosen. Cards' @mentions are the first
+// consumer; the shape is deliberately generic because emoji and issue-links
+// want exactly this and should not each grow their own plugin.
+//
+// WHY THIS LIVES IN CORE. text/ already has a working trigger framework for its
+// slash menu, built on the same @tiptap/suggestion plugin and with both render
+// strategies solved. It is not reusable: siblings must not depend on each other
+// (CLAUDE.md), it is bound to text's own editor stack rather than
+// useRichEditor, and — decisively — the NATIVE editor is a prebuilt WebView
+// bundle compiled from core's source, so a package-side ProseMirror plugin
+// cannot be injected into it at runtime at all. Any trigger that works on both
+// platforms has to be compiled into core. text's slash menu is the proof this
+// approach works; this is that idea, generalized and moved to where every
+// package can reach it.
+//
+// RENDER STRATEGY. The plugin owns trigger detection, query parsing and range
+// tracking. Where the popover actually renders is the consumer's problem, and
+// it differs by platform: on web the popover is a DOM overlay positioned from
+// `clientRect`; inside the native WebView there is no host UI, so the page
+// posts `show-popover` over the message bus and the host renders it (the
+// protocol is already specified in lib/editor/message-bus/types.ts). This
+// module therefore takes CALLBACKS rather than rendering anything — the caller
+// supplies `onStateChange`, and web/native each answer it their own way.
+
+/** One selectable entry in a trigger's popover. */
+export interface TriggerItem {
+    /** Stable identity — echoed back to `onSelect`. */
+    id: string
+    /** Primary line. */
+    label: string
+    /** Optional secondary line (an email, a role). Falsy values are ignored. */
+    secondary?: string
+}
+
+/** Where the popover should point, in viewport coordinates. */
+export interface TriggerAnchor {
+    top: number
+    left: number
+    bottom: number
+    right: number
+    width: number
+    height: number
+}
+
+/** What the popover needs to render itself. */
+export interface TriggerState {
+    isOpen: boolean
+    /** The text typed after the trigger character. */
+    query: string
+    items: TriggerItem[]
+    /** Index of the highlighted row; keyboard nav moves it. */
+    selectedIndex: number
+    anchor: TriggerAnchor | null
+    /**
+     * Commit an entry — what a POINTER click calls. Keyboard selection is
+     * handled inside the plugin, which owns the keystrokes.
+     *
+     * This must be the plugin's live command rather than anything the popover
+     * assembles itself: the trigger's text range moves as the query grows, and
+     * only the plugin knows where it currently is. A popover that inserted text
+     * on its own would leave the typed `@query` behind.
+     */
+    onSelect: (item: TriggerItem) => void
+}
+
+export const CLOSED_TRIGGER_STATE: TriggerState = {
+    isOpen: false,
+    query: '',
+    items: [],
+    selectedIndex: 0,
+    anchor: null,
+    onSelect: () => {},
+}
+
+export interface TriggerConfig {
+    /** Distinguishes this trigger's plugin from any other on the editor. */
+    id: string
+    /** The character that opens it. */
+    char: string
+    /** Candidates for the current query. Called on every keystroke. */
+    items: (query: string) => TriggerItem[]
+    /**
+     * The text to put in the document in place of `<char><query>`. Returning ''
+     * removes the trigger text and inserts nothing.
+     */
+    toInsertText: (item: TriggerItem) => string
+    /** Notifies the consumer whenever the popover should change. */
+    onStateChange: (state: TriggerState) => void
+}
+
+// Translate the plugin's DOMRect into the serializable anchor shape. A DOMRect
+// is a live object whose values mutate between frames, so it must not be held.
+function toAnchor(rect: DOMRect | null | undefined): TriggerAnchor | null {
+    if (!rect) return null
+    return {
+        top: rect.top,
+        left: rect.left,
+        bottom: rect.bottom,
+        right: rect.right,
+        width: rect.width,
+        height: rect.height,
+    }
+}
+
+/**
+ * Build the ProseMirror extension for one trigger.
+ *
+ * Keyboard handling lives here rather than in the popover because the editor
+ * owns the keystrokes: the popover is not focused, so ArrowUp/Down/Enter/Escape
+ * would otherwise move the text caret instead of the selection.
+ */
+export function createTriggerExtension(config: TriggerConfig): Extension {
+    const pluginKey = new PluginKey(`tinycldTrigger:${config.id}`)
+
+    return Extension.create({
+        name: `tinycldTrigger_${config.id}`,
+
+        addProseMirrorPlugins() {
+            // Selection index is owned here — it survives `onUpdate` (the list
+            // re-filters as the query grows) and resets when the popover opens.
+            let selectedIndex = 0
+            let items: TriggerItem[] = []
+            let query = ''
+            let anchor: TriggerAnchor | null = null
+
+            // The plugin rebuilds `command` on every transaction with an
+            // updated range. Holding the one from `onStart` would insert at the
+            // ORIGINAL trigger position, dropping whatever was typed after it.
+            let currentCommand: ((item: TriggerItem) => void) | null = null
+
+            const select = (item: TriggerItem | undefined) => {
+                if (!item) return false
+                currentCommand?.(item)
+                return true
+            }
+
+            const publish = (isOpen: boolean) => {
+                config.onStateChange(
+                    isOpen
+                        ? {
+                              isOpen,
+                              query,
+                              items,
+                              selectedIndex,
+                              anchor,
+                              onSelect: item => {
+                                  select(item)
+                              },
+                          }
+                        : CLOSED_TRIGGER_STATE
+                )
+            }
+
+            return [
+                Suggestion<TriggerItem>({
+                    editor: this.editor,
+                    pluginKey,
+                    char: config.char,
+                    // Fire mid-line too, not only at the start of a block.
+                    startOfLine: false,
+                    // A mention query is one token; allowing spaces would keep
+                    // the popover open across the rest of the sentence.
+                    allowSpaces: false,
+                    items: ({ query: q }) => config.items(q),
+                    command: ({ editor, range, props }) => {
+                        const text = config.toInsertText(props)
+                        const chain = editor.chain().focus().deleteRange(range)
+                        if (text) chain.insertContent(text)
+                        chain.run()
+                    },
+                    render: () => ({
+                        onStart: props => {
+                            currentCommand = props.command
+                            items = props.items
+                            query = props.query
+                            selectedIndex = 0
+                            anchor = toAnchor(props.clientRect?.())
+                            publish(true)
+                        },
+                        onUpdate: props => {
+                            currentCommand = props.command
+                            items = props.items
+                            query = props.query
+                            // Clamp rather than reset: re-filtering must not
+                            // throw the highlight back to the top on every key.
+                            if (selectedIndex >= items.length) {
+                                selectedIndex = Math.max(0, items.length - 1)
+                            }
+                            anchor = toAnchor(props.clientRect?.())
+                            publish(true)
+                        },
+                        onKeyDown: ({ event }) => {
+                            if (items.length === 0) return false
+                            switch (event.key) {
+                                case 'ArrowDown':
+                                    selectedIndex = (selectedIndex + 1) % items.length
+                                    publish(true)
+                                    event.preventDefault()
+                                    return true
+                                case 'ArrowUp':
+                                    selectedIndex =
+                                        (selectedIndex - 1 + items.length) % items.length
+                                    publish(true)
+                                    event.preventDefault()
+                                    return true
+                                case 'Enter':
+                                case 'Tab':
+                                    if (!select(items[selectedIndex])) return false
+                                    event.preventDefault()
+                                    return true
+                                case 'Escape':
+                                    publish(false)
+                                    event.preventDefault()
+                                    return true
+                                default:
+                                    return false
+                            }
+                        },
+                        onExit: () => {
+                            currentCommand = null
+                            items = []
+                            query = ''
+                            anchor = null
+                            publish(false)
+                        },
+                    }),
+                }),
+            ]
+        },
+    })
+}

--- a/core/lib/editor/rich/triggers.ts
+++ b/core/lib/editor/rich/triggers.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
 import { PluginKey } from '@tiptap/pm/state'
-import Suggestion from '@tiptap/suggestion'
+import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion'
 
 // Character-triggered autocomplete for the shared rich editor.
 //
@@ -25,9 +25,21 @@ import Suggestion from '@tiptap/suggestion'
 // it differs by platform: on web the popover is a DOM overlay positioned from
 // `clientRect`; inside the native WebView there is no host UI, so the page
 // posts `show-popover` over the message bus and the host renders it (the
-// protocol is already specified in lib/editor/message-bus/types.ts). This
-// module therefore takes CALLBACKS rather than rendering anything — the caller
-// supplies `onStateChange`, and web/native each answer it their own way.
+// protocol lives in lib/editor/message-bus/popover-protocol.ts). Web therefore
+// gets the default CALLBACK strategy — the caller supplies `onStateChange` —
+// while the native page injects its own `render` (webview/source/
+// trigger-render-bridge.ts). An injectable rather than a mode flag, so the
+// bridge module (which reaches for `window.ReactNativeWebView`) never lands in
+// the web bundle.
+//
+// WHY THE CONFIG IS DECLARATIVE. `allItems` + `insertTemplate` rather than
+// `items(query)` + `toInsertText(item)` closures, because the native editor
+// page is a PREBUILT BUNDLE: a closure cannot cross into it. The host pushes
+// the candidate array over the bridge and the page filters locally, which also
+// keeps typing off the WebView round-trip. Both platforms then run the SAME
+// `filterTriggerItems`/`renderInsertTemplate`, so web and native cannot rank or
+// insert differently — a divergence that would otherwise be invisible until a
+// user compared their phone against their laptop.
 
 /** One selectable entry in a trigger's popover. */
 export interface TriggerItem {
@@ -79,20 +91,91 @@ export const CLOSED_TRIGGER_STATE: TriggerState = {
     onSelect: () => {},
 }
 
-export interface TriggerConfig {
+/**
+ * The part of a trigger that survives JSON — everything the native WebView
+ * page needs to run the plugin itself. Kept separate from {@link TriggerConfig}
+ * because the page receives exactly this and nothing more.
+ */
+export interface SerializableTriggerConfig {
     /** Distinguishes this trigger's plugin from any other on the editor. */
     id: string
     /** The character that opens it. */
     char: string
-    /** Candidates for the current query. Called on every keystroke. */
-    items: (query: string) => TriggerItem[]
+    /** The full candidate pool. Filtering happens per keystroke, locally. */
+    allItems: TriggerItem[]
+    /** How many rows to offer. Beyond this the user narrows by typing. */
+    limit?: number
     /**
-     * The text to put in the document in place of `<char><query>`. Returning ''
+     * What replaces `<char><query>`, with `{id}` / `{label}` / `{secondary}`
+     * substituted from the chosen item — e.g. `'[[@{id}]] '`. An empty result
      * removes the trigger text and inserts nothing.
      */
-    toInsertText: (item: TriggerItem) => string
+    insertTemplate: string
+}
+
+export interface TriggerConfig extends SerializableTriggerConfig {
     /** Notifies the consumer whenever the popover should change. */
     onStateChange: (state: TriggerState) => void
+    /**
+     * Overrides how the popover is presented. Absent → the callback strategy,
+     * which is what web uses. The native page supplies a bridge that posts over
+     * the message bus instead.
+     */
+    render?: NonNullable<SuggestionOptions<TriggerItem>['render']>
+}
+
+/** How many rows a trigger offers when its config does not say. */
+const DEFAULT_TRIGGER_LIMIT = 6
+
+/**
+ * Narrow a candidate pool to a query, case-insensitively, across both lines.
+ *
+ * Shared deliberately: web calls it through {@link createTriggerExtension} and
+ * the native page calls it directly, so the two cannot rank differently.
+ */
+export function filterTriggerItems(
+    items: TriggerItem[],
+    query: string,
+    limit: number = DEFAULT_TRIGGER_LIMIT
+): TriggerItem[] {
+    const q = query.trim().toLowerCase()
+    const matches = q
+        ? items.filter(
+              item =>
+                  item.label.toLowerCase().includes(q) ||
+                  (item.secondary?.toLowerCase().includes(q) ?? false)
+          )
+        : items
+    return matches.slice(0, limit)
+}
+
+/**
+ * Fill a trigger's insert template from the chosen item.
+ *
+ * Unknown placeholders are left verbatim rather than blanked: a template is
+ * author-supplied, and silently swallowing a typo would produce a token that
+ * looks right in the source and parses as nothing downstream.
+ */
+export function renderInsertTemplate(template: string, item: TriggerItem): string {
+    return template.replace(/\{(id|label|secondary)\}/g, (whole, field: string) => {
+        const value = item[field as keyof TriggerItem]
+        return typeof value === 'string' ? value : whole
+    })
+}
+
+/**
+ * The plugin key for a trigger id.
+ *
+ * Stable per id, because the native bridge needs the SAME instance the plugin
+ * registered under in order to call `exitSuggestion` when the host dismisses.
+ */
+const pluginKeys = new Map<string, PluginKey>()
+export function triggerPluginKey(id: string): PluginKey {
+    const existing = pluginKeys.get(id)
+    if (existing) return existing
+    const created = new PluginKey(`tinycldTrigger:${id}`)
+    pluginKeys.set(id, created)
+    return created
 }
 
 // Translate the plugin's DOMRect into the serializable anchor shape. A DOMRect
@@ -117,7 +200,7 @@ function toAnchor(rect: DOMRect | null | undefined): TriggerAnchor | null {
  * would otherwise move the text caret instead of the selection.
  */
 export function createTriggerExtension(config: TriggerConfig): Extension {
-    const pluginKey = new PluginKey(`tinycldTrigger:${config.id}`)
+    const pluginKey = triggerPluginKey(config.id)
 
     return Extension.create({
         name: `tinycldTrigger_${config.id}`,
@@ -168,69 +251,71 @@ export function createTriggerExtension(config: TriggerConfig): Extension {
                     // A mention query is one token; allowing spaces would keep
                     // the popover open across the rest of the sentence.
                     allowSpaces: false,
-                    items: ({ query: q }) => config.items(q),
+                    items: ({ query: q }) => filterTriggerItems(config.allItems, q, config.limit),
                     command: ({ editor, range, props }) => {
-                        const text = config.toInsertText(props)
+                        const text = renderInsertTemplate(config.insertTemplate, props)
                         const chain = editor.chain().focus().deleteRange(range)
                         if (text) chain.insertContent(text)
                         chain.run()
                     },
-                    render: () => ({
-                        onStart: props => {
-                            currentCommand = props.command
-                            items = props.items
-                            query = props.query
-                            selectedIndex = 0
-                            anchor = toAnchor(props.clientRect?.())
-                            publish(true)
-                        },
-                        onUpdate: props => {
-                            currentCommand = props.command
-                            items = props.items
-                            query = props.query
-                            // Clamp rather than reset: re-filtering must not
-                            // throw the highlight back to the top on every key.
-                            if (selectedIndex >= items.length) {
-                                selectedIndex = Math.max(0, items.length - 1)
-                            }
-                            anchor = toAnchor(props.clientRect?.())
-                            publish(true)
-                        },
-                        onKeyDown: ({ event }) => {
-                            if (items.length === 0) return false
-                            switch (event.key) {
-                                case 'ArrowDown':
-                                    selectedIndex = (selectedIndex + 1) % items.length
-                                    publish(true)
-                                    event.preventDefault()
-                                    return true
-                                case 'ArrowUp':
-                                    selectedIndex =
-                                        (selectedIndex - 1 + items.length) % items.length
-                                    publish(true)
-                                    event.preventDefault()
-                                    return true
-                                case 'Enter':
-                                case 'Tab':
-                                    if (!select(items[selectedIndex])) return false
-                                    event.preventDefault()
-                                    return true
-                                case 'Escape':
-                                    publish(false)
-                                    event.preventDefault()
-                                    return true
-                                default:
-                                    return false
-                            }
-                        },
-                        onExit: () => {
-                            currentCommand = null
-                            items = []
-                            query = ''
-                            anchor = null
-                            publish(false)
-                        },
-                    }),
+                    render:
+                        config.render ??
+                        (() => ({
+                            onStart: props => {
+                                currentCommand = props.command
+                                items = props.items
+                                query = props.query
+                                selectedIndex = 0
+                                anchor = toAnchor(props.clientRect?.())
+                                publish(true)
+                            },
+                            onUpdate: props => {
+                                currentCommand = props.command
+                                items = props.items
+                                query = props.query
+                                // Clamp rather than reset: re-filtering must not
+                                // throw the highlight back to the top on every key.
+                                if (selectedIndex >= items.length) {
+                                    selectedIndex = Math.max(0, items.length - 1)
+                                }
+                                anchor = toAnchor(props.clientRect?.())
+                                publish(true)
+                            },
+                            onKeyDown: ({ event }) => {
+                                if (items.length === 0) return false
+                                switch (event.key) {
+                                    case 'ArrowDown':
+                                        selectedIndex = (selectedIndex + 1) % items.length
+                                        publish(true)
+                                        event.preventDefault()
+                                        return true
+                                    case 'ArrowUp':
+                                        selectedIndex =
+                                            (selectedIndex - 1 + items.length) % items.length
+                                        publish(true)
+                                        event.preventDefault()
+                                        return true
+                                    case 'Enter':
+                                    case 'Tab':
+                                        if (!select(items[selectedIndex])) return false
+                                        event.preventDefault()
+                                        return true
+                                    case 'Escape':
+                                        publish(false)
+                                        event.preventDefault()
+                                        return true
+                                    default:
+                                        return false
+                                }
+                            },
+                            onExit: () => {
+                                currentCommand = null
+                                items = []
+                                query = ''
+                                anchor = null
+                                publish(false)
+                            },
+                        })),
                 }),
             ]
         },

--- a/core/lib/editor/rich/use-rich-editor.native.tsx
+++ b/core/lib/editor/rich/use-rich-editor.native.tsx
@@ -3,12 +3,16 @@ import { useFileToken } from '@tinycld/core/file-viewer/use-authed-file-url'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { pb } from '../../pocketbase'
 import { useThemeColor } from '../../use-app-theme'
+import { UI_POPOVER_DISMISS_ON_SCROLL } from '../message-bus/popover-protocol'
 import { makeMessage } from '../message-bus/types'
+import { publishUiMessage, registerEditorOverlay } from '../overlay'
 import type { EditorHandle, EditorResult } from '../types'
 import { useWebViewEditor } from '../use-webview-editor'
 import { AwarenessWebViewHost } from './awareness-webview-host'
 import { MarkdownWebViewHost } from './markdown-webview-host'
 import type { UseRichEditorOptions } from './options'
+import { TriggerItemsWebViewHost } from './trigger-items-webview-host'
+import type { TriggerItem } from './triggers'
 import { editorHtml } from './webview/build/editorHtml'
 import {
     APP_ESCAPE,
@@ -44,6 +48,9 @@ import { YjsWebViewHost } from './yjs-webview-host'
  * credential into the page and give the local user a second awareness identity,
  * so one human would show up as two peers.
  */
+/** Distinguishes concurrently-mounted editors. Never reused within a session. */
+let editorInstanceCounter = 0
+
 export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult {
     const {
         initialContent,
@@ -58,6 +65,8 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         onBlur,
         theme,
         collab,
+        triggers,
+        overlayKey,
     } = options
 
     const bgColor = useThemeColor('background')
@@ -130,6 +139,26 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     const collabUserId = collab?.user?.id
     const collabUserName = collab?.user?.name
     const collabUserColor = collab?.user?.color
+    // Identifies this editor among any others on the same screen, so a host
+    // overlay answers only its own popovers. A module counter rather than
+    // useId(): the value crosses to the page and back over a JSON pipe, and
+    // useId's colons are awkward in that round trip.
+    const instanceIdRef = useRef<string>('')
+    if (!instanceIdRef.current) instanceIdRef.current = `rich-${++editorInstanceCounter}`
+    const editorInstanceId = instanceIdRef.current
+
+    // Only the SHAPE of the triggers belongs in the init payload — the roster
+    // is pushed separately, because it changes as members come and go while
+    // init is one-shot per mount.
+    const triggerSignature = JSON.stringify(
+        (triggers ?? []).map(t => ({
+            id: t.id,
+            char: t.char,
+            limit: t.limit,
+            insertTemplate: t.insertTemplate,
+        }))
+    )
+
     const initPayload: RichEditorInitPayload = useMemo(() => {
         const peersAtHandshake = awarenessHost?.encodePeers() ?? null
         return {
@@ -146,6 +175,22 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                 primary: primaryColor,
             },
             ...(fileToken ? { fileAuth: { baseURL: pb.baseURL, token: fileToken } } : {}),
+            editorInstanceId,
+            // Seeded with an EMPTY roster: the real one follows immediately as
+            // a push, and baking it in here would rebuild the whole handshake
+            // every time someone joined the board.
+            ...(triggerSignature === '[]'
+                ? {}
+                : {
+                      triggers: (
+                          JSON.parse(triggerSignature) as {
+                              id: string
+                              char: string
+                              limit?: number
+                              insertTemplate: string
+                          }[]
+                      ).map(t => ({ ...t, allItems: [] })),
+                  }),
             // Snapshotted at handshake time. Anything the doc gains between
             // now and the page mounting arrives as a normal relayed update, so
             // a slightly stale seed is not a lost edit.
@@ -191,6 +236,8 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         collabUserName,
         collabUserColor,
         fileToken,
+        editorInstanceId,
+        triggerSignature,
     ])
 
     // Token rotations (and a token that resolves after the handshake) reach
@@ -218,10 +265,37 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
 
     useEffect(() => () => markdownHost.destroy(), [markdownHost])
 
+    const triggerItemsHostRef = useRef<TriggerItemsWebViewHost | null>(null)
+    if (triggerItemsHostRef.current === null) {
+        triggerItemsHostRef.current = new TriggerItemsWebViewHost({
+            postMessage: message => posterRef.current?.(message as never) ?? false,
+        })
+    }
+    const triggerItemsHost = triggerItemsHostRef.current
+
+    // Push each roster whenever it changes. The effect depends on the
+    // SERIALIZED rosters rather than the array: a live query hands back a fresh
+    // array on every emission, so an identity dep would post on writes that
+    // changed nobody. Parsing the signature back is what keeps the dep honest —
+    // the effect reads only what it depends on.
+    const rosterSignature = useMemo(
+        () => JSON.stringify((triggers ?? []).map(t => [t.id, t.allItems])),
+        [triggers]
+    )
+    useEffect(() => {
+        for (const [id, items] of JSON.parse(rosterSignature) as [string, TriggerItem[]][]) {
+            triggerItemsHost.push(id, items)
+        }
+    }, [rosterSignature, triggerItemsHost])
+
     // TenTap's stock bridges still drive the toolbar commands and the
     // getHTML/getText/setContent/focus surface that mail relies on. Their
     // Tiptap counterparts live in our page, which registers the same schema.
     const bridgeExtensions = useMemo(() => [...TenTapStartKit, CoreBridge.configureCSS('')], [])
+
+    const onDocumentScroll = useCallback(() => {
+        publishUiMessage({ namespace: 'ui', type: UI_POPOVER_DISMISS_ON_SCROLL, payload: null })
+    }, [])
 
     const onMessage = useCallback(
         (message: { namespace?: string; type?: string }) => {
@@ -246,6 +320,15 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         // an inner scroll surface would fight it.
         scrollEnabled: false,
         onMessage,
+        // Everything on the 'ui' namespace goes to the bus, where a mounted
+        // overlay controller for THIS editor picks it up. The hook itself draws
+        // nothing — an autocomplete popover is the consumer's UI, not core's.
+        onUiMessage: publishUiMessage,
+        // An overlay anchored to a range that has scrolled away is worse than
+        // no overlay, so a document scroll closes any open popover. Published
+        // without an instance id: it is a screen-wide gesture, so every
+        // controller should hear it.
+        onScroll: onDocumentScroll,
         // Split the host's single edge callback into the same pair of handlers
         // the web variant exposes, so the shared .d.ts contract holds.
         onFocusChange: (isFocused: boolean) => {
@@ -255,6 +338,15 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     })
 
     posterRef.current = result.postMessage ?? null
+
+    // Publish the handle a host overlay needs to anchor to this editor. The
+    // popover is rendered as a sibling (often in another subtree entirely), so
+    // context cannot reach it — see editor-overlay-registry.ts.
+    const webViewRef = result.webViewRef
+    useEffect(() => {
+        if (!overlayKey) return
+        return registerEditorOverlay(overlayKey, { webViewRef, editorInstanceId })
+    }, [overlayKey, webViewRef, editorInstanceId])
 
     // Layer the markdown channel onto the shared handle. Everything else —
     // getHTML, setContent, focus, clear — is TenTap's, unchanged, which is what

--- a/core/lib/editor/rich/use-rich-editor.web.tsx
+++ b/core/lib/editor/rich/use-rich-editor.web.tsx
@@ -112,7 +112,8 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
 
     // Each trigger is wrapped once in a stable config that forwards to whatever
     // is current, looked up by id through the ref. Without this the editor
-    // would be recreated on every keystroke.
+    // would be recreated on every keystroke — and, since `allItems` is a fresh
+    // array whenever the roster query re-emits, on every membership change too.
     const stableTriggers = useMemo(
         () =>
             triggerSignature
@@ -122,11 +123,21 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                     const id = entry.slice(0, entry.lastIndexOf(':'))
                     const char = entry.slice(entry.lastIndexOf(':') + 1)
                     const current = () => triggersRef.current?.find(x => x.id === id)
+                    // `allItems` is a getter rather than a value: the roster
+                    // changes as members join, and baking the array in here
+                    // would freeze the candidate list at editor-creation time.
                     return {
                         id,
                         char,
-                        items: query => current()?.items(query) ?? [],
-                        toInsertText: item => current()?.toInsertText(item) ?? '',
+                        get allItems() {
+                            return current()?.allItems ?? []
+                        },
+                        get limit() {
+                            return current()?.limit
+                        },
+                        get insertTemplate() {
+                            return current()?.insertTemplate ?? ''
+                        },
                         onStateChange: state => current()?.onStateChange(state),
                     }
                 }),

--- a/core/lib/editor/rich/use-rich-editor.web.tsx
+++ b/core/lib/editor/rich/use-rich-editor.web.tsx
@@ -13,6 +13,7 @@ import { buildRichEditorExtensions } from './extensions'
 import { extractImageFilesFromDrop, extractImageFilesFromPaste } from './extract-image-files'
 import { repairMarkdown } from './markdown-repair'
 import type { UseRichEditorOptions } from './options'
+import type { TriggerConfig } from './triggers'
 
 /**
  * Inject the shared content stylesheet once per page.
@@ -76,6 +77,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         onBlur,
         onImageDrop,
         collab,
+        triggers,
     } = options
 
     const placeholderColor = useThemeColor('field-placeholder')
@@ -92,6 +94,45 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     focusRef.current = onFocus
     const blurRef = useRef(onBlur)
     blurRef.current = onBlur
+    // Triggers carry callbacks (`items`, `onStateChange`) that close over
+    // fresh state, and callers build the array inline — so its identity churns
+    // every render. Rebuilding the extension list on that identity would
+    // recreate the whole editor on every keystroke. Instead the array is read
+    // through a ref and each trigger is wrapped ONCE in a stable config that
+    // forwards to the current one, keyed by trigger id. Same reasoning as the
+    // handler refs above; the extra step is that the wrapper must survive too.
+    const triggersRef = useRef(triggers)
+    triggersRef.current = triggers
+
+    // What actually warrants a rebuild: which triggers exist, not the identity
+    // of the callbacks they carry. Derived into a plain string so the memo
+    // below depends on a VALUE rather than an array literal — a dependency the
+    // linter can check, instead of one it has to be told to ignore.
+    const triggerSignature = (triggers ?? []).map(t => `${t.id}:${t.char}`).join(',')
+
+    // Each trigger is wrapped once in a stable config that forwards to whatever
+    // is current, looked up by id through the ref. Without this the editor
+    // would be recreated on every keystroke.
+    const stableTriggers = useMemo(
+        () =>
+            triggerSignature
+                .split(',')
+                .filter(Boolean)
+                .map((entry): TriggerConfig => {
+                    const id = entry.slice(0, entry.lastIndexOf(':'))
+                    const char = entry.slice(entry.lastIndexOf(':') + 1)
+                    const current = () => triggersRef.current?.find(x => x.id === id)
+                    return {
+                        id,
+                        char,
+                        items: query => current()?.items(query) ?? [],
+                        toInsertText: item => current()?.toInsertText(item) ?? '',
+                        onStateChange: state => current()?.onStateChange(state),
+                    }
+                }),
+        [triggerSignature]
+    )
+
     const imageDropRef = useRef(onImageDrop)
     imageDropRef.current = onImageDrop
 
@@ -118,6 +159,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
             buildRichEditorExtensions({
                 placeholder,
                 characterLimit,
+                triggers: stableTriggers,
                 imageNodeView: AUTHED_IMAGE_NODE_VIEW,
                 onSubmitShortcut: hasSubmitShortcut ? () => submitRef.current?.() : undefined,
                 collab:
@@ -140,6 +182,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         [
             placeholder,
             characterLimit,
+            stableTriggers,
             hasSubmitShortcut,
             collabDoc,
             collabField,

--- a/core/lib/editor/rich/webview/source/Editor.tsx
+++ b/core/lib/editor/rich/webview/source/Editor.tsx
@@ -6,7 +6,8 @@ import {
     ReactNodeViewRenderer,
     useEditor,
 } from '@tiptap/react'
-import { useEffect, useState, useSyncExternalStore } from 'react'
+import { exitSuggestion } from '@tiptap/suggestion'
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { Awareness, applyAwarenessUpdate, removeAwarenessStates } from 'y-protocols/awareness'
 import * as Y from 'yjs'
 import type { EditorMessage } from '../../../message-bus/types'
@@ -19,6 +20,7 @@ import {
     APP_ESCAPE,
     APP_FILE_TOKEN,
     APP_SUBMIT_SHORTCUT,
+    APP_TRIGGER_ITEMS,
     AWARENESS_CURSOR,
     AWARENESS_LEAVE,
     AWARENESS_PEERS,
@@ -34,12 +36,19 @@ import {
     type RichEditorFileAuth,
     type RichEditorInitCollab,
     type RichEditorInitPayload,
+    type TriggerItemsPayload,
     UI_CONTENT_HEIGHT,
     YJS_UPDATE,
     type YjsUpdatePayload,
 } from './protocol'
 import { deriveWebViewState } from './state'
 import { buildEditorCSS } from './styles'
+import { getTriggerItems, setTriggerItems } from './trigger-items-store'
+import {
+    createTriggerBridgeRender,
+    defaultNewRequestId,
+    defaultPostToHost,
+} from './trigger-render-bridge'
 
 declare global {
     interface Window {
@@ -150,6 +159,15 @@ function EditorMounted({ init }: { init: RichEditorInitPayload }) {
         if (init.fileAuth) setFileAuth(init.fileAuth)
     }, [init.fileAuth])
 
+    // Same reasoning for the trigger rosters, but seeded during render rather
+    // than in an effect: the suggestion plugin reads the store synchronously
+    // from a transaction, and an effect would leave an `@` typed before the
+    // first paint looking at an empty roster. Idempotent, so a re-render costs
+    // a Map write; a later APP_TRIGGER_ITEMS overwrites it.
+    useMemo(() => {
+        for (const trigger of init.triggers ?? []) setTriggerItems(trigger.id, trigger.allItems)
+    }, [init.triggers])
+
     const collab = useCollabDoc(init.collab)
 
     const editor = useEditor({
@@ -160,6 +178,24 @@ function EditorMounted({ init }: { init: RichEditorInitPayload }) {
             characterLimit: init.characterLimit,
             imageNodeView: AUTHED_IMAGE_NODE_VIEW,
             onSubmitShortcut: () => postToNative(makeMessage('app', APP_SUBMIT_SHORTCUT, null)),
+            // Candidates come from the store rather than the init payload's
+            // frozen copy, so a roster pushed later is picked up without
+            // rebuilding the editor. `onStateChange` is the web callback
+            // channel and has nobody to talk to here — the bridge posts to the
+            // host instead.
+            triggers: (init.triggers ?? []).map(trigger => ({
+                ...trigger,
+                get allItems() {
+                    return getTriggerItems(trigger.id)
+                },
+                onStateChange: () => {},
+                render: createTriggerBridgeRender(trigger, {
+                    postToHost: defaultPostToHost,
+                    newRequestId: defaultNewRequestId,
+                    exitSuggestion,
+                    editorInstanceId: init.editorInstanceId,
+                }),
+            })),
             collab: collab
                 ? {
                       document: collab.doc,
@@ -494,6 +530,13 @@ function useHostMessages(editor: TiptapEditor | null, isCollab: boolean) {
                 const auth = parsed.payload as RichEditorFileAuth | undefined
                 if (auth && typeof auth.token === 'string' && typeof auth.baseURL === 'string') {
                     setFileAuth(auth)
+                }
+                return
+            }
+            if (parsed.namespace === 'app' && parsed.type === APP_TRIGGER_ITEMS) {
+                const roster = parsed.payload as TriggerItemsPayload | undefined
+                if (roster && typeof roster.triggerId === 'string' && Array.isArray(roster.items)) {
+                    setTriggerItems(roster.triggerId, roster.items)
                 }
                 return
             }

--- a/core/lib/editor/rich/webview/source/protocol.ts
+++ b/core/lib/editor/rich/webview/source/protocol.ts
@@ -10,6 +10,7 @@
  * types their payloads.
  */
 import type { EditorContentFormat } from '../../options'
+import type { SerializableTriggerConfig, TriggerItem } from '../../triggers'
 
 /** host → WebView. Replaces the document. */
 export const MARKDOWN_SET = 'set'
@@ -37,6 +38,18 @@ export const APP_ESCAPE = 'escape'
  * common case where the token exists before the handshake.
  */
 export const APP_FILE_TOKEN = 'file-auth'
+
+/**
+ * host → WebView: replace one trigger's candidate pool.
+ *
+ * The page holds a SNAPSHOT of the candidates rather than asking per keystroke.
+ * A round-trip per character would cross the bridge on a JS thread already
+ * carrying the Yjs relay, and would need sequence numbers to stop a late `@na`
+ * response rendering under a typed `@nath`. The cost is that a member added
+ * while the popover is open appears on the next push rather than the next
+ * keystroke — bounded, and invisible at human speed.
+ */
+export const APP_TRIGGER_ITEMS = 'trigger-items'
 
 /**
  * Yjs document update, base64-encoded. Sent in BOTH directions: the host
@@ -145,6 +158,23 @@ export interface RichEditorInitPayload {
      * handshake time. Later rotations arrive as {@link APP_FILE_TOKEN}.
      */
     fileAuth?: RichEditorFileAuth
+    /**
+     * Character-triggered autocompletes, in their serializable form. Absent →
+     * the page installs none. Rosters are refreshed by {@link APP_TRIGGER_ITEMS}.
+     */
+    triggers?: SerializableTriggerConfig[]
+    /**
+     * Identifies this editor among any others mounted on the same screen, so a
+     * host overlay can tell whose popover it is drawing. See
+     * {@link ShowPopoverPayload.editorInstanceId}.
+     */
+    editorInstanceId?: string
+}
+
+/** Payload for {@link APP_TRIGGER_ITEMS}. */
+export interface TriggerItemsPayload {
+    triggerId: string
+    items: TriggerItem[]
 }
 
 /** Payload for {@link APP_FILE_TOKEN} and `RichEditorInitPayload.fileAuth`. */

--- a/core/lib/editor/rich/webview/source/trigger-items-store.ts
+++ b/core/lib/editor/rich/webview/source/trigger-items-store.ts
@@ -1,0 +1,30 @@
+import type { TriggerItem } from '../../triggers'
+
+/**
+ * The page's copy of each trigger's candidate pool, keyed by trigger id.
+ *
+ * A plain module store rather than React state because of WHO reads it: the
+ * suggestion plugin's `items` callback runs inside a ProseMirror transaction,
+ * not a render, and must see the current roster synchronously. A `useState`
+ * value would be a render behind, and the plugin holds no component to
+ * subscribe with. `file-auth-store.ts` solves the same problem for the file
+ * token; this one needs no listeners, since nothing re-renders on a change —
+ * the next keystroke simply reads the new value.
+ *
+ * Seeded from the init payload and refreshed by APP_TRIGGER_ITEMS whenever the
+ * host's roster query re-emits.
+ */
+const items = new Map<string, TriggerItem[]>()
+
+export function setTriggerItems(triggerId: string, next: TriggerItem[]): void {
+    items.set(triggerId, next)
+}
+
+export function getTriggerItems(triggerId: string): TriggerItem[] {
+    return items.get(triggerId) ?? []
+}
+
+/** Test-only. The store is module-global, so suites would otherwise leak. */
+export function resetTriggerItems(): void {
+    items.clear()
+}

--- a/core/lib/editor/rich/webview/source/trigger-render-bridge.ts
+++ b/core/lib/editor/rich/webview/source/trigger-render-bridge.ts
@@ -1,0 +1,249 @@
+import type { exitSuggestion, SuggestionOptions } from '@tiptap/suggestion'
+import {
+    type PopoverRect,
+    type PopoverResultPayload,
+    type TriggerPopoverSelection,
+    triggerPopoverKind,
+    UI_POPOVER_EXITED,
+    UI_POPOVER_RESULT,
+    UI_POPOVER_UPDATE,
+    UI_SHOW_POPOVER,
+} from '../../../message-bus/popover-protocol'
+import { type SerializableTriggerConfig, type TriggerItem, triggerPluginKey } from '../../triggers'
+
+/**
+ * The bridge render strategy for a trigger, running INSIDE the WebView page.
+ *
+ * The page has no host UI of its own, so instead of drawing a popover it posts
+ * `show-popover` and lets the native side render one, answering over
+ * `popover-result`. Selections and dismissals arrive on a 'message' listener
+ * held for the lifetime of the open popover.
+ *
+ * What stays in the page, deliberately: item filtering, the selected index, and
+ * the insert itself. Only the page holds the suggestion plugin's live `range`,
+ * which moves as the query grows — a host that assembled its own insert would
+ * write at the ORIGINAL trigger position and leave the typed query behind. The
+ * host's job is to draw pixels and report taps.
+ *
+ * Keyboard handling stays here too: the overlay is never focused, so a hardware
+ * or Android soft keyboard's arrows would otherwise move the text caret.
+ *
+ * Deps are injected so the wire format can be asserted in a unit test without a
+ * device — nothing else on this path is testable, which is exactly why it is
+ * worth the indirection.
+ */
+
+/**
+ * Post a 'ui' message out of the WebView. Silently no-ops on the host, where
+ * `window.ReactNativeWebView` is undefined.
+ */
+export function defaultPostToHost(message: object) {
+    const target = (
+        globalThis as { window?: { ReactNativeWebView?: { postMessage: (s: string) => void } } }
+    ).window
+    target?.ReactNativeWebView?.postMessage(JSON.stringify(message))
+}
+
+/**
+ * Correlation id for a show-popover. `crypto.randomUUID` is not guaranteed in
+ * the WebView's content world; a timestamp plus a random tail disambiguates
+ * plenty within one editing session.
+ */
+export function defaultNewRequestId(triggerId: string): string {
+    return `${triggerId}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+/** Translate the plugin's live DOMRect into the serializable wire shape. */
+export function toPopoverRect(rect: DOMRect | null | undefined): PopoverRect | null {
+    if (!rect) return null
+    return {
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+        scrollX: typeof window === 'undefined' ? 0 : window.scrollX,
+        scrollY: typeof window === 'undefined' ? 0 : window.scrollY,
+    }
+}
+
+export interface TriggerBridgeDeps {
+    postToHost: (message: object) => void
+    newRequestId: (triggerId: string) => string
+    exitSuggestion: typeof exitSuggestion
+    /**
+     * Which editor this page is. Rides on every posted message so a host with
+     * several editors mounted answers only its own — see
+     * `ShowPopoverPayload.editorInstanceId`.
+     */
+    editorInstanceId?: string
+}
+
+export function createTriggerBridgeRender(
+    config: SerializableTriggerConfig,
+    deps: TriggerBridgeDeps
+): NonNullable<SuggestionOptions<TriggerItem>['render']> {
+    const kind = triggerPopoverKind(config.id)
+    // The same instance the plugin registered under — exitSuggestion resolves
+    // its state by key, so a fresh PluginKey here would silently find nothing.
+    const pluginKey = triggerPluginKey(config.id)
+
+    return () => {
+        let currentRequestId: string | null = null
+        // `SuggestionProps.command` is the WRAPPED form — the plugin captures
+        // editor and range internally and hands back a closure taking only the
+        // item. It is rebuilt every transaction, so holding the one from
+        // onStart would insert at a stale position.
+        let currentCommand: ((item: TriggerItem) => void) | null = null
+        let currentItems: TriggerItem[] = []
+        let currentQuery = ''
+        let selectedIndex = 0
+        let editorView: import('@tiptap/pm/view').EditorView | null = null
+
+        const dismissPlugin = () => {
+            if (!editorView) return
+            try {
+                deps.exitSuggestion(editorView, pluginKey)
+            } catch {
+                // The plugin state can already be cleared by an intervening
+                // transaction; there is nothing left to exit.
+            }
+        }
+
+        const post = (type: string, payload: unknown) => {
+            if (!currentRequestId) return
+            deps.postToHost({
+                namespace: 'ui',
+                type,
+                requestId: currentRequestId,
+                payload,
+            })
+        }
+
+        const postUpdate = () => {
+            post(UI_POPOVER_UPDATE, {
+                payload: { items: currentItems, query: currentQuery, selectedIndex },
+                editorInstanceId: deps.editorInstanceId,
+            })
+        }
+
+        const listen = (add: boolean) => {
+            if (typeof window === 'undefined') return
+            // Android delivers on `document`, iOS on `window`. Both, always.
+            if (add) {
+                window.addEventListener('message', onHostMessage)
+                document.addEventListener('message', onHostMessage as EventListener)
+            } else {
+                window.removeEventListener('message', onHostMessage)
+                document.removeEventListener('message', onHostMessage as EventListener)
+            }
+        }
+
+        function onHostMessage(evt: MessageEvent) {
+            if (typeof evt.data !== 'string') return
+            let parsed: { namespace?: string; type?: string; requestId?: string; payload?: unknown }
+            try {
+                parsed = JSON.parse(evt.data)
+            } catch {
+                return
+            }
+            if (parsed.namespace !== 'ui' || parsed.type !== UI_POPOVER_RESULT) return
+            if (!currentRequestId || parsed.requestId !== currentRequestId) return
+
+            const payload = parsed.payload as
+                | PopoverResultPayload<TriggerPopoverSelection>
+                | null
+                | undefined
+            if (payload?.action === 'select') {
+                const picked = currentItems.find(item => item.id === payload.payload?.itemId)
+                if (picked) currentCommand?.(picked)
+                currentRequestId = null
+            } else if (payload?.action === 'dismiss') {
+                dismissPlugin()
+                currentRequestId = null
+            }
+        }
+
+        return {
+            onStart: props => {
+                currentCommand = props.command
+                currentItems = props.items
+                currentQuery = props.query
+                selectedIndex = 0
+                editorView = props.editor.view
+
+                const rect = toPopoverRect(props.clientRect?.())
+                // No anchor means nowhere to put the overlay. Staying silent
+                // beats asking the host to draw at (0,0).
+                if (!rect) return
+
+                currentRequestId = deps.newRequestId(config.id)
+                listen(true)
+                post(UI_SHOW_POPOVER, {
+                    kind,
+                    rect,
+                    payload: { items: currentItems, query: currentQuery, selectedIndex },
+                    editorInstanceId: deps.editorInstanceId,
+                })
+            },
+
+            onUpdate: props => {
+                currentCommand = props.command
+                currentItems = props.items
+                currentQuery = props.query
+                // Clamp rather than reset: re-filtering as the query grows must
+                // not throw the highlight back to the top on every keystroke.
+                if (selectedIndex >= currentItems.length) {
+                    selectedIndex = Math.max(0, currentItems.length - 1)
+                }
+                postUpdate()
+            },
+
+            onKeyDown: ({ event }) => {
+                if (!currentRequestId) return false
+                switch (event.key) {
+                    case 'ArrowDown':
+                        if (currentItems.length === 0) return false
+                        selectedIndex = (selectedIndex + 1) % currentItems.length
+                        postUpdate()
+                        event.preventDefault()
+                        return true
+                    case 'ArrowUp':
+                        if (currentItems.length === 0) return false
+                        selectedIndex =
+                            (selectedIndex - 1 + currentItems.length) % currentItems.length
+                        postUpdate()
+                        event.preventDefault()
+                        return true
+                    case 'Enter':
+                    case 'Tab': {
+                        const item = currentItems[selectedIndex]
+                        if (!item) return false
+                        currentCommand?.(item)
+                        event.preventDefault()
+                        return true
+                    }
+                    case 'Escape':
+                        dismissPlugin()
+                        event.preventDefault()
+                        return true
+                    default:
+                        return false
+                }
+            },
+
+            onExit: () => {
+                // The plugin wound down on its own — a space broke the trigger,
+                // an item was picked, Escape. Tell the host so it closes any
+                // overlay still open for this request.
+                post(UI_POPOVER_EXITED, { editorInstanceId: deps.editorInstanceId })
+                listen(false)
+                currentRequestId = null
+                currentCommand = null
+                currentItems = []
+                currentQuery = ''
+                selectedIndex = 0
+                editorView = null
+            },
+        }
+    }
+}

--- a/core/lib/use-notification-preferences.ts
+++ b/core/lib/use-notification-preferences.ts
@@ -1,5 +1,10 @@
 import { useUserPreference } from '@tinycld/core/lib/use-user-preference'
 
+// Each key is a notification TYPE string, matching the `Type` the server sends
+// in NotifyParams — server/notify/notify.go looks the type up in this map by
+// name and skips the send when it is false. A type missing from the stored
+// preferences is NOT muted (the server defaults to sending), so adding a key
+// here is what makes an existing notification mutable, not what enables it.
 export interface NotificationPreferences {
     calendar_reminder: boolean
     calendar_invite: boolean
@@ -8,6 +13,22 @@ export interface NotificationPreferences {
     drive_file_shared: boolean
     org_invite: boolean
     system_error: boolean
+    /**
+     * Being @mentioned in a document comment (text, calc) — the type
+     * server/notify/comment_mentions.go sends. This was MISSING, which meant
+     * mention notifications could not be muted at all; the omission predates
+     * cards and affected text/calc too.
+     */
+    comment_mention: boolean
+    /**
+     * Being @mentioned on a card — its own switch rather than sharing
+     * `comment_mention`, because the two are different enough in cadence to
+     * want muting separately: a board is chattier than a document, and someone
+     * who wants card noise off usually still wants a doc mention. Sent by
+     * cards' description flush hook (server/description_mentions.go) and by
+     * the comment path for `cards_comments`.
+     */
+    cards_mention: boolean
 }
 
 const DEFAULT_PREFS: NotificationPreferences = {
@@ -18,6 +39,8 @@ const DEFAULT_PREFS: NotificationPreferences = {
     drive_file_shared: true,
     org_invite: true,
     system_error: true,
+    comment_mention: true,
+    cards_mention: true,
 }
 
 export type MailNotifyMode = 'batched' | 'important_only'

--- a/core/package.json
+++ b/core/package.json
@@ -81,6 +81,7 @@
         "@tiptap/markdown": "^3.29.2",
         "@tiptap/react": "^3.29.2",
         "@tiptap/starter-kit": "^3.29.2",
+        "@tiptap/suggestion": "^3.29.2",
         "expo-clipboard": "~55.0.13",
         "expo-constants": "~55.0.16",
         "expo-crypto": "^55.0.12",

--- a/core/server/notify/comment_mentions.go
+++ b/core/server/notify/comment_mentions.go
@@ -15,8 +15,22 @@ import (
 // Each entry maps the comment table to its owning package's URL slug
 // (e.g. `text_comments` → `text`), used to build the deep-link.
 var allowedCommentCollections = map[string]string{
-	"text_comments": "text",
-	"calc_comments": "calc",
+	"text_comments":  "text",
+	"calc_comments":  "calc",
+	"cards_comments": "cards",
+}
+
+// documentPackages are the packages whose content is stored as a drive
+// item, and whose deep-link is therefore `/p/<slug>/<driveItemId>`.
+// A package absent from this set links through linkForTarget instead.
+//
+// This set exists because `comment_mentions` is no longer drive-only.
+// Core migration 1985000002 generalized it with `target_collection` /
+// `target_record`, so a mention can now hang off any package's record —
+// cards is the first — and those packages have their own URL shapes.
+var documentPackages = map[string]bool{
+	"text": true,
+	"calc": true,
 }
 
 // RegisterCommentMentionHooks wires the OnRecordAfterCreateSuccess hook
@@ -76,29 +90,25 @@ func handleCommentMention(app core.App, mention *core.Record) {
 		return
 	}
 
+	// Resolve what the mention points at. `target_collection` /
+	// `target_record` are authoritative (core 1985000002 backfilled every
+	// pre-existing row to `drive_items` + the drive_item id), but
+	// `drive_item` is still read as a fallback: a row written by an older
+	// client between the migration landing and that client updating would
+	// carry only the legacy column.
+	targetCollection := mention.GetString("target_collection")
+	targetRecord := mention.GetString("target_record")
 	driveItemID := mention.GetString("drive_item")
-	if driveItemID == "" {
+	if targetRecord == "" {
+		targetCollection, targetRecord = "drive_items", driveItemID
+	}
+	if targetRecord == "" {
 		return
 	}
 
-	// Build the deep-link. For an anchored comment, the `?thread=<id>`
-	// query param is read by the document screen's useCommentsLifecycle
-	// hook to open the drawer focused on the mentioned thread. For a
-	// suggestion-reply mention (carries a non-empty `suggestion_id`),
-	// the deep-link uses `?focusSuggestion=<id>` instead so the
-	// document screen's useFocusSuggestionParam hook opens the review
-	// drawer focused on the matching suggestion row rather than the
-	// comments drawer. Routes are slug-scoped (/p/<slug>/…) — single-org,
-	// no org slug in the path.
 	threadID := commentThreadID(comment)
 	suggestionID := comment.GetString("suggestion_id")
-	appURL := strings.TrimRight(app.Settings().Meta.AppURL, "/")
-	var url string
-	if suggestionID != "" {
-		url = fmt.Sprintf("%s/p/%s/%s?focusSuggestion=%s", appURL, packageSlug, driveItemID, suggestionID)
-	} else {
-		url = fmt.Sprintf("%s/p/%s/%s?thread=%s", appURL, packageSlug, driveItemID, threadID)
-	}
+	url := linkForTarget(app, packageSlug, targetRecord, threadID, suggestionID)
 
 	authorName := comment.GetString("author_name")
 	if authorName == "" {
@@ -110,7 +120,7 @@ func handleCommentMention(app core.App, mention *core.Record) {
 
 	NotifyUser(app, NotifyParams{
 		UserID:  mentionedUserID,
-		Type:    "comment_mention",
+		Type:    mentionTypeFor(packageSlug),
 		Package: packageSlug,
 		Title:   title,
 		Body:    body,
@@ -118,11 +128,76 @@ func handleCommentMention(app core.App, mention *core.Record) {
 		Meta: map[string]any{
 			"commentCollection": commentCollection,
 			"commentRecord":     comment.Id,
-			"driveItem":         driveItemID,
-			"threadId":          threadID,
-			"suggestionId":      suggestionID,
+			// driveItem is kept for drive-backed packages so existing
+			// consumers of the payload keep reading the field they expect;
+			// it is empty for a non-document package.
+			"driveItem":        driveItemID,
+			"targetCollection": targetCollection,
+			"targetRecord":     targetRecord,
+			"threadId":         threadID,
+			"suggestionId":     suggestionID,
 		},
 	})
+}
+
+// mentionTypeFor picks the notification TYPE, which is what the per-user mute
+// preference is keyed on (see isNotificationMuted + core's
+// lib/use-notification-preferences.ts).
+//
+// Document packages share `comment_mention`: being @mentioned in a text or calc
+// comment is one thing to a reader, and one switch should silence it.
+//
+// A non-document package gets `<slug>_mention` instead, because its mentions
+// arrive at a different cadence and are worth muting separately — a board is
+// chattier than a document. This ALSO keeps a package's two mention sources on
+// one switch: cards' description mentions come from its own flush hook
+// (cards/server/description_mentions.go) and already send `cards_mention`, so a
+// comment mention must too, or muting cards would silence only half of them.
+func mentionTypeFor(packageSlug string) string {
+	if documentPackages[packageSlug] {
+		return "comment_mention"
+	}
+	return packageSlug + "_mention"
+}
+
+// linkForTarget builds the deep-link back to the mentioned content.
+//
+// Document packages (text, calc) store content as a drive item and route it
+// at `/p/<slug>/<driveItemId>`. For an anchored comment the `?thread=<id>`
+// param is read by the document screen's useCommentsLifecycle hook to open the
+// drawer focused on the mentioned thread; a suggestion-reply mention (non-empty
+// `suggestion_id`) uses `?focusSuggestion=<id>` instead, so the review drawer
+// opens on the matching suggestion row rather than the comments drawer.
+//
+// Every other package owns its own route, so there is no drive item to point
+// at and no generic shape to guess. Cards routes its board at `/cards` and
+// opens a card with `?focused=<key|id>` (usePeekUrl). The record id is used
+// rather than the OTTER-123 key because the key is composed from the board's
+// slug and a server-assigned number that this hook would have to re-derive —
+// resolveOnBoard accepts either spelling, so the id is the link that cannot go
+// stale.
+//
+// Routes are slug-scoped — single-org, so no org slug in the path.
+func linkForTarget(app core.App, packageSlug, targetRecord, threadID, suggestionID string) string {
+	appURL := strings.TrimRight(app.Settings().Meta.AppURL, "/")
+
+	if documentPackages[packageSlug] {
+		if suggestionID != "" {
+			return fmt.Sprintf("%s/p/%s/%s?focusSuggestion=%s",
+				appURL, packageSlug, targetRecord, suggestionID)
+		}
+		return fmt.Sprintf("%s/p/%s/%s?thread=%s",
+			appURL, packageSlug, targetRecord, threadID)
+	}
+
+	if packageSlug == "cards" {
+		return fmt.Sprintf("%s/cards?focused=%s", appURL, targetRecord)
+	}
+
+	// A package in the allowlist but with no link shape declared. Better a
+	// notification that lands in the bell with a bare package link than one
+	// that is dropped entirely.
+	return fmt.Sprintf("%s/%s", appURL, packageSlug)
 }
 
 // commentThreadID returns the root comment id for the thread. For

--- a/core/server/notify/comment_mentions_test.go
+++ b/core/server/notify/comment_mentions_test.go
@@ -379,3 +379,270 @@ func TestCommentMention_HookIsRegisteredAndFiresAsync(t *testing.T) {
 		t.Fatal("expected notification to be written by registered hook within 1s")
 	}
 }
+
+// --- polymorphic target (core 1985000002) ---
+//
+// `comment_mentions` is no longer drive-only: it carries target_collection /
+// target_record so a mention can hang off any package's record. These tests
+// cover the cards path (no drive item at all) and the legacy fallback.
+
+// addCardsComments extends the fixture app with the cards_comments table the
+// cards path resolves its author through. Mirrors the real collection's
+// shape only as far as this hook reads it.
+func addCardsComments(t *testing.T, app core.App, usersID string) *core.Collection {
+	t.Helper()
+	c := core.NewBaseCollection("cards_comments")
+	c.Fields.Add(&core.TextField{Name: "card"})
+	c.Fields.Add(&core.TextField{Name: "project"})
+	c.Fields.Add(&core.TextField{Name: "body"})
+	c.Fields.Add(&core.TextField{Name: "parent_comment"})
+	c.Fields.Add(&core.RelationField{
+		Name: "author", Required: true, CollectionId: usersID, MaxSelect: 1,
+	})
+	c.Fields.Add(&core.TextField{Name: "author_name"})
+	if err := app.Save(c); err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// seedCardsMention builds a cards comment + a mention row pointing at a CARD,
+// with drive_item deliberately empty — the shape drive's schema used to forbid.
+func seedCardsMention(t *testing.T, f *mentionFixture, cardID string) *core.Record {
+	t.Helper()
+	usersCol, _ := f.app.FindCollectionByNameOrId("users")
+	cardsCol := addCardsComments(t, f.app, usersCol.Id)
+
+	comment := core.NewRecord(cardsCol)
+	comment.Set("card", cardID)
+	comment.Set("project", "proj0000000000")
+	comment.Set("body", "ping [[@"+f.mentionUser.Id+"]]")
+	comment.Set("author", f.authorUser.Id)
+	comment.Set("author_name", "Alice")
+	if err := f.app.Save(comment); err != nil {
+		t.Fatal(err)
+	}
+
+	cmCol, _ := f.app.FindCollectionByNameOrId("comment_mentions")
+	mention := core.NewRecord(cmCol)
+	mention.Set("comment_collection", "cards_comments")
+	mention.Set("comment_record", comment.Id)
+	mention.Set("target_collection", "cards_cards")
+	mention.Set("target_record", cardID)
+	mention.Set("mentioned_user", f.mentionUser.Id)
+	// drive_item intentionally NOT set.
+	if err := f.app.Save(mention); err != nil {
+		t.Fatal(err)
+	}
+	return mention
+}
+
+func TestCommentMention_CardsTargetNotifiesWithoutDriveItem(t *testing.T) {
+	f := seedMentionFixture(t)
+	// The drive_item relation is required in this fixture's inline schema, so
+	// relax it the way core 1985000002 does before inserting a cards row.
+	relaxFixtureDriveItem(t, f.app)
+
+	const cardID = "card0000000000"
+	mention := seedCardsMention(t, f, cardID)
+	runHookSync(t, f.app, mention)
+
+	n := findLatestNotification(t, f.app, f.mentionUser.Id)
+	if n == nil {
+		t.Fatal("expected a notification for a cards mention, got none")
+	}
+	if got := n.GetString("package"); got != "cards" {
+		t.Errorf("package = %q, want cards", got)
+	}
+	// Cards routes its board at /cards and opens a card via ?focused=.
+	wantURL := "https://app.test.local/cards?focused=" + cardID
+	if got := n.GetString("url"); got != wantURL {
+		t.Errorf("url = %q, want %q", got, wantURL)
+	}
+}
+
+// A cards author who mentions themselves must not be notified — the same
+// defense-in-depth check the drive path gets.
+func TestCommentMention_CardsSkipsSelfMention(t *testing.T) {
+	f := seedMentionFixture(t)
+	relaxFixtureDriveItem(t, f.app)
+
+	usersCol, _ := f.app.FindCollectionByNameOrId("users")
+	cardsCol := addCardsComments(t, f.app, usersCol.Id)
+	comment := core.NewRecord(cardsCol)
+	comment.Set("card", "card0000000000")
+	comment.Set("body", "talking to myself")
+	// Author IS the mentioned user.
+	comment.Set("author", f.mentionUser.Id)
+	comment.Set("author_name", "Bob")
+	if err := f.app.Save(comment); err != nil {
+		t.Fatal(err)
+	}
+
+	cmCol, _ := f.app.FindCollectionByNameOrId("comment_mentions")
+	mention := core.NewRecord(cmCol)
+	mention.Set("comment_collection", "cards_comments")
+	mention.Set("comment_record", comment.Id)
+	mention.Set("target_collection", "cards_cards")
+	mention.Set("target_record", "card0000000000")
+	mention.Set("mentioned_user", f.mentionUser.Id)
+	if err := f.app.Save(mention); err != nil {
+		t.Fatal(err)
+	}
+
+	runHookSync(t, f.app, mention)
+	if got := findLatestNotification(t, f.app, f.mentionUser.Id); got != nil {
+		t.Errorf("expected no notification for a self-mention, got %v", got.Id)
+	}
+}
+
+// A row written by an older client carries only `drive_item`. The hook must
+// still resolve it, or the migration window silently drops notifications.
+func TestCommentMention_LegacyRowWithoutTargetColumns(t *testing.T) {
+	f := seedMentionFixture(t)
+	mention := mkMention(t, f.app, f, "text_comments") // sets drive_item only
+	runHookSync(t, f.app, mention)
+
+	n := findLatestNotification(t, f.app, f.mentionUser.Id)
+	if n == nil {
+		t.Fatal("expected a notification for a legacy drive-only row, got none")
+	}
+	wantURL := "https://app.test.local/p/text/" + f.driveItem.Id + "?thread=" + f.commentRoot.Id
+	if got := n.GetString("url"); got != wantURL {
+		t.Errorf("url = %q, want %q", got, wantURL)
+	}
+}
+
+// relaxFixtureDriveItem mirrors what core migration 1985000002 does to the
+// real table, so the inline fixture can hold a row with no drive item.
+func relaxFixtureDriveItem(t *testing.T, app core.App) {
+	t.Helper()
+	cm, err := app.FindCollectionByNameOrId("comment_mentions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := cm.Fields.GetByName("drive_item")
+	if rel, ok := f.(*core.RelationField); ok {
+		rel.Required = false
+	}
+	cm.Fields.Add(&core.TextField{Name: "target_collection", Max: 64})
+	cm.Fields.Add(&core.TextField{Name: "target_record", Max: 32})
+	if err := app.Save(cm); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The notification TYPE is what the per-user mute preference is keyed on, so a
+// package's two mention sources must agree. Cards' DESCRIPTION mentions come
+// from its own flush hook and send "cards_mention"; a cards COMMENT mention
+// must send the same, or muting cards would silence only half of them.
+func TestCommentMention_CardsUsesPackageScopedType(t *testing.T) {
+	f := seedMentionFixture(t)
+	relaxFixtureDriveItem(t, f.app)
+
+	mention := seedCardsMention(t, f, "card0000000000")
+	runHookSync(t, f.app, mention)
+
+	n := findLatestNotification(t, f.app, f.mentionUser.Id)
+	if n == nil {
+		t.Fatal("expected a notification, got none")
+	}
+	if got := n.GetString("type"); got != "cards_mention" {
+		t.Errorf("type = %q, want cards_mention (must match the description "+
+			"hook's type, or one mute switch cannot cover both)", got)
+	}
+}
+
+// Document packages keep sharing one switch: being @mentioned in a text or calc
+// comment is one thing to a reader.
+func TestCommentMention_DocumentPackagesShareOneType(t *testing.T) {
+	f := seedMentionFixture(t)
+	mention := mkMention(t, f.app, f, "text_comments")
+	runHookSync(t, f.app, mention)
+
+	n := findLatestNotification(t, f.app, f.mentionUser.Id)
+	if n == nil {
+		t.Fatal("expected a notification, got none")
+	}
+	if got := n.GetString("type"); got != "comment_mention" {
+		t.Errorf("type = %q, want comment_mention", got)
+	}
+}
+
+// --- muting ---
+//
+// The preference is a flat {type: bool} JSON map on a user_preferences row
+// (app='notifications', key='preferences'); isNotificationMuted reads it by
+// TYPE. Nothing exercised that path before, so a rename of either the type
+// string or the row's app/key would have silently stopped honouring mutes.
+
+// addUserPreferences extends the fixture with the collection isNotificationMuted
+// queries. Not in the base fixture because most tests do not mute anything.
+func addUserPreferences(t *testing.T, app core.App, usersID string) *core.Collection {
+	t.Helper()
+	c := core.NewBaseCollection("user_preferences")
+	c.Fields.Add(&core.RelationField{
+		Name: "user", Required: true, CollectionId: usersID, MaxSelect: 1,
+	})
+	c.Fields.Add(&core.TextField{Name: "app"})
+	c.Fields.Add(&core.TextField{Name: "key"})
+	c.Fields.Add(&core.JSONField{Name: "value"})
+	if err := app.Save(c); err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func mutePreference(t *testing.T, app core.App, userID string, prefs map[string]any) {
+	t.Helper()
+	usersCol, _ := app.FindCollectionByNameOrId("users")
+	col := addUserPreferences(t, app, usersCol.Id)
+	rec := core.NewRecord(col)
+	rec.Set("user", userID)
+	rec.Set("app", "notifications")
+	rec.Set("key", "preferences")
+	rec.Set("value", prefs)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCommentMention_MutedTypeIsNotDelivered(t *testing.T) {
+	f := seedMentionFixture(t)
+	mutePreference(t, f.app, f.mentionUser.Id, map[string]any{"comment_mention": false})
+
+	mention := mkMention(t, f.app, f, "text_comments")
+	runHookSync(t, f.app, mention)
+
+	if got := findLatestNotification(t, f.app, f.mentionUser.Id); got != nil {
+		t.Errorf("a muted mention was delivered: %v", got.Id)
+	}
+}
+
+// Muting cards must NOT mute document mentions — the reason they are separate
+// switches at all.
+func TestCommentMention_MutingCardsLeavesDocumentMentions(t *testing.T) {
+	f := seedMentionFixture(t)
+	mutePreference(t, f.app, f.mentionUser.Id, map[string]any{"cards_mention": false})
+
+	mention := mkMention(t, f.app, f, "text_comments")
+	runHookSync(t, f.app, mention)
+
+	if got := findLatestNotification(t, f.app, f.mentionUser.Id); got == nil {
+		t.Error("muting cards_mention also silenced a document mention")
+	}
+}
+
+// A type left enabled (or absent entirely) must still deliver — the server
+// defaults to sending, so a missing key is not a mute.
+func TestCommentMention_UnrelatedMuteDoesNotBlock(t *testing.T) {
+	f := seedMentionFixture(t)
+	mutePreference(t, f.app, f.mentionUser.Id, map[string]any{"mail_new_message": false})
+
+	mention := mkMention(t, f.app, f, "text_comments")
+	runHookSync(t, f.app, mention)
+
+	if got := findLatestNotification(t, f.app, f.mentionUser.Id); got == nil {
+		t.Error("an unrelated mute blocked a mention")
+	}
+}

--- a/core/server/pb_migrations/1985000002_generalize_comment_mentions_target.js
+++ b/core/server/pb_migrations/1985000002_generalize_comment_mentions_target.js
@@ -1,0 +1,138 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Generalize `comment_mentions` from a drive-only table to a polymorphic one,
+// so packages that don't store their content as drive items (cards is the
+// first) can use the same mentions → notify pipeline.
+//
+// The table is created by @tinycld/drive
+// (drive/pb-migrations/1781000000_create_comment_mentions.js) with
+// `drive_item` as a REQUIRED relation, and its createRule authorizes THROUGH
+// that relation:
+//
+//     @request.auth.id != "" && drive_item.drive_shares_via_item.user ?= @request.auth.id
+//
+// A cards mention is therefore both unrepresentable (no drive item exists to
+// point at) and unauthorizable (the only rule branch resolves through drive).
+// Drive's header called that coupling deliberate — "the entire
+// comments-with-mentions feature is gated on documents being stored as drive
+// items". Cards is the case that retires the assumption.
+//
+// WHAT THIS MIGRATION DOES *NOT* DO: it does not add an authorization branch
+// for any package. It cannot. PocketBase's rule validator resolves every
+// `@collection.<name>` reference eagerly at save time and REJECTS the whole
+// rule if one is missing — verified directly, including for an OR-ed rule
+// where only one branch is absent (the validator does not short-circuit).
+// Because migrations are symlinked into a single flat directory from the
+// INSTALLED packages only (tinycld/scripts/generate.ts), a core migration
+// naming `cards_cards` would hard-fail at boot in every workspace that has no
+// cards — breaking the lean-shell guarantee.
+//
+// So the work is split at the only seam that holds:
+//   - core (here): the SHAPE. New target columns, `drive_item` relaxed,
+//     existing rows backfilled. Names no feature collection, safe everywhere.
+//   - each package: its own OR branch, appended by its own migration, which
+//     ships only when that package ships and may therefore name its own
+//     collections.
+//
+// Consequence for package authors: the createRule grows by CONCATENATION and
+// feature migrations have no ordering guarantee between them, so a package
+// must READ the current rule and append to it — never overwrite a hardcoded
+// string, which would silently drop another package's branch.
+//
+// `comment_mentions` belongs to drive, which may be absent. Every step is
+// therefore guarded: with no drive installed there is no table to alter and
+// this migration is a no-op.
+migrate(
+    app => {
+        let mentions
+        try {
+            mentions = app.findCollectionByNameOrId('comment_mentions')
+        } catch {
+            // No @tinycld/drive in this workspace — nothing to generalize.
+            // A package that wants mentions without drive creates the table
+            // itself; this migration only adapts drive's copy when present.
+            return
+        }
+
+        // target_collection / target_record mirror the existing
+        // comment_collection / comment_record pair: plain text, because
+        // PocketBase does not model polymorphic relations. The Go notify hook
+        // validates `comment_collection` against an allowlist before it
+        // notifies, so a row naming an unknown target is dropped server-side.
+        //
+        // Sized to match their non-polymorphic counterparts: a collection
+        // name is bounded well under 64, a record id is 15 chars today and
+        // 32 leaves room.
+        if (!mentions.fields.getByName('target_collection')) {
+            mentions.fields.add(
+                new TextField({
+                    id: 'cm_target_collection',
+                    name: 'target_collection',
+                    max: 64,
+                    // Not required: existing drive rows predate the column and
+                    // the backfill below fills them in the same transaction.
+                    // Requiring it here would reject those rows on save.
+                    required: false,
+                })
+            )
+        }
+        if (!mentions.fields.getByName('target_record')) {
+            mentions.fields.add(
+                new TextField({
+                    id: 'cm_target_record',
+                    name: 'target_record',
+                    max: 32,
+                    required: false,
+                })
+            )
+        }
+
+        // Relax drive_item. It stays a real relation (with its cascadeDelete,
+        // which is what removes a document's mentions when the document dies)
+        // — it simply no longer applies to rows whose target isn't a drive
+        // item. Drive's own insert path is untouched and keeps setting it.
+        const driveItem = mentions.fields.getById('cm_drive_item')
+        if (driveItem) {
+            driveItem.required = false
+        }
+
+        app.save(mentions)
+
+        // Backfill BEFORE anything reads the new columns, so they are
+        // authoritative from here on and consumers need only one code path.
+        // Existing rows are drive rows by definition — the table had no other
+        // possible target.
+        app.db()
+            .newQuery(
+                "UPDATE comment_mentions" +
+                    " SET target_collection = 'drive_items', target_record = drive_item" +
+                    " WHERE target_collection IS NULL OR target_collection = ''"
+            )
+            .execute()
+    },
+    app => {
+        let mentions
+        try {
+            mentions = app.findCollectionByNameOrId('comment_mentions')
+        } catch {
+            return
+        }
+
+        // Restoring `required` on drive_item would reject any row a package
+        // inserted with a non-drive target, so the down migration drops those
+        // rows first. They are notification provenance, not user content —
+        // the notifications they produced are separate records and survive.
+        app.db()
+            .newQuery(
+                "DELETE FROM comment_mentions WHERE drive_item IS NULL OR drive_item = ''"
+            )
+            .execute()
+
+        const driveItem = mentions.fields.getById('cm_drive_item')
+        if (driveItem) {
+            driveItem.required = true
+        }
+        mentions.fields.removeById('cm_target_collection')
+        mentions.fields.removeById('cm_target_record')
+        app.save(mentions)
+    }
+)

--- a/core/tests/unit/anchored-overlay-state.test.ts
+++ b/core/tests/unit/anchored-overlay-state.test.ts
@@ -1,0 +1,192 @@
+import type { EditorMessage } from '@tinycld/core/lib/editor/message-bus/types'
+import {
+    type AnchoredOverlayRequest,
+    anchoredOverlayReducer,
+    decodeUiMessage,
+    initialAnchoredOverlayState,
+    resolvePopoverPosition,
+} from '@tinycld/core/lib/editor/overlay/anchored-overlay-state'
+import { describe, expect, it } from 'vitest'
+
+const RECT = { top: 100, left: 40, width: 2, height: 18, scrollX: 0, scrollY: 0 }
+
+function open(requestId = 'req1'): AnchoredOverlayRequest {
+    return { kind: 'trigger:cards-mention', requestId, rect: RECT, payload: null }
+}
+
+describe('decodeUiMessage', () => {
+    it('decodes show-popover', () => {
+        const message: EditorMessage = {
+            namespace: 'ui',
+            type: 'show-popover',
+            requestId: 'req1',
+            payload: { kind: 'trigger:cards-mention', rect: RECT, payload: { items: [] } },
+        }
+        expect(decodeUiMessage(message)).toEqual({
+            type: 'show',
+            request: {
+                kind: 'trigger:cards-mention',
+                requestId: 'req1',
+                rect: RECT,
+                payload: { items: [] },
+            },
+        })
+    })
+
+    it('UNWRAPS popover-update, so the body is not handed a payload.payload', () => {
+        // The wire carries the contents alongside routing metadata; the body
+        // expects only the contents. Getting this wrong renders an empty
+        // popover that looks like a data problem rather than a decode bug.
+        const message: EditorMessage = {
+            namespace: 'ui',
+            type: 'popover-update',
+            requestId: 'req1',
+            payload: { payload: { items: [{ id: 'u1' }] }, editorInstanceId: 'rich-1' },
+        }
+        expect(decodeUiMessage(message)).toEqual({
+            type: 'update',
+            requestId: 'req1',
+            payload: { items: [{ id: 'u1' }] },
+        })
+    })
+
+    it('decodes popover-exited and dismiss-on-scroll', () => {
+        expect(
+            decodeUiMessage({
+                namespace: 'ui',
+                type: 'popover-exited',
+                requestId: 'req1',
+                payload: null,
+            })
+        ).toEqual({ type: 'webview-exited', requestId: 'req1' })
+
+        expect(
+            decodeUiMessage({
+                namespace: 'ui',
+                type: 'popover-dismiss-on-scroll',
+                payload: null,
+            })
+        ).toEqual({ type: 'dismiss-on-scroll' })
+    })
+
+    it('rejects a show-popover with no requestId — there would be nobody to answer', () => {
+        expect(
+            decodeUiMessage({
+                namespace: 'ui',
+                type: 'show-popover',
+                payload: { kind: 'x', rect: RECT, payload: null },
+            })
+        ).toBeNull()
+    })
+
+    it('rejects a malformed rect rather than drawing somewhere arbitrary', () => {
+        expect(
+            decodeUiMessage({
+                namespace: 'ui',
+                type: 'show-popover',
+                requestId: 'req1',
+                payload: { kind: 'x', rect: { top: 'nope' }, payload: null },
+            })
+        ).toBeNull()
+    })
+
+    it('ignores other namespaces', () => {
+        expect(
+            decodeUiMessage({ namespace: 'markdown', type: 'show-popover', payload: null })
+        ).toBeNull()
+    })
+})
+
+describe('anchoredOverlayReducer', () => {
+    it('opens, then re-renders on a matching update', () => {
+        const shown = anchoredOverlayReducer(initialAnchoredOverlayState, {
+            type: 'show',
+            request: open(),
+        })
+        const updated = anchoredOverlayReducer(shown, {
+            type: 'update',
+            requestId: 'req1',
+            payload: { items: [1] },
+        })
+        expect(updated.open?.payload).toEqual({ items: [1] })
+    })
+
+    it('drops an update for a request that is no longer open', () => {
+        const shown = anchoredOverlayReducer(initialAnchoredOverlayState, {
+            type: 'show',
+            request: open('req1'),
+        })
+        const stale = anchoredOverlayReducer(shown, {
+            type: 'update',
+            requestId: 'req-old',
+            payload: { items: [1] },
+        })
+        expect(stale).toBe(shown)
+    })
+
+    it('closes on a matching respond and ignores a stale one', () => {
+        const shown = anchoredOverlayReducer(initialAnchoredOverlayState, {
+            type: 'show',
+            request: open('req1'),
+        })
+        expect(
+            anchoredOverlayReducer(shown, { type: 'respond', requestId: 'req1' }).open
+        ).toBeNull()
+        expect(anchoredOverlayReducer(shown, { type: 'respond', requestId: 'other' })).toBe(shown)
+    })
+
+    it('a scroll closes whatever is open, without needing a requestId', () => {
+        const shown = anchoredOverlayReducer(initialAnchoredOverlayState, {
+            type: 'show',
+            request: open(),
+        })
+        expect(anchoredOverlayReducer(shown, { type: 'dismiss-on-scroll' }).open).toBeNull()
+    })
+
+    it('a newer show replaces an open one', () => {
+        const first = anchoredOverlayReducer(initialAnchoredOverlayState, {
+            type: 'show',
+            request: open('req1'),
+        })
+        const second = anchoredOverlayReducer(first, { type: 'show', request: open('req2') })
+        expect(second.open?.requestId).toBe('req2')
+    })
+})
+
+describe('resolvePopoverPosition', () => {
+    const base = {
+        rect: RECT,
+        webViewOriginX: 0,
+        webViewOriginY: 200,
+        viewportWidth: 400,
+        viewportHeight: 800,
+        popoverWidth: 260,
+        popoverHeightEstimate: 220,
+        gap: 4,
+    }
+
+    it('sits below the anchor when there is room', () => {
+        const { top } = resolvePopoverPosition(base)
+        expect(top).toBe(200 + 100 + 18 + 4)
+    })
+
+    it('flips above the anchor when it would overflow the bottom', () => {
+        // Otherwise the picker lands off-screen exactly when someone is typing
+        // at the bottom of a long description.
+        const { top } = resolvePopoverPosition({ ...base, viewportHeight: 340 })
+        expect(top).toBeLessThan(200 + 100)
+    })
+
+    it('clamps to the left edge instead of going negative', () => {
+        const { left } = resolvePopoverPosition({
+            ...base,
+            rect: { ...RECT, left: -50 },
+        })
+        expect(left).toBeGreaterThanOrEqual(0)
+    })
+
+    it('clamps to the right edge so the popover stays on screen', () => {
+        const { left } = resolvePopoverPosition({ ...base, rect: { ...RECT, left: 390 } })
+        expect(left + base.popoverWidth).toBeLessThanOrEqual(base.viewportWidth)
+    })
+})

--- a/core/tests/unit/trigger-config.test.ts
+++ b/core/tests/unit/trigger-config.test.ts
@@ -1,0 +1,93 @@
+import {
+    filterTriggerItems,
+    renderInsertTemplate,
+    type TriggerItem,
+    triggerPluginKey,
+} from '@tinycld/core/lib/editor/rich/triggers'
+import { describe, expect, it } from 'vitest'
+
+const ROSTER: TriggerItem[] = [
+    { id: 'u1', label: 'Ada Lovelace', secondary: 'ada@example.com' },
+    { id: 'u2', label: 'Grace Hopper', secondary: 'grace@navy.mil' },
+    { id: 'u3', label: 'Alan Turing', secondary: 'alan@example.com' },
+    { id: 'u4', label: 'Katherine Johnson' },
+]
+
+describe('filterTriggerItems', () => {
+    it('returns the whole pool for an empty query, up to the limit', () => {
+        expect(filterTriggerItems(ROSTER, '', 10).map(i => i.id)).toEqual(['u1', 'u2', 'u3', 'u4'])
+    })
+
+    it('matches the label case-insensitively', () => {
+        expect(filterTriggerItems(ROSTER, 'ADA', 10).map(i => i.id)).toEqual(['u1'])
+    })
+
+    it('matches the secondary line too, so an email finds someone', () => {
+        expect(filterTriggerItems(ROSTER, 'navy.mil', 10).map(i => i.id)).toEqual(['u2'])
+    })
+
+    it('matches a substring anywhere, not just a prefix', () => {
+        expect(filterTriggerItems(ROSTER, 'turing', 10).map(i => i.id)).toEqual(['u3'])
+    })
+
+    it('tolerates an item with no secondary line', () => {
+        expect(filterTriggerItems(ROSTER, 'katherine', 10).map(i => i.id)).toEqual(['u4'])
+    })
+
+    it('trims the query, so a trailing space does not empty the list', () => {
+        expect(filterTriggerItems(ROSTER, ' ada ', 10).map(i => i.id)).toEqual(['u1'])
+    })
+
+    it('caps at the limit', () => {
+        expect(filterTriggerItems(ROSTER, '', 2)).toHaveLength(2)
+    })
+
+    it('returns nothing when nothing matches', () => {
+        expect(filterTriggerItems(ROSTER, 'zzzz', 10)).toEqual([])
+    })
+
+    it('defaults the limit rather than returning an unbounded list', () => {
+        const many = Array.from({ length: 50 }, (_, i) => ({ id: `u${i}`, label: `User ${i}` }))
+        expect(filterTriggerItems(many, '').length).toBeLessThan(many.length)
+    })
+})
+
+describe('renderInsertTemplate', () => {
+    const item: TriggerItem = { id: 'abc123XYZ_-', label: 'Ada', secondary: 'ada@example.com' }
+
+    it('substitutes the id and keeps the trailing space', () => {
+        // The space is what lets someone keep typing after picking rather than
+        // landing inside the token — cards depends on it.
+        expect(renderInsertTemplate('[[@{id}]] ', item)).toBe('[[@abc123XYZ_-]] ')
+    })
+
+    it('substitutes label and secondary', () => {
+        expect(renderInsertTemplate('{label} <{secondary}>', item)).toBe('Ada <ada@example.com>')
+    })
+
+    it('leaves an unknown placeholder verbatim rather than blanking it', () => {
+        expect(renderInsertTemplate('{nope}-{id}', item)).toBe('{nope}-abc123XYZ_-')
+    })
+
+    it('leaves {secondary} verbatim when the item has none', () => {
+        // Blanking would silently produce a different token than the author
+        // wrote; leaving it visible makes the mistake findable.
+        expect(renderInsertTemplate('{secondary}', { id: 'u1', label: 'Ada' })).toBe('{secondary}')
+    })
+
+    it('returns an empty string for an empty template, which inserts nothing', () => {
+        expect(renderInsertTemplate('', item)).toBe('')
+    })
+})
+
+describe('triggerPluginKey', () => {
+    it('returns the SAME instance for an id', () => {
+        // Load-bearing: the native bridge calls exitSuggestion with this key,
+        // and a fresh PluginKey would resolve to no plugin state at all.
+        expect(triggerPluginKey('cards-mention')).toBe(triggerPluginKey('cards-mention'))
+    })
+
+    it('separates distinct triggers', () => {
+        expect(triggerPluginKey('cards-mention')).not.toBe(triggerPluginKey('emoji'))
+    })
+})

--- a/core/tests/unit/trigger-items-webview-host.test.ts
+++ b/core/tests/unit/trigger-items-webview-host.test.ts
@@ -1,0 +1,71 @@
+import type { EditorMessage } from '@tinycld/core/lib/editor/message-bus/types'
+import { TriggerItemsWebViewHost } from '@tinycld/core/lib/editor/rich/trigger-items-webview-host'
+import { describe, expect, it } from 'vitest'
+
+function setup() {
+    const sent: EditorMessage[] = []
+    const host = new TriggerItemsWebViewHost({
+        postMessage: message => {
+            sent.push(message)
+            return true
+        },
+    })
+    return { host, sent }
+}
+
+const ROSTER = [{ id: 'u1', label: 'Ada' }]
+
+describe('TriggerItemsWebViewHost', () => {
+    it('pushes a roster in the shape the page parses', () => {
+        const { host, sent } = setup()
+        host.push('cards-mention', ROSTER)
+
+        expect(sent).toHaveLength(1)
+        expect(sent[0]).toMatchObject({
+            namespace: 'app',
+            type: 'trigger-items',
+            payload: { triggerId: 'cards-mention', items: ROSTER },
+        })
+    })
+
+    it('SKIPS an equal roster that arrived as a fresh array', () => {
+        // The whole point. A live query re-emits a new array on unrelated
+        // writes, so without the identity skip every board edit would push the
+        // same roster across the bridge again.
+        const { host, sent } = setup()
+        host.push('cards-mention', ROSTER)
+        host.push('cards-mention', [{ id: 'u1', label: 'Ada' }])
+        expect(sent).toHaveLength(1)
+    })
+
+    it('pushes when the roster actually changes', () => {
+        const { host, sent } = setup()
+        host.push('cards-mention', ROSTER)
+        host.push('cards-mention', [...ROSTER, { id: 'u2', label: 'Grace' }])
+        expect(sent).toHaveLength(2)
+    })
+
+    it('notices a changed label, not just a changed length', () => {
+        const { host, sent } = setup()
+        host.push('cards-mention', ROSTER)
+        host.push('cards-mention', [{ id: 'u1', label: 'Ada Lovelace' }])
+        expect(sent).toHaveLength(2)
+    })
+
+    it('tracks each trigger separately', () => {
+        const { host, sent } = setup()
+        host.push('cards-mention', ROSTER)
+        host.push('emoji', ROSTER)
+        expect(sent).toHaveLength(2)
+    })
+
+    it('re-sends after a reset, because the page lost its copy', () => {
+        // A reloaded page starts with an empty store while the host still
+        // remembers sending; without the reset the popover would offer nothing.
+        const { host, sent } = setup()
+        host.push('cards-mention', ROSTER)
+        host.reset()
+        host.push('cards-mention', ROSTER)
+        expect(sent).toHaveLength(2)
+    })
+})

--- a/core/tests/unit/trigger-render-bridge.test.ts
+++ b/core/tests/unit/trigger-render-bridge.test.ts
@@ -1,0 +1,245 @@
+import type { SerializableTriggerConfig, TriggerItem } from '@tinycld/core/lib/editor/rich/triggers'
+import { createTriggerBridgeRender } from '@tinycld/core/lib/editor/rich/webview/source/trigger-render-bridge'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The wire format between the WebView page and the native host. Nothing on this
+// path can be e2e'd — cards' Playwright suite runs on web, where none of this
+// code executes — so these assertions are the only automated proof the two
+// sides agree.
+
+const CONFIG: SerializableTriggerConfig = {
+    id: 'cards-mention',
+    char: '@',
+    allItems: [],
+    insertTemplate: '[[@{id}]] ',
+}
+
+const ITEMS: TriggerItem[] = [
+    { id: 'u1', label: 'Ada Lovelace', secondary: 'ada@example.com' },
+    { id: 'u2', label: 'Grace Hopper', secondary: 'grace@navy.mil' },
+]
+
+function makeRect(): DOMRect {
+    return { top: 100, left: 40, width: 2, height: 18 } as DOMRect
+}
+
+// The bridge listens on both window and document (platforms differ in which
+// one delivers), so the fake records BOTH and dispatches to whatever is
+// registered. Stubbing rather than booting jsdom keeps the suite in node and
+// makes the listener add/remove itself observable.
+type Listener = (evt: { data: unknown }) => void
+
+function fakeTarget() {
+    const listeners = new Set<Listener>()
+    return {
+        listeners,
+        addEventListener: (_type: string, fn: Listener) => listeners.add(fn),
+        removeEventListener: (_type: string, fn: Listener) => listeners.delete(fn),
+    }
+}
+
+let win: ReturnType<typeof fakeTarget>
+let doc: ReturnType<typeof fakeTarget>
+
+function setup(overrides: { editorInstanceId?: string } = {}) {
+    const posted: Record<string, unknown>[] = []
+    const command = vi.fn()
+    const exit = vi.fn()
+    const render = createTriggerBridgeRender(CONFIG, {
+        postToHost: message => posted.push(message as Record<string, unknown>),
+        newRequestId: id => `${id}-req1`,
+        exitSuggestion: exit as never,
+        editorInstanceId: overrides.editorInstanceId ?? 'rich-1',
+    })
+    const handlers = render()
+    const props = {
+        items: ITEMS,
+        query: '',
+        command,
+        clientRect: () => makeRect(),
+        editor: { view: {} },
+    }
+    return { posted, command, exit, handlers, props }
+}
+
+/** Deliver a host→page message the way the WebView runtime would. */
+function deliver(message: unknown) {
+    deliverRaw(JSON.stringify(message))
+}
+
+function deliverRaw(data: unknown) {
+    for (const fn of [...win.listeners, ...doc.listeners]) fn({ data })
+}
+
+beforeEach(() => {
+    win = fakeTarget()
+    doc = fakeTarget()
+    vi.stubGlobal('window', { ...win, scrollX: 0, scrollY: 0 })
+    vi.stubGlobal('document', doc)
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe('show-popover', () => {
+    it('posts the kind, rect, items and instance id', () => {
+        const { posted, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+
+        expect(posted).toHaveLength(1)
+        expect(posted[0]).toMatchObject({
+            namespace: 'ui',
+            type: 'show-popover',
+            requestId: 'cards-mention-req1',
+            payload: {
+                kind: 'trigger:cards-mention',
+                rect: { top: 100, left: 40, width: 2, height: 18 },
+                payload: { items: ITEMS, query: '', selectedIndex: 0 },
+                editorInstanceId: 'rich-1',
+            },
+        })
+    })
+
+    it('posts NOTHING when there is no anchor', () => {
+        // Better to stay silent than ask the host to draw at (0,0), which reads
+        // to a user as a popover that appeared in the corner for no reason.
+        const { posted, handlers, props } = setup()
+        handlers.onStart?.({ ...props, clientRect: () => null } as never)
+        expect(posted).toEqual([])
+    })
+})
+
+describe('popover-update', () => {
+    it('re-posts the filtered items as the query grows', () => {
+        const { posted, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        handlers.onUpdate?.({ ...props, items: [ITEMS[0]], query: 'ada' } as never)
+
+        expect(posted[1]).toMatchObject({
+            type: 'popover-update',
+            requestId: 'cards-mention-req1',
+            payload: { payload: { items: [ITEMS[0]], query: 'ada', selectedIndex: 0 } },
+        })
+    })
+
+    it('clamps the selection instead of resetting it when the list shrinks', () => {
+        const { posted, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        handlers.onKeyDown?.({ event: { key: 'ArrowDown', preventDefault: () => {} } } as never)
+        handlers.onUpdate?.({ ...props, items: [ITEMS[0]], query: 'ada' } as never)
+
+        const last = posted.at(-1) as { payload: { payload: { selectedIndex: number } } }
+        expect(last.payload.payload.selectedIndex).toBe(0)
+    })
+
+    it('carries the real query on arrow keys', () => {
+        // text's slash-menu bridge posts an empty query here; a body that
+        // renders the query would blank it on every arrow press.
+        const { posted, handlers, props } = setup()
+        handlers.onStart?.({ ...props, query: 'ad' } as never)
+        handlers.onKeyDown?.({ event: { key: 'ArrowDown', preventDefault: () => {} } } as never)
+
+        const last = posted.at(-1) as { payload: { payload: { query: string } } }
+        expect(last.payload.payload.query).toBe('ad')
+    })
+})
+
+describe('popover-result', () => {
+    it('runs the plugin command for the chosen item', () => {
+        const { command, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        deliver({
+            namespace: 'ui',
+            type: 'popover-result',
+            requestId: 'cards-mention-req1',
+            payload: { action: 'select', payload: { itemId: 'u2' } },
+        })
+        expect(command).toHaveBeenCalledWith(ITEMS[1])
+    })
+
+    it('ignores a result for a DIFFERENT request', () => {
+        const { command, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        deliver({
+            namespace: 'ui',
+            type: 'popover-result',
+            requestId: 'someone-elses-request',
+            payload: { action: 'select', payload: { itemId: 'u2' } },
+        })
+        expect(command).not.toHaveBeenCalled()
+    })
+
+    it('ignores an unknown item id rather than inserting something wrong', () => {
+        const { command, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        deliver({
+            namespace: 'ui',
+            type: 'popover-result',
+            requestId: 'cards-mention-req1',
+            payload: { action: 'select', payload: { itemId: 'ghost' } },
+        })
+        expect(command).not.toHaveBeenCalled()
+    })
+
+    it('exits the in-page plugin on dismiss', () => {
+        const { exit, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        deliver({
+            namespace: 'ui',
+            type: 'popover-result',
+            requestId: 'cards-mention-req1',
+            payload: { action: 'dismiss' },
+        })
+        expect(exit).toHaveBeenCalled()
+    })
+
+    it('ignores a message from another namespace', () => {
+        const { command, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        deliver({
+            namespace: 'markdown',
+            type: 'popover-result',
+            requestId: 'cards-mention-req1',
+            payload: { action: 'select', payload: { itemId: 'u2' } },
+        })
+        expect(command).not.toHaveBeenCalled()
+    })
+
+    it('survives a non-JSON message', () => {
+        const { handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        expect(() => deliverRaw('not json')).not.toThrow()
+    })
+})
+
+describe('onExit', () => {
+    it('tells the host it wound down, then stops listening', () => {
+        const { posted, command, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        handlers.onExit?.(props as never)
+
+        expect(posted.at(-1)).toMatchObject({
+            type: 'popover-exited',
+            requestId: 'cards-mention-req1',
+            payload: { editorInstanceId: 'rich-1' },
+        })
+
+        // A late result must not reach a torn-down popover.
+        deliver({
+            namespace: 'ui',
+            type: 'popover-result',
+            requestId: 'cards-mention-req1',
+            payload: { action: 'select', payload: { itemId: 'u2' } },
+        })
+        expect(command).not.toHaveBeenCalled()
+    })
+
+    it('can reopen after exiting', () => {
+        const { posted, handlers, props } = setup()
+        handlers.onStart?.(props as never)
+        handlers.onExit?.(props as never)
+        handlers.onStart?.(props as never)
+        expect(posted.at(-1)).toMatchObject({ type: 'show-popover' })
+    })
+})

--- a/core/tests/unit/ui-message-bus.test.ts
+++ b/core/tests/unit/ui-message-bus.test.ts
@@ -1,0 +1,109 @@
+import type { EditorMessage } from '@tinycld/core/lib/editor/message-bus/types'
+import {
+    publishUiMessage,
+    resetUiMessageBus,
+    subscribeUiMessage,
+} from '@tinycld/core/lib/editor/overlay/ui-message-bus'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+function showPopover(editorInstanceId?: string): EditorMessage {
+    return {
+        namespace: 'ui',
+        type: 'show-popover',
+        requestId: 'req1',
+        payload: {
+            kind: 'trigger:cards-mention',
+            ...(editorInstanceId ? { editorInstanceId } : {}),
+        },
+    }
+}
+
+beforeEach(() => {
+    resetUiMessageBus()
+})
+
+describe('subscribe and publish', () => {
+    it('delivers to a subscriber', () => {
+        const handler = vi.fn()
+        subscribeUiMessage(handler)
+        publishUiMessage(showPopover())
+        expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it('stops delivering after unsubscribe', () => {
+        const handler = vi.fn()
+        subscribeUiMessage(handler)()
+        publishUiMessage(showPopover())
+        expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('double-unsubscribe is harmless', () => {
+        const unsubscribe = subscribeUiMessage(vi.fn())
+        unsubscribe()
+        expect(() => unsubscribe()).not.toThrow()
+    })
+
+    it('a throwing handler does not starve the others, and the error still surfaces', () => {
+        const second = vi.fn()
+        subscribeUiMessage(() => {
+            throw new Error('boom')
+        })
+        subscribeUiMessage(second)
+        expect(() => publishUiMessage(showPopover())).toThrow('boom')
+        expect(second).toHaveBeenCalledOnce()
+    })
+})
+
+describe('instance scoping', () => {
+    // The regression guard for the multi-editor bug. A card detail mounts a
+    // description editor, a comment composer, and sometimes an inline comment
+    // editor at once — each with its own overlay controller. Without filtering,
+    // one `@` opens three popovers, two of them measured against the wrong
+    // WebView.
+    it('a scoped subscriber receives only its own editor traffic', () => {
+        const mine = vi.fn()
+        const theirs = vi.fn()
+        subscribeUiMessage(mine, 'rich-1')
+        subscribeUiMessage(theirs, 'rich-2')
+
+        publishUiMessage(showPopover('rich-1'))
+
+        expect(mine).toHaveBeenCalledOnce()
+        expect(theirs).not.toHaveBeenCalled()
+    })
+
+    it('an unaddressed message broadcasts to every scoped subscriber', () => {
+        // dismiss-on-scroll is a screen-wide gesture: every open popover should
+        // close, whichever editor it belongs to.
+        const first = vi.fn()
+        const second = vi.fn()
+        subscribeUiMessage(first, 'rich-1')
+        subscribeUiMessage(second, 'rich-2')
+
+        publishUiMessage({
+            namespace: 'ui',
+            type: 'popover-dismiss-on-scroll',
+            payload: null,
+        })
+
+        expect(first).toHaveBeenCalledOnce()
+        expect(second).toHaveBeenCalledOnce()
+    })
+
+    it('an UNSCOPED subscriber still sees addressed traffic', () => {
+        // Preserves the single-editor case, where passing an id is pointless.
+        const handler = vi.fn()
+        subscribeUiMessage(handler)
+        publishUiMessage(showPopover('rich-1'))
+        expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it('tolerates a payload that is not an object', () => {
+        const handler = vi.fn()
+        subscribeUiMessage(handler, 'rich-1')
+        expect(() =>
+            publishUiMessage({ namespace: 'ui', type: 'popover-exited', payload: null })
+        ).not.toThrow()
+        expect(handler).toHaveBeenCalledOnce()
+    })
+})


### PR DESCRIPTION
Adds the shared `@`/`:`/`#` trigger framework to the rich editor, and makes it work inside the native WebView. Paired with tinycld/cards#28, which consumes it for card mentions — **that PR needs this one**.

## The gap this closes

The trigger framework ran on web only. On native it silently did nothing: `use-rich-editor.native.tsx` never destructured `triggers`, `RichEditorInitPayload` had no field for them, and the WebView page contained no suggestion plugin at all. The page is a prebuilt bundle, so a package-side ProseMirror plugin cannot be injected at runtime — the plumbing has to live here.

## Notable decisions

**The config is declarative** — `allItems` + `insertTemplate` instead of `items(query)` + `toInsertText(item)` — because a closure cannot cross into the prebuilt page. Both platforms then run the same `filterTriggerItems`/`renderInsertTemplate`, so they cannot rank or insert differently. That divergence would otherwise be invisible until someone compared their phone against their laptop.

**The host pushes the roster; the page filters locally.** A round-trip per keystroke would cross the bridge on a thread already carrying the Yjs relay, and would need sequence numbers to stop a late `@na` response rendering under a typed `@nath`. Accepted cost: a member added while the popover is open appears on the next push rather than the next keystroke.

**text/'s anchored-overlay moves to `core/lib/editor/overlay`.** Cards is its second consumer and siblings cannot import each other, so the alternative was a second copy of a non-trivial state machine plus its geometry. text/ still owns its copy — migrating it is a follow-up, not this PR.

**The bus gained per-editor scoping**, which is a deviation from text's version rather than a port of it. A card detail mounts a description editor, a comment composer, and sometimes an inline comment editor at once. text never has two, so its module-global bus had every mounted controller answer every `show-popover` — one `@` would open three overlays, two measured against the wrong WebView.

## Tests

Six new unit files, 45 tests. Nothing on the native path can be e2e'd, so the wire-format assertions are the only automated proof the two sides agree: request/instance-id correlation, stale-message rejection, the null-anchor bail, listener teardown, and the roster identity-skip.

`pnpm exec tinycld-pkg check` — 162 files, 1189 tests, green.

## Not verified

**The native path has not been run on a device.** The rebuilt `editorHtml.ts` is committed, but nothing here has been exercised on iOS or Android. Web behaviour is unchanged and covered by cards' existing e2e.