### PR TITLE
feat(editor): mentions as nodes, and a purpose-scaled markdown renderer

### DIFF
--- a/core/components/help/MarkdownRenderer.tsx
+++ b/core/components/help/MarkdownRenderer.tsx
@@ -14,6 +14,7 @@ import {
 import Markdown, { type MarkedStyles, Renderer } from 'react-native-marked'
 import { openHelp } from '../../lib/help/open-help'
 import { parseHelpTopicId } from '../../lib/help/types'
+import { type MarkdownPurpose, markdownScale } from './markdown-purpose'
 
 interface Props {
     body: string
@@ -48,6 +49,15 @@ interface Props {
      * Undefined keeps the library's own sizing.
      */
     imageMaxHeight?: number
+    /**
+     * Which surface this is rendering into — see markdown-purpose.ts.
+     *
+     * Defaults to 'documentation': the values every existing caller was
+     * already getting, so the help hub is untouched. `description` matches the
+     * card editor to the pixel, so tapping a description to edit it does not
+     * reflow the prose; `compact` is a comment in a thread.
+     */
+    purpose?: MarkdownPurpose
 }
 
 const HELP_SCHEME = 'help://'
@@ -358,7 +368,9 @@ export function MarkdownRenderer({
     shortcutTableHeuristic = true,
     transformImageUri,
     imageMaxHeight,
+    purpose = 'documentation',
 }: Props) {
+    const scale = markdownScale(purpose)
     // Codespan text uses `primary` (the brand teal — has matching
     // light + dark tokens) rather than `accent`. `accent` in this
     // theme is a near-white background fill, so `color: accent`
@@ -374,41 +386,64 @@ export function MarkdownRenderer({
 
     const styles = useMemo<MarkedStyles>(
         () => ({
-            text: { color: foreground, fontSize: 15, lineHeight: 22 },
-            paragraph: { marginVertical: 6 },
+            text: { color: foreground, fontSize: scale.bodySize, lineHeight: scale.bodyLineHeight },
+            paragraph: { marginVertical: scale.paragraphSpacing },
             em: { fontStyle: 'italic' },
             strong: { fontWeight: '600' },
             link: { color: link, textDecorationLine: 'underline' },
+            // The library gives h1 and h2 a bottom border of their own, which
+            // our styles merge ON TOP of rather than replace — so a card
+            // comment drew a full-width rule under any `#` heading and read as
+            // if it had sections. Zeroed explicitly wherever a rule is wrong
+            // for the surface; the help hub still gets one.
             h1: {
                 color: foreground,
-                fontSize: 24,
-                fontWeight: '700',
-                marginTop: 16,
-                marginBottom: 8,
+                fontSize: scale.h1.size,
+                fontWeight: scale.h1.weight,
+                marginTop: scale.h1.marginTop,
+                marginBottom: scale.h1.marginBottom,
+                ...(scale.headingRule ? {} : { borderBottomWidth: 0, paddingBottom: 0 }),
             },
             h2: {
                 color: foreground,
-                fontSize: 20,
-                fontWeight: '600',
-                marginTop: 16,
-                marginBottom: 6,
+                fontSize: scale.h2.size,
+                fontWeight: scale.h2.weight,
+                marginTop: scale.h2.marginTop,
+                marginBottom: scale.h2.marginBottom,
+                ...(scale.headingRule ? {} : { borderBottomWidth: 0, paddingBottom: 0 }),
             },
             h3: {
                 color: foreground,
-                fontSize: 17,
-                fontWeight: '600',
-                marginTop: 12,
-                marginBottom: 4,
+                fontSize: scale.h3.size,
+                fontWeight: scale.h3.weight,
+                marginTop: scale.h3.marginTop,
+                marginBottom: scale.h3.marginBottom,
             },
             h4: {
                 color: foreground,
-                fontSize: 15,
-                fontWeight: '600',
-                marginTop: 10,
-                marginBottom: 4,
+                fontSize: scale.h4.size,
+                fontWeight: scale.h4.weight,
+                marginTop: scale.h4.marginTop,
+                marginBottom: scale.h4.marginBottom,
             },
-            h5: { color: muted, fontSize: 14, fontWeight: '600', marginTop: 8 },
-            h6: { color: muted, fontSize: 13, fontWeight: '600', marginTop: 8 },
+            // h5/h6 keep the muted color ONLY where headings carry document
+            // hierarchy. On a comment they are just small emphasis, and greying
+            // them made the deepest heading read as less important than the
+            // body text around it.
+            h5: {
+                color: purpose === 'documentation' ? muted : foreground,
+                fontSize: scale.h5.size,
+                fontWeight: scale.h5.weight,
+                marginTop: scale.h5.marginTop,
+                marginBottom: scale.h5.marginBottom,
+            },
+            h6: {
+                color: purpose === 'documentation' ? muted : foreground,
+                fontSize: scale.h6.size,
+                fontWeight: scale.h6.weight,
+                marginTop: scale.h6.marginTop,
+                marginBottom: scale.h6.marginBottom,
+            },
             codespan: {
                 color: codeColor,
                 backgroundColor: surfaceSecondary,
@@ -435,8 +470,12 @@ export function MarkdownRenderer({
                 marginVertical: 8,
             },
             hr: { borderBottomColor: border, borderBottomWidth: 1, marginVertical: 12 },
-            list: { marginVertical: 6 },
-            li: { color: foreground, fontSize: 15, lineHeight: 22 },
+            list: { marginVertical: scale.listSpacing },
+            li: {
+                color: foreground,
+                fontSize: scale.bodySize,
+                lineHeight: scale.bodyLineHeight,
+            },
             // The library merges these with its defaults and passes them
             // to HelpRenderer.table(), which then draws the per-cell grid.
             // Setting borderWidth: 0 here suppresses the library's
@@ -444,7 +483,7 @@ export function MarkdownRenderer({
             table: { borderColor: border, borderWidth: 0 },
             tableCell: { padding: 8 },
         }),
-        [foreground, muted, codeColor, link, surfaceSecondary, border]
+        [foreground, muted, codeColor, link, surfaceSecondary, border, scale, purpose]
     )
 
     // The glyph swap only ever applies off Mac — on a Mac the source glyphs

--- a/core/components/help/__tests__/markdown-purpose.test.ts
+++ b/core/components/help/__tests__/markdown-purpose.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { EDITOR_CONTENT_STYLES } from '../../../lib/editor/rich/editor-content-styles'
+import { markdownScale } from '../markdown-purpose'
+
+// The `description` scale exists to make the READ state of a card description
+// pixel-identical to the editor that replaces it on tap. Two files, one
+// appearance — exactly the shape that drifts silently, so the editor's CSS is
+// parsed here and compared rather than trusted to stay in step. (The two
+// resolvePopoverPosition copies drifted this way and shipped the same bug
+// twice.)
+//
+// If this fails after an intentional editor restyle, port the new value into
+// markdown-purpose.ts. Do not relax the assertion: a mismatch means tapping a
+// description visibly reflows the text under the reader's finger.
+
+/** The editor page's own base, from rich/webview/source/styles.ts. */
+const EDITOR_BASE_PX = 14
+
+/** Pull `font-size: <n>em` for a selector out of the editor stylesheet. */
+function editorEm(selector: string): number {
+    const rule = new RegExp(`\\.ProseMirror ${selector}[^{]*\\{([^}]*)\\}`)
+    const body = EDITOR_CONTENT_STYLES.match(rule)?.[1]
+    if (!body) throw new Error(`no rule for ${selector} in the editor stylesheet`)
+    const size = body.match(/font-size:\s*([\d.]+)em/)?.[1]
+    if (!size) throw new Error(`no em font-size for ${selector}`)
+    return Number.parseFloat(size)
+}
+
+describe('the description scale matches the editor', () => {
+    const scale = markdownScale('description')
+
+    it('uses the editor page’s base font size for body text', () => {
+        expect(scale.bodySize).toBe(EDITOR_BASE_PX)
+    })
+
+    it.each([
+        ['h1', 'h1'],
+        ['h2', 'h2'],
+        ['h3', 'h3'],
+    ] as const)('sizes %s exactly as the editor does', (key, selector) => {
+        const expected = Math.round(EDITOR_BASE_PX * editorEm(selector))
+        expect(scale[key].size).toBe(expected)
+    })
+
+    // `.ProseMirror > * + * { margin-top: 0.6em }` — one rule for every block,
+    // so a heading gets the same gap as a paragraph. Per-heading margins here
+    // would reflow the prose the moment someone tapped to edit.
+    it('spaces blocks on the editor’s single rhythm', () => {
+        const emMatch = EDITOR_CONTENT_STYLES.match(
+            /\.ProseMirror > \* \+ \*\s*\{[^}]*margin-top:\s*([\d.]+)em/
+        )
+        expect(emMatch).not.toBeNull()
+        const expected = Math.round(EDITOR_BASE_PX * Number.parseFloat(emMatch?.[1] ?? '0'))
+        expect(scale.paragraphSpacing).toBe(expected)
+        expect(scale.h1.marginTop).toBe(expected)
+        expect(scale.h2.marginTop).toBe(expected)
+        expect(scale.h3.marginTop).toBe(expected)
+    })
+
+    // CSS margins collapse; React Native's do not. Setting both would double
+    // every gap relative to the editor.
+    it('sets a top margin only, because RN margins do not collapse', () => {
+        expect(scale.h1.marginBottom).toBe(0)
+        expect(scale.h2.marginBottom).toBe(0)
+        expect(scale.h3.marginBottom).toBe(0)
+    })
+
+    it('draws no rule under a heading, because the editor draws none', () => {
+        expect(scale.headingRule).toBe(false)
+        expect(EDITOR_CONTENT_STYLES).not.toMatch(/\.ProseMirror h[12][^{]*\{[^}]*border-bottom/)
+    })
+})
+
+describe('the other purposes', () => {
+    // The help hub must be untouched by this refactor.
+    it('leaves documentation on its original values', () => {
+        const doc = markdownScale('documentation')
+        expect(doc.bodySize).toBe(15)
+        expect(doc.h1.size).toBe(24)
+        expect(doc.h1.marginTop).toBe(16)
+        expect(doc.headingRule).toBe(true)
+    })
+
+    it('defaults to documentation, so an existing caller is unaffected', () => {
+        expect(markdownScale()).toEqual(markdownScale('documentation'))
+    })
+
+    // A `#` in a chat message is emphasis, not a document title.
+    it('caps headings in a comment near body size', () => {
+        const compact = markdownScale('compact')
+        expect(compact.h1.size).toBeLessThanOrEqual(compact.bodySize + 2)
+        expect(compact.headingRule).toBe(false)
+    })
+
+    it('spaces a comment more tightly than a help topic', () => {
+        expect(markdownScale('compact').paragraphSpacing).toBeLessThan(
+            markdownScale('documentation').paragraphSpacing
+        )
+    })
+})

--- a/core/components/help/markdown-purpose.ts
+++ b/core/components/help/markdown-purpose.ts
@@ -1,0 +1,154 @@
+// Typographic scale per rendering surface.
+//
+// One markdown renderer serves three surfaces with genuinely different needs,
+// and styling them all as documentation is what made a five-line card comment
+// fill a screen: a help topic's h1 is a page title, a comment's is someone
+// shouting one word in a chat message.
+//
+//   documentation — help topics. The original values; nothing about the help
+//                   hub changes because this is the default.
+//   description   — a card description in its READ state. Must match the
+//                   editor that replaces it on tap, to the pixel.
+//   compact       — a card comment. A message in a thread, not a document.
+
+/** Which surface is being rendered. */
+export type MarkdownPurpose = 'documentation' | 'description' | 'compact'
+
+/**
+ * The values a purpose contributes. Everything else — colors, code spans,
+ * tables — is shared, because those do not change with the surface.
+ */
+export interface MarkdownScale {
+    bodySize: number
+    bodyLineHeight: number
+    paragraphSpacing: number
+    h1: HeadingScale
+    h2: HeadingScale
+    h3: HeadingScale
+    h4: HeadingScale
+    h5: HeadingScale
+    h6: HeadingScale
+    /** A rule under h1/h2 suits a long document and nothing shorter. */
+    headingRule: boolean
+    listSpacing: number
+}
+
+interface HeadingScale {
+    size: number
+    weight: '400' | '500' | '600' | '700'
+    marginTop: number
+    marginBottom: number
+}
+
+/**
+ * The editor's own base font size, from the WebView page's `body` rule
+ * (rich/webview/source/styles.ts). Every heading below is that base times the
+ * `em` multiplier in editor-content-styles.ts, which is what makes the read
+ * view and the editor the same size rather than merely similar.
+ */
+const EDITOR_BASE_PX = 14
+
+/** `.ProseMirror > * + * { margin-top: 0.6em }` — the editor's block rhythm. */
+const EDITOR_BLOCK_SPACING = Math.round(EDITOR_BASE_PX * 0.6)
+
+/**
+ * Ported from `.ProseMirror h1/h2/h3` in editor-content-styles.ts.
+ *
+ * The editor spaces blocks with a single `* + *` rule rather than per-element
+ * margins, so a heading gets the same gap as a paragraph — hence the uniform
+ * marginTop and the zero marginBottom. Giving headings their own larger margins
+ * here would reflow the text the instant someone tapped to edit, which is the
+ * one thing this scale exists to prevent.
+ *
+ * CSS margins collapse and React Native's do not, so these are expressed as a
+ * top margin only. Setting both would double every gap.
+ */
+const DESCRIPTION_SCALE: MarkdownScale = {
+    bodySize: EDITOR_BASE_PX,
+    // 1.5 line-height, matching the page's `body` rule.
+    bodyLineHeight: Math.round(EDITOR_BASE_PX * 1.5),
+    paragraphSpacing: EDITOR_BLOCK_SPACING,
+    h1: {
+        size: Math.round(EDITOR_BASE_PX * 1.6),
+        weight: '700',
+        marginTop: EDITOR_BLOCK_SPACING,
+        marginBottom: 0,
+    },
+    h2: {
+        size: Math.round(EDITOR_BASE_PX * 1.35),
+        weight: '700',
+        marginTop: EDITOR_BLOCK_SPACING,
+        marginBottom: 0,
+    },
+    h3: {
+        size: Math.round(EDITOR_BASE_PX * 1.15),
+        weight: '600',
+        marginTop: EDITOR_BLOCK_SPACING,
+        marginBottom: 0,
+    },
+    // h4-h6 are all `font-size: 1em; font-weight: 600` in the editor.
+    h4: { size: EDITOR_BASE_PX, weight: '600', marginTop: EDITOR_BLOCK_SPACING, marginBottom: 0 },
+    h5: { size: EDITOR_BASE_PX, weight: '600', marginTop: EDITOR_BLOCK_SPACING, marginBottom: 0 },
+    h6: { size: EDITOR_BASE_PX, weight: '600', marginTop: EDITOR_BLOCK_SPACING, marginBottom: 0 },
+    // The editor draws no rule under a heading, so neither may this.
+    headingRule: false,
+    listSpacing: EDITOR_BLOCK_SPACING,
+}
+
+/**
+ * Help topics: the original values, unchanged.
+ *
+ * A topic is a page someone reads top to bottom, so headings carry real
+ * hierarchy and the rule under h1/h2 helps rather than intrudes.
+ */
+const DOCUMENTATION_SCALE: MarkdownScale = {
+    bodySize: 15,
+    bodyLineHeight: 22,
+    paragraphSpacing: 6,
+    h1: { size: 24, weight: '700', marginTop: 16, marginBottom: 8 },
+    h2: { size: 20, weight: '600', marginTop: 16, marginBottom: 6 },
+    h3: { size: 17, weight: '600', marginTop: 12, marginBottom: 4 },
+    h4: { size: 15, weight: '600', marginTop: 10, marginBottom: 4 },
+    h5: { size: 14, weight: '600', marginTop: 8, marginBottom: 2 },
+    h6: { size: 13, weight: '600', marginTop: 8, marginBottom: 2 },
+    headingRule: true,
+    listSpacing: 6,
+}
+
+/**
+ * Comments: a message in a thread.
+ *
+ * Headings are CAPPED rather than scaled — an `# H1` in a chat message is
+ * someone reaching for emphasis, not declaring a document title, so the
+ * loudest it gets is a little above body text. Spacing is tight for the same
+ * reason: five short lines should read as five short lines, not fill a screen.
+ */
+const COMPACT_SCALE: MarkdownScale = {
+    bodySize: 15,
+    bodyLineHeight: 21,
+    paragraphSpacing: 4,
+    h1: { size: 17, weight: '700', marginTop: 8, marginBottom: 2 },
+    h2: { size: 16, weight: '700', marginTop: 8, marginBottom: 2 },
+    h3: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
+    h4: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
+    h5: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
+    h6: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
+    headingRule: false,
+    listSpacing: 4,
+}
+
+const SCALES: Record<MarkdownPurpose, MarkdownScale> = {
+    documentation: DOCUMENTATION_SCALE,
+    description: DESCRIPTION_SCALE,
+    compact: COMPACT_SCALE,
+}
+
+export function markdownScale(purpose: MarkdownPurpose = 'documentation'): MarkdownScale {
+    return SCALES[purpose]
+}
+
+/** Exported for the parity test that keeps `description` matching the editor. */
+export const EDITOR_SCALE_SOURCE = {
+    basePx: EDITOR_BASE_PX,
+    blockSpacing: EDITOR_BLOCK_SPACING,
+}

--- a/core/lib/editor/__tests__/editor-focus-state.test.ts
+++ b/core/lib/editor/__tests__/editor-focus-state.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    isEditorFocused,
+    releaseEditorFocus,
+    resetEditorFocusState,
+    setEditorFocused,
+} from '../editor-focus-state'
+
+// This module is what stops a plain letter typed into a rich editor from being
+// read as a global shortcut on native. The card detail binds `e` to "edit
+// title", so a false negative here does not merely miss a shortcut — it steals
+// the keystroke and appends the rest of the sentence to the card's title.
+
+describe('editor focus state', () => {
+    beforeEach(() => {
+        resetEditorFocusState()
+    })
+
+    it('is unfocused before any editor reports in', () => {
+        expect(isEditorFocused()).toBe(false)
+    })
+
+    it('tracks a single editor focusing and blurring', () => {
+        setEditorFocused(true)
+        expect(isEditorFocused()).toBe(true)
+        setEditorFocused(false)
+        expect(isEditorFocused()).toBe(false)
+    })
+
+    // The card detail mounts three editors. Moving from the description to the
+    // comment composer delivers the new editor's focus BEFORE the old one's
+    // blur, so a boolean would be left false by that trailing blur while an
+    // editor is still focused — and the next letter would fire a shortcut.
+    it('stays focused when focus moves between two editors', () => {
+        setEditorFocused(true)
+        setEditorFocused(true)
+        setEditorFocused(false)
+        expect(isEditorFocused()).toBe(true)
+        setEditorFocused(false)
+        expect(isEditorFocused()).toBe(false)
+    })
+
+    // A blur with no matching focus must not drive the count negative, or the
+    // next real focus would leave it at zero and shortcuts would fire while the
+    // user types.
+    it('clamps unmatched blurs at zero', () => {
+        setEditorFocused(false)
+        setEditorFocused(false)
+        expect(isEditorFocused()).toBe(false)
+
+        setEditorFocused(true)
+        expect(isEditorFocused()).toBe(true)
+    })
+
+    // An editor unmounted while focused never delivers a blur; without the
+    // release its claim would latch and mute shortcuts for the whole session.
+    it('releases a focused editor that unmounts', () => {
+        setEditorFocused(true)
+        releaseEditorFocus(true)
+        expect(isEditorFocused()).toBe(false)
+    })
+
+    it('ignores the release of an editor that was not focused', () => {
+        setEditorFocused(true)
+        releaseEditorFocus(false)
+        expect(isEditorFocused()).toBe(true)
+    })
+})

--- a/core/lib/editor/editor-focus-state.ts
+++ b/core/lib/editor/editor-focus-state.ts
@@ -1,0 +1,55 @@
+/**
+ * Does a WebView-backed rich editor currently hold focus?
+ *
+ * This exists for the native shortcut provider. It decides whether a keypress
+ * is a global shortcut or ordinary typing by asking
+ * `TextInput.State.currentlyFocusedInput()`, which only knows about React
+ * Native `TextInput`s. A rich editor is a WebView, so that check reports "no
+ * input focused" while the user is mid-sentence, and every plain letter is
+ * offered to the matcher as a shortcut — `e` opened the card title for editing
+ * and swallowed the rest of the sentence.
+ *
+ * The count is a COUNT, not a boolean: a card detail mounts several editors
+ * (description, comment composer, inline comment edit) and moving focus between
+ * two of them interleaves the new one's focus with the old one's blur. A
+ * boolean would be left false by that trailing blur even though an editor is
+ * still focused.
+ *
+ * Deliberately module-global rather than context: the shortcut provider sits at
+ * the app root, far above any editor, and reads this from a plain event handler
+ * rather than during render — there is nothing for React to subscribe to.
+ */
+
+let focusedCount = 0
+
+/** Called by the native editor host on every focus edge. */
+export function setEditorFocused(isFocused: boolean): void {
+    if (isFocused) {
+        focusedCount += 1
+        return
+    }
+    // Clamp: an unmatched blur (a blur delivered after the editor unmounted,
+    // say) must not drive the count negative and latch the flag off forever.
+    focusedCount = Math.max(0, focusedCount - 1)
+}
+
+/** True while any rich editor holds focus. */
+export function isEditorFocused(): boolean {
+    return focusedCount > 0
+}
+
+/**
+ * Release a mount's focus claim.
+ *
+ * An editor that unmounts while focused never delivers its blur, so without
+ * this the count stays above zero and shortcuts are suppressed app-wide. The
+ * native host calls it from its unmount cleanup.
+ */
+export function releaseEditorFocus(wasFocused: boolean): void {
+    if (wasFocused) setEditorFocused(false)
+}
+
+/** Test-only. The counter is module-global and would otherwise leak. */
+export function resetEditorFocusState(): void {
+    focusedCount = 0
+}

--- a/core/lib/editor/overlay/anchored-overlay-controller.tsx
+++ b/core/lib/editor/overlay/anchored-overlay-controller.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useReducer, useState } from 'react'
-import { Dimensions, Modal, Platform, Pressable, View } from 'react-native'
+import { Dimensions, Platform, StyleSheet, View } from 'react-native'
+import { FullWindowOverlay } from 'react-native-screens'
 import { UI_POPOVER_RESULT } from '../message-bus/popover-protocol'
 import { makeMessage } from '../message-bus/types'
 import {
@@ -9,6 +10,7 @@ import {
     anchoredOverlayReducer,
     decodeUiMessage,
     initialAnchoredOverlayState,
+    type PopoverPosition,
     resolvePopoverPosition,
 } from './anchored-overlay-state'
 import { subscribeUiMessage } from './ui-message-bus'
@@ -39,6 +41,16 @@ interface WebViewMeasurable {
             pageY: number
         ) => void
     ): void
+    /**
+     * The PRIMARY measurement, despite the name order here.
+     *
+     * It reports WINDOW coordinates, which is the space the popover is
+     * positioned in — `measure` reports parent-relative ones, so an editor low
+     * on the screen anchored its popover far above the caret. It is also the
+     * one that fires at all for a WebView under the New Architecture
+     * (Bridgeless), where `measure` silently never invokes its callback.
+     */
+    measureInWindow(cb: (x: number, y: number, width: number, height: number) => void): void
     postMessage(message: string): void
 }
 
@@ -64,6 +76,13 @@ export interface AnchoredOverlayRegistry {
 
 export interface AnchoredOverlayControllerProps {
     webViewRef: WebViewRef
+    /**
+     * The view to measure for positioning. Falls back to `webViewRef`, which
+     * only works on the old architecture — under Bridgeless the WebView ref
+     * exposes no measurement methods, so a caller that wants a popover to
+     * actually appear must pass the host view wrapping the editor.
+     */
+    measureRef?: WebViewRef
     registry: AnchoredOverlayRegistry
     /**
      * Which editor's popovers this controller answers. Omitted → it answers
@@ -83,27 +102,58 @@ export interface AnchoredOverlayControllerProps {
 async function measureWebView(
     ref: WebViewRef
 ): Promise<{ pageX: number; pageY: number; width: number; height: number } | null> {
+    // measureInWindow FIRST, and it is the one that is actually correct here.
+    //
+    // The popover is positioned in screen space, and only measureInWindow
+    // reports screen coordinates. `measure`'s pageX/pageY are relative to the
+    // view's PARENT, which for an editor low on the screen — the comment
+    // composer pinned at the bottom of a card — is a far smaller Y than the
+    // caret's real position, so the popover drew hundreds of points above the
+    // text it belonged to.
+    //
+    // `measure` stays as the fallback rather than being dropped: it is the one
+    // that answers when the view is not yet attached to a window.
+    const inWindow = await runMeasure(ref, 'measureInWindow')
+    if (inWindow && inWindow.width > 0) return inWindow
+    return runMeasure(ref, 'measure')
+}
+
+/**
+ * Run one of the two measurement methods, resolving null if it does not answer.
+ *
+ * Both are callback-based and neither reports failure, so the timeout is the
+ * only way to notice that a call was dropped — which is the normal outcome for
+ * `measure` on a WebView under Bridgeless.
+ */
+function runMeasure(
+    ref: WebViewRef,
+    method: 'measure' | 'measureInWindow'
+): Promise<{ pageX: number; pageY: number; width: number; height: number } | null> {
     const r = ref?.current as Partial<WebViewMeasurable> | null | undefined
-    if (!r || typeof r.measure !== 'function') return null
+    if (!r || typeof r[method] !== 'function') return Promise.resolve(null)
     return new Promise(resolve => {
         let resolved = false
-        const fallback = setTimeout(() => {
-            if (!resolved) {
-                resolved = true
-                resolve(null)
-            }
-        }, 250)
-        try {
-            ;(r as WebViewMeasurable).measure((_x, _y, width, height, pageX, pageY) => {
-                if (resolved) return
-                resolved = true
-                clearTimeout(fallback)
-                resolve({ pageX, pageY, width, height })
-            })
-        } catch {
-            clearTimeout(fallback)
+        const settle = (
+            value: { pageX: number; pageY: number; width: number; height: number } | null
+        ) => {
+            if (resolved) return
             resolved = true
-            resolve(null)
+            clearTimeout(fallback)
+            resolve(value)
+        }
+        const fallback = setTimeout(() => settle(null), 250)
+        try {
+            if (method === 'measureInWindow') {
+                ;(r as WebViewMeasurable).measureInWindow((x, y, width, height) => {
+                    settle({ pageX: x, pageY: y, width, height })
+                })
+            } else {
+                ;(r as WebViewMeasurable).measure((_x, _y, width, height, pageX, pageY) => {
+                    settle({ pageX, pageY, width, height })
+                })
+            }
+        } catch {
+            settle(null)
         }
     })
 }
@@ -134,11 +184,12 @@ function postUiToWebView(ref: WebViewRef, type: string, payload: unknown, reques
 // Modal), which keeps screen-level mounting platform-agnostic.
 export function AnchoredOverlayController({
     webViewRef,
+    measureRef,
     registry,
     editorInstanceId,
 }: AnchoredOverlayControllerProps): React.ReactElement | null {
     const [state, dispatch] = useReducer(anchoredOverlayReducer, initialAnchoredOverlayState)
-    const [screenPos, setScreenPos] = useState<{ top: number; left: number } | null>(null)
+    const [screenPos, setScreenPos] = useState<PopoverPosition | null>(null)
 
     // Subscribe to the bus so 'show-popover' / 'popover-update' /
     // 'popover-dismiss-on-scroll' / 'popover-exited' messages get
@@ -176,7 +227,7 @@ export function AnchoredOverlayController({
         let cancelled = false
         const open = state.open
         ;(async () => {
-            const m = await measureWebView(webViewRef)
+            const m = await measureWebView(measureRef ?? webViewRef)
             if (cancelled) return
             if (!m) {
                 // Measure failed (no ref, timed out, threw). Falling
@@ -195,18 +246,17 @@ export function AnchoredOverlayController({
                 return
             }
             const { width: vw, height: vh } = Dimensions.get('window')
-            setScreenPos(
-                resolvePopoverPosition({
-                    rect: open.rect,
-                    webViewOriginX: m.pageX,
-                    webViewOriginY: m.pageY,
-                    viewportWidth: vw,
-                    viewportHeight: vh,
-                    popoverWidth: POPOVER_WIDTH_PX,
-                    popoverHeightEstimate: POPOVER_HEIGHT_ESTIMATE_PX,
-                    gap: POPOVER_GAP_PX,
-                })
-            )
+            const pos = resolvePopoverPosition({
+                rect: open.rect,
+                webViewOriginX: m.pageX,
+                webViewOriginY: m.pageY,
+                viewportWidth: vw,
+                viewportHeight: vh,
+                popoverWidth: POPOVER_WIDTH_PX,
+                popoverHeightEstimate: POPOVER_HEIGHT_ESTIMATE_PX,
+                gap: POPOVER_GAP_PX,
+            })
+            setScreenPos(pos)
         })()
         return () => {
             cancelled = true
@@ -230,53 +280,83 @@ export function AnchoredOverlayController({
         dispatch({ type: 'respond', requestId: open.requestId })
     }
 
-    const dismissExternal = () => {
-        postUiToWebView(
-            webViewRef,
-            UI_POPOVER_RESULT,
-            { action: 'dismiss' as AnchoredOverlayResponseAction },
-            open.requestId
-        )
-        dispatch({ type: 'dismiss-external' })
-    }
-
-    // Modal is transparent so the absolutely-positioned popover floats
-    // over the WebView at the computed screen coords. The full-screen
-    // Pressable behind it captures backdrop taps for dismiss without
-    // intercepting touches on the popover itself.
+    // Deliberately NOT a <Modal>. On iOS a Modal is a separate window that
+    // takes first responder the moment it appears, which blurs the WebView and
+    // dismisses the soft keyboard — so the caret vanished mid-word and the user
+    // could not keep typing to narrow the list, which is the whole point of an
+    // autocomplete. (Worse, with the keyboard gone the editor no longer held
+    // the keys, so on iOS the next letter reached the global shortcut matcher.)
+    //
+    // An absolutely-positioned sibling in the SAME window has no first-responder
+    // of its own, so the WebView keeps focus and the keyboard stays up. The
+    // coordinates are already screen-space — resolvePopoverPosition translated
+    // them through the WebView's measured origin — so the layer this renders
+    // into must also be screen-space: it is pinned to the full window rather
+    // than laid out in flow, which is what `position: absolute` with all four
+    // insets at 0 gives us inside a parent that does not clip.
+    //
+    // pointerEvents="box-none" on the wrapper is load-bearing: it lets touches
+    // pass through the transparent full-screen layer to the editor underneath,
+    // so tapping outside the popover still moves the caret rather than being
+    // swallowed by an invisible backdrop.
     return (
-        <Modal
-            transparent
-            visible
-            animationType="none"
-            onRequestClose={dismissExternal}
-            // statusBarTranslucent matches our app's other Modals so the
-            // popover anchor math (which uses Dimensions.get('window'))
-            // matches the actual layer the popover renders into.
-            statusBarTranslucent
-        >
-            <Pressable
-                onPress={dismissExternal}
-                accessibilityRole="button"
-                accessibilityLabel="Dismiss popover"
-                style={{ flex: 1 }}
+        <ScreenOverlayLayer>
+            {/* There is no backdrop catcher on purpose. Tapping away moves the
+                caret in the still-focused editor, which breaks the trigger and
+                makes the page post popover-exited — the overlay closes on its
+                own. A full-screen catcher would have to swallow that tap to
+                report it, so the tap would dismiss the popover WITHOUT moving
+                the caret, and the user would have to tap twice. */}
+            {/* Exactly one of top/bottom is set: below the caret the popover
+                hangs from its top edge, flipped above it the BOTTOM edge is
+                pinned to the caret instead. Anchoring the flipped case by its
+                bottom is what lets the box be whatever height it turns out to
+                be — the estimate below only caps it and decides which way to
+                open, and is never used to compute a position. */}
+            <View
+                style={{
+                    position: 'absolute',
+                    ...(screenPos.top === undefined ? {} : { top: screenPos.top }),
+                    ...(screenPos.bottom === undefined ? {} : { bottom: screenPos.bottom }),
+                    left: screenPos.left,
+                    width: POPOVER_WIDTH_PX,
+                    maxHeight: POPOVER_HEIGHT_ESTIMATE_PX,
+                }}
             >
-                <View
-                    style={{
-                        position: 'absolute',
-                        top: screenPos.top,
-                        left: screenPos.left,
-                        width: POPOVER_WIDTH_PX,
-                        maxHeight: POPOVER_HEIGHT_ESTIMATE_PX,
-                    }}
-                    // onStartShouldSetResponder=true stops backdrop taps
-                    // that originate inside the popover from bubbling up
-                    // to the backdrop Pressable.
-                    onStartShouldSetResponder={() => true}
-                >
-                    <Body payload={open.payload} respond={respond} />
-                </View>
-            </Pressable>
-        </Modal>
+                <Body payload={open.payload} respond={respond} />
+            </View>
+        </ScreenOverlayLayer>
+    )
+}
+
+/**
+ * The screen-space layer the popover is positioned into.
+ *
+ * The coordinates handed to it are absolute screen coordinates
+ * (resolvePopoverPosition already translated them through the WebView's
+ * measured origin), so this layer must span the window and must not be clipped
+ * or scrolled by whatever subtree the controller happens to be mounted in — in
+ * a card detail that is a `View` several levels inside a `ScrollView`.
+ *
+ * On iOS `FullWindowOverlay` gives exactly that: a sibling UIView in the window
+ * above the app's content. Crucially it is NOT a UIWindow and has no first
+ * responder of its own, so — unlike the `Modal` this replaced — presenting it
+ * does not blur the WebView or dismiss the keyboard, and the user can keep
+ * typing to filter.
+ *
+ * Elsewhere it is a plain absolutely-positioned layer. Android has no
+ * equivalent primitive (FullWindowOverlay warns and degrades to a View there),
+ * so the popover relies on its ancestors staying overflow-visible; it is
+ * `box-none` so the transparent layer never swallows a touch meant for the
+ * editor beneath it.
+ */
+function ScreenOverlayLayer({ children }: { children: React.ReactNode }) {
+    if (Platform.OS === 'ios') {
+        return <FullWindowOverlay>{children}</FullWindowOverlay>
+    }
+    return (
+        <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+            {children}
+        </View>
     )
 }

--- a/core/lib/editor/overlay/anchored-overlay-state.ts
+++ b/core/lib/editor/overlay/anchored-overlay-state.ts
@@ -222,10 +222,21 @@ export interface ResolvePositionInput {
     gap: number
 }
 
-export function resolvePopoverPosition(input: ResolvePositionInput): {
-    top: number
+/**
+ * Where the popover should sit, in screen coordinates.
+ *
+ * Exactly one of `top` / `bottom` is set. Below the caret the TOP edge is
+ * anchored; flipped above it, the BOTTOM edge is — so the popover always
+ * touches the caret regardless of how tall it turns out to be, and its real
+ * height never has to be known in advance.
+ */
+export interface PopoverPosition {
+    top?: number
+    bottom?: number
     left: number
-} {
+}
+
+export function resolvePopoverPosition(input: ResolvePositionInput): PopoverPosition {
     const {
         rect,
         webViewOriginX,
@@ -248,14 +259,23 @@ export function resolvePopoverPosition(input: ResolvePositionInput): {
 
     const wouldOverflowBottom = anchorBottomScreen + gap + popoverHeightEstimate > viewportHeight
 
-    const top = wouldOverflowBottom
-        ? Math.max(8, anchorTopScreen - gap - popoverHeightEstimate)
-        : anchorBottomScreen + gap
-
     const left = Math.min(
         Math.max(8, anchorLeftScreen),
         Math.max(8, viewportWidth - popoverWidth - 8)
     )
 
-    return { top, left }
+    if (!wouldOverflowBottom) {
+        return { top: anchorBottomScreen + gap, left }
+    }
+
+    // Flipped above the caret, the popover's BOTTOM is what must sit against
+    // it — so that edge is pinned and the box grows upward from there.
+    //
+    // Returning a `top` computed as `anchorTop - gap - estimate` is what the
+    // first version did, and it put the popover wherever the ESTIMATE said
+    // rather than against the caret: the estimate is a deliberately generous
+    // 320px, a one-row picker is nearer 70, and the gap between those two
+    // numbers is exactly how far above the text it drew. The estimate should
+    // only decide WHETHER to flip, never where the popover lands.
+    return { bottom: Math.max(8, viewportHeight - (anchorTopScreen - gap)), left }
 }

--- a/core/lib/editor/overlay/editor-overlay-registry.ts
+++ b/core/lib/editor/overlay/editor-overlay-registry.ts
@@ -18,7 +18,17 @@ import { useCallback, useSyncExternalStore } from 'react'
  * other's WebView.
  */
 export interface EditorOverlayHandle {
+    /** Where responses are POSTED. Only the WebView ref can reach the page. */
     webViewRef: unknown
+    /**
+     * What the overlay is MEASURED against — the host View wrapping the
+     * WebView. Separate from webViewRef because under the New Architecture
+     * that ref carries native WebView commands and no measurement methods, so
+     * measuring it returns nothing and the popover is dismissed before it can
+     * be drawn. Optional: a caller that has no host view still positions
+     * nothing, which is the pre-existing fail-closed behavior.
+     */
+    measureRef?: unknown
     editorInstanceId: string
 }
 

--- a/core/lib/editor/rich/__tests__/mention-load.test.ts
+++ b/core/lib/editor/rich/__tests__/mention-load.test.ts
@@ -2,7 +2,7 @@
 //
 // Tiptap needs a DOM to mount an editor; core's suite defaults to node.
 import { Editor } from '@tiptap/core'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { buildRichEditorExtensions } from '../extensions'
 import { resetMentionLabels, setMentionLabels } from '../mention-node'
 
@@ -18,8 +18,15 @@ import { resetMentionLabels, setMentionLabels } from '../mention-node'
 // `Hi @admin@admin&lt;/span&gt;`. Real data loss, caught on a device rather than
 // here, which is why these tests exist.
 
+// Every editor made here is destroyed after its test. ProseMirror's DOMObserver
+// schedules a flush on a timer, and that flush reads `document` — so an editor
+// left alive past teardown throws "document is not defined" from a stray timer,
+// surfacing as an uncaught exception that fails the run even though every
+// assertion passed.
+const openEditors: Editor[] = []
+
 function makeEditor() {
-    return new Editor({
+    const editor = new Editor({
         extensions: buildRichEditorExtensions({
             triggers: [
                 {
@@ -33,12 +40,18 @@ function makeEditor() {
             ],
         }),
     })
+    openEditors.push(editor)
+    return editor
 }
 
 describe('loading content that contains mentions', () => {
     beforeEach(() => {
         resetMentionLabels()
         setMentionLabels('m', [{ id: 'u1', label: 'Ada' }])
+    })
+
+    afterEach(() => {
+        for (const editor of openEditors.splice(0)) editor.destroy()
     })
 
     it('turns a stored token into a mention node', () => {

--- a/core/lib/editor/rich/__tests__/mention-load.test.ts
+++ b/core/lib/editor/rich/__tests__/mention-load.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+//
+// Tiptap needs a DOM to mount an editor; core's suite defaults to node.
+import { Editor } from '@tiptap/core'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { buildRichEditorExtensions } from '../extensions'
+import { resetMentionLabels, setMentionLabels } from '../mention-node'
+
+// Mentions arrive as TOKEN TEXT in stored content, and must become nodes
+// however that content reaches the editor — opening an existing comment, a Yjs
+// update from a collaborator, a paste. The input rule only fires while typing,
+// so it does not cover any of those: an existing comment opened showing the raw
+// `[[@id|Name]]`.
+//
+// The round trip is the assertion that matters. An earlier attempt rewrote the
+// markdown into an HTML span before parsing, which the native page did not
+// parse — and the next blur SAVED the literal markup, turning a comment into
+// `Hi @admin@admin&lt;/span&gt;`. Real data loss, caught on a device rather than
+// here, which is why these tests exist.
+
+function makeEditor() {
+    return new Editor({
+        extensions: buildRichEditorExtensions({
+            triggers: [
+                {
+                    id: 'm',
+                    char: '@',
+                    allItems: [{ id: 'u1', label: 'Ada' }],
+                    insertTemplate: '[[@{id}]] ',
+                    insertsMentionNode: true,
+                    onStateChange: () => {},
+                },
+            ],
+        }),
+    })
+}
+
+describe('loading content that contains mentions', () => {
+    beforeEach(() => {
+        resetMentionLabels()
+        setMentionLabels('m', [{ id: 'u1', label: 'Ada' }])
+    })
+
+    it('turns a stored token into a mention node', () => {
+        const editor = makeEditor()
+        editor.commands.setContent('Hi [[@u1|Ada]]', { contentType: 'markdown' as never })
+        expect(JSON.stringify(editor.getJSON())).toContain('tinycldMention')
+    })
+
+    // The whole point: what was loaded must serialize back byte-identically, or
+    // merely opening a comment and closing it corrupts the stored text.
+    it('round-trips back to the same markdown', () => {
+        const editor = makeEditor()
+        editor.commands.setContent('Hi [[@u1|Ada]]', { contentType: 'markdown' as never })
+        expect(editor.getMarkdown().trim()).toBe('Hi [[@u1|Ada]]')
+    })
+
+    it('never leaves markup in the saved text', () => {
+        const editor = makeEditor()
+        editor.commands.setContent('Hi [[@u1|Ada]]', { contentType: 'markdown' as never })
+        const out = editor.getMarkdown()
+        expect(out).not.toContain('span')
+        expect(out).not.toContain('&lt;')
+    })
+
+    it('handles the legacy token that carries no name', () => {
+        const editor = makeEditor()
+        editor.commands.setContent('Hi [[@u1]]', { contentType: 'markdown' as never })
+        expect(editor.getMarkdown().trim()).toBe('Hi [[@u1]]')
+    })
+
+    it('converts several mentions in one body', () => {
+        const editor = makeEditor()
+        editor.commands.setContent('[[@u1|Ada]] and [[@u2|Grace]]', {
+            contentType: 'markdown' as never,
+        })
+        const md = editor.getMarkdown()
+        expect(md).toContain('[[@u1|Ada]]')
+        expect(md).toContain('[[@u2|Grace]]')
+    })
+
+    it('leaves ordinary text alone', () => {
+        const editor = makeEditor()
+        editor.commands.setContent('no mentions here', { contentType: 'markdown' as never })
+        expect(editor.getMarkdown().trim()).toBe('no mentions here')
+    })
+})

--- a/core/lib/editor/rich/__tests__/mention-node.test.ts
+++ b/core/lib/editor/rich/__tests__/mention-node.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    mentionTokensToHtml,
+    resetMentionLabels,
+    serializeMentionToken,
+    setMentionLabels,
+} from '../mention-node'
+
+// The mention node shows a NAME while storing an ID. Both halves matter: the
+// name is what makes a description readable, and the id is what cards' Go flush
+// hook parses to notify someone. A bug in either direction is silent — a
+// mention that renders correctly but serializes wrong notifies nobody.
+
+const TRIGGER = 'cards-mention'
+
+describe('mention labels', () => {
+    beforeEach(() => {
+        resetMentionLabels()
+        setMentionLabels(TRIGGER, [
+            { id: 'u1', label: 'Ada Lovelace' },
+            { id: 'u2', label: 'Grace Hopper' },
+        ])
+    })
+
+    it('renders a known id as that person’s name', () => {
+        expect(mentionTokensToHtml('hi [[@u1]]', TRIGGER)).toBe(
+            'hi <span data-mention-id="u1">@Ada Lovelace</span>'
+        )
+    })
+
+    it('rewrites every mention in a body', () => {
+        const html = mentionTokensToHtml('[[@u1]] and [[@u2]]', TRIGGER)
+        expect(html).toContain('@Ada Lovelace')
+        expect(html).toContain('@Grace Hopper')
+    })
+
+    // The editor serializes through markdown, where `[` is syntax, so a stored
+    // token round-trips escaped. Matching only the bare spelling is what left
+    // raw tokens on screen before — the same trap cards' own regex documents.
+    it('matches the backslash-escaped spelling markdown produces', () => {
+        expect(mentionTokensToHtml('hi \\[\\[@u1\\]\\]', TRIGGER)).toContain('@Ada Lovelace')
+    })
+
+    // A token with no name AND no roster entry is the only case left with
+    // nothing to show — a legacy `[[@id]]` naming someone who has since left.
+    it('falls back to a placeholder for an unknown id with no name', () => {
+        expect(mentionTokensToHtml('hi [[@ghost]]', TRIGGER)).toBe(
+            'hi <span data-mention-id="ghost">@someone</span>'
+        )
+    })
+
+    // The whole point of carrying the name: leaving the board does not un-say
+    // the sentence that named you, so the mention stays readable even though
+    // the roster cannot resolve the id.
+    it('uses the name in the token when the roster does not know the id', () => {
+        const html = mentionTokensToHtml('hi [[@gone|Grace Hopper]]', TRIGGER)
+        expect(html).toContain('@Grace Hopper')
+        expect(html).not.toContain('@someone')
+    })
+
+    // The roster is live, so a rename shows up without rewriting stored text.
+    it('prefers the live roster over the name baked into the token', () => {
+        expect(mentionTokensToHtml('hi [[@u1|Old Name]]', TRIGGER)).toContain('@Ada Lovelace')
+    })
+
+    describe('the wire token', () => {
+        it('omits the name when there is none', () => {
+            expect(serializeMentionToken('u1')).toBe('[[@u1]]')
+        })
+
+        it('carries the name when there is one', () => {
+            expect(serializeMentionToken('u1', 'Ada Lovelace')).toBe('[[@u1|Ada Lovelace]]')
+        })
+
+        // `]` and `|` would end the token early and spill the rest of the name
+        // into the document as visible text. Percent-encoded, not backslashed:
+        // markdown strips a backslash before the token is ever matched.
+        it('encodes delimiters a user could type into their own name', () => {
+            const token = serializeMentionToken('u1', 'a]b|c')
+            expect(token).toBe('[[@u1|a%5Db%7Cc]]')
+            expect(mentionTokensToHtml(token, 'unregistered')).toContain('@a]b|c')
+        })
+
+        it('round-trips a percent sign without corrupting it', () => {
+            const token = serializeMentionToken('u1', '100%5D')
+            expect(mentionTokensToHtml(token, 'unregistered')).toContain('@100%5D')
+        })
+    })
+
+    it('leaves a body with no tokens untouched', () => {
+        expect(mentionTokensToHtml('nothing here', TRIGGER)).toBe('nothing here')
+    })
+
+    it('preserves the id, not the label, in the markup', () => {
+        // The id is the wire format — it must survive into the node's attribute
+        // so serializing back reproduces the token the server parses.
+        expect(mentionTokensToHtml('[[@u1]]', TRIGGER)).toContain('data-mention-id="u1"')
+    })
+
+    // Two triggers on one editor must not resolve each other's ids.
+    it('scopes labels to their own trigger', () => {
+        setMentionLabels('other', [{ id: 'u1', label: 'Wrong Person' }])
+        expect(mentionTokensToHtml('[[@u1]]', TRIGGER)).toContain('@Ada Lovelace')
+        expect(mentionTokensToHtml('[[@u1]]', 'other')).toContain('@Wrong Person')
+    })
+
+    it('placeholders everything when the trigger is unknown', () => {
+        expect(mentionTokensToHtml('[[@u1]]', 'never-registered')).toContain('@someone')
+    })
+})

--- a/core/lib/editor/rich/__tests__/trigger-items-webview-host.test.ts
+++ b/core/lib/editor/rich/__tests__/trigger-items-webview-host.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { TriggerItemsWebViewHost } from '../trigger-items-webview-host'
+
+// The host memoizes what it has sent so a live query re-emitting an unchanged
+// roster does not flood the bridge. The subtlety is WHEN it is allowed to
+// record that memo — see the delivery test below, which is the bug that made
+// `@` offer "No matches" for a whole session.
+
+const ITEMS = [{ id: 'u1', label: 'Ada' }]
+
+function hostWith(deliver: () => boolean) {
+    const sent: unknown[] = []
+    const host = new TriggerItemsWebViewHost({
+        postMessage: message => {
+            const ok = deliver()
+            if (ok) sent.push(message)
+            return ok
+        },
+    })
+    return { host, sent }
+}
+
+describe('TriggerItemsWebViewHost', () => {
+    it('pushes a roster the first time', () => {
+        const { host, sent } = hostWith(() => true)
+        expect(host.push('m', ITEMS)).toBe(true)
+        expect(sent).toHaveLength(1)
+    })
+
+    it('skips an unchanged roster', () => {
+        const { host, sent } = hostWith(() => true)
+        host.push('m', ITEMS)
+        expect(host.push('m', ITEMS)).toBe(false)
+        expect(sent).toHaveLength(1)
+    })
+
+    it('pushes again when the roster changes', () => {
+        const { host, sent } = hostWith(() => true)
+        host.push('m', ITEMS)
+        host.push('m', [...ITEMS, { id: 'u2', label: 'Grace' }])
+        expect(sent).toHaveLength(2)
+    })
+
+    // The regression. The editor mounts before the members query resolves, so
+    // the first push is []. When the real roster arrives the WebView may still
+    // be mounting and postMessage returns false — if that attempt were memoized,
+    // every later emission would carry the same members, match the memo, and be
+    // skipped forever. The page would keep the empty list and the picker would
+    // say "No matches" for the rest of the session.
+    it('does not memoize a push the bridge refused', () => {
+        let online = false
+        const { host, sent } = hostWith(() => online)
+
+        expect(host.push('m', ITEMS)).toBe(false)
+        expect(sent).toHaveLength(0)
+
+        online = true
+        expect(host.push('m', ITEMS)).toBe(true)
+        expect(sent).toHaveLength(1)
+    })
+
+    it('re-sends everything after a reset, for a reloaded page', () => {
+        const { host, sent } = hostWith(() => true)
+        host.push('m', ITEMS)
+        host.reset()
+        expect(host.push('m', ITEMS)).toBe(true)
+        expect(sent).toHaveLength(2)
+    })
+
+    it('tracks each trigger id separately', () => {
+        const { host, sent } = hostWith(() => true)
+        host.push('mention', ITEMS)
+        host.push('slash', ITEMS)
+        expect(sent).toHaveLength(2)
+    })
+})

--- a/core/lib/editor/rich/__tests__/trigger-serialization.test.ts
+++ b/core/lib/editor/rich/__tests__/trigger-serialization.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import type { SerializableTriggerConfig } from '../triggers'
+
+// The native editor receives triggers as JSON built by a HAND-MAINTAINED
+// mapping in use-rich-editor.native.tsx. A field added to
+// SerializableTriggerConfig but forgotten there reaches web and silently not
+// native — which is exactly how `insertsMentionNode` shipped: mentions rendered
+// as names on web and as raw `[[@id]]` tokens on the phone, with nothing
+// failing to say so.
+//
+// This test pins the field list. When it fails, add the new field to the
+// triggerSignature mapping FIRST, then update the list here.
+
+const SERIALIZABLE_FIELDS = [
+    'id',
+    'char',
+    'allItems',
+    'limit',
+    'insertTemplate',
+    'insertsMentionNode',
+] as const
+
+describe('SerializableTriggerConfig', () => {
+    it('carries exactly the fields the native init payload knows how to send', () => {
+        // A total value: TypeScript fails to compile this if the type gains a
+        // required field missing from SERIALIZABLE_FIELDS, and the runtime
+        // assertion below catches an optional one.
+        const complete: Required<SerializableTriggerConfig> = {
+            id: 'cards-mention',
+            char: '@',
+            allItems: [],
+            limit: 6,
+            insertTemplate: '[[@{id}]] ',
+            insertsMentionNode: true,
+        }
+
+        expect(Object.keys(complete).sort()).toEqual([...SERIALIZABLE_FIELDS].sort())
+    })
+})

--- a/core/lib/editor/rich/editor-content-styles.ts
+++ b/core/lib/editor/rich/editor-content-styles.ts
@@ -99,6 +99,34 @@ export const EDITOR_CONTENT_STYLES = `
 .ProseMirror pre code {
     font-size: 0.9em;
 }
+/* A mention is one indivisible thing, so it reads as a chip rather than as
+   styled prose — the tint and rounding are what tell you the name is a
+   reference to a person and not a word someone typed. Uses the accent already
+   carrying links so it inherits the theme in both light and dark, rather than
+   a hex that would be right in exactly one of them.
+
+   white-space: nowrap keeps a two-word name from breaking across lines and
+   splitting the chip in half. */
+.ProseMirror .tinycld-mention {
+    /* inline-block, not inline: an inline box does not lay out its own
+       background, padding or rounding the way a chip needs — the tint either
+       does not paint at all or bleeds past the text — so the pill only exists
+       once the node is given a box of its own. */
+    display: inline-block;
+    white-space: nowrap;
+    padding: 0.05em 0.35em;
+    border-radius: 999px;
+    font-size: 0.95em;
+    font-weight: 500;
+    /* Text in the accent that already carries links, so it follows the theme
+       in both light and dark rather than a hex that is right in only one.
+
+       The fill is a mid-grey at low alpha: it reads as a subtle tint against
+       both a light and a dark page, so it needs no theme-specific variant and
+       no second CSS variable for the host to keep in step. */
+    color: var(--editor-primary-color, #2563eb);
+    background-color: rgba(127, 127, 127, 0.16);
+}
 /* Task lists: the checkbox is interactive, so it needs a real hit area on touch,
    and the marker must not double up with the <ul> bullet. */
 .ProseMirror ul[data-type='taskList'] {

--- a/core/lib/editor/rich/extensions.ts
+++ b/core/lib/editor/rich/extensions.ts
@@ -10,6 +10,7 @@ import { Markdown } from '@tiptap/markdown'
 import StarterKit from '@tiptap/starter-kit'
 import type { Awareness } from 'y-protocols/awareness'
 import type * as Y from 'yjs'
+import { MentionNode, setMentionLabels } from './mention-node'
 import { SubmitShortcut } from './submit-shortcut'
 import { createTriggerExtension, type TriggerConfig } from './triggers'
 
@@ -96,6 +97,12 @@ export function buildRichEditorExtensions(
     }
     for (const trigger of triggers ?? []) {
         extensions.push(createTriggerExtension(trigger))
+        // One node instance per mention trigger, bound to that trigger's
+        // roster, so two triggers on one editor cannot resolve each other's ids.
+        if (trigger.insertsMentionNode) {
+            extensions.push(MentionNode.configure({ triggerId: trigger.id }))
+            setMentionLabels(trigger.id, trigger.allItems)
+        }
     }
     if (collab) {
         extensions.push(Collaboration.configure({ document: collab.document, field: collab.field }))

--- a/core/lib/editor/rich/mention-node.ts
+++ b/core/lib/editor/rich/mention-node.ts
@@ -1,0 +1,396 @@
+import { mergeAttributes, Node, nodeInputRule } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+
+/** The attributes a mention node carries. */
+interface MentionAttrs {
+    userId: string
+    name: string | null
+}
+
+// The `[[@<userId>|<name>]]` mention token, as an editor node.
+//
+// The token is the WIRE format: the ID is what cards' Go flush hook parses to
+// derive description mentions, and being id-based is what lets a mention
+// survive the person renaming themselves. What it must NOT be is what someone
+// reads while typing — before this node existed the picker inserted the token
+// as literal text, so choosing a colleague put `[[@9rsya4ylg4y2vkp]]` in the
+// middle of the sentence.
+//
+// So: id in the document, name on the screen. The node holds both, renders the
+// label, and serializes back to the token.
+//
+// The NAME half is a display fallback, and it is why a mention stays readable
+// when the id cannot be resolved — the person left the board, or the roster has
+// not loaded yet. Leaving a board does not un-say the sentence that named you.
+// The live roster still wins when it has an answer, so a rename is reflected
+// without rewriting stored documents. The name is optional on the wire, so the
+// bare `[[@id]]` in already-stored descriptions keeps working.
+//
+// It is an ATOM. A mention is one indivisible thing — arrow keys step over it,
+// backspace removes the whole mention rather than eating the name a letter at a
+// time, and no one can edit the label into disagreeing with the id it carries.
+//
+// Defined in the shared builder, so the schema is identical on web and inside
+// the WebView bundle. A node present on one platform and missing on the other
+// silently drops its attributes when a document crosses between them, which for
+// a mention would mean losing the id and with it the notification.
+
+export interface MentionNodeOptions {
+    /**
+     * Which trigger's roster names these mentions.
+     *
+     * A trigger id rather than a resolver function, deliberately. The native
+     * editor is a PREBUILT WebView bundle, so a closure cannot cross into it —
+     * the same constraint that made TriggerConfig declarative. The roster is
+     * already pushed into the page and kept current there, so both platforms
+     * look the label up in that one store and cannot disagree about it.
+     */
+    triggerId?: string
+    HTMLAttributes?: Record<string, unknown>
+}
+
+/** Shown when an id resolves to nobody. Mirrors renderMentionTokens'. */
+const UNKNOWN_LABEL = 'someone'
+
+/**
+ * The roster a mention's label comes from, registered per trigger id.
+ *
+ * A module-global map for the same reason the page's trigger-items store is
+ * one: `renderHTML` runs inside a ProseMirror transaction rather than a React
+ * render, so it needs the current roster synchronously and has no component to
+ * subscribe with. Both platforms populate this from the same roster they
+ * already push to the picker, so the name in the document and the name in the
+ * list cannot disagree.
+ */
+const rosters = new Map<string, Map<string, string>>()
+
+/**
+ * Editors waiting to redraw when a roster changes.
+ *
+ * The roster almost always arrives AFTER the document: on native it is pushed
+ * over the bridge once the page is ready, and on web it comes from a live query
+ * that resolves after mount. By then every mention has already rendered — with
+ * an empty roster, so all of them say "@someone" — and ProseMirror will not
+ * redraw a node whose attributes have not changed. The label is derived, not
+ * stored, so nothing about the node ever does change and the stale text stays
+ * on screen for the life of the mount. These listeners are what close that gap.
+ */
+const rosterListeners = new Set<() => void>()
+
+/** Subscribe to roster changes. Returns the unsubscribe function. */
+export function onMentionLabelsChange(listener: () => void): () => void {
+    rosterListeners.add(listener)
+    return () => {
+        rosterListeners.delete(listener)
+    }
+}
+
+/** Publish the id→label map a trigger's mentions should render with. */
+export function setMentionLabels(triggerId: string, items: { id: string; label: string }[]): void {
+    const next = new Map(items.map(item => [item.id, item.label]))
+    const prev = rosters.get(triggerId)
+    // Skip the redraw when nothing a mention renders actually changed — the
+    // roster re-emits on unrelated writes, and forcing a redraw per emission
+    // would fight the caret.
+    if (prev && prev.size === next.size && [...next].every(([k, v]) => prev.get(k) === v)) {
+        return
+    }
+    rosters.set(triggerId, next)
+    for (const listener of rosterListeners) listener()
+}
+
+/**
+ * The name to show for a mention.
+ *
+ * The roster wins when it has the id — it is live, so a rename shows up
+ * immediately. The name CARRIED BY THE TOKEN is the fallback, which is what
+ * makes a mention readable when the roster cannot answer: the person left the
+ * board, the id belongs to another org's user, or (on native) the roster simply
+ * has not arrived yet. Leaving the board does not un-say the sentence someone
+ * wrote, so their name stays legible either way.
+ *
+ * UNKNOWN_LABEL is now a genuine last resort — only a token with no name in it
+ * at all, which means a pre-existing `[[@id]]` written before the format
+ * carried one.
+ */
+function lookupLabel(triggerId: string | undefined, userId: string, fallbackName?: string): string {
+    const label = triggerId ? rosters.get(triggerId)?.get(userId) : undefined
+    return label || fallbackName || UNKNOWN_LABEL
+}
+
+/** Test-only. The roster map is module-global and would otherwise leak. */
+export function resetMentionLabels(): void {
+    rosters.clear()
+}
+
+/**
+ * Matches the token in markdown being parsed INTO the editor.
+ *
+ * The wire format is `[[@<userId>|<name>]]`, and the name half is OPTIONAL so
+ * the bare `[[@id]]` written before it existed still parses — those documents
+ * are already stored and must keep working.
+ *
+ * Carrying the name is what keeps a mention readable when the id cannot be
+ * resolved: the person left the board, or the roster has not arrived yet. The id
+ * stays the identity — it drives notifications and survives a rename — and the
+ * name is only a fallback for display, so a stale one is corrected the moment
+ * the live roster answers.
+ *
+ * The name may not contain `]` or `|`, which is what keeps the token
+ * unambiguous; the writer percent-encodes them (see escapeMentionName).
+ *
+ * Accepts the backslash-escaped spelling too. The editor serializes through
+ * markdown, where `[` is syntax, so a stored token round-trips as `\[\[@id\]\]`
+ * — matching only the bare form would leave escaped tokens as visible text,
+ * which is the same trap cards' own TOKEN regex documents.
+ */
+const TOKEN_PATTERN = /\\?\[\\?\[@([A-Za-z0-9_-]+)(?:\|([^\]|]*))?\\?\]\\?\]/
+
+export const MentionNode = Node.create<MentionNodeOptions>({
+    name: 'tinycldMention',
+    group: 'inline',
+    inline: true,
+    atom: true,
+    selectable: true,
+    // Nothing inside to edit — the label is derived from the id, not stored.
+    draggable: false,
+
+    addOptions() {
+        return { triggerId: undefined, HTMLAttributes: {} }
+    },
+
+    addStorage() {
+        return { unsubscribeRoster: undefined as (() => void) | undefined }
+    },
+
+    addAttributes() {
+        return {
+            userId: {
+                default: null,
+                parseHTML: element => element.getAttribute('data-mention-id'),
+                renderHTML: attributes =>
+                    attributes.userId ? { 'data-mention-id': attributes.userId } : {},
+            },
+            // The name as it stood when the mention was written. Display only —
+            // the roster overrides it whenever it can, so a rename is reflected
+            // without rewriting stored documents. Kept on the node so it
+            // survives into the serialized token.
+            name: {
+                default: null,
+                parseHTML: element => element.getAttribute('data-mention-name'),
+                renderHTML: attributes =>
+                    attributes.name ? { 'data-mention-name': attributes.name } : {},
+            },
+        }
+    },
+
+    parseHTML() {
+        return [{ tag: 'span[data-mention-id]' }]
+    },
+
+    renderHTML({ node, HTMLAttributes }) {
+        const userId = String(node.attrs.userId ?? '')
+        const name = node.attrs.name ? String(node.attrs.name) : undefined
+        const label = lookupLabel(this.options.triggerId, userId, name)
+        return [
+            'span',
+            mergeAttributes(
+                { 'data-mention-id': userId, class: 'tinycld-mention' },
+                this.options.HTMLAttributes ?? {},
+                HTMLAttributes
+            ),
+            `@${label}`,
+        ]
+    },
+
+    // What the editor shows for the node in a plain-text context (copy, the
+    // character counter). The name, not the id — the id is not prose.
+    renderText({ node }) {
+        const name = node.attrs.name ? String(node.attrs.name) : undefined
+        return `@${lookupLabel(this.options.triggerId, String(node.attrs.userId ?? ''), name)}`
+    },
+
+    /**
+     * Redraw this editor's mentions when the roster changes.
+     *
+     * A no-op transaction is enough: ProseMirror re-renders the nodes it
+     * touches, and `renderHTML` reads the label fresh from the roster. Cheap
+     * because setMentionLabels only notifies on an actual change.
+     *
+     * `setMeta('addToHistory', false)` keeps this out of the undo stack — a
+     * roster arriving is not an edit the user made, and without it their first
+     * undo would be spent on our redraw.
+     */
+    onCreate() {
+        this.storage.unsubscribeRoster = onMentionLabelsChange(() => {
+            const { view } = this.editor
+            if (!view || view.isDestroyed) return
+            view.dispatch(view.state.tr.setMeta('addToHistory', false))
+        })
+    },
+
+    onDestroy() {
+        ;(this.storage.unsubscribeRoster as (() => void) | undefined)?.()
+    },
+
+    /**
+     * Turn a literal token into a node as it is typed or pasted.
+     *
+     * This is what makes EXISTING descriptions readable. Stored bodies are full
+     * of `[[@id]]`, and they reach the editor by several routes — setContent on
+     * open, a Yjs update from a collaborator, a paste — so converting at any one
+     * load point would leave the others showing raw tokens. An input rule runs
+     * wherever the text appears, so all of them are covered by one rule.
+     */
+    addInputRules() {
+        return [
+            nodeInputRule({
+                find: new RegExp(`${TOKEN_PATTERN.source}$`),
+                type: this.type,
+                getAttributes: match => ({
+                    userId: match[1],
+                    name: unescapeMentionName(match[2]),
+                }),
+            }),
+        ]
+    },
+
+    /**
+     * Convert token TEXT that arrives in the document into mention nodes.
+     *
+     * The input rule above only fires while typing, so it covers a mention
+     * someone writes and nothing that was LOADED — an existing comment opened
+     * showing the raw `[[@id|Name]]`. This plugin closes that gap wherever the
+     * text comes from: setContent on open, a Yjs update from a collaborator, a
+     * paste.
+     *
+     * It works on the document rather than on the markdown string, which is the
+     * important part. Rewriting the source into HTML before parsing seemed
+     * simpler and was actively dangerous: the markdown parsers on the two
+     * platforms treat an inline `<span>` differently, so on native the markup
+     * survived as literal text, and the next blur SAVED it — turning a comment
+     * into `Hi @admin@admin&lt;/span&gt;`. Never round-trip user content through
+     * a second syntax to solve a parsing problem.
+     */
+    addProseMirrorPlugins() {
+        const type = this.type
+        return [
+            new Plugin({
+                key: new PluginKey(`${this.name}_textToNode`),
+                appendTransaction(_transactions, _oldState, newState) {
+                    const replacements: { from: number; to: number; attrs: MentionAttrs }[] = []
+                    newState.doc.descendants((node, pos) => {
+                        if (!node.isText || !node.text) return
+                        const pattern = new RegExp(TOKEN_PATTERN.source, 'g')
+                        let match = pattern.exec(node.text)
+                        while (match !== null) {
+                            replacements.push({
+                                from: pos + match.index,
+                                to: pos + match.index + match[0].length,
+                                attrs: {
+                                    userId: match[1],
+                                    name: unescapeMentionName(match[2]),
+                                },
+                            })
+                            match = pattern.exec(node.text)
+                        }
+                    })
+                    if (replacements.length === 0) return null
+
+                    const tr = newState.tr
+                    // Applied back-to-front so each replacement's positions are
+                    // still valid — an earlier one would shift everything after it.
+                    for (let i = replacements.length - 1; i >= 0; i--) {
+                        const { from, to, attrs } = replacements[i]
+                        tr.replaceWith(from, to, type.create(attrs))
+                    }
+                    // Not an edit the user made: keeping it out of the undo
+                    // stack stops their first undo being spent on our rewrite.
+                    return tr.setMeta('addToHistory', false)
+                },
+            }),
+        ]
+    },
+
+    /**
+     * Serialize back to the wire token.
+     *
+     * This is the half that makes a mention PERSIST. The editor stores markdown,
+     * and an atom node the serializer does not recognize contributes nothing —
+     * so without this the mention renders correctly, and then silently vanishes
+     * the moment the description round-trips through markdown. (It has to be
+     * `renderMarkdown` on the extension config: @tiptap/markdown reads
+     * `markdownName` / `parseMarkdown` / `renderMarkdown` off the config, not
+     * out of `addStorage`.)
+     */
+    renderMarkdown(node: { attrs?: Record<string, unknown> }) {
+        return serializeMentionToken(
+            String(node.attrs?.userId ?? ''),
+            node.attrs?.name ? String(node.attrs.name) : undefined
+        )
+    },
+})
+
+/**
+ * Build the stored token for a mention.
+ *
+ * The name rides along so the mention stays readable when the roster cannot
+ * name the id — see TOKEN_PATTERN. It is omitted entirely when unknown, which
+ * produces the original `[[@id]]` spelling and keeps the two formats one.
+ */
+export function serializeMentionToken(userId: string, name?: string): string {
+    const trimmed = name?.trim()
+    if (!trimmed) return `[[@${userId}]]`
+    return `[[@${userId}|${escapeMentionName(trimmed)}]]`
+}
+
+/**
+ * `]` and `|` would end the token early, so they are PERCENT-encoded.
+ *
+ * Not backslash-escaped, which is the obvious choice and does not survive:
+ * markdown owns the backslash, so the parser strips it before the token is ever
+ * matched — `a\]b` arrives as `a]b`, the bracket then closes the token, and the
+ * rest of the name spills into the document as visible text. Percent-encoding
+ * passes through markdown untouched.
+ *
+ * `%` itself is encoded first so decoding cannot turn a literal `%5D` a user
+ * typed into a bracket.
+ */
+function escapeMentionName(name: string): string {
+    return name.replace(/%/g, '%25').replace(/\|/g, '%7C').replace(/\]/g, '%5D')
+}
+
+function unescapeMentionName(raw: string | undefined): string | null {
+    if (!raw) return null
+    return raw.replace(/%5D/gi, ']').replace(/%7C/gi, '|').replace(/%25/gi, '%') || null
+}
+
+/**
+ * Rewrite the wire tokens in a markdown string into the HTML the node parses.
+ *
+ * Content reaches the editor as markdown, and `[[@id]]` means nothing to a
+ * markdown parser — it would arrive as literal text and the node would never be
+ * created. Converting first is what makes an existing description open with its
+ * mentions already rendered as names.
+ */
+export function mentionTokensToHtml(markdown: string, triggerId?: string): string {
+    if (!markdown || markdown.indexOf('[@') === -1) return markdown
+    return markdown.replace(
+        new RegExp(TOKEN_PATTERN, 'g'),
+        (_match, userId: string, rawName: string | undefined) => {
+            const name = unescapeMentionName(rawName)
+            const label = lookupLabel(triggerId, userId, name ?? undefined)
+            const nameAttr = name ? ` data-mention-name="${escapeHtmlAttr(name)}"` : ''
+            return `<span data-mention-id="${userId}"${nameAttr}>@${escapeHtmlAttr(label)}</span>`
+        }
+    )
+}
+
+/** The name is user-controlled, so it must not be able to close the attribute. */
+function escapeHtmlAttr(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+}

--- a/core/lib/editor/rich/options.ts
+++ b/core/lib/editor/rich/options.ts
@@ -23,6 +23,16 @@ export interface UseRichEditorOptions {
     editable?: boolean
     /** Extra classes for the wrapping view (web). */
     containerClassName?: string
+    /**
+     * Minimum height of the editing surface, in px.
+     *
+     * Needed because `containerClassName` is WEB-ONLY: a WebView has no
+     * intrinsic height and reports its own once the page measures itself, so
+     * the caller's `min-h-[60px]` did nothing on native and the composer
+     * collapsed to a one-line sliver until the first measurement arrived.
+     * Express the floor here and both platforms honour it.
+     */
+    minHeight?: number
     /** Hard character ceiling; typing stops here rather than failing on save. */
     characterLimit?: number
     /** ⌘/Ctrl+Enter handler. See SubmitShortcut for why this is not a DOM listener. */

--- a/core/lib/editor/rich/trigger-items-webview-host.ts
+++ b/core/lib/editor/rich/trigger-items-webview-host.ts
@@ -37,9 +37,18 @@ export class TriggerItemsWebViewHost {
     push(triggerId: string, items: TriggerItem[]): boolean {
         const serialized = JSON.stringify(items)
         if (this.sent.get(triggerId) === serialized) return false
-        this.sent.set(triggerId, serialized)
         const payload: TriggerItemsPayload = { triggerId, items }
-        return this.postMessage(makeMessage('app', APP_TRIGGER_ITEMS, payload))
+        const delivered = this.postMessage(makeMessage('app', APP_TRIGGER_ITEMS, payload))
+        // Remember ONLY what actually crossed the bridge. postMessage returns
+        // false while the WebView is still mounting, and recording that attempt
+        // made the roster unsendable forever: the editor mounts before the
+        // members query resolves, so the first push is the empty array, and the
+        // real roster that follows differs from it and goes out — but if THAT
+        // one is dropped, every later emission carries the same members, matches
+        // the memo, and is skipped. The page keeps the empty list and `@` offers
+        // "No matches" for the rest of the session.
+        if (delivered) this.sent.set(triggerId, serialized)
+        return delivered
     }
 
     /**

--- a/core/lib/editor/rich/triggers.ts
+++ b/core/lib/editor/rich/triggers.ts
@@ -111,6 +111,19 @@ export interface SerializableTriggerConfig {
      * removes the trigger text and inserts nothing.
      */
     insertTemplate: string
+    /**
+     * Insert a mention NODE rather than the template's raw text.
+     *
+     * The node carries the chosen item's id and renders that person's name, so
+     * the document reads as prose while still serializing to `insertTemplate`'s
+     * token. Without it the picker writes the template literally and the reader
+     * is left looking at `[[@9rsya4ylg4y2vkp]]` mid-sentence.
+     *
+     * Serializable, so the native page makes the same choice — a mention that
+     * was a node on web and raw text on the phone would round-trip differently
+     * depending on which device last touched the card.
+     */
+    insertsMentionNode?: boolean
 }
 
 export interface TriggerConfig extends SerializableTriggerConfig {
@@ -253,9 +266,27 @@ export function createTriggerExtension(config: TriggerConfig): Extension {
                     allowSpaces: false,
                     items: ({ query: q }) => filterTriggerItems(config.allItems, q, config.limit),
                     command: ({ editor, range, props }) => {
-                        const text = renderInsertTemplate(config.insertTemplate, props)
                         const chain = editor.chain().focus().deleteRange(range)
-                        if (text) chain.insertContent(text)
+                        if (config.insertsMentionNode) {
+                            // A node plus the trailing space the template's
+                            // text form carried, so typing continues after the
+                            // mention rather than inside it. The node is an
+                            // atom, so without the space the caret would sit
+                            // against it with nowhere to put the next word.
+                            chain.insertContent([
+                                {
+                                    type: 'tinycldMention',
+                                    // The label rides along so the mention stays
+                                    // readable for anyone who cannot resolve the
+                                    // id later — see the mention node's token.
+                                    attrs: { userId: props.id, name: props.label },
+                                },
+                                { type: 'text', text: ' ' },
+                            ])
+                        } else {
+                            const text = renderInsertTemplate(config.insertTemplate, props)
+                            if (text) chain.insertContent(text)
+                        }
                         chain.run()
                     },
                     render:

--- a/core/lib/editor/rich/use-rich-editor.native.tsx
+++ b/core/lib/editor/rich/use-rich-editor.native.tsx
@@ -1,8 +1,9 @@
 import { CoreBridge, TenTapStartKit } from '@10play/tentap-editor'
 import { useFileToken } from '@tinycld/core/file-viewer/use-authed-file-url'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { pb } from '../../pocketbase'
 import { useThemeColor } from '../../use-app-theme'
+import { releaseEditorFocus, setEditorFocused } from '../editor-focus-state'
 import { UI_POPOVER_DISMISS_ON_SCROLL } from '../message-bus/popover-protocol'
 import { makeMessage } from '../message-bus/types'
 import { publishUiMessage, registerEditorOverlay } from '../overlay'
@@ -12,7 +13,7 @@ import { AwarenessWebViewHost } from './awareness-webview-host'
 import { MarkdownWebViewHost } from './markdown-webview-host'
 import type { UseRichEditorOptions } from './options'
 import { TriggerItemsWebViewHost } from './trigger-items-webview-host'
-import type { TriggerItem } from './triggers'
+import type { SerializableTriggerConfig, TriggerItem } from './triggers'
 import { editorHtml } from './webview/build/editorHtml'
 import {
     APP_ESCAPE,
@@ -59,6 +60,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         autofocus,
         editable = true,
         characterLimit,
+        minHeight,
         onSubmitShortcut,
         onEscape,
         onFocus,
@@ -90,6 +92,16 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     focusRef.current = onFocus
     const blurRef = useRef(onBlur)
     blurRef.current = onBlur
+    // Mirrors the focus flag published to editor-focus-state, so an editor that
+    // unmounts while focused can release its claim — no blur is delivered in
+    // that case, and the count would stay raised, muting shortcuts app-wide.
+    const isFocusedRef = useRef(false)
+    useEffect(() => {
+        return () => {
+            releaseEditorFocus(isFocusedRef.current)
+            isFocusedRef.current = false
+        }
+    }, [])
 
     // Constructed before the WebView exists, so it holds a poster indirection
     // rather than the poster itself — `postMessage` only becomes available
@@ -150,12 +162,17 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     // Only the SHAPE of the triggers belongs in the init payload — the roster
     // is pushed separately, because it changes as members come and go while
     // init is one-shot per mount.
+    // Every SerializableTriggerConfig field must be listed here. This mapping is
+    // hand-maintained, so a field added to the type but forgotten here reaches
+    // web and silently not native — which is how the mention node shipped as a
+    // rendered name on web and a raw `[[@id]]` token on the phone.
     const triggerSignature = JSON.stringify(
         (triggers ?? []).map(t => ({
             id: t.id,
             char: t.char,
             limit: t.limit,
             insertTemplate: t.insertTemplate,
+            insertsMentionNode: t.insertsMentionNode,
         }))
     )
 
@@ -183,12 +200,10 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                 ? {}
                 : {
                       triggers: (
-                          JSON.parse(triggerSignature) as {
-                              id: string
-                              char: string
-                              limit?: number
-                              insertTemplate: string
-                          }[]
+                          JSON.parse(triggerSignature) as Omit<
+                              SerializableTriggerConfig,
+                              'allItems'
+                          >[]
                       ).map(t => ({ ...t, allItems: [] })),
                   }),
             // Snapshotted at handshake time. Anything the doc gains between
@@ -272,6 +287,10 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         })
     }
     const triggerItemsHost = triggerItemsHostRef.current
+    // Assigned from `result` further down — declared here because the roster
+    // effect below is written before `useWebViewEditor` is called, and effects
+    // run after the whole body regardless.
+    const [isPageReady, setIsPageReady] = useState(false)
 
     // Push each roster whenever it changes. The effect depends on the
     // SERIALIZED rosters rather than the array: a live query hands back a fresh
@@ -282,11 +301,19 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         () => JSON.stringify((triggers ?? []).map(t => [t.id, t.allItems])),
         [triggers]
     )
+    // Gated on the page being ready, not just on the roster changing. The
+    // editor mounts well before a members query resolves, so the first roster
+    // is pushed at a WebView that cannot receive it; and a page reload gives
+    // the page a fresh, empty store while the host still remembers sending the
+    // roster. Re-running when readiness flips (and clearing the memo first, so
+    // an unchanged roster is not skipped as a duplicate) covers both.
     useEffect(() => {
+        if (!isPageReady) return
+        triggerItemsHost.reset()
         for (const [id, items] of JSON.parse(rosterSignature) as [string, TriggerItem[]][]) {
             triggerItemsHost.push(id, items)
         }
-    }, [rosterSignature, triggerItemsHost])
+    }, [rosterSignature, triggerItemsHost, isPageReady])
 
     // TenTap's stock bridges still drive the toolbar commands and the
     // getHTML/getText/setContent/focus surface that mail relies on. Their
@@ -315,6 +342,9 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         initPayload,
         editable,
         theme: { webview: { backgroundColor: theme?.backgroundColor ?? bgColor } },
+        // The floor the WebView is laid out at until the page reports its own
+        // height — and the floor it never shrinks below afterwards.
+        ...(minHeight === undefined ? {} : { minHeight }),
         avoidIosKeyboard: true,
         // The description editor sits inside the card detail's scroll view;
         // an inner scroll surface would fight it.
@@ -332,6 +362,14 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         // Split the host's single edge callback into the same pair of handlers
         // the web variant exposes, so the shared .d.ts contract holds.
         onFocusChange: (isFocused: boolean) => {
+            // Tell the shortcut provider a WebView holds the keyboard. It reads
+            // TextInput.State, which cannot see into a WebView, so without this
+            // every plain letter typed here is offered to the global matcher as
+            // a shortcut — see editor-focus-state.ts.
+            if (isFocusedRef.current !== isFocused) {
+                isFocusedRef.current = isFocused
+                setEditorFocused(isFocused)
+            }
             if (isFocused) focusRef.current?.()
             else blurRef.current?.()
         },
@@ -339,14 +377,29 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
 
     posterRef.current = result.postMessage ?? null
 
+    // Mirror the bridge's readiness into state so the roster effect above can
+    // depend on it. Compared before setting: this runs on every render, and an
+    // unconditional set would loop.
+    const isReadyNow = result.isReady === true
+    if (isReadyNow !== isPageReady) setIsPageReady(isReadyNow)
+
     // Publish the handle a host overlay needs to anchor to this editor. The
     // popover is rendered as a sibling (often in another subtree entirely), so
     // context cannot reach it — see editor-overlay-registry.ts.
+    // Two refs, two jobs: the popover is MEASURED against the host View
+    // (measureRef) because the WebView ref has no measurement methods under
+    // Bridgeless, but responses are still POSTED to the WebView ref, which is
+    // the only one that can reach the page.
     const webViewRef = result.webViewRef
+    const measureRef = result.measureRef
     useEffect(() => {
         if (!overlayKey) return
-        return registerEditorOverlay(overlayKey, { webViewRef, editorInstanceId })
-    }, [overlayKey, webViewRef, editorInstanceId])
+        return registerEditorOverlay(overlayKey, {
+            webViewRef,
+            measureRef,
+            editorInstanceId,
+        })
+    }, [overlayKey, webViewRef, measureRef, editorInstanceId])
 
     // Layer the markdown channel onto the shared handle. Everything else —
     // getHTML, setContent, focus, clear — is TenTap's, unchanged, which is what

--- a/core/lib/editor/rich/use-rich-editor.web.tsx
+++ b/core/lib/editor/rich/use-rich-editor.web.tsx
@@ -1,5 +1,5 @@
 import { EditorContent, ReactNodeViewRenderer, useEditor } from '@tiptap/react'
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { View } from 'react-native'
 import { useThemeColor } from '../../use-app-theme'
 import type { EditorCommands, EditorHandle, EditorResult, EditorToolbarState } from '../types'
@@ -12,6 +12,7 @@ import {
 import { buildRichEditorExtensions } from './extensions'
 import { extractImageFilesFromDrop, extractImageFilesFromPaste } from './extract-image-files'
 import { repairMarkdown } from './markdown-repair'
+import { setMentionLabels } from './mention-node'
 import type { UseRichEditorOptions } from './options'
 import type { TriggerConfig } from './triggers'
 
@@ -138,11 +139,39 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                         get insertTemplate() {
                             return current()?.insertTemplate ?? ''
                         },
+                        get insertsMentionNode() {
+                            return current()?.insertsMentionNode
+                        },
                         onStateChange: state => current()?.onStateChange(state),
                     }
                 }),
         [triggerSignature]
     )
+
+    // Keep each mention trigger's label roster current.
+    //
+    // The extension list is deliberately NOT rebuilt when the roster changes
+    // (that would recreate the editor on every membership change), so a node
+    // registered only at build time would resolve names against whatever the
+    // query had returned at mount — usually nothing, since it resolves after.
+    // Publishing on every change is what makes a mention render as a name
+    // rather than "@someone".
+    const mentionRosterSignature = JSON.stringify(
+        (triggers ?? [])
+            .filter(t => t.insertsMentionNode)
+            .map(t => [t.id, t.allItems.map(i => [i.id, i.label])])
+    )
+    useEffect(() => {
+        for (const [id, pairs] of JSON.parse(mentionRosterSignature) as [
+            string,
+            [string, string][],
+        ][]) {
+            setMentionLabels(
+                id,
+                pairs.map(([itemId, label]) => ({ id: itemId, label }))
+            )
+        }
+    }, [mentionRosterSignature])
 
     const imageDropRef = useRef(onImageDrop)
     imageDropRef.current = onImageDrop

--- a/core/lib/editor/rich/webview/source/trigger-items-store.ts
+++ b/core/lib/editor/rich/webview/source/trigger-items-store.ts
@@ -1,3 +1,4 @@
+import { setMentionLabels } from '../../mention-node'
 import type { TriggerItem } from '../../triggers'
 
 /**
@@ -18,6 +19,13 @@ const items = new Map<string, TriggerItem[]>()
 
 export function setTriggerItems(triggerId: string, next: TriggerItem[]): void {
     items.set(triggerId, next)
+    // Mention nodes render a NAME from an id, and they resolve it through this
+    // same roster. Keeping the two in step here is what makes an existing
+    // description readable: on native the extensions are built from the init
+    // payload, whose roster is deliberately EMPTY (it is pushed separately), so
+    // a node registered only at build time would resolve every id to
+    // "@someone" for the life of the mount.
+    setMentionLabels(triggerId, next)
 }
 
 export function getTriggerItems(triggerId: string): TriggerItem[] {

--- a/core/lib/editor/types.ts
+++ b/core/lib/editor/types.ts
@@ -230,6 +230,13 @@ export interface EditorResult {
     // the call site (e.g. cast to a shape that has .measure /
     // .postMessage).
     webViewRef?: React.RefObject<unknown> | null
+    // The view host overlays should MEASURE against (native only; null on
+    // web). Points at the plain RN View wrapping the WebView, not at the
+    // WebView itself: under Bridgeless the WebView ref is a native-command
+    // handle with no .measure/.measureInWindow, so measuring it always failed
+    // and anchored popovers were dismissed before they could be drawn. Same
+    // box, so the origin is identical — but an ordinary measurable view.
+    measureRef?: React.RefObject<unknown> | null
     // Post an arbitrary message to the WebView. Native variants use
     // this to drive WebView-side bridge protocols (e.g. text's
     // 'comment' namespace) that don't have first-class command

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -262,6 +262,10 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     // when the WebView sends a `stateUpdate`, which our custom Editor
     // only sends after init arrives — chicken-and-egg.
     const [webviewReady, setWebviewReady] = useState(false)
+    // Mount timestamp for the dev-only phase timings below. A WebView editor is
+    // an expensive thing to create — a browser cold start plus a bundle — and
+    // the three marks (page-ready, init-sent, first-height) are what tell you
+    // WHICH of those phases a slow open actually spent its time in.
     const mountAtRef = useRef(Date.now())
 
     // Height the page reported for its own content, held in a tiny store
@@ -293,7 +297,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         if (!webview) return
         const message = makeMessage('app', 'init', initPayload)
         try {
-            console.log('[LAG] init-sent at', Date.now() - mountAtRef.current, 'ms')
+            if (__DEV__) {
+                console.debug('[editor.mount] init-sent', Date.now() - mountAtRef.current, 'ms')
+            }
             webview.postMessage(JSON.stringify(message))
             initSentRef.current = true
         } catch {
@@ -362,7 +368,13 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
             // alongside its dispatch), but it doesn't flip any
             // bridgeState flag from it.
             if (parsed.type === 'editor-ready') {
-                console.log('[LAG] page-ready at', Date.now() - mountAtRef.current, 'ms')
+                if (__DEV__) {
+                    console.debug(
+                        '[editor.mount] page-ready',
+                        Date.now() - mountAtRef.current,
+                        'ms'
+                    )
+                }
                 setWebviewReady(true)
                 return
             }
@@ -379,7 +391,13 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
                 if (parsed.type === 'content-height') {
                     const height = (parsed.payload as { height?: unknown } | undefined)?.height
                     if (typeof height === 'number' && height > 0) {
-                        console.log('[LAG] first-height at', Date.now() - mountAtRef.current, 'ms')
+                        if (__DEV__) {
+                            console.debug(
+                                '[editor.mount] first-height',
+                                Date.now() - mountAtRef.current,
+                                'ms'
+                            )
+                        }
                         setContentHeight(height)
                     }
                     return

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -262,6 +262,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     // when the WebView sends a `stateUpdate`, which our custom Editor
     // only sends after init arrives — chicken-and-egg.
     const [webviewReady, setWebviewReady] = useState(false)
+    const mountAtRef = useRef(Date.now())
 
     // Height the page reported for its own content, held in a tiny store
     // rather than state so that a new measurement re-renders ONLY the box
@@ -292,6 +293,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         if (!webview) return
         const message = makeMessage('app', 'init', initPayload)
         try {
+            console.log('[LAG] init-sent at', Date.now() - mountAtRef.current, 'ms')
             webview.postMessage(JSON.stringify(message))
             initSentRef.current = true
         } catch {
@@ -360,6 +362,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
             // alongside its dispatch), but it doesn't flip any
             // bridgeState flag from it.
             if (parsed.type === 'editor-ready') {
+                console.log('[LAG] page-ready at', Date.now() - mountAtRef.current, 'ms')
                 setWebviewReady(true)
                 return
             }
@@ -375,7 +378,10 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
                 // zero, invisible).
                 if (parsed.type === 'content-height') {
                     const height = (parsed.payload as { height?: unknown } | undefined)?.height
-                    if (typeof height === 'number' && height > 0) setContentHeight(height)
+                    if (typeof height === 'number' && height > 0) {
+                        console.log('[LAG] first-height at', Date.now() - mountAtRef.current, 'ms')
+                        setContentHeight(height)
+                    }
                     return
                 }
                 onUiMessageRef.current?.(parsed)
@@ -412,6 +418,22 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         [setContentHeight]
     )
 
+    // The anchor host overlays measure against.
+    //
+    // NOT the WebView ref. Under the New Architecture (Bridgeless) TenTap's
+    // `webviewRef.current` is a Fabric native-command handle exposing only
+    // WebView commands — goForward, reload, postMessage, injectJavaScript and
+    // friends — with no `measure` or `measureInWindow` on it or its prototype.
+    // Every anchored popover therefore measured null, and the controller's
+    // fail-closed path dismissed the request before drawing anything: on
+    // device the mention picker never appeared at all.
+    //
+    // This ref points at the plain host View wrapping the WebView, which is an
+    // ordinary RN view with the usual measurement methods. It is the same box,
+    // so its origin is the WebView's origin — exactly what the popover math
+    // wants — and it keeps working regardless of what TenTap's ref becomes.
+    const measureRef = useRef<View | null>(null)
+
     // RichText is loaded lazily inside the EditorComponent because this
     // hook is a single non-platform file (not a .native.tsx split). A
     // top-level import of RichText would force web bundles to resolve
@@ -437,6 +459,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
                         heightStore={heightStore}
                         minHeight={minHeight}
                         grows={!scrollEnabled}
+                        measureRef={measureRef}
                     >
                         <RichText
                             editor={bridge}
@@ -453,6 +476,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         // viewport to minHeight — so feeding the measured height in here
         // makes the editor thrash between 72px and its real height and never
         // settle. The height is subscribed to inside EditorHeightBox instead.
+        // measureRef is deliberately absent: it is a useRef object, stable for
+        // the life of the mount. Listing it would be a no-op at best, and this
+        // memo produces a component IDENTITY — a new one remounts the WebView.
         [bridge, scrollEnabled, onWebViewMessage, minHeight, heightStore]
     )
 
@@ -489,6 +515,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         commands,
         toolbarState,
         webViewRef,
+        measureRef,
         postMessage,
         isReady: bridgeState.isReady === true,
     }
@@ -507,20 +534,32 @@ function EditorHeightBox({
     heightStore,
     minHeight,
     grows,
+    measureRef,
     children,
 }: {
     heightStore: HeightStore
     minHeight: number
     grows: boolean
+    /** Anchor for host overlays — see `measureRef` on the hook's result. */
+    measureRef?: React.RefObject<View | null>
     children: React.ReactNode
 }) {
     const height = useSyncExternalStore(heightStore.subscribe, heightStore.get, heightStore.get)
+    const resolved =
+        grows && height != null ? { height: Math.max(height, minHeight) } : { minHeight }
     return (
         <View
-            className="flex-1"
-            style={
-                grows && height != null ? { height: Math.max(height, minHeight) } : { minHeight }
-            }
+            ref={measureRef}
+            // `flex-1` ONLY when the editor is the scroll surface and should
+            // fill its parent. When it grows with its content the height above
+            // is the answer, and flex-1 actively fights it: it carries
+            // flexShrink:1, so a tight parent shrinks the box below that height
+            // — the comment composer inside the card peek collapsed to a
+            // one-line sliver while its own toolbar and Send button, which do
+            // not shrink, kept their size. flexShrink:0 pins the measured
+            // height as a floor the layout cannot claw back.
+            className={grows ? undefined : 'flex-1'}
+            style={grows ? { ...resolved, flexShrink: 0 } : resolved}
         >
             {children}
         </View>

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -267,6 +267,14 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     // the three marks (page-ready, init-sent, first-height) are what tell you
     // WHICH of those phases a slow open actually spent its time in.
     const mountAtRef = useRef(Date.now())
+    // t0. Logged once per editor so the marks below have a visible origin —
+    // without it a slow open is indistinguishable from an editor that mounted
+    // late for reasons upstream of this hook.
+    const loggedMountRef = useRef(false)
+    if (__DEV__ && !loggedMountRef.current) {
+        loggedMountRef.current = true
+        console.log('[editor.mount] mounted (t0)')
+    }
 
     // Height the page reported for its own content, held in a tiny store
     // rather than state so that a new measurement re-renders ONLY the box
@@ -298,7 +306,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         const message = makeMessage('app', 'init', initPayload)
         try {
             if (__DEV__) {
-                console.debug('[editor.mount] init-sent', Date.now() - mountAtRef.current, 'ms')
+                console.log('[editor.mount] init-sent', Date.now() - mountAtRef.current, 'ms')
             }
             webview.postMessage(JSON.stringify(message))
             initSentRef.current = true
@@ -369,11 +377,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
             // bridgeState flag from it.
             if (parsed.type === 'editor-ready') {
                 if (__DEV__) {
-                    console.debug(
-                        '[editor.mount] page-ready',
-                        Date.now() - mountAtRef.current,
-                        'ms'
-                    )
+                    console.log('[editor.mount] page-ready', Date.now() - mountAtRef.current, 'ms')
                 }
                 setWebviewReady(true)
                 return
@@ -392,7 +396,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
                     const height = (parsed.payload as { height?: unknown } | undefined)?.height
                     if (typeof height === 'number' && height > 0) {
                         if (__DEV__) {
-                            console.debug(
+                            console.log(
                                 '[editor.mount] first-height',
                                 Date.now() - mountAtRef.current,
                                 'ms'

--- a/core/lib/shortcuts/provider.native.tsx
+++ b/core/lib/shortcuts/provider.native.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useRef } from 'react'
 import { TextInput, View } from 'react-native'
 import { KeyboardExtendedView } from 'react-native-external-keyboard'
+import { isEditorFocused } from '../editor/editor-focus-state'
 import { createMatcher } from './matcher'
 
 export interface ShortcutsProviderProps {
@@ -76,6 +77,12 @@ function namedKeyFromCode(keyCode: number, char: string): string | null {
 }
 
 function isTextInputFocused(): boolean {
+    // A rich editor is a WebView, and TextInput.State cannot see inside one, so
+    // it reports "nothing focused" while the user is typing a description. Every
+    // plain letter then reached the matcher as a global shortcut — `e` opened
+    // the card title and swallowed the rest of the sentence. Ask the editor
+    // registry first.
+    if (isEditorFocused()) return true
     // React Native exposes a single global text input focus state via
     // TextInput.State, which isn't in the public RN type surface.
     const State = (TextInput as unknown as { State?: { currentlyFocusedInput?: () => unknown } })

--- a/core/server/markdown/md_to_pm.go
+++ b/core/server/markdown/md_to_pm.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/yuin/goldmark"
@@ -244,7 +245,7 @@ func codeText(n ast.Node, src []byte) []PMNode {
 
 func rawLines(lines *text.Segments, src []byte) string {
 	var b []byte
-	for i := 0; i < lines.Len(); i++ {
+	for i := range lines.Len() {
 		seg := lines.At(i)
 		b = append(b, seg.Value(src)...)
 	}
@@ -259,7 +260,24 @@ func inlineToPM(n ast.Node, src []byte) []PMNode {
 	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
 		out = append(out, inlineNodeToPM(child, src, nil)...)
 	}
-	return mergeAdjacentText(out)
+	// Mentions are extracted AFTER the runs are merged, never per text node.
+	// `[` is link syntax, so goldmark shreds `[[@u1]]` across four Text nodes
+	// ("owner is [", "[", "@u1]", "]") — a token can only be recognized once
+	// those are stitched back together.
+	return extractMentions(mergeAdjacentText(out))
+}
+
+// extractMentions replaces `[[@id]]` inside merged text runs with mention atoms.
+func extractMentions(nodes []PMNode) []PMNode {
+	out := make([]PMNode, 0, len(nodes))
+	for _, node := range nodes {
+		if node.Type != NodeText || !strings.Contains(node.Text, "[@") {
+			out = append(out, node)
+			continue
+		}
+		out = append(out, splitMentions(node.Text, node.Marks)...)
+	}
+	return out
 }
 
 func inlineNodeToPM(n ast.Node, src []byte, marks []PMMark) []PMNode {
@@ -455,4 +473,73 @@ func sameMarks(a, b []PMMark) bool {
 		}
 	}
 	return true
+}
+
+// mentionToken matches the `[[@<userId>|<name>]]` wire format inside a text run.
+//
+// The name half is OPTIONAL, so the bare `[[@id]]` written before the format
+// carried one still parses — those documents are already stored. It exists so a
+// mention stays readable when the id cannot be resolved (the person left the
+// board, or the roster has not loaded), while the id remains the identity that
+// drives notifications and survives a rename.
+//
+// Mirrors TOKEN_PATTERN in mention-node.ts — the two sides must agree exactly
+// about what counts as a mention. The backslash-escaped spelling is accepted
+// too: the editor serializes through markdown, where `[` is syntax, so a stored
+// token can come back as `\[\[@id\]\]`.
+var mentionToken = regexp.MustCompile(`\\?\[\\?\[@([A-Za-z0-9_-]+)(?:\|([^\]|]*))?\\?\]\\?\]`)
+
+// splitMentions breaks a text run into text nodes and mention atoms.
+//
+// Mentions are stored as tokens in the markdown, but the editor represents them
+// as a node — so seeding a room from stored text without this leaves the raw
+// `[[@id]]` sitting in the document, which is exactly what a reader must never
+// see. Marks carry across the split: a mention inside bold text stays bold.
+func splitMentions(txt string, marks []PMMark) []PMNode {
+	matches := mentionToken.FindAllStringSubmatchIndex(txt, -1)
+	if len(matches) == 0 {
+		return []PMNode{{Type: NodeText, Text: txt, Marks: cloneMarks(marks)}}
+	}
+	var out []PMNode
+	cursor := 0
+	for _, m := range matches {
+		if lead := txt[cursor:m[0]]; lead != "" {
+			out = append(out, PMNode{Type: NodeText, Text: lead, Marks: cloneMarks(marks)})
+		}
+		attrs := map[string]any{"userId": txt[m[2]:m[3]]}
+		// Capture group 2 is the optional display name. -1 means the token was
+		// the bare `[[@id]]` form, which carries no name.
+		if m[4] >= 0 {
+			if name := unescapeMentionName(txt[m[4]:m[5]]); name != "" {
+				attrs["name"] = name
+			}
+		}
+		out = append(out, PMNode{
+			Type:  NodeMention,
+			Attrs: attrs,
+			Marks: cloneMarks(marks),
+		})
+		cursor = m[1]
+	}
+	if tail := txt[cursor:]; tail != "" {
+		out = append(out, PMNode{Type: NodeText, Text: tail, Marks: cloneMarks(marks)})
+	}
+	return out
+}
+
+// unescapeMentionName reverses the encoding the writer applies to a mention's
+// display name.
+//
+// `]` and `|` would end the token early and are stored PERCENT-encoded, not
+// backslash-escaped: markdown owns the backslash and strips it before the token
+// is matched, so an escaped bracket arrives bare and truncates the name.
+// Mirrors unescapeMentionName in mention-node.ts; `%25` is decoded last so a
+// literal `%5D` a user typed cannot become a bracket.
+func unescapeMentionName(raw string) string {
+	if !strings.Contains(raw, "%") {
+		return raw
+	}
+	r := strings.NewReplacer("%5D", "]", "%5d", "]", "%7C", "|", "%7c", "|")
+	out := r.Replace(raw)
+	return strings.ReplaceAll(strings.ReplaceAll(out, "%25", "%"), "%25", "%")
 }

--- a/core/server/markdown/mention_test.go
+++ b/core/server/markdown/mention_test.go
@@ -1,0 +1,132 @@
+package markdown
+
+import "testing"
+
+// A mention is an ATOM: it carries a user id and has no children. The
+// serializer's default branch renders an unknown inline node's descendants, so
+// without an explicit case a mention emits NOTHING — the description flushes
+// back to storage with the mention silently deleted, while every other edit in
+// the same paragraph is saved. That is the bug these tests exist to prevent.
+
+func TestMentionRoundTrip(t *testing.T) {
+	const md = "owner is [[@u1]]\n"
+
+	doc := ToPM(md)
+	got := FromPM(doc)
+	if got != md {
+		t.Fatalf("round trip lost the mention:\n got %q\nwant %q", got, md)
+	}
+}
+
+func TestMentionParsesToAnAtom(t *testing.T) {
+	doc := ToPM("hi [[@abc123]] there\n")
+	para := doc.Content[0]
+
+	var found *PMNode
+	for i := range para.Content {
+		if para.Content[i].Type == NodeMention {
+			found = &para.Content[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("no mention node produced; the raw token would be visible to readers")
+	}
+	if got := attrString(found.Attrs, "userId"); got != "abc123" {
+		t.Fatalf("userId = %q, want %q", got, "abc123")
+	}
+	if len(found.Content) != 0 {
+		t.Fatalf("mention should be an atom, got %d children", len(found.Content))
+	}
+}
+
+func TestMentionSurvivesSurroundingText(t *testing.T) {
+	// The text on either side must not be swallowed by the split.
+	doc := ToPM("a [[@u1]] b [[@u2]] c\n")
+	if got, want := FromPM(doc), "a [[@u1]] b [[@u2]] c\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestTextWithoutMentionsIsUnchanged(t *testing.T) {
+	const md = "just ordinary prose\n"
+	if got := FromPM(ToPM(md)); got != md {
+		t.Fatalf("got %q, want %q", got, md)
+	}
+}
+
+// A bracketed phrase that is not a mention must be left alone.
+func TestNonMentionBracketsAreNotConsumed(t *testing.T) {
+	doc := ToPM("see [[not a mention]] here\n")
+	for _, n := range doc.Content[0].Content {
+		if n.Type == NodeMention {
+			t.Fatal("plain bracketed text was parsed as a mention")
+		}
+	}
+}
+
+// The name rides in the token so a mention stays readable when the id cannot be
+// resolved — the person left the board, or the roster has not loaded yet.
+func TestMentionCarriesTheDisplayName(t *testing.T) {
+	const md = "hi [[@u1|Ada Lovelace]]\n"
+	if got := FromPM(ToPM(md)); got != md {
+		t.Fatalf("round trip lost the name:\n got %q\nwant %q", got, md)
+	}
+
+	doc := ToPM(md)
+	var mention *PMNode
+	for i := range doc.Content[0].Content {
+		if doc.Content[0].Content[i].Type == NodeMention {
+			mention = &doc.Content[0].Content[i]
+		}
+	}
+	if mention == nil {
+		t.Fatal("no mention node")
+	}
+	if got := attrString(mention.Attrs, "name"); got != "Ada Lovelace" {
+		t.Fatalf("name = %q, want %q", got, "Ada Lovelace")
+	}
+	if got := attrString(mention.Attrs, "userId"); got != "u1" {
+		t.Fatalf("userId = %q, want %q", got, "u1")
+	}
+}
+
+// The bare form predates the name half and is already in stored documents.
+func TestLegacyTokenWithoutNameStillParses(t *testing.T) {
+	doc := ToPM("hi [[@u1]]\n")
+	for _, n := range doc.Content[0].Content {
+		if n.Type == NodeMention {
+			if name := attrString(n.Attrs, "name"); name != "" {
+				t.Fatalf("expected no name, got %q", name)
+			}
+			return
+		}
+	}
+	t.Fatal("legacy token did not parse into a mention")
+}
+
+// A name containing `]` or `|` would otherwise end the token early and spill
+// the rest of it into the document as visible text.
+func TestMentionNameWithDelimitersRoundTrips(t *testing.T) {
+	doc := &PMNode{Type: NodeDoc, Content: []PMNode{{
+		Type: NodeParagraph,
+		Content: []PMNode{{
+			Type:  NodeMention,
+			Attrs: map[string]any{"userId": "u1", "name": "a]b|c"},
+		}},
+	}}}
+
+	md := FromPM(doc)
+	back := ToPM(md)
+	var got *PMNode
+	for i := range back.Content[0].Content {
+		if back.Content[0].Content[i].Type == NodeMention {
+			got = &back.Content[0].Content[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("mention did not survive %q", md)
+	}
+	if name := attrString(got.Attrs, "name"); name != "a]b|c" {
+		t.Fatalf("name = %q, want %q (serialized: %q)", name, "a]b|c", md)
+	}
+}

--- a/core/server/markdown/pm_to_md.go
+++ b/core/server/markdown/pm_to_md.go
@@ -158,6 +158,17 @@ func renderInline(nodes []PMNode) string {
 			// Two trailing spaces is the portable hard break; a backslash
 			// break is GFM-only and reads as a stray character elsewhere.
 			b.WriteString("  \n")
+		case NodeMention:
+			// Back to the wire token, which is what the whole mention feature
+			// is keyed on: the flush hook parses the ID out of the stored
+			// description to decide who to notify, and an id survives the
+			// person renaming themselves. The display name is written beside
+			// it as a FALLBACK, so the mention stays readable to anyone who
+			// cannot resolve the id — leaving a board does not un-say the
+			// sentence that named you.
+			if userID := attrString(node.Attrs, "userId"); userID != "" {
+				b.WriteString(serializeMention(userID, attrString(node.Attrs, "name")))
+			}
 		case NodeText:
 			if node.Text == "\n" {
 				b.WriteString("  \n")
@@ -481,4 +492,26 @@ func itoa(n int) string {
 		buf[i] = '-'
 	}
 	return string(buf[i:])
+}
+
+// serializeMention writes the stored form of a mention.
+//
+// The display name rides along so the mention stays readable when the id cannot
+// be resolved — the person left the board, or the roster has not loaded. Names
+// are user-controlled, so `]` and `|` are PERCENT-encoded: they would otherwise
+// end the token early and spill the rest into visible text, and a backslash
+// escape does not survive (markdown strips it before the token is matched).
+// Mirrors serializeMentionToken in mention-node.ts.
+func serializeMention(userID, name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "[[@" + userID + "]]"
+	}
+	return "[[@" + userID + "|" + escapeMentionName(trimmed) + "]]"
+}
+
+// `%` is encoded FIRST so decoding cannot turn a literal `%5D` into a bracket.
+func escapeMentionName(name string) string {
+	r := strings.NewReplacer("%", "%25", "|", "%7C", "]", "%5D")
+	return r.Replace(name)
 }

--- a/core/server/markdown/types.go
+++ b/core/server/markdown/types.go
@@ -39,8 +39,15 @@ const (
 	// flattening is NOT copied here, because a doc seeded with plain cells
 	// loses its header row the first time it round-trips.
 	NodeTableHeader    = "tableHeader"
-	NodeImage          = "image"
-	NodeText           = "text"
+	NodeImage = "image"
+	NodeText  = "text"
+	// NodeMention is an @mention. It is an ATOM carrying only a user id — the
+	// name a reader sees is resolved at render time from the board roster, so
+	// the node has no children and no text of its own. That is why it needs an
+	// explicit case in the serializer: the default branch renders an unknown
+	// inline node's descendants, and an atom has none, so a mention would
+	// serialize to nothing and be wiped from the description on the next flush.
+	NodeMention        = "tinycldMention"
 	NodeHardBreak      = "hardBreak"
 	NodeHorizontalRule = "horizontalRule"
 )

--- a/core/tests/unit/anchored-overlay-state.test.ts
+++ b/core/tests/unit/anchored-overlay-state.test.ts
@@ -173,8 +173,47 @@ describe('resolvePopoverPosition', () => {
     it('flips above the anchor when it would overflow the bottom', () => {
         // Otherwise the picker lands off-screen exactly when someone is typing
         // at the bottom of a long description.
-        const { top } = resolvePopoverPosition({ ...base, viewportHeight: 340 })
-        expect(top).toBeLessThan(200 + 100)
+        //
+        // Anchored by its BOTTOM edge, not its top. Returning a `top` computed
+        // from the height ESTIMATE is what this used to do, and it placed the
+        // popover where the estimate said rather than against the caret — a
+        // generous 320px estimate against a ~70px one-row picker drew it some
+        // 250px above the text it belonged to. The estimate may decide WHICH
+        // WAY to open and nothing else.
+        const { top, bottom } = resolvePopoverPosition({ ...base, viewportHeight: 340 })
+        expect(top).toBeUndefined()
+        // The anchor's top is 200 + 100 = 300, so the popover's bottom sits a
+        // gap above it: 340 - (300 - 4) = 44 up from the viewport bottom.
+        expect(bottom).toBe(44)
+    })
+
+    // The exact geometry the bug was reported with: an iPhone-sized window,
+    // the comment composer pinned near the bottom of a card detail. The
+    // popover drew at top=351 while the caret sat at 693.
+    it('anchors to the caret for a composer at the bottom of a phone screen', () => {
+        const { top, bottom } = resolvePopoverPosition({
+            rect: { top: 1, left: 17, width: 2, height: 18, scrollX: 0, scrollY: 0 },
+            webViewOriginX: 54,
+            webViewOriginY: 674,
+            viewportWidth: 402,
+            viewportHeight: 874,
+            popoverWidth: 260,
+            popoverHeightEstimate: 320,
+            gap: 4,
+        })
+        expect(top).toBeUndefined()
+        // Caret top is 674 + 1 = 675; 874 - (675 - 4) = 203.
+        expect(bottom).toBe(203)
+    })
+
+    it('never runs off the top when the caret is near it', () => {
+        const { bottom } = resolvePopoverPosition({
+            ...base,
+            rect: { ...RECT, top: 0 },
+            webViewOriginY: 0,
+            viewportHeight: 100,
+        })
+        expect(bottom).toBeGreaterThanOrEqual(8)
     })
 
     it('clamps to the left edge instead of going negative', () => {

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -200,6 +200,55 @@ Package authors don't implement any of this, but should know it:
   match any element of multi-value fields; dates accept PB datetime, bare
   date, or RFC3339).
 
+## Your ingress must finish before it fires a trigger
+
+**If your package writes records around the one a trigger watches, wrap that
+write path in `app.RunInTransaction`.** This is the one execution detail that
+*is* your responsibility, and getting it wrong produces a rule that reports
+success and does nothing visible.
+
+Dispatch is bound to `OnRecordAfterCreateSuccess` (and the update/delete
+equivalents). Outside a transaction that hook fires *the instant the record is
+saved* — while the rest of your ingress function is still running. Rule actions
+then execute on a worker goroutine, concurrently with your remaining writes.
+
+Mail hit this. Its inbound path stored the message (firing the trigger), then
+wrote each recipient's `mail_thread_state` with `folder: "inbox"`. A
+`mail:move-to-folder` action archived the thread, and delivery's write landed
+afterwards and put it back:
+
+```go
+storeMessage(app, thread.Id, stored)   // fires the trigger; actions start
+...
+ensureThreadState(app, thread.Id, userID, "inbox", false)  // clobbers the action
+```
+
+The run logged `matched: true` with `status: "ok"`. Nothing was red — no error,
+no failed test — and the message simply stayed in the inbox.
+
+The fix is structural, because `OnModelAfterCreateSuccess` is *"delayed and
+executed only AFTER the transaction has been committed"* and is **not**
+triggered on rollback:
+
+```go
+return app.RunInTransaction(func(txApp core.App) error {
+    // every write for this delivery, using txApp
+    return nil
+})  // hook fires here, once, over settled state
+```
+
+Two properties you get for free: rules fire exactly once with all related rows
+in place, and a failure partway through means rules never fire at all rather
+than firing against a half-written record.
+
+Reordering so the triggering save comes last also works, but leaves the
+ordering load-bearing — the next person to add a write to that function
+reintroduces the bug. Prefer the transaction.
+
+Worth checking in your package: bulk importers that save in a loop (each
+iteration is a dispatch), and any path that writes a parent/summary record
+after the child rows.
+
 ## The catalog (how the UI learns about you)
 
 At boot the engine resolves every declared trigger/action against live
@@ -225,6 +274,11 @@ unavailable rather than vanishing.
 - E2E: drive the builder UI and use your package's real ingress (mail uses
   its inbound webhook helper) — never raw PB writes. `mail/tests/rules.spec.ts`
   is the reference.
+- **Assert the visible effect, not the run row.** `rule_runs` saying
+  `matched: true` / `status: "ok"` only proves the action was called — it
+  survives the ingress race above, and it survives an action that writes
+  somewhere no view reads. Assert what the user would see: the row appears in
+  the destination, and is gone from where it was.
 
 ## Gotchas
 

--- a/docs/superpowers/specs/2026-08-14-lazy-editor-warm-instance-design.md
+++ b/docs/superpowers/specs/2026-08-14-lazy-editor-warm-instance-design.md
@@ -128,20 +128,52 @@ and "save" have nowhere to live.
 #### Switch policy
 
 When a surface acquires the instance from another, the outgoing surface's text
-is **committed if it has commit semantics, discarded if it does not**. Applied
-per surface, this preserves existing behavior:
+is **committed if it has commit semantics, and otherwise preserved rather than
+lost**. Applied per surface, this preserves existing behavior in every case:
 
 - An inline comment edit already commits on blur today → switching away commits.
   Unchanged.
-- The composer has no blur-commit → its draft is discarded.
+- The composer has no blur-commit → its draft is stashed, not discarded. See
+  below.
 
-This is a deliberate, known behavior change. Today `CommentComposer` stays
-mounted for the life of the open card specifically so a half-typed draft
-survives (`CommentComposer.tsx:44` documents this). Under a singleton, opening
-the composer, typing, then tapping an existing comment to edit will discard the
-composer draft. Accepted: the affected sequence is narrow, and the alternative
-(a host-side draft store keyed by surface) was considered and set aside as scope
-not worth carrying now.
+Discarding the composer's draft outright would be a behavior regression. Today
+`CommentComposer` stays mounted for the life of the open card specifically so a
+half-typed draft survives (`CommentComposer.tsx:44` documents this), and under a
+singleton that mount no longer holds the text. A composer-scoped draft store
+closes exactly that gap.
+
+#### The composer draft store
+
+Release already has the outgoing text in hand — the singleton must be read
+before it is handed over. For the composer, that value is kept instead of
+dropped:
+
+- On **release**, read the content back through the format's channel
+  (`markdownHost.get()`, `use-rich-editor.native.tsx:410`) and stash it.
+- On **acquire**, seed a stashed draft into the init payload's `initialContent`
+  in place of the persisted value.
+- On **commit or explicit clear**, drop the entry.
+
+**Scoped to the composer, and to the life of the open card.** That is the whole
+of the lifetime policy, and it costs nothing to enforce: `CardDetail` is already
+keyed on the card id at both mount sites (`CardPeek.tsx:172` and
+`screens/[cardId].tsx:167`, both keyed because the description editor binds to
+one Yjs fragment per mount), so a card switch remounts the subtree and the store
+goes with it. The result is today's behavior exactly — a draft that survives
+switching to another editor within the card, and dies with the card.
+
+Deliberately **not** carried further:
+
+- **Not the description.** It is Yjs-backed, so a stashed draft could contradict
+  the shared document. It has no draft to lose in any case — every keystroke is
+  already flushed.
+- **Not inline comment edits.** They commit on blur today, so switching away
+  commits rather than stashing. Unchanged.
+- **Not across card close, logout, or restart.** Surviving a reopen would be new
+  behavior nobody asked for, and it is what forces an eviction policy, a
+  persisted-vs-draft arbitration on acquire, and an answer for what clears a
+  draft whose comment someone else deleted. Scoping to the mount avoids all of
+  it.
 
 ### Web is a pass-through
 
@@ -218,12 +250,17 @@ a broken editor.
 
   **E2E cannot cover the switch policy.** Playwright runs on web, where there is
   no warm singleton and each surface still mounts its own editor — so the
-  commit-or-discard behavior never triggers there. No existing spec asserts
-  composer-draft survival across an inline edit (checked), so nothing goes red;
-  but nothing guards it either. The switch policy is therefore covered by unit
-  tests over the acquire/release state machine (which surface holds the
-  instance, what release does to its content) rather than end to end, and the
-  discard path needs one manual device check.
+  handover never triggers there. No existing spec asserts composer-draft
+  survival across an inline edit (checked), so nothing goes red; but nothing
+  guards it either.
+
+  The switch policy is therefore covered by unit tests over the acquire/release
+  state machine — which surface holds the instance, what release does to its
+  content — rather than end to end. The draft store is plain host code with no
+  WebView in it, so it is directly unit-testable: stash on release, seed on
+  acquire, drop on commit, and that a description or inline-edit release stashes
+  nothing. One manual device check confirms the composer draft survives a
+  round-trip through an inline edit.
 - **Device:** the measurement that motivated this work, re-taken. The four
   `__DEV__` marks in `use-webview-editor.tsx` stay; a warm acquire should show
   no `page-ready` mark at all, only `init-sent` and `first-height`.
@@ -235,5 +272,7 @@ a broken editor.
   picker has not been exercised there. Called out in the handoff doc as owed
   regardless of this work.
 - **Backfilling old `@someone` mentions.** A migration, no decision made.
-- **A host-side draft store.** Considered for the composer-draft case above and
-  set aside; revisit if the discard proves annoying in use.
+- **Draft persistence beyond the open card.** The composer draft store is scoped
+  to `CardDetail`'s mount (see above). Surviving card close, logout, or restart
+  is deliberately excluded — it is new behavior, and it is what would force an
+  eviction policy and a persisted-vs-draft arbitration.

--- a/docs/superpowers/specs/2026-08-14-lazy-editor-warm-instance-design.md
+++ b/docs/superpowers/specs/2026-08-14-lazy-editor-warm-instance-design.md
@@ -1,0 +1,239 @@
+# LazyEditor and the warm editor instance
+
+**Date:** 2026-08-14
+**Status:** Design, approved for planning
+**Context:** `HANDOFF-editor-webview-cost.md`
+
+## The problem
+
+Tapping to edit a comment on iOS takes ~1.2 s before text appears. The cause is
+measured, not guessed: creating a WebView editor is a browser cold start, and
+the app creates one per edit.
+
+```
+[editor.mount] mounted (t0)
+[editor.mount] page-ready    1135 ms   96%
+[editor.mount] init-sent     1152 ms    1%
+[editor.mount] first-height  1186 ms    3%
+```
+
+Everything the host controls after the page reports ready totals 51 ms. The
+cost is entirely *creation*, which is why reuse is the fix rather than tuning.
+
+## The finding that shapes the design
+
+**The WebView page already mounts in two stages.** `rich/webview/source/Editor.tsx`
+boots, posts `EDITOR_READY`, and renders `null` until the init payload arrives.
+Only then does it construct Tiptap.
+
+The 1135 ms is spent entirely in stage one — browser cold start, 0.86 MB bundle
+parse, React boot — all of it **independent of any editor's configuration**.
+Stage two is part of the 51 ms.
+
+So the mechanism is not something to invent. It is already the page's
+architecture. Two things block reuse:
+
+1. The host treats init as one-shot (`initSentRef`, `use-webview-editor.tsx:300`).
+2. A WebView's lifetime is tied to a consumer component's mount.
+
+The work is therefore: **let a booted page be re-initialized, and let one WebView
+outlive its consumers.**
+
+## What ships
+
+Two pieces in core, plus the cards migration.
+
+### 1. A single warm editor instance
+
+Exactly one WebView, owned by core, booted to `EDITOR_READY` and parked. Not a
+pool: nowhere in the app are two editors focused at once, so one suffices.
+
+Acquiring it posts a fresh init payload; the page rebuilds stage two for that
+configuration. Cost per acquire is Tiptap construction — the 34 ms figure above
+— instead of 1135 ms.
+
+**Re-initialization is a full reconstruction, not a mutation.** This is the
+central safety property. `EditorMounted` takes its entire configuration from one
+prop, so keying it on an init generation gives a new Tiptap instance, a new
+`Y.Doc` (`useCollabDoc`'s `useState` initializer reruns), a new undo stack, and a
+new extension set. The handoff doc's leaked-undo-history risk — undoing another
+comment's text into this one — cannot occur, because nothing survives the swap.
+
+The alternative, making placeholder / characterLimit / collab individually
+settable to avoid rebuilding Tiptap, is rejected: it trades ~30 ms for a class
+of state-leak bugs in a surface where **a blur commits**, making leaked state a
+data-loss risk rather than a cosmetic one.
+
+### 2. `LazyEditor` — the view/edit swap as a core component
+
+Today `CardDetail` and `DetailActivity` each hand-roll the swap. `LazyEditor`
+makes it core's job: render the read view, and on press acquire the warm
+instance.
+
+This subsumes the handoff doc's "cheap win" (render existing text while the
+editor boots) structurally rather than as a bolted-on placeholder — the read
+view *is* what shows during the acquire.
+
+**`LazyEditor` does not own rendering.** It takes the read view as a prop:
+
+```tsx
+<LazyEditor
+    // Consumer's component. Core never interprets the content.
+    readView={<MarkdownText body={description} projectId={projectId} />}
+
+    contentFormat="markdown"        // passed to the init payload
+    value={description}
+
+    editorOptions={{ placeholder, characterLimit, triggers, collab }}
+
+    canEdit={canEdit}
+    onCommit={body => save(body)}
+    onCancel={...}                  // absent => no commit semantics
+/>
+```
+
+#### Format neutrality
+
+`LazyEditor` must never be markdown-only. Three things secure this:
+
+- **Rendering is the consumer's.** `readView` is a prop. Cards' `MarkdownText`
+  carries cards-specific concerns — mention-token resolution against
+  `useProjectMembers`, protected-file image srcs, a per-surface type scale —
+  none of which belong in core. Mail's read view is a different component
+  entirely.
+- **Content crosses as an opaque string.** `contentFormat` is already
+  first-class on `RichEditorInitPayload` and `UseRichEditorOptions`; it selects
+  `getMarkdown`/`setMarkdown` versus `getHTML`/`setContent` on the existing
+  `EditorResult`. `LazyEditor` forwards it and reads back through whichever
+  channel the format names.
+- **`editorOptions` is `UseRichEditorOptions`.** Not a curated subset, so an
+  option added for mail needs no change here.
+
+#### `LazyEditor` owns the commit semantics
+
+These rules were each found on a device and cost real debugging. Centralizing
+them means mail and text inherit the fixes instead of rediscovering them.
+
+| Rule | Why it exists |
+|---|---|
+| A blur before the session ever held focus must not commit | `hasFocusedRef` — an editor that mounted too short blurred immediately and saved a comment nobody had touched |
+| Save and the blur-commit must not both write | `settledRef` — an edit session ends at its first commit; the parent unmounts the component |
+| An unchanged value is a cancel, not a write | `EditableText`'s convention |
+| A dialog taking focus is not the end of the session | The image picker and link prompt both steal focus; closing the editor under the picker unmounts the surface the image is about to land in |
+
+`commitOnBlur` selects the variant. The description passes no `onCancel`: every
+keystroke is already shared through Yjs and flushed by the server, so "revert"
+and "save" have nowhere to live.
+
+#### Switch policy
+
+When a surface acquires the instance from another, the outgoing surface's text
+is **committed if it has commit semantics, discarded if it does not**. Applied
+per surface, this preserves existing behavior:
+
+- An inline comment edit already commits on blur today → switching away commits.
+  Unchanged.
+- The composer has no blur-commit → its draft is discarded.
+
+This is a deliberate, known behavior change. Today `CommentComposer` stays
+mounted for the life of the open card specifically so a half-typed draft
+survives (`CommentComposer.tsx:44` documents this). Under a singleton, opening
+the composer, typing, then tapping an existing comment to edit will discard the
+composer draft. Accepted: the affected sequence is narrow, and the alternative
+(a host-side draft store keyed by surface) was considered and set aside as scope
+not worth carrying now.
+
+### Web is a pass-through
+
+Web's `useRichEditor` builds Tiptap in-process — no WebView, no cold start.
+`LazyEditor` on web still renders the read view and swaps on press, so both
+platforms walk the same code path and the e2e suite exercises the real thing,
+but there is no warm instance and no parking. No behavior divergence between
+platforms; the native path simply skips a cost web never paid.
+
+## Architecture
+
+### Protocol changes (`rich/webview/source/protocol.ts`)
+
+- `APP_INIT` gains a `generation` field and becomes re-sendable. The page keys
+  `EditorMounted` on it, so a new generation is a full stage-two remount.
+- New host→page `APP_PARK`: tear down to stage one — render `null`, drop the
+  Y.Doc, release awareness. Makes release explicit rather than implicit.
+
+### Host changes
+
+- `use-webview-editor.tsx`: replace the one-shot `initSentRef` latch with
+  generation tracking, so a new payload is posted rather than suppressed.
+- **The host-side relays must be rebuilt on each acquire, not just the page's.**
+  `YjsWebViewHost` and `AwarenessWebViewHost` subscribe to a specific Y.Doc and
+  Awareness (`use-rich-editor.native.tsx:116-143`, memoized on doc identity). A
+  relay left over from the previous occupant would pump a dead document's
+  updates into the live editor. Acquire destroys and reconstructs both, mirroring
+  the page-side teardown; the existing `destroy()` cleanups are the hook.
+  `MarkdownWebViewHost` likewise re-seeds so a `getMarkdown` that times out
+  returns the newly-acquired content rather than the prior surface's.
+- New `lib/editor/warm/`:
+  - `WarmEditorHost` — renders the parked WebView. Positioned absolutely
+    off-viewport **at real size**, not `display:none` and not zero-height: a
+    zero-size WebView may not lay out or paint on iOS, which would defeat the
+    warming. `pointerEvents="none"` and `accessibilityElementsHidden`.
+  - `useWarmEditor(options)` — acquire/release around the singleton, returning
+    the same `EditorResult` contract as `useRichEditor` so call sites change
+    minimally. On web, an alias for `useRichEditor`.
+- `LazyEditor` — the swap component described above.
+
+### Fallback
+
+If the warm instance is unavailable for any reason — not yet booted, or held by
+another surface mid-release — the consumer mounts its own editor exactly as
+today, paying the cold start. **Warm is an optimization, never a correctness
+dependency**: a bug in the warm path degrades to current behavior rather than to
+a broken editor.
+
+### Cards changes
+
+- `screens/_layout.tsx` mounts `WarmEditorHost`. This is the per-package mount
+  point that matches "warm as soon as cards loads" — a manifest `provider`
+  would not, because `PackageProviderWrapper` builds its chain at module load
+  and wraps the whole app, booting a WebView at app launch for anyone with cards
+  installed whether or not they ever open it.
+- `CardDetail`'s `DescriptionReadView` swap and `DetailActivity`'s inline-edit
+  swap are both replaced by `LazyEditor`.
+- The board's Y.Doc is per-board, not per-card (`useBoardPresence.ts:138` — one
+  doc holding a fragment per card), so the warm instance binds to the board doc
+  and only the field (`card:<id>`) varies per acquire. This is what makes the
+  description work through the same instance as comments.
+
+## Testing
+
+- **Unit, core:** re-init generation handling; that a new generation produces a
+  fresh Y.Doc and empty undo stack; park/unpark; the commit-semantics matrix
+  above (each rule from the table, driven through `LazyEditor`'s props);
+  `contentFormat` routing to the correct read-back channel.
+- **Unit, protocol:** re-sendable init round-trips, alongside the existing
+  `trigger-serialization.test.ts` pinning.
+- **E2E:** the existing comment-editing and description specs must pass
+  unchanged — they are the regression net for the swap's layout neutrality
+  (the ±2px anchor `comment-editing.spec` asserts).
+
+  **E2E cannot cover the switch policy.** Playwright runs on web, where there is
+  no warm singleton and each surface still mounts its own editor — so the
+  commit-or-discard behavior never triggers there. No existing spec asserts
+  composer-draft survival across an inline edit (checked), so nothing goes red;
+  but nothing guards it either. The switch policy is therefore covered by unit
+  tests over the acquire/release state machine (which surface holds the
+  instance, what release does to its content) rather than end to end, and the
+  discard path needs one manual device check.
+- **Device:** the measurement that motivated this work, re-taken. The four
+  `__DEV__` marks in `use-webview-editor.tsx` stay; a warm acquire should show
+  no `page-ready` mark at all, only `init-sent` and `first-height`.
+
+## Explicitly out of scope
+
+- **Android verification.** Everything measured to date is iOS simulator. The
+  mount cost should be comparable but is unmeasured, and the native mention
+  picker has not been exercised there. Called out in the handoff doc as owed
+  regardless of this work.
+- **Backfilling old `@someone` mentions.** A migration, no decision made.
+- **A host-side draft store.** Considered for the composer-draft case above and
+  set aside; revisit if the discard proves annoying in use.


### PR DESCRIPTION
Shared-editor half of tinycld/cards#28. Mentions rendered as their raw wire token and could not survive being saved; both are fixed here, along with the native focus and positioning bugs that surfaced while testing on a device.

## The mention node

`[[@<userId>|<name>]]` stays the stored format. The **id** is what cards' Go flush hook parses to notify someone, and being id-based is what lets a mention survive a rename. The node holds that id and renders the person's name, so the document reads as prose.

The **name** now rides along as a display fallback — leaving a board does not un-say the sentence that named you, and on native it means a mention is readable before the roster has loaded. Optional on the wire, so already-stored `[[@id]]` keeps working.

## Two serializers, not one

The editor's own `renderMarkdown` is only half the job. Card descriptions are flushed by the **Go** serializer, whose default branch renders an unknown inline node's *children* — and an atom has none, so every mention silently vanished on save while the prose around it persisted.

`md_to_pm` extracts tokens **after** text runs are merged: `[` is link syntax, so goldmark shreds `[[@u1]]` across four nodes and a per-node regex can never match.

## Loading is a plugin, not a string rewrite

Converting the markdown to an HTML span before parsing looked simpler and **corrupted a comment**: the two platforms' parsers disagree about an inline `<span>`, so on native the markup survived as literal text and the next blur saved it. The node now converts token text to nodes inside the editor, where there is no second parser to disagree.

## Native fixes found on device

- Plain letters typed into a WebView editor reached the **global shortcut matcher** — `TextInput.State` cannot see into a WebView, so `e` opened the card title and swallowed the rest of the sentence.
- The anchored popover measured `webViewRef`, which under **Bridgeless** carries WebView commands and no measurement methods at all, so every popover measured null and was dismissed before drawing. It now measures the host view wrapping the editor.
- A flipped popover computed its top from a 320px height **estimate** while a one-row picker is nearer 70 — drawing it ~250px above the caret. It now pins its **bottom** edge, so the estimate only decides which way to open.
- `containerClassName` is web-only, so native had no way to express a minimum height.
- `EditorHeightBox` carried `flex-1`, whose `flexShrink` let a tight parent squash the box below its measured height.

## `purpose` on MarkdownRenderer

`documentation` (unchanged default), `description`, `compact`. It was tuned for help topics, so a five-line card comment filled a screen.

`description` is derived from the editor's own CSS and **pinned to it by a test** — that surface now swaps to the editor on tap, so any mismatch reflows the text under the reader.

## Tests

1157 core unit tests passing. New: mention markdown round-trips (Go + TS), the load path that proves saving cannot corrupt text, popover positioning (including the exact device geometry from the bug report), the editor-focus state, the roster-delivery race, and the serializable-trigger field list — a hand-maintained mapping that let a flag reach web and silently not native.