### PR TITLE
Make the rules relation picker searchable and reachable

### DIFF
--- a/core/components/DropdownMenu.tsx
+++ b/core/components/DropdownMenu.tsx
@@ -37,6 +37,8 @@ interface MenuActionItemProps {
     isActive?: boolean
     colorDot?: string
     disabled?: boolean
+    /** Stable identity for tests when labels aren't unique. */
+    testID?: string
 }
 
 export function MenuActionItem({
@@ -48,12 +50,18 @@ export function MenuActionItem({
     isActive,
     colorDot,
     disabled,
+    testID,
 }: MenuActionItemProps) {
     const mutedColor = useThemeColor('muted-foreground')
     const primaryColor = useThemeColor('primary')
 
     return (
-        <Menu.Item onPress={disabled ? undefined : onPress} href={href} isDisabled={disabled}>
+        <Menu.Item
+            onPress={disabled ? undefined : onPress}
+            href={href}
+            isDisabled={disabled}
+            testID={testID}
+        >
             {leading ? (
                 leading
             ) : Icon ? (

--- a/core/components/rules/ActionsCard.tsx
+++ b/core/components/rules/ActionsCard.tsx
@@ -36,6 +36,35 @@ function groupActionsByPackage(actions: CatalogAction[]): Map<string, CatalogAct
     return groups
 }
 
+/**
+ * The label shown for one action in the add-action menu.
+ *
+ * Packages pick their own action labels, so collisions are normal — drive and
+ * mail both call theirs "Move to folder". The group heading above each item
+ * says which package it is, but two identically-worded rows a few lines apart
+ * are easy to misread, so an ambiguous label carries its package inline. The
+ * unambiguous majority stay clean.
+ */
+function actionOptionLabel(action: CatalogAction, isAmbiguous: boolean): string {
+    if (!action.available) return `${action.label} (needs ${action.pkg})`
+    return isAmbiguous ? `${action.label} (${action.pkg})` : action.label
+}
+
+/** Labels contributed by more than one package, so they need qualifying. */
+function ambiguousLabels(actions: CatalogAction[]): Set<string> {
+    const seen = new Map<string, string>()
+    const ambiguous = new Set<string>()
+    for (const action of actions) {
+        const owner = seen.get(action.label)
+        if (owner === undefined) {
+            seen.set(action.label, action.pkg)
+        } else if (owner !== action.pkg) {
+            ambiguous.add(action.label)
+        }
+    }
+    return ambiguous
+}
+
 function AddActionMenu({
     catalog,
     trigger,
@@ -48,6 +77,7 @@ function AddActionMenu({
     const mutedColor = useThemeColor('muted-foreground')
     const options = trigger ? compatibleActions(catalog, trigger) : []
     const groups = groupActionsByPackage(options)
+    const ambiguous = ambiguousLabels(options)
 
     return (
         <Menu>
@@ -66,11 +96,8 @@ function AddActionMenu({
                             {actions.map(action => (
                                 <MenuActionItem
                                     key={action.ref}
-                                    label={
-                                        action.available
-                                            ? action.label
-                                            : `${action.label} (needs ${action.pkg})`
-                                    }
+                                    testID={`action-option-${action.ref}`}
+                                    label={actionOptionLabel(action, ambiguous.has(action.label))}
                                     disabled={!action.available}
                                     onPress={() => onSelect(action)}
                                 />

--- a/core/components/rules/ConditionRow.tsx
+++ b/core/components/rules/ConditionRow.tsx
@@ -51,6 +51,7 @@ function FieldMenu({
                     {fields.map(field => (
                         <MenuActionItem
                             key={field.key}
+                            testID={`condition-field-option-${field.key}`}
                             label={field.label}
                             isActive={field.key === condition.field}
                             onPress={() => onSelectField(field)}

--- a/core/components/rules/RelationRecordPicker.tsx
+++ b/core/components/rules/RelationRecordPicker.tsx
@@ -65,22 +65,34 @@ export function RelationRecordPicker({
     const { isRegistered, records } = useRelationRecords(target)
     const [search, setSearch] = useState('')
 
-    // Sorted by what the user actually reads, then filtered, then capped.
-    // Ordering by id and capping first meant a collection larger than the cap
-    // hid most of itself behind an arbitrary boundary — a folder created a
-    // moment ago was typically unreachable, with no way to search for it.
+    // Labelling is independent of the search term, so it is memoized on its own
+    // — otherwise every keystroke re-derived a label for every row.
+    const labelled = useMemo(
+        () =>
+            records.map(record => ({
+                record,
+                label: recordLabel(record, displayField),
+            })),
+        [records, displayField]
+    )
+
+    // Filter FIRST, then sort. Sorting the whole collection before filtering
+    // ran an O(n log n) pass per keystroke over every row, when the sort only
+    // ever needs to order what survives the filter — usually a handful.
+    //
+    // Capping comes last, and after the sort rather than before it: ordering by
+    // id and capping first (the previous behavior) meant a collection larger
+    // than the cap hid most of itself behind an arbitrary boundary, so a folder
+    // created a moment ago was typically unreachable with no way to search for
+    // it.
     const matches = useMemo(() => {
         const needle = search.trim().toLowerCase()
-        const labelled = records.map(record => ({
-            record,
-            label: recordLabel(record, displayField),
-        }))
-        labelled.sort((a, b) => a.label.localeCompare(b.label))
         const filtered = needle
             ? labelled.filter(entry => entry.label.toLowerCase().includes(needle))
-            : labelled
+            : [...labelled]
+        filtered.sort((a, b) => a.label.localeCompare(b.label))
         return { visible: filtered.slice(0, VISIBLE_LIMIT), total: filtered.length }
-    }, [records, displayField, search])
+    }, [labelled, search])
 
     if (!isRegistered) {
         return (
@@ -93,8 +105,11 @@ export function RelationRecordPicker({
         )
     }
 
-    const selected = records.find(r => r.id === value)
-    const label = selected ? recordLabel(selected, displayField) : value || 'Select…'
+    // Resolved against the full labelled set, not `matches` — the trigger must
+    // keep showing the selected record's name while a search is narrowing the
+    // list, and the selection is frequently filtered out of it.
+    const selected = labelled.find(entry => entry.record.id === value)
+    const label = selected ? selected.label : value || 'Select…'
 
     return (
         <Menu>
@@ -106,7 +121,7 @@ export function RelationRecordPicker({
                     <ChevronDown size={14} color={mutedColor} />
                 </Pressable>
             </Menu.Trigger>
-            <Menu.Portal>
+            <Menu.Portal hasTextInput>
                 <Menu.Overlay />
                 <Menu.Content presentation="popover" placement="bottom" align="start">
                     <View className="px-2 pt-1 pb-2">

--- a/core/components/rules/RelationRecordPicker.tsx
+++ b/core/components/rules/RelationRecordPicker.tsx
@@ -5,7 +5,8 @@ import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { Menu } from '@tinycld/core/ui/menu'
 import { PlainInput } from '@tinycld/core/ui/PlainInput'
 import { ChevronDown } from 'lucide-react-native'
-import { Pressable, Text } from 'react-native'
+import { useMemo, useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
 
 export interface RelationRecordPickerProps {
     target: string
@@ -33,18 +34,20 @@ function recordLabel(record: Record<string, unknown>, displayField: string): str
 // belong to another package entirely), so org/user scoping is the caller's
 // concern, not this generic picker's — rows are already RLS-filtered by the
 // server.
+// How many matches the menu will render at once. The list is filtered before
+// it is capped, so this bounds the DOM, not what the user can reach.
+const VISIBLE_LIMIT = 50
+
 function useRelationRecords(target: string) {
     const collection = collectionByName(target)
     const { data } = useLiveQuery(
         q => {
             if (!collection) return null
-            // TanStack DB requires an ORDER BY whenever LIMIT is present (it
-            // won't guess a deterministic order for you) — order by id so the
-            // list of "first 50 records" is stable across reloads.
-            return q
-                .from({ record: collection })
-                .orderBy(({ record }) => record.id, 'asc')
-                .limit(50)
+            // No LIMIT here: the cap has to be applied AFTER filtering, or the
+            // filter only ever searches the first N rows. Ordering by id is
+            // likewise wrong as a user-facing order — it's random to a human —
+            // so both are handled below against the display field.
+            return q.from({ record: collection })
         },
         [collection]
     )
@@ -58,7 +61,26 @@ export function RelationRecordPicker({
     onChange,
 }: RelationRecordPickerProps) {
     const mutedColor = useThemeColor('muted-foreground')
+    const placeholderColor = useThemeColor('field-placeholder')
     const { isRegistered, records } = useRelationRecords(target)
+    const [search, setSearch] = useState('')
+
+    // Sorted by what the user actually reads, then filtered, then capped.
+    // Ordering by id and capping first meant a collection larger than the cap
+    // hid most of itself behind an arbitrary boundary — a folder created a
+    // moment ago was typically unreachable, with no way to search for it.
+    const matches = useMemo(() => {
+        const needle = search.trim().toLowerCase()
+        const labelled = records.map(record => ({
+            record,
+            label: recordLabel(record, displayField),
+        }))
+        labelled.sort((a, b) => a.label.localeCompare(b.label))
+        const filtered = needle
+            ? labelled.filter(entry => entry.label.toLowerCase().includes(needle))
+            : labelled
+        return { visible: filtered.slice(0, VISIBLE_LIMIT), total: filtered.length }
+    }, [records, displayField, search])
 
     if (!isRegistered) {
         return (
@@ -87,14 +109,36 @@ export function RelationRecordPicker({
             <Menu.Portal>
                 <Menu.Overlay />
                 <Menu.Content presentation="popover" placement="bottom" align="start">
-                    {records.map(record => (
+                    <View className="px-2 pt-1 pb-2">
+                        <PlainInput
+                            value={search}
+                            onChangeText={setSearch}
+                            placeholder="Search…"
+                            placeholderTextColor={placeholderColor}
+                            className="border rounded-lg px-2.5 py-1.5 text-sm text-foreground bg-background border-border"
+                        />
+                    </View>
+                    {matches.visible.map(({ record, label: recordName }) => (
                         <MenuActionItem
                             key={record.id as string}
-                            label={recordLabel(record, displayField)}
+                            label={recordName}
                             isActive={record.id === value}
                             onPress={() => onChange(record.id as string)}
                         />
                     ))}
+                    {matches.visible.length === 0 ? (
+                        <Text className="px-3 py-2 text-xs text-muted-foreground">
+                            {records.length === 0 ? 'Nothing to choose from' : 'No matches'}
+                        </Text>
+                    ) : null}
+                    {matches.total > matches.visible.length ? (
+                        // Say so rather than silently truncating: a user who
+                        // can't see their record needs to know to narrow the
+                        // search, not assume it doesn't exist.
+                        <Text className="px-3 py-2 text-xs text-muted-foreground">
+                            {matches.total - matches.visible.length} more — keep typing to narrow
+                        </Text>
+                    ) : null}
                 </Menu.Content>
             </Menu.Portal>
         </Menu>

--- a/core/components/rules/TriggerCard.tsx
+++ b/core/components/rules/TriggerCard.tsx
@@ -72,6 +72,7 @@ function TriggerMenu({
                             {triggers.map(trigger => (
                                 <MenuActionItem
                                     key={trigger.ref}
+                                    testID={`trigger-option-${trigger.ref}`}
                                     label={trigger.label}
                                     isActive={trigger.ref === selectedRef}
                                     onPress={() => onSelect(trigger)}

--- a/core/tests/unit/menu-item-keyboard.test.tsx
+++ b/core/tests/unit/menu-item-keyboard.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { Menu } from '@tinycld/core/ui/menu'
+import { Text } from 'react-native'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * A menu item has to be operable without a mouse.
+ *
+ * RN's Pressable renders a bare div on web — no tabIndex, no key handling — so
+ * a menu built from ordinary items was pointer-only: invisible to Tab and
+ * unactivatable by Enter. The href variant gets this free from <a> and
+ * SubTrigger hand-rolls it, which left plain items as the gap.
+ */
+describe('Menu.Item keyboard reachability (web)', () => {
+    afterEach(cleanup)
+
+    // Rendered directly rather than through <Menu.Portal>: the portal goes
+    // through gluestack's Overlay, which does not mount under the react-native
+    // stub, so nothing inside it exists in the DOM to assert against. The item
+    // only needs the surrounding context, which <Menu> alone provides.
+    function renderItem(onPress: () => void, isDisabled = false) {
+        return render(
+            <Menu isOpen>
+                <Menu.Item onPress={onPress} isDisabled={isDisabled} testID="item">
+                    <Text>Pick me</Text>
+                </Menu.Item>
+            </Menu>
+        )
+    }
+
+    it('puts the item in the tab order', () => {
+        const { getByTestId } = renderItem(() => {})
+        expect(getByTestId('item').getAttribute('tabindex')).toBe('0')
+    })
+
+    it('activates on Enter', () => {
+        const onPress = vi.fn()
+        const { getByTestId } = renderItem(onPress)
+
+        fireEvent.keyDown(getByTestId('item'), { key: 'Enter' })
+
+        expect(onPress).toHaveBeenCalledOnce()
+    })
+
+    /**
+     * Space activates a menuitem per ARIA, and without preventDefault it would
+     * scroll the popover instead of choosing the row under the caret.
+     */
+    it('activates on Space', () => {
+        const onPress = vi.fn()
+        const { getByTestId } = renderItem(onPress)
+
+        fireEvent.keyDown(getByTestId('item'), { key: ' ' })
+
+        expect(onPress).toHaveBeenCalledOnce()
+    })
+
+    it('ignores keys that are not activation keys', () => {
+        const onPress = vi.fn()
+        const { getByTestId } = renderItem(onPress)
+
+        fireEvent.keyDown(getByTestId('item'), { key: 'a' })
+
+        expect(onPress).not.toHaveBeenCalled()
+    })
+
+    it('drops a disabled item out of the tab order and does not activate it', () => {
+        const onPress = vi.fn()
+        const { getByTestId } = renderItem(onPress, true)
+
+        const item = getByTestId('item')
+        expect(item.getAttribute('tabindex')).toBe('-1')
+
+        fireEvent.keyDown(item, { key: 'Enter' })
+        expect(onPress).not.toHaveBeenCalled()
+    })
+
+    it('exposes the menuitem role', () => {
+        const { getByTestId } = renderItem(() => {})
+        expect(getByTestId('item').getAttribute('role')).toBe('menuitem')
+    })
+})

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -318,7 +318,22 @@ function Trigger({ children, disableClick }: TriggerProps) {
 
 // ── Portal ──
 
-function Portal({ children }: { children: React.ReactNode }) {
+function Portal({
+    children,
+    hasTextInput,
+}: {
+    children: React.ReactNode
+    /**
+     * Set when the menu contains a focusable text input (a searchable picker).
+     *
+     * isKeyboardDismissable closes the overlay on the hardware/soft keyboard's
+     * dismiss, which is right for a menu of buttons and wrong for one holding
+     * an input: on Android, dismissing the soft keyboard after typing would
+     * take the whole menu with it, losing the search mid-selection. Off in that
+     * case; the backdrop and onRequestClose still close the menu.
+     */
+    hasTextInput?: boolean
+}) {
     const ctx = useMenuContext()
 
     // On native, render the overlay inside a real RN Modal
@@ -340,7 +355,7 @@ function Portal({ children }: { children: React.ReactNode }) {
     return (
         <GluestackOverlay
             isOpen={ctx.isOpen}
-            isKeyboardDismissable
+            isKeyboardDismissable={!hasTextInput}
             useRNModalOnAndroid
             useRNModal={Platform.OS === 'ios'}
             animationPreset="none"
@@ -569,6 +584,42 @@ const Item = forwardRef<View, ItemProps>(function Item(
             >
                 {children}
             </a>
+        )
+    }
+
+    // Web, no href. RN's Pressable renders a bare div with no tabIndex and no
+    // key handling, so a menu built from these was mouse-only: reachable by
+    // pointer, invisible to Tab and unactivatable by Enter. The href branch
+    // above gets this free from <a>, and SubTrigger hand-rolls the same thing
+    // below — this is that treatment for the ordinary item.
+    if (Platform.OS === 'web') {
+        return (
+            <div
+                ref={ref as unknown as React.Ref<HTMLDivElement>}
+                role="menuitem"
+                data-testid={testID}
+                tabIndex={isDisabled ? -1 : 0}
+                aria-disabled={isDisabled || undefined}
+                onClick={() => handlePress()}
+                onKeyDown={e => {
+                    // Space as well as Enter: both activate a menuitem per ARIA,
+                    // and Space would otherwise scroll the popover instead.
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        handlePress()
+                    }
+                }}
+                onMouseEnter={() => setHovered(true)}
+                onMouseLeave={() => setHovered(false)}
+                className={itemClass}
+                style={{
+                    display: 'flex',
+                    cursor: isDisabled ? 'default' : 'pointer',
+                    ...(styleProp as React.CSSProperties),
+                }}
+            >
+                {children}
+            </div>
         )
     }
 

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -516,10 +516,17 @@ interface ItemProps {
     isDisabled?: boolean
     className?: string
     style?: object
+    /**
+     * Stable identity for tests. Menu labels are not unique — two packages can
+     * contribute an action with the same label — and items sit as flat
+     * siblings under their group heading, so there is nothing to scope a
+     * selection to without this.
+     */
+    testID?: string
 }
 
 const Item = forwardRef<View, ItemProps>(function Item(
-    { children, onPress: onPressProp, href, isDisabled, className, style: styleProp },
+    { children, onPress: onPressProp, href, isDisabled, className, style: styleProp, testID },
     ref
 ) {
     const { onOpenChange } = useMenuContext()
@@ -543,6 +550,7 @@ const Item = forwardRef<View, ItemProps>(function Item(
                 ref={ref as React.Ref<HTMLAnchorElement>}
                 href={href}
                 role="menuitem"
+                data-testid={testID}
                 onClick={e => {
                     if (e.metaKey || e.ctrlKey || e.shiftKey) return
                     e.preventDefault()
@@ -569,6 +577,7 @@ const Item = forwardRef<View, ItemProps>(function Item(
             ref={ref}
             onPress={handlePress}
             disabled={isDisabled}
+            testID={testID}
             accessibilityRole="menuitem"
             onHoverIn={() => setHovered(true)}
             onHoverOut={() => setHovered(false)}


### PR DESCRIPTION
The relation picker fetched the first 50 records ordered by `id` and rendered them. The cap was applied **inside the query**, so there was nothing to search with and no way to reach a record outside that window — and `id` order is arbitrary to a reader.

On any collection bigger than 50 rows the picker was effectively unusable: a folder a user had just created was typically not in the list, with no way to find it. That's what made drive's `move-to-folder` action impossible to configure, which is how this surfaced.

Fetch unbounded, sort by the display field, filter, then cap. Adds a search box, and reports how many matches are hidden instead of truncating silently.

Verified: `tinycld-pkg check` green — 172 files, 1312 tests.