### PR TITLE
feat(editor): warm editor instance and LazyEditor

### DIFF
--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -113,32 +113,23 @@ export function useLazyEditor({
     const hasFocusedRef = useRef(false)
     const settledRef = useRef(false)
 
-    const lease = useWarmEditor(surfaceId, {
-        ...editorOptions,
-        contentFormat,
-        initialContent: value,
-    })
-
     const submitRef = useRef<() => void>(() => {})
     const blurRef = useRef<() => void>(() => {})
 
-    // The warm instance when one is available; otherwise this surface mounts its
-    // own and pays the cold start. Warm is an optimization, never a correctness
-    // dependency.
-    //
-    // Called unconditionally, including while idle: a hook cannot sit behind the
-    // swap's branch. On native that costs nothing — the WebView belongs to the
-    // warm host, and this hook only builds the host-side handle. On web it is
-    // the same Tiptap instance the previous hand-rolled swaps mounted.
     // The consumer's own focus handlers are CHAINED rather than replaced: a
     // caller uses them to drive its chrome (a card description swaps its section
     // label for a formatting toolbar on focus), and silently dropping them
     // leaves that chrome permanently in its idle state.
-    const own = useRichEditor({
+    //
+    // These wrappers carry the entire commit policy — hasFocusedRef gates
+    // shouldCommitOnBlur, blurRef fires the blur-commit, submitRef answers ⌘↵ —
+    // so BOTH the warm instance and the cold fallback must receive them. Giving
+    // them only to `own` left the policy inert on the warm path, which is the
+    // only path native ever takes: blur never committed and ⌘↵ never submitted.
+    const chainedOptions: UseRichEditorOptions = {
         ...editorOptions,
         contentFormat,
         initialContent: value,
-        autofocus: true,
         onFocus: () => {
             hasFocusedRef.current = true
             editorOptions.onFocus?.()
@@ -151,7 +142,18 @@ export function useLazyEditor({
             editorOptions.onSubmitShortcut?.()
             submitRef.current()
         },
-    })
+    }
+
+    const lease = useWarmEditor(surfaceId, chainedOptions)
+
+    // The cold fallback, used when no warm host is mounted (always on web, and
+    // on native before the host boots). Warm is an optimization, never a
+    // correctness dependency.
+    //
+    // Called unconditionally, including while idle: a hook cannot sit behind the
+    // swap's branch. On web it is the same Tiptap instance the previous
+    // hand-rolled swaps mounted.
+    const own = useRichEditor({ ...chainedOptions, autofocus: true })
     const active = lease.result ?? own
 
     const startEditing = useCallback(() => {
@@ -161,6 +163,28 @@ export function useLazyEditor({
         lease.acquire()
         setIsEditing(true)
     }, [lease, value])
+
+    // The warm instance parks with autofocus off — focusing a parked editor
+    // would open the keyboard over a card nobody is editing — so the surface
+    // that acquires it has to take the caret itself. Without this, tapping a
+    // description on native swaps in an editor with no cursor and the user has
+    // to tap a second time.
+    //
+    // Keyed on the generation rather than isEditing so a handover refocuses the
+    // incoming surface too. The cold fallback sets autofocus: true and needs
+    // none of this, hence the isWarm guard.
+    const focusedGenerationRef = useRef<number | null>(null)
+    if (isEditing && lease.isWarm && lease.result != null) {
+        if (focusedGenerationRef.current !== lease.generation) {
+            focusedGenerationRef.current = lease.generation
+            // Deferred: the editor is reconfigured during this commit, and
+            // focusing before it has applied the new content moves the caret in
+            // the outgoing surface's document.
+            queueMicrotask(() => lease.result?.editor.focus('end'))
+        }
+    } else if (!isEditing) {
+        focusedGenerationRef.current = null
+    }
 
     const endSession = useCallback(() => {
         settledRef.current = true
@@ -178,25 +202,45 @@ export function useLazyEditor({
 
     const submit = useCallback(() => {
         if (settledRef.current) return
+        // Claimed BEFORE the await, not after. On native every surface shares
+        // one editor, so a tap on another surface during the read reconfigures
+        // it under us: the content that resolves then belongs to the incoming
+        // surface, and writing it through onCommit would put one card's text on
+        // another card's record. Settling up front makes the second caller a
+        // no-op, and the generation check below discards the stale read.
+        settledRef.current = true
+        const generationAtRead = lease.generation
         void (async () => {
             let content: string
             try {
                 content = (await readContent(active.editor)).trim()
             } catch (err) {
                 captureException('editor.lazy.readContent', err)
+                endSession()
+                return
+            }
+            // A handover bumps the generation, so a mismatch means these bytes
+            // came from an editor that has already been handed to someone else.
+            // Dropping the write is the only safe move: we cannot tell whose
+            // text this is, and the outgoing surface keeps its persisted value.
+            if (lease.generation !== generationAtRead) {
+                captureException(
+                    'editor.lazy.staleRead',
+                    new Error('editor was handed over mid-submit; dropping the read'),
+                    { surfaceId, generationAtRead, generationNow: lease.generation }
+                )
+                endSession()
                 return
             }
             if (onCancel && isNoOpEdit(content, baselineRef.current)) {
-                settledRef.current = true
                 endSession()
                 onCancel()
                 return
             }
-            settledRef.current = true
             onCommit(content)
             endSession()
         })()
-    }, [active.editor, readContent, onCommit, onCancel, endSession])
+    }, [active.editor, readContent, onCommit, onCancel, endSession, lease.generation, surfaceId])
 
     const cancel = useCallback(() => {
         settledRef.current = true

--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -130,6 +130,10 @@ export function useLazyEditor({
     // swap's branch. On native that costs nothing — the WebView belongs to the
     // warm host, and this hook only builds the host-side handle. On web it is
     // the same Tiptap instance the previous hand-rolled swaps mounted.
+    // The consumer's own focus handlers are CHAINED rather than replaced: a
+    // caller uses them to drive its chrome (a card description swaps its section
+    // label for a formatting toolbar on focus), and silently dropping them
+    // leaves that chrome permanently in its idle state.
     const own = useRichEditor({
         ...editorOptions,
         contentFormat,
@@ -137,9 +141,16 @@ export function useLazyEditor({
         autofocus: true,
         onFocus: () => {
             hasFocusedRef.current = true
+            editorOptions.onFocus?.()
         },
-        onBlur: () => blurRef.current(),
-        onSubmitShortcut: () => submitRef.current(),
+        onBlur: () => {
+            editorOptions.onBlur?.()
+            blurRef.current()
+        },
+        onSubmitShortcut: () => {
+            editorOptions.onSubmitShortcut?.()
+            submitRef.current()
+        },
     })
     const active = lease.result ?? own
 

--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -18,6 +18,20 @@ export interface LazyEditorSlots {
     setDialogOpen: (open: boolean) => void
 }
 
+export interface LazyEditorHeaderState {
+    /** Drives the label ⇄ toolbar swap; the row itself is always rendered. */
+    isEditing: boolean
+    /** Null while idle — there is no editor to drive a toolbar with. */
+    slots: LazyEditorSlots | null
+}
+
+export interface LazyEditorRenderSlots {
+    /** The row above the surface, or null when no `renderHeader` was given. */
+    header: ReactNode
+    /** The read view, or the editing surface once a session opens. */
+    body: ReactNode
+}
+
 export interface LazyEditorProps {
     /** Shown while idle. The consumer's component — core never interprets content. */
     readView: ReactNode
@@ -34,6 +48,16 @@ export interface LazyEditorProps {
     onCancel?: () => void
     /** The consumer's chrome around the editing surface. */
     renderEditor: (slots: LazyEditorSlots) => ReactNode
+    /**
+     * A row drawn ABOVE the editing surface, placed by the caller rather than
+     * nested in the returned tree.
+     *
+     * Only meaningful through {@link useLazyEditor}. A card description draws
+     * its formatting toolbar into a row that must stay a direct child of the
+     * scroll view for `stickyHeaderIndices` to pin it, so the two halves cannot
+     * be one tree. Given no `renderHeader`, the header slot is null.
+     */
+    renderHeader?: (state: LazyEditorHeaderState) => ReactNode
     testID?: string
     accessibilityLabel?: string
 }
@@ -55,7 +79,18 @@ export interface LazyEditorProps {
  * back through — so mail's HTML surfaces use this exactly as cards' markdown
  * ones do.
  */
-export function LazyEditor({
+export function LazyEditor(props: LazyEditorProps) {
+    return <>{useLazyEditor(props).body}</>
+}
+
+/**
+ * The slot-returning form of {@link LazyEditor}.
+ *
+ * Same swap, same commit rules; the only difference is that the header comes
+ * back separately instead of nested, for a caller that must place the two halves
+ * in different parents. `LazyEditor` is this hook with the header dropped.
+ */
+export function useLazyEditor({
     readView,
     value,
     contentFormat,
@@ -66,9 +101,10 @@ export function LazyEditor({
     onCommit,
     onCancel,
     renderEditor,
+    renderHeader,
     testID,
     accessibilityLabel = 'Edit',
-}: LazyEditorProps) {
+}: LazyEditorProps): LazyEditorRenderSlots {
     const [isEditing, setIsEditing] = useState(false)
     const [isDialogOpen, setIsDialogOpen] = useState(false)
     // The revert/no-op baseline, snapshotted when the session opens so a
@@ -82,6 +118,30 @@ export function LazyEditor({
         contentFormat,
         initialContent: value,
     })
+
+    const submitRef = useRef<() => void>(() => {})
+    const blurRef = useRef<() => void>(() => {})
+
+    // The warm instance when one is available; otherwise this surface mounts its
+    // own and pays the cold start. Warm is an optimization, never a correctness
+    // dependency.
+    //
+    // Called unconditionally, including while idle: a hook cannot sit behind the
+    // swap's branch. On native that costs nothing — the WebView belongs to the
+    // warm host, and this hook only builds the host-side handle. On web it is
+    // the same Tiptap instance the previous hand-rolled swaps mounted.
+    const own = useRichEditor({
+        ...editorOptions,
+        contentFormat,
+        initialContent: value,
+        autofocus: true,
+        onFocus: () => {
+            hasFocusedRef.current = true
+        },
+        onBlur: () => blurRef.current(),
+        onSubmitShortcut: () => submitRef.current(),
+    })
+    const active = lease.result ?? own
 
     const startEditing = useCallback(() => {
         baselineRef.current = value
@@ -97,75 +157,6 @@ export function LazyEditor({
         setIsEditing(false)
     }, [lease])
 
-    if (!isEditing) {
-        if (!canEdit) return <>{readView}</>
-        return (
-            <Pressable
-                testID={testID}
-                onPress={startEditing}
-                accessibilityRole="button"
-                accessibilityLabel={accessibilityLabel}
-            >
-                {readView}
-            </Pressable>
-        )
-    }
-
-    return (
-        <LazyEditorSession
-            lease={lease}
-            value={value}
-            contentFormat={contentFormat}
-            editorOptions={editorOptions}
-            commitOnBlur={commitOnBlur}
-            isDialogOpen={isDialogOpen}
-            setDialogOpen={setIsDialogOpen}
-            baselineRef={baselineRef}
-            hasFocusedRef={hasFocusedRef}
-            settledRef={settledRef}
-            onCommit={onCommit}
-            onCancel={onCancel}
-            endSession={endSession}
-            renderEditor={renderEditor}
-        />
-    )
-}
-
-/**
- * The live editing session, split out so the fallback `useRichEditor` below is
- * only ever called while editing — a hook cannot sit behind the swap's branch.
- */
-function LazyEditorSession({
-    lease,
-    value,
-    contentFormat,
-    editorOptions,
-    commitOnBlur,
-    isDialogOpen,
-    setDialogOpen,
-    baselineRef,
-    hasFocusedRef,
-    settledRef,
-    onCommit,
-    onCancel,
-    endSession,
-    renderEditor,
-}: {
-    lease: ReturnType<typeof useWarmEditor>
-    value: string
-    contentFormat: 'markdown' | 'html'
-    editorOptions: UseRichEditorOptions
-    commitOnBlur: boolean
-    isDialogOpen: boolean
-    setDialogOpen: (open: boolean) => void
-    baselineRef: { current: string }
-    hasFocusedRef: { current: boolean }
-    settledRef: { current: boolean }
-    onCommit: (content: string) => void
-    onCancel?: () => void
-    endSession: () => void
-    renderEditor: (slots: LazyEditorSlots) => ReactNode
-}) {
     const readContent = useCallback(
         async (editor: EditorHandle): Promise<string> =>
             contentFormat === 'markdown'
@@ -173,25 +164,6 @@ function LazyEditorSession({
                 : editor.getHTML(),
         [contentFormat]
     )
-
-    const submitRef = useRef<() => void>(() => {})
-    const blurRef = useRef<() => void>(() => {})
-
-    // The warm instance when one is available; otherwise this surface mounts
-    // its own and pays the cold start. Warm is an optimization, never a
-    // correctness dependency.
-    const own = useRichEditor({
-        ...editorOptions,
-        contentFormat,
-        initialContent: value,
-        autofocus: true,
-        onFocus: () => {
-            hasFocusedRef.current = true
-        },
-        onBlur: () => blurRef.current(),
-        onSubmitShortcut: () => submitRef.current(),
-    })
-    const active = lease.result ?? own
 
     const submit = useCallback(() => {
         if (settledRef.current) return
@@ -213,7 +185,13 @@ function LazyEditorSession({
             onCommit(content)
             endSession()
         })()
-    }, [active.editor, readContent, onCommit, onCancel, endSession, baselineRef, settledRef])
+    }, [active.editor, readContent, onCommit, onCancel, endSession])
+
+    const cancel = useCallback(() => {
+        settledRef.current = true
+        endSession()
+        onCancel?.()
+    }, [endSession, onCancel])
 
     submitRef.current = submit
     blurRef.current = () => {
@@ -233,22 +211,40 @@ function LazyEditorSession({
         if (!commitOnBlur && hasFocusedRef.current && !isDialogOpen) endSession()
     }
 
-    const cancel = useCallback(() => {
-        settledRef.current = true
-        endSession()
-        onCancel?.()
-    }, [endSession, onCancel, settledRef])
+    if (!isEditing) {
+        return {
+            // Rendered even while idle: the row reserves its height, so swapping
+            // a toolbar into it does not shift the prose under the reader's
+            // finger at the moment they tap it.
+            header: renderHeader?.({ isEditing: false, slots: null }) ?? null,
+            body: canEdit ? (
+                <Pressable
+                    testID={testID}
+                    onPress={startEditing}
+                    accessibilityRole="button"
+                    accessibilityLabel={accessibilityLabel}
+                >
+                    {readView}
+                </Pressable>
+            ) : (
+                readView
+            ),
+        }
+    }
 
-    return (
-        <>
-            {renderEditor({
-                EditorComponent: active.EditorComponent,
-                commands: active.commands,
-                toolbarState: active.toolbarState,
-                submit,
-                cancel,
-                setDialogOpen,
-            })}
-        </>
-    )
+    // One set of slots feeds both halves, so the header's toolbar and the body's
+    // surface are driven by the SAME editor rather than two mounts of it.
+    const slots: LazyEditorSlots = {
+        EditorComponent: active.EditorComponent,
+        commands: active.commands,
+        toolbarState: active.toolbarState,
+        submit,
+        cancel,
+        setDialogOpen: setIsDialogOpen,
+    }
+
+    return {
+        header: renderHeader?.({ isEditing: true, slots }) ?? null,
+        body: renderEditor(slots),
+    }
 }

--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -1,0 +1,254 @@
+import { type ComponentType, type ReactNode, useCallback, useRef, useState } from 'react'
+import { Pressable } from 'react-native'
+import { useRichEditor } from '../../lib/editor/rich'
+import type { UseRichEditorOptions } from '../../lib/editor/rich/options'
+import type { EditorCommands, EditorHandle, EditorToolbarState } from '../../lib/editor/types'
+import { useWarmEditor } from '../../lib/editor/warm'
+import type { SurfaceId } from '../../lib/editor/warm/warm-editor-store'
+import { captureException } from '../../lib/errors'
+import { isNoOpEdit, shouldCommitOnBlur } from './commit-policy'
+
+export interface LazyEditorSlots {
+    EditorComponent: ComponentType
+    commands: EditorCommands
+    toolbarState: EditorToolbarState
+    submit: () => void
+    cancel: () => void
+    /** Tell the swap a dialog holds the focus, so a blur is not the session ending. */
+    setDialogOpen: (open: boolean) => void
+}
+
+export interface LazyEditorProps {
+    /** Shown while idle. The consumer's component — core never interprets content. */
+    readView: ReactNode
+    /** Current persisted content, in `contentFormat`. */
+    value: string
+    contentFormat: 'markdown' | 'html'
+    editorOptions: UseRichEditorOptions
+    surfaceId: SurfaceId
+    canEdit: boolean
+    /** True for an edit of existing content; false for a composer. */
+    commitOnBlur?: boolean
+    onCommit: (content: string) => void
+    /** Absent when there is nothing to revert (a collaborative description). */
+    onCancel?: () => void
+    /** The consumer's chrome around the editing surface. */
+    renderEditor: (slots: LazyEditorSlots) => ReactNode
+    testID?: string
+    accessibilityLabel?: string
+}
+
+/**
+ * Renders content, and swaps in a real editor when someone starts editing.
+ *
+ * Two jobs, both previously hand-rolled per consumer:
+ *
+ *  - **The swap.** The read view IS the boot placeholder, so an edit never
+ *    shows an empty box while the editor initializes. On native the editor is
+ *    the package's warm instance when one is available, which turns a ~1135 ms
+ *    cold start into a ~34 ms reconfiguration.
+ *  - **The commit rules.** See commit-policy.ts — each clause protects a write,
+ *    and a blur COMMITS, so getting them wrong loses or invents user text.
+ *
+ * Deliberately NOT format-aware. `readView` is the consumer's, content crosses
+ * as an opaque string, and `contentFormat` only selects which channel to read
+ * back through — so mail's HTML surfaces use this exactly as cards' markdown
+ * ones do.
+ */
+export function LazyEditor({
+    readView,
+    value,
+    contentFormat,
+    editorOptions,
+    surfaceId,
+    canEdit,
+    commitOnBlur = false,
+    onCommit,
+    onCancel,
+    renderEditor,
+    testID,
+    accessibilityLabel = 'Edit',
+}: LazyEditorProps) {
+    const [isEditing, setIsEditing] = useState(false)
+    const [isDialogOpen, setIsDialogOpen] = useState(false)
+    // The revert/no-op baseline, snapshotted when the session opens so a
+    // realtime update mid-edit cannot become the comparison target.
+    const baselineRef = useRef(value)
+    const hasFocusedRef = useRef(false)
+    const settledRef = useRef(false)
+
+    const lease = useWarmEditor(surfaceId, {
+        ...editorOptions,
+        contentFormat,
+        initialContent: value,
+    })
+
+    const startEditing = useCallback(() => {
+        baselineRef.current = value
+        hasFocusedRef.current = false
+        settledRef.current = false
+        lease.acquire()
+        setIsEditing(true)
+    }, [lease, value])
+
+    const endSession = useCallback(() => {
+        settledRef.current = true
+        lease.release()
+        setIsEditing(false)
+    }, [lease])
+
+    if (!isEditing) {
+        if (!canEdit) return <>{readView}</>
+        return (
+            <Pressable
+                testID={testID}
+                onPress={startEditing}
+                accessibilityRole="button"
+                accessibilityLabel={accessibilityLabel}
+            >
+                {readView}
+            </Pressable>
+        )
+    }
+
+    return (
+        <LazyEditorSession
+            lease={lease}
+            value={value}
+            contentFormat={contentFormat}
+            editorOptions={editorOptions}
+            commitOnBlur={commitOnBlur}
+            isDialogOpen={isDialogOpen}
+            setDialogOpen={setIsDialogOpen}
+            baselineRef={baselineRef}
+            hasFocusedRef={hasFocusedRef}
+            settledRef={settledRef}
+            onCommit={onCommit}
+            onCancel={onCancel}
+            endSession={endSession}
+            renderEditor={renderEditor}
+        />
+    )
+}
+
+/**
+ * The live editing session, split out so the fallback `useRichEditor` below is
+ * only ever called while editing — a hook cannot sit behind the swap's branch.
+ */
+function LazyEditorSession({
+    lease,
+    value,
+    contentFormat,
+    editorOptions,
+    commitOnBlur,
+    isDialogOpen,
+    setDialogOpen,
+    baselineRef,
+    hasFocusedRef,
+    settledRef,
+    onCommit,
+    onCancel,
+    endSession,
+    renderEditor,
+}: {
+    lease: ReturnType<typeof useWarmEditor>
+    value: string
+    contentFormat: 'markdown' | 'html'
+    editorOptions: UseRichEditorOptions
+    commitOnBlur: boolean
+    isDialogOpen: boolean
+    setDialogOpen: (open: boolean) => void
+    baselineRef: { current: string }
+    hasFocusedRef: { current: boolean }
+    settledRef: { current: boolean }
+    onCommit: (content: string) => void
+    onCancel?: () => void
+    endSession: () => void
+    renderEditor: (slots: LazyEditorSlots) => ReactNode
+}) {
+    const readContent = useCallback(
+        async (editor: EditorHandle): Promise<string> =>
+            contentFormat === 'markdown'
+                ? ((await editor.getMarkdown?.()) ?? '')
+                : editor.getHTML(),
+        [contentFormat]
+    )
+
+    const submitRef = useRef<() => void>(() => {})
+    const blurRef = useRef<() => void>(() => {})
+
+    // The warm instance when one is available; otherwise this surface mounts
+    // its own and pays the cold start. Warm is an optimization, never a
+    // correctness dependency.
+    const own = useRichEditor({
+        ...editorOptions,
+        contentFormat,
+        initialContent: value,
+        autofocus: true,
+        onFocus: () => {
+            hasFocusedRef.current = true
+        },
+        onBlur: () => blurRef.current(),
+        onSubmitShortcut: () => submitRef.current(),
+    })
+    const active = lease.result ?? own
+
+    const submit = useCallback(() => {
+        if (settledRef.current) return
+        void (async () => {
+            let content: string
+            try {
+                content = (await readContent(active.editor)).trim()
+            } catch (err) {
+                captureException('editor.lazy.readContent', err)
+                return
+            }
+            if (onCancel && isNoOpEdit(content, baselineRef.current)) {
+                settledRef.current = true
+                endSession()
+                onCancel()
+                return
+            }
+            settledRef.current = true
+            onCommit(content)
+            endSession()
+        })()
+    }, [active.editor, readContent, onCommit, onCancel, endSession, baselineRef, settledRef])
+
+    submitRef.current = submit
+    blurRef.current = () => {
+        if (
+            shouldCommitOnBlur({
+                commitOnBlur,
+                hasFocused: hasFocusedRef.current,
+                isSettled: settledRef.current,
+                isDialogOpen,
+            })
+        ) {
+            submit()
+            return
+        }
+        // A surface with no blur-commit still ends its session on blur — the
+        // caller decides whether that text was worth keeping.
+        if (!commitOnBlur && hasFocusedRef.current && !isDialogOpen) endSession()
+    }
+
+    const cancel = useCallback(() => {
+        settledRef.current = true
+        endSession()
+        onCancel?.()
+    }, [endSession, onCancel, settledRef])
+
+    return (
+        <>
+            {renderEditor({
+                EditorComponent: active.EditorComponent,
+                commands: active.commands,
+                toolbarState: active.toolbarState,
+                submit,
+                cancel,
+                setDialogOpen,
+            })}
+        </>
+    )
+}

--- a/core/components/editor/__tests__/commit-policy.test.ts
+++ b/core/components/editor/__tests__/commit-policy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { isNoOpEdit, shouldCommitOnBlur } from '../commit-policy'
+
+/**
+ * Each of these rules was found on a device, and each protects a write. They
+ * live in core so a second consumer inherits the fixes rather than
+ * rediscovering them.
+ */
+describe('commit on blur', () => {
+    const base = { commitOnBlur: true, hasFocused: true, isSettled: false, isDialogOpen: false }
+
+    it('commits when a focused session loses focus', () => {
+        expect(shouldCommitOnBlur(base)).toBe(true)
+    })
+
+    /**
+     * The composer has no blur-commit: leaving it must not post a comment.
+     */
+    it('never commits a surface that does not commit on blur', () => {
+        expect(shouldCommitOnBlur({ ...base, commitOnBlur: false })).toBe(false)
+    })
+
+    /**
+     * The editor opens with autofocus at a placeholder height, and until the
+     * page reports its real content height the caret can land outside the
+     * visible box and blur immediately. Since a blur COMMITS, that saved a
+     * comment nobody had touched.
+     */
+    it('never commits before the session has held focus', () => {
+        expect(shouldCommitOnBlur({ ...base, hasFocused: false })).toBe(false)
+    })
+
+    /**
+     * Save and the blur-commit race each other: pressing Save blurs the editor.
+     * Both writing would submit twice.
+     */
+    it('does not commit again once the session has settled', () => {
+        expect(shouldCommitOnBlur({ ...base, isSettled: true })).toBe(false)
+    })
+
+    /**
+     * The image picker and link prompt both steal focus. Treating that as the
+     * end of the session unmounts the surface the picked image is about to be
+     * inserted into.
+     */
+    it('does not commit while a dialog holds the focus', () => {
+        expect(shouldCommitOnBlur({ ...base, isDialogOpen: true })).toBe(false)
+    })
+})
+
+describe('no-op edits', () => {
+    it('treats an unchanged value as nothing to write', () => {
+        expect(isNoOpEdit('same text', 'same text')).toBe(true)
+    })
+
+    it('ignores surrounding whitespace, which the editor adds on its own', () => {
+        expect(isNoOpEdit('  same text\n', 'same text')).toBe(true)
+    })
+
+    it('treats a real change as a write', () => {
+        expect(isNoOpEdit('new text', 'old text')).toBe(false)
+    })
+
+    /** An emptied editor is a deletion the caller must decide about, not a no-op. */
+    it('does not call an emptied editor unchanged', () => {
+        expect(isNoOpEdit('', 'had content')).toBe(false)
+    })
+})

--- a/core/components/editor/__tests__/lazy-editor-handover.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-handover.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import { isValidElement } from 'react'
+import { Text, View } from 'react-native'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WarmEditorLease } from '../../../lib/editor/warm/types'
+
+/**
+ * The mid-submit handover.
+ *
+ * On native every surface shares one editor, and reading its content is async.
+ * If another surface acquires the instance during that read, the bytes that
+ * resolve belong to the INCOMING surface — writing them through onCommit puts
+ * one card's text onto another card's record.
+ *
+ * This is the shape the handoff doc warned about, and it was reachable: the
+ * settled flag was set after the await rather than before it, so the guard at
+ * the top of submit never fired for the second caller.
+ *
+ * Driven through mocked warm/rich modules rather than a real WebView — the
+ * race is in LazyEditor's bookkeeping, and a booted editor would only make it
+ * harder to schedule deterministically.
+ */
+
+let generation = 1
+let resolveRead: ((markdown: string) => void) | null = null
+
+const warmEditor = {
+    getHTML: vi.fn(async () => '<p>warm</p>'),
+    getText: vi.fn(async () => 'warm'),
+    getMarkdown: vi.fn(
+        () =>
+            new Promise<string>(resolve => {
+                resolveRead = resolve
+            })
+    ),
+    setContent: vi.fn(),
+    focus: vi.fn(),
+    clear: vi.fn(),
+    getSelection: vi.fn(async () => null),
+}
+
+const warmResult = {
+    editor: warmEditor,
+    EditorComponent: () => null,
+    commands: {},
+    toolbarState: {},
+}
+
+const lease: WarmEditorLease = {
+    isWarm: true,
+    acquire: vi.fn(),
+    release: vi.fn(),
+    result: warmResult as never,
+    get generation() {
+        return generation
+    },
+}
+
+vi.mock('../../../lib/editor/warm', () => ({
+    useWarmEditor: () => lease,
+}))
+
+vi.mock('../../../lib/editor/rich', () => ({
+    useRichEditor: () => ({
+        editor: {
+            getHTML: vi.fn(async () => '<p>cold</p>'),
+            getText: vi.fn(async () => 'cold'),
+            getMarkdown: vi.fn(async () => 'cold'),
+            setContent: vi.fn(),
+            focus: vi.fn(),
+            clear: vi.fn(),
+            getSelection: vi.fn(async () => null),
+        },
+        EditorComponent: () => null,
+        commands: {},
+        toolbarState: {},
+    }),
+}))
+
+const { useLazyEditor } = await import('../LazyEditor')
+
+let startEditing: (() => void) | null = null
+let submit: (() => void) | null = null
+
+function Probe({ onCommit }: { onCommit: (content: string) => void }) {
+    const slots = useLazyEditor({
+        readView: <Text>read view</Text>,
+        value: 'persisted',
+        contentFormat: 'markdown',
+        editorOptions: {},
+        surfaceId: 'comment:a',
+        canEdit: true,
+        onCommit,
+        renderEditor: s => {
+            submit = s.submit
+            return <Text>editing surface</Text>
+        },
+        testID: 'probe',
+    })
+    startEditing =
+        (isValidElement<{ onPress?: () => void }>(slots.body) ? slots.body.props.onPress : null) ??
+        null
+    return <View>{slots.body}</View>
+}
+
+beforeEach(() => {
+    generation = 1
+    resolveRead = null
+    vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('LazyEditor handover safety', () => {
+    it('commits when no handover happened during the read', async () => {
+        const onCommit = vi.fn()
+        render(<Probe onCommit={onCommit} />)
+
+        act(() => startEditing?.())
+        act(() => submit?.())
+
+        await act(async () => {
+            resolveRead?.('the text I typed')
+        })
+
+        expect(onCommit).toHaveBeenCalledWith('the text I typed')
+    })
+
+    /**
+     * The data-loss case. The editor is handed to another surface while this
+     * one's read is in flight, so the resolved content is not this surface's
+     * text. Committing it would overwrite this record with another's.
+     */
+    it('drops the read when the editor was handed over mid-submit', async () => {
+        const onCommit = vi.fn()
+        render(<Probe onCommit={onCommit} />)
+
+        act(() => startEditing?.())
+        act(() => submit?.())
+
+        // Another surface takes the instance while the read is pending.
+        generation = 2
+
+        await act(async () => {
+            resolveRead?.("the OTHER surface's text")
+        })
+
+        expect(onCommit).not.toHaveBeenCalled()
+    })
+
+    /**
+     * Settling before the await also makes a second submit a no-op, so a
+     * double-tap on Save cannot produce two writes.
+     */
+    it('ignores a second submit while the first read is in flight', async () => {
+        const onCommit = vi.fn()
+        render(<Probe onCommit={onCommit} />)
+
+        act(() => startEditing?.())
+        act(() => submit?.())
+        act(() => submit?.())
+
+        await act(async () => {
+            resolveRead?.('typed once')
+        })
+
+        expect(onCommit).toHaveBeenCalledTimes(1)
+        expect(warmEditor.getMarkdown).toHaveBeenCalledTimes(1)
+    })
+})

--- a/core/components/editor/__tests__/lazy-editor-slots.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-slots.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import { isValidElement } from 'react'
+import { Text, View } from 'react-native'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useLazyEditor } from '../LazyEditor'
+
+/**
+ * Some surfaces cannot take the editor as one tree. A card description draws its
+ * toolbar into a row that must stay a DIRECT child of the scroll view for
+ * `stickyHeaderIndices` to pin it, so the header and the editing surface are
+ * placed separately by the caller.
+ *
+ * The hook therefore returns slots. Both are still the consumer's to render —
+ * core owns the swap and the commit rules, never the chrome.
+ */
+/**
+ * The react-native stub renders Pressable as a bare host element, so `onPress`
+ * is never bound to a DOM event and a click cannot reach it. The Probe hands its
+ * press handler out here instead, which is what lets a test open a session.
+ */
+let startEditing: (() => void) | null = null
+
+function Probe({ canEdit = true }: { canEdit?: boolean }) {
+    const slots = useLazyEditor({
+        readView: <Text>read view</Text>,
+        value: 'persisted',
+        contentFormat: 'markdown',
+        editorOptions: {},
+        surfaceId: 'description:card1',
+        canEdit,
+        onCommit: () => {},
+        renderHeader: ({ isEditing }) => <Text>{isEditing ? 'toolbar' : 'label'}</Text>,
+        renderEditor: () => <Text>editing surface</Text>,
+        testID: 'probe-press',
+    })
+    // The read view's press target is the Pressable in the body slot; its
+    // onPress is what the swap hangs off.
+    startEditing =
+        (isValidElement<{ onPress?: () => void }>(slots.body) ? slots.body.props.onPress : null) ??
+        null
+
+    return (
+        <View>
+            {slots.header}
+            {slots.body}
+        </View>
+    )
+}
+
+describe('useLazyEditor slots', () => {
+    afterEach(cleanup)
+
+    it('renders the read view and the idle header while nobody is editing', () => {
+        const { getByText } = render(<Probe />)
+        expect(getByText('read view')).toBeTruthy()
+        expect(getByText('label')).toBeTruthy()
+    })
+
+    /**
+     * The header has to follow the swap. It is a separate slot, so nothing else
+     * would tell it an edit had started — and on a card that row is where the
+     * formatting toolbar replaces the section label.
+     */
+    it('swaps both slots together when editing starts', () => {
+        const { getByText } = render(<Probe />)
+        // The react-native stub renders Pressable as a bare host element, so
+        // onPress is never bound to a DOM event and a click cannot reach it.
+        // Starting the session directly is what the harness allows.
+        act(() => startEditing?.())
+        expect(getByText('editing surface')).toBeTruthy()
+        expect(getByText('toolbar')).toBeTruthy()
+    })
+
+    it('offers no press target when the surface is read-only', () => {
+        const { queryByTestId, getByText } = render(<Probe canEdit={false} />)
+        expect(queryByTestId('probe-press')).toBeNull()
+        expect(getByText('read view')).toBeTruthy()
+    })
+})

--- a/core/components/editor/commit-policy.ts
+++ b/core/components/editor/commit-policy.ts
@@ -1,0 +1,38 @@
+export interface CommitState {
+    /** Does this surface write on focus loss? An edit does; a composer does not. */
+    commitOnBlur: boolean
+    /** Has the session ever actually held focus? */
+    hasFocused: boolean
+    /** Has it already committed or cancelled? */
+    isSettled: boolean
+    /** Is a dialog (image picker, link prompt) holding the focus? */
+    isDialogOpen: boolean
+}
+
+/**
+ * Whether a blur should write.
+ *
+ * Every clause here exists because of a bug found on a device, and the stakes
+ * are asymmetric: a missed commit loses an edit the user can redo, while a
+ * spurious one writes text nobody typed.
+ */
+export function shouldCommitOnBlur(state: CommitState): boolean {
+    if (!state.commitOnBlur) return false
+    // The mount racing itself, not a person finishing an edit.
+    if (!state.hasFocused) return false
+    if (state.isSettled) return false
+    // A detour inside the session, not the end of it.
+    if (state.isDialogOpen) return false
+    return true
+}
+
+/**
+ * Whether a submitted value differs from what the session opened with.
+ *
+ * An unchanged edit is a cancel rather than a write — EditableText's rule. The
+ * baseline is snapshotted at acquire, so a realtime update arriving mid-edit
+ * cannot become the comparison target.
+ */
+export function isNoOpEdit(next: string, baseline: string): boolean {
+    return next.trim() === baseline.trim()
+}

--- a/core/lib/editor/__tests__/init-dispatch.test.ts
+++ b/core/lib/editor/__tests__/init-dispatch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { shouldPostInit } from '../use-webview-editor'
+
+/**
+ * Init used to be latched one-shot per mount. A warm editor is handed between
+ * surfaces by re-initializing it, so the latch becomes generation tracking —
+ * post each generation exactly once, and never before the page is ready.
+ */
+describe('init dispatch', () => {
+    it('posts the first init once the page is ready', () => {
+        expect(shouldPostInit(null, 0, true)).toBe(true)
+    })
+
+    it('waits for the page, since nothing would receive it', () => {
+        expect(shouldPostInit(null, 0, false)).toBe(false)
+    })
+
+    it('does not repost the generation it already sent', () => {
+        expect(shouldPostInit(0, 0, true)).toBe(false)
+    })
+
+    it('posts a bumped generation, which is how a handover happens', () => {
+        expect(shouldPostInit(0, 1, true)).toBe(true)
+    })
+})

--- a/core/lib/editor/rich/__tests__/markdown-webview-host.test.ts
+++ b/core/lib/editor/rich/__tests__/markdown-webview-host.test.ts
@@ -118,4 +118,39 @@ describe('MarkdownWebViewHost', () => {
         expect(host.handleMessage(resultMessage('pushed'))).toBe(true)
         await expect(host.get()).resolves.toBe('pushed')
     })
+
+    /**
+     * A warm editor is reused across surfaces, and `lastKnown` sits on the save
+     * path — so a handover that left it holding the previous surface's text
+     * would write one comment's words over another's.
+     */
+    describe('handover between surfaces', () => {
+        it('moves the fallback to the incoming surface', async () => {
+            const { host } = makeHost({ canPost: false })
+            host.seedGeneration(1, 'first surface')
+            host.seedGeneration(2, 'second surface')
+            await expect(host.get()).resolves.toBe('second surface')
+        })
+
+        /** Driven from an effect, so a re-render must not re-seed over typing. */
+        it('ignores a repeated generation', async () => {
+            const { host } = makeHost({ canPost: false })
+            host.seedGeneration(1, 'opened with')
+            host.handleMessage(resultMessage('typed since'))
+            host.seedGeneration(1, 'opened with')
+            await expect(host.get()).resolves.toBe('typed since')
+        })
+
+        /**
+         * The displaced surface's save is still in flight. Left pending it would
+         * time out against the INCOMING surface's seed and persist that text.
+         */
+        it('settles a displaced surface request with its own text', async () => {
+            const { host } = makeHost()
+            host.seedGeneration(1, 'first surface')
+            const pending = host.get()
+            host.seedGeneration(2, 'second surface')
+            await expect(pending).resolves.toBe('first surface')
+        })
+    })
 })

--- a/core/lib/editor/rich/markdown-webview-host.ts
+++ b/core/lib/editor/rich/markdown-webview-host.ts
@@ -46,6 +46,8 @@ export class MarkdownWebViewHost {
      * document the user opened rather than an empty string.
      */
     private lastKnown = ''
+    /** Which warm-editor generation `lastKnown` belongs to. See seedGeneration. */
+    private seededGeneration: number | null = null
     private destroyed = false
 
     constructor(options: MarkdownWebViewHostOptions) {
@@ -55,6 +57,30 @@ export class MarkdownWebViewHost {
 
     /** Seed the fallback value, e.g. with the editor's initial content. */
     seed(markdown: string): void {
+        this.lastKnown = markdown
+    }
+
+    /**
+     * Seed the fallback for a warm editor that has just been handed to another
+     * surface.
+     *
+     * Distinct from {@link seed} because a handover has to invalidate requests
+     * the PREVIOUS surface left in flight. Those resolve from `lastKnown` on
+     * timeout, so re-seeding alone would hand one surface's text to the other's
+     * pending save. Repeat calls for the same generation are ignored, which is
+     * what lets a caller drive this from an effect.
+     */
+    seedGeneration(generation: number, markdown: string): void {
+        if (generation === this.seededGeneration) return
+        this.seededGeneration = generation
+        // Anything still pending belongs to the surface being displaced. Settle
+        // it with the text it was opened with rather than letting it time out
+        // against the incoming surface's seed.
+        for (const [id, entry] of this.pending) {
+            clearTimeout(entry.timer)
+            entry.resolve(this.lastKnown)
+            this.pending.delete(id)
+        }
         this.lastKnown = markdown
     }
 

--- a/core/lib/editor/rich/options.ts
+++ b/core/lib/editor/rich/options.ts
@@ -82,4 +82,12 @@ export interface UseRichEditorOptions {
      * board alone would anchor one's popover to the other's WebView.
      */
     overlayKey?: string
+    /**
+     * Configuration generation, for a reused (warm) editor.
+     *
+     * Bumping this re-initializes the underlying WebView page in place — a full
+     * stage-two reconstruction — instead of mounting a new one. Omitted by
+     * ordinary consumers, which mount and destroy their own editor.
+     */
+    generation?: number
 }

--- a/core/lib/editor/rich/use-rich-editor.native.tsx
+++ b/core/lib/editor/rich/use-rich-editor.native.tsx
@@ -69,6 +69,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         collab,
         triggers,
         overlayKey,
+        generation = 0,
     } = options
 
     const bgColor = useThemeColor('background')
@@ -179,7 +180,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     const initPayload: RichEditorInitPayload = useMemo(() => {
         const peersAtHandshake = awarenessHost?.encodePeers() ?? null
         return {
-            generation: 0,
+            generation,
             contentFormat,
             initialContent: initialContent ?? '',
             placeholder,
@@ -234,6 +235,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                 : {}),
         }
     }, [
+        generation,
         contentFormat,
         initialContent,
         placeholder,
@@ -280,6 +282,19 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     const markdownHost = markdownHostRef.current
 
     useEffect(() => () => markdownHost.destroy(), [markdownHost])
+
+    // A warm editor is reused across surfaces, so the timeout fallback has to
+    // follow the current one. Without this a slow getMarkdown during a handover
+    // resolves with the PREVIOUS surface's text — and that value gets saved.
+    //
+    // Keyed on `generation` rather than `initialContent`: a handover between two
+    // surfaces holding identical text leaves initialContent unchanged, and the
+    // seed still has to move — along with any request the displaced surface left
+    // in flight.
+    useEffect(() => {
+        if (contentFormat !== 'markdown') return
+        markdownHost.seedGeneration(generation, initialContent ?? '')
+    }, [markdownHost, contentFormat, initialContent, generation])
 
     const triggerItemsHostRef = useRef<TriggerItemsWebViewHost | null>(null)
     if (triggerItemsHostRef.current === null) {

--- a/core/lib/editor/rich/use-rich-editor.native.tsx
+++ b/core/lib/editor/rich/use-rich-editor.native.tsx
@@ -179,6 +179,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     const initPayload: RichEditorInitPayload = useMemo(() => {
         const peersAtHandshake = awarenessHost?.encodePeers() ?? null
         return {
+            generation: 0,
             contentFormat,
             initialContent: initialContent ?? '',
             placeholder,

--- a/core/lib/editor/rich/webview/source/Editor.tsx
+++ b/core/lib/editor/rich/webview/source/Editor.tsx
@@ -19,6 +19,7 @@ import { getFileAuth, setFileAuth, subscribeFileAuth } from './file-auth-store'
 import {
     APP_ESCAPE,
     APP_FILE_TOKEN,
+    APP_PARK,
     APP_SUBMIT_SHORTCUT,
     APP_TRIGGER_ITEMS,
     AWARENESS_CURSOR,
@@ -91,6 +92,25 @@ function AuthedImagePageView({ node }: ReactNodeViewProps<HTMLSpanElement>) {
 const AUTHED_IMAGE_NODE_VIEW = ReactNodeViewRenderer(AuthedImagePageView)
 
 /**
+ * Decide what an incoming init means for the page's current configuration.
+ *
+ * Pure so it can be tested without a DOM — the message plumbing around it needs
+ * a WebView, but the interesting decisions are here.
+ *
+ * `null` incoming is a park request: drop to stage one, keeping the booted page.
+ */
+export function reduceInit(
+    current: RichEditorInitPayload | null,
+    incoming: RichEditorInitPayload | null
+): RichEditorInitPayload | null {
+    if (incoming === null) return null
+    // A repeat or a late-arriving older payload must not rebuild the editor —
+    // that discards whatever has been typed since the current one was applied.
+    if (current !== null && incoming.generation <= current.generation) return current
+    return incoming
+}
+
+/**
  * The rich editor's in-WebView page.
  *
  * This is what makes markdown the editor's native format on mobile. The editor
@@ -122,7 +142,12 @@ export function Editor() {
                 return
             }
             if (parsed.namespace === 'app' && parsed.type === 'init') {
-                setInit(parsed.payload as RichEditorInitPayload)
+                const incoming = parsed.payload as RichEditorInitPayload
+                setInit(current => reduceInit(current, incoming))
+                return
+            }
+            if (parsed.namespace === 'app' && parsed.type === APP_PARK) {
+                setInit(current => reduceInit(current, null))
             }
         }
         // Some platforms deliver WebView messages on window, others on
@@ -140,7 +165,11 @@ export function Editor() {
 
     if (init == null) return null
 
-    return <EditorMounted init={init} />
+    // Keyed on the generation so a handover is a full reconstruction: new
+    // Tiptap, new Y.Doc (useCollabDoc's useState initializer reruns), new undo
+    // stack, new extension set. Nothing survives the swap, which is what makes
+    // it safe to reuse one page across surfaces.
+    return <EditorMounted key={init.generation} init={init} />
 }
 
 function EditorMounted({ init }: { init: RichEditorInitPayload }) {

--- a/core/lib/editor/rich/webview/source/__tests__/init-reducer.test.ts
+++ b/core/lib/editor/rich/webview/source/__tests__/init-reducer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { reduceInit } from '../Editor'
+import type { RichEditorInitPayload } from '../protocol'
+
+function payload(generation: number, content = ''): RichEditorInitPayload {
+    return {
+        generation,
+        contentFormat: 'markdown',
+        initialContent: content,
+        placeholder: '',
+        editable: true,
+        autofocus: false,
+        colors: { bg: '#000', fg: '#fff', placeholder: '#888', primary: '#0f0' },
+    }
+}
+
+describe('init reducer', () => {
+    it('accepts the first init', () => {
+        expect(reduceInit(null, payload(0))?.generation).toBe(0)
+    })
+
+    it('accepts a bumped generation, so a handover reconfigures the page', () => {
+        expect(reduceInit(payload(0), payload(1, 'next surface'))?.initialContent).toBe(
+            'next surface'
+        )
+    })
+
+    /**
+     * The host posts init from an effect, and a re-delivery of the SAME
+     * configuration must not rebuild the editor — that would discard whatever
+     * the user has typed since it was applied.
+     */
+    it('ignores a repeated generation, so typing is not discarded', () => {
+        const current = payload(2, 'typed by the user')
+        expect(reduceInit(current, payload(2, 'the original seed'))).toBe(current)
+    })
+
+    /** Out-of-order delivery must not roll the page back to an older surface. */
+    it('ignores an older generation', () => {
+        const current = payload(5)
+        expect(reduceInit(current, payload(4))).toBe(current)
+    })
+
+    it('parks on a null, dropping to stage one', () => {
+        expect(reduceInit(payload(3), null)).toBeNull()
+    })
+})

--- a/core/lib/editor/rich/webview/source/__tests__/protocol-generation.test.ts
+++ b/core/lib/editor/rich/webview/source/__tests__/protocol-generation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { makeMessage } from '../../../../message-bus/types'
+import { APP_INIT, APP_PARK, type RichEditorInitPayload } from '../protocol'
+
+/**
+ * A warm editor is re-initialized rather than remounted, so the page needs a
+ * way to tell a NEW configuration from a re-delivery of the one it already
+ * applied. The generation is that discriminator: the page keys its Tiptap
+ * subtree on it, so a bumped value is a full stage-two reconstruction and a
+ * repeated value is a no-op.
+ */
+describe('init generation', () => {
+    it('rides in the init payload so the page can rebuild on a bump', () => {
+        const payload: RichEditorInitPayload = {
+            generation: 3,
+            contentFormat: 'markdown',
+            initialContent: 'hello',
+            placeholder: '',
+            editable: true,
+            autofocus: false,
+            colors: { bg: '#000', fg: '#fff', placeholder: '#888', primary: '#0f0' },
+        }
+        const message = makeMessage('app', APP_INIT, payload)
+
+        expect(message.namespace).toBe('app')
+        expect((message.payload as RichEditorInitPayload).generation).toBe(3)
+    })
+
+    it('names a park message so a released editor can drop to stage one', () => {
+        expect(APP_PARK).toBe('park')
+        expect(makeMessage('app', APP_PARK, null).type).toBe('park')
+    })
+})

--- a/core/lib/editor/rich/webview/source/protocol.ts
+++ b/core/lib/editor/rich/webview/source/protocol.ts
@@ -23,6 +23,16 @@ export const MARKDOWN_RESULT = 'result'
 export const EDITOR_READY = 'editor-ready'
 /** host → WebView, the one-shot init payload. */
 export const APP_INIT = 'init'
+/**
+ * host → WebView: drop back to stage one — no Tiptap, no document, no
+ * awareness — while keeping the page itself booted.
+ *
+ * This is what makes a warm editor possible. The expensive part of an editor is
+ * the browser cold start and bundle parse, which happen BEFORE init; tearing
+ * down only what init built leaves a page that can be reconfigured for the next
+ * surface in ~34 ms instead of ~1135 ms.
+ */
+export const APP_PARK = 'park'
 /** WebView → host, ⌘/Ctrl+Enter inside the editor. */
 export const APP_SUBMIT_SHORTCUT = 'submit-shortcut'
 /** WebView → host, Escape inside the editor. */
@@ -137,6 +147,21 @@ export const UI_CONTENT_HEIGHT = 'content-height'
  * placeholder, character limit, and (later) the collaboration binding.
  */
 export interface RichEditorInitPayload {
+    /**
+     * Monotonic counter identifying this configuration.
+     *
+     * Init is no longer one-shot: a warm editor is handed from surface to
+     * surface by re-sending this payload. The page keys its editor subtree on
+     * this value, so a bump is a full reconstruction — new Tiptap, new Y.Doc,
+     * new undo stack. That is deliberate rather than wasteful: a partial reset
+     * would risk leaking one surface's undo history into another, and since a
+     * blur COMMITS an inline comment edit, leaked state is a data-loss risk
+     * rather than a cosmetic one.
+     *
+     * A repeated value must be ignored, so a re-delivered payload does not
+     * discard what the user has typed.
+     */
+    generation: number
     /**
      * How `initialContent` is interpreted. Markdown is the native format for
      * card descriptions; mail passes 'html' and never touches the markdown

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -8,6 +8,7 @@ import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { View } from 'react-native'
 import type { WebViewMessageEvent } from 'react-native-webview'
+import { captureException } from '../errors'
 import { deriveToolbarState } from './derive-toolbar-state'
 import { createHeightStore, type HeightStore } from './height-store'
 import { type EditorMessage, makeMessage } from './message-bus/types'
@@ -142,6 +143,22 @@ export interface UseWebViewEditorOptions {
     //
     // The callback identity is read through a ref.
     onMessage?: (message: EditorMessage) => void
+}
+
+/**
+ * Whether the host should post this init payload.
+ *
+ * Replaces the previous one-shot latch. A warm editor is reconfigured by
+ * re-sending init, so the rule is "each generation exactly once, never before
+ * the page reports ready" rather than "only ever once".
+ */
+export function shouldPostInit(
+    lastPostedGeneration: number | null,
+    incomingGeneration: number,
+    isReady: boolean
+): boolean {
+    if (!isReady) return false
+    return lastPostedGeneration === null || incomingGeneration > lastPostedGeneration
 }
 
 // Shared TenTap-customSource wrapper. Encapsulates:
@@ -291,16 +308,15 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     const heightStore = heightStoreRef.current
     const setContentHeight = heightStore.set
 
-    // Post the package's init payload once the WebView signals ready.
-    // Idempotent guard prevents double-init on hot-reload edge cases.
-    // Intentionally one-shot per mount; if the in-WebView page reloads
-    // itself (transient disconnect, in-WebView crash), it must re-fetch
-    // state from its own bootstrap rather than rely on a re-init
-    // payload from native.
-    const initSentRef = useRef(false)
+    // Which generation has been posted, rather than whether ANY init was — the
+    // warm editor reconfigures itself by posting a new one.
+    const lastInitGenerationRef = useRef<number | null>(null)
     useEffect(() => {
-        if (initSentRef.current) return
-        if (!webviewReady) return
+        const generation = (initPayload as { generation?: unknown })?.generation
+        // Consumers that predate the warm path (mail, text) send no generation;
+        // treat those as a single one-shot init, exactly as before.
+        const incoming = typeof generation === 'number' ? generation : 0
+        if (!shouldPostInit(lastInitGenerationRef.current, incoming, webviewReady)) return
         const webview = bridge.webviewRef?.current
         if (!webview) return
         const message = makeMessage('app', 'init', initPayload)
@@ -309,10 +325,12 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
                 console.log('[editor.mount] init-sent', Date.now() - mountAtRef.current, 'ms')
             }
             webview.postMessage(JSON.stringify(message))
-            initSentRef.current = true
-        } catch {
+            lastInitGenerationRef.current = incoming
+        } catch (err) {
             // postMessage can fail mid-handshake; the next render's
-            // webviewReady or bridge identity change will retry.
+            // webviewReady or bridge identity change will retry. The generation
+            // is deliberately NOT recorded here, so the retry still fires.
+            captureException('editor.postInit', err, { generation: incoming })
         }
     }, [bridge, webviewReady, initPayload])
 

--- a/core/lib/editor/warm/WarmEditorHost.d.ts
+++ b/core/lib/editor/warm/WarmEditorHost.d.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+import type { UseRichEditorOptions } from '../rich/options'
+import type { DraftStore } from './draft-store'
+
+/**
+ * Platform-neutral declaration for the warm host.
+ *
+ * `WarmEditorHost.native.tsx` mounts one parked WebView and provides the warm
+ * context; `WarmEditorHost.web.tsx` is a pass-through. Both take the same props,
+ * so a package mounts this component unconditionally.
+ */
+export declare function WarmEditorHost(props: {
+    options: UseRichEditorOptions
+    children: ReactNode
+}): ReactNode
+
+/** The surrounding host's composer draft store, or null when there is none. */
+export declare function useDraftStore(): DraftStore | null

--- a/core/lib/editor/warm/WarmEditorHost.native.tsx
+++ b/core/lib/editor/warm/WarmEditorHost.native.tsx
@@ -1,0 +1,127 @@
+import {
+    createContext,
+    type ReactNode,
+    useContext,
+    useMemo,
+    useRef,
+    useSyncExternalStore,
+} from 'react'
+import { View } from 'react-native'
+import { useRichEditor } from '../rich'
+import type { UseRichEditorOptions } from '../rich/options'
+import type { EditorResult } from '../types'
+import { createDraftStore, type DraftStore } from './draft-store'
+import { createWarmEditorStore, type WarmEditorStore } from './warm-editor-store'
+
+interface WarmContextValue {
+    store: WarmEditorStore
+    drafts: DraftStore
+    result: EditorResult
+    setOptions: (options: UseRichEditorOptions) => void
+}
+
+const WarmContext = createContext<WarmContextValue | null>(null)
+
+export function useWarmContext(): WarmContextValue | null {
+    return useContext(WarmContext)
+}
+
+/**
+ * The composer draft store for the surrounding warm host.
+ *
+ * Returns null when no host is mounted, which is also the web case — a consumer
+ * with no store keeps whatever draft behavior it had before.
+ */
+export function useDraftStore(): DraftStore | null {
+    return useContext(WarmContext)?.drafts ?? null
+}
+
+/**
+ * Keeps ONE WebView editor booted and parked, ready to be handed to whichever
+ * surface the user starts editing.
+ *
+ * The cost this removes is measured: creating a WebView editor is a browser cold
+ * start plus a 0.86 MB bundle parse — 1135 ms of the 1186 ms an edit used to
+ * take. That work is configuration-independent and finishes before the init
+ * payload is even sent, so a page booted in advance can be reconfigured for a
+ * new surface in the remaining ~34 ms.
+ *
+ * Mount this where the package's editing surfaces live — for cards, the route
+ * layout, so it warms on entering the section and stays warm across boards and
+ * cards. NOT a manifest `provider`: PackageProviderWrapper builds its chain at
+ * module load and wraps the whole app, which would boot a WebView at launch for
+ * anyone who has the package installed but never opens it.
+ */
+export function WarmEditorHost({
+    options,
+    children,
+}: {
+    options: UseRichEditorOptions
+    children: ReactNode
+}) {
+    const storeRef = useRef<WarmEditorStore | null>(null)
+    if (storeRef.current === null) storeRef.current = createWarmEditorStore()
+    const store = storeRef.current
+
+    const draftsRef = useRef<DraftStore | null>(null)
+    if (draftsRef.current === null) draftsRef.current = createDraftStore()
+    const drafts = draftsRef.current
+
+    // The live configuration, held in a ref and read through the store's
+    // generation: putting it in state would re-render this provider (and so the
+    // whole section) on every handover.
+    const optionsRef = useRef<UseRichEditorOptions>(options)
+    const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot)
+
+    const result = useRichEditor({
+        ...optionsRef.current,
+        generation: snapshot.generation,
+        // Never on acquire: the surface decides when to take the caret, and
+        // focusing a parked editor would open the keyboard over a card nobody
+        // is editing.
+        autofocus: false,
+    })
+
+    const value = useMemo<WarmContextValue>(
+        () => ({
+            store,
+            drafts,
+            result,
+            setOptions: next => {
+                optionsRef.current = next
+            },
+        }),
+        [store, drafts, result]
+    )
+
+    return (
+        <WarmContext.Provider value={value}>
+            {children}
+            <WarmEditorViewport isParked={snapshot.holder === null}>
+                <result.EditorComponent />
+            </WarmEditorViewport>
+        </WarmContext.Provider>
+    )
+}
+
+/**
+ * Where the WebView lives while nobody is editing.
+ *
+ * Deliberately NOT `display: none` or a zero-size box: an unlaid-out WebView may
+ * never paint on iOS, and a page that never paints never finishes booting —
+ * which would defeat the entire point of warming it. It is therefore kept at a
+ * real size and pushed off-viewport instead.
+ */
+function WarmEditorViewport({ isParked, children }: { isParked: boolean; children: ReactNode }) {
+    if (!isParked) return null
+    return (
+        <View
+            style={{ position: 'absolute', left: -10000, top: 0, width: 320, height: 200 }}
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+        >
+            {children}
+        </View>
+    )
+}

--- a/core/lib/editor/warm/WarmEditorHost.web.tsx
+++ b/core/lib/editor/warm/WarmEditorHost.web.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+import type { UseRichEditorOptions } from '../rich/options'
+import type { DraftStore } from './draft-store'
+
+/**
+ * No warm host on web, so no draft store either — the composer keeps its own
+ * mounted editor and its draft survives exactly as it did before.
+ */
+export function useDraftStore(): DraftStore | null {
+    return null
+}
+
+/**
+ * A pass-through on web. Kept so a package mounts the same component on both
+ * platforms and the e2e suite walks the same tree.
+ */
+export function WarmEditorHost({
+    children,
+}: {
+    options: UseRichEditorOptions
+    children: ReactNode
+}) {
+    return <>{children}</>
+}

--- a/core/lib/editor/warm/__tests__/draft-store.test.ts
+++ b/core/lib/editor/warm/__tests__/draft-store.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { createDraftStore } from '../draft-store'
+
+/**
+ * With one shared editor, a half-typed comment no longer survives in a mounted
+ * composer — the instance moves to whatever the user tapped. The draft store is
+ * where that text lives instead: stashed on release, re-seeded on acquire.
+ *
+ * Scoped to the composer and to the life of the open card. CardDetail is
+ * already keyed on the card id at both mount sites, so a card switch drops the
+ * store with the subtree and there is no eviction policy to get wrong.
+ */
+describe('draft store', () => {
+    it('has nothing for an untouched surface', () => {
+        expect(createDraftStore().take('composer:card1')).toBeNull()
+    })
+
+    it('returns what was stashed', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'half a thought')
+        expect(drafts.take('composer:card1')).toBe('half a thought')
+    })
+
+    /** Re-acquiring twice without typing must not lose the draft. */
+    it('does not consume the draft on read', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'still here')
+        drafts.take('composer:card1')
+        expect(drafts.take('composer:card1')).toBe('still here')
+    })
+
+    it('keeps drafts separate per surface', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'one')
+        drafts.stash('composer:card2', 'two')
+        expect(drafts.take('composer:card1')).toBe('one')
+    })
+
+    it('replaces an earlier draft for the same surface', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'first')
+        drafts.stash('composer:card1', 'second')
+        expect(drafts.take('composer:card1')).toBe('second')
+    })
+
+    /**
+     * An empty editor is not a draft. Stashing one would re-seed an empty
+     * string over the placeholder and make the composer look broken.
+     */
+    it('treats empty content as no draft', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'typed')
+        drafts.stash('composer:card1', '   \n  ')
+        expect(drafts.take('composer:card1')).toBeNull()
+    })
+
+    it('clears on commit', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'sent now')
+        drafts.clear('composer:card1')
+        expect(drafts.take('composer:card1')).toBeNull()
+    })
+
+    it('clears everything when the card closes', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'one')
+        drafts.stash('composer:card2', 'two')
+        drafts.clearAll()
+        expect(drafts.take('composer:card1')).toBeNull()
+        expect(drafts.take('composer:card2')).toBeNull()
+    })
+})

--- a/core/lib/editor/warm/__tests__/use-warm-editor.native.test.tsx
+++ b/core/lib/editor/warm/__tests__/use-warm-editor.native.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { EditorResult } from '../../types'
+import type { WarmEditorLease } from '../types'
+import { createWarmEditorStore } from '../warm-editor-store'
+
+/**
+ * Covers the NATIVE lease — the path every other warm test skips.
+ *
+ * The rest of the suite imports the `.web` variants, where `isWarm` is false
+ * and `result` is always null, so the branch LazyEditor actually takes on
+ * native is never exercised. That gap hid two real defects: the commit policy
+ * never reaching the warm editor, and a handover mid-submit writing one
+ * surface's text onto another's record.
+ *
+ * The WebView is mocked, not booted. What matters here is the lease's
+ * bookkeeping — who holds the instance, what generation is live, and whether
+ * the surface's options reach the host — none of which needs a real editor.
+ */
+
+const editorResult = () =>
+    ({
+        editor: {
+            getHTML: vi.fn(async () => '<p>x</p>'),
+            getText: vi.fn(async () => 'x'),
+            getMarkdown: vi.fn(async () => 'x'),
+            setContent: vi.fn(),
+            focus: vi.fn(),
+            clear: vi.fn(),
+            getSelection: vi.fn(async () => null),
+        },
+        EditorComponent: () => null,
+        commands: {},
+        toolbarState: {},
+    }) as unknown as EditorResult
+
+/**
+ * A stand-in for WarmEditorHost that shares its contract — one store, one
+ * result, an options setter — without mounting a WebView. useWarmEditor reads
+ * the context through useWarmContext, so the module is mocked to hand back
+ * this fake.
+ */
+function createFakeHost() {
+    const store = createWarmEditorStore()
+    const result = editorResult()
+    const setOptions = vi.fn()
+    return { store, result, setOptions, drafts: null as never }
+}
+
+let host = createFakeHost()
+
+vi.mock('../WarmEditorHost.native', () => ({
+    useWarmContext: () => host,
+}))
+
+const { useWarmEditor } = await import('../use-warm-editor.native')
+
+function Harness({
+    surfaceId,
+    onLease,
+    onFocus,
+}: {
+    surfaceId: string
+    onLease: (lease: WarmEditorLease) => void
+    onFocus?: () => void
+}): ReactNode {
+    const lease = useWarmEditor(surfaceId, {
+        contentFormat: 'markdown',
+        initialContent: '',
+        onFocus,
+    })
+    onLease(lease)
+    return null
+}
+
+afterEach(() => {
+    cleanup()
+    host = createFakeHost()
+})
+
+describe('useWarmEditor (native)', () => {
+    it('reports warm when a host is mounted', () => {
+        let lease!: WarmEditorLease
+        render(<Harness surfaceId="comment:a" onLease={l => (lease = l)} />)
+        expect(lease.isWarm).toBe(true)
+    })
+
+    it('hands the instance over only to the surface holding it', () => {
+        let a!: WarmEditorLease
+        let b!: WarmEditorLease
+        render(
+            <>
+                <Harness surfaceId="comment:a" onLease={l => (a = l)} />
+                <Harness surfaceId="comment:b" onLease={l => (b = l)} />
+            </>
+        )
+
+        // Nobody has acquired: neither surface gets an editor.
+        expect(a.result).toBeNull()
+        expect(b.result).toBeNull()
+
+        act(() => a.acquire())
+        expect(a.result).not.toBeNull()
+        expect(b.result).toBeNull()
+
+        // The handover — tapping a second comment.
+        act(() => b.acquire())
+        expect(a.result).toBeNull()
+        expect(b.result).not.toBeNull()
+    })
+
+    /**
+     * The generation is what lets an in-flight read know it has gone stale. A
+     * handover must move it, or LazyEditor's mid-submit guard cannot fire.
+     */
+    it('bumps the generation on every handover', () => {
+        let a!: WarmEditorLease
+        let b!: WarmEditorLease
+        render(
+            <>
+                <Harness surfaceId="comment:a" onLease={l => (a = l)} />
+                <Harness surfaceId="comment:b" onLease={l => (b = l)} />
+            </>
+        )
+
+        act(() => a.acquire())
+        const atAcquire = a.generation
+
+        act(() => b.acquire())
+        expect(b.generation).toBeGreaterThan(atAcquire)
+    })
+
+    /**
+     * The surface's options — including the wrapped focus/blur/submit handlers
+     * that carry the commit policy — must reach the host on acquire. Passing
+     * only the raw consumer options here is what left blur-commit and ⌘↵ inert
+     * on native.
+     */
+    it("posts the acquiring surface's options to the host", () => {
+        const onFocus = vi.fn()
+        let lease!: WarmEditorLease
+        render(<Harness surfaceId="comment:a" onLease={l => (lease = l)} onFocus={onFocus} />)
+
+        act(() => lease.acquire())
+
+        expect(host.setOptions).toHaveBeenCalledOnce()
+        const posted = host.setOptions.mock.calls[0][0]
+        expect(posted.onFocus).toBe(onFocus)
+    })
+
+    /**
+     * A surface can unmount while still holding the instance (the card closes
+     * mid-edit). Without the release-on-unmount effect the store keeps a holder
+     * that no longer exists and the editor never parks.
+     */
+    it('releases when a holding surface unmounts', () => {
+        let lease!: WarmEditorLease
+        const view = render(<Harness surfaceId="comment:a" onLease={l => (lease = l)} />)
+
+        act(() => lease.acquire())
+        expect(host.store.holder()).toBe('comment:a')
+
+        view.unmount()
+        expect(host.store.holder()).toBeNull()
+    })
+
+    /**
+     * A displaced surface still unmounts and still releases. Honouring that
+     * release would blank the editor that just took over.
+     */
+    it('a displaced surface unmounting does not evict the new holder', () => {
+        let a!: WarmEditorLease
+        let b!: WarmEditorLease
+        const view = render(
+            <>
+                <Harness surfaceId="comment:a" onLease={l => (a = l)} />
+                <Harness surfaceId="comment:b" onLease={l => (b = l)} />
+            </>
+        )
+
+        act(() => a.acquire())
+        act(() => b.acquire())
+        expect(host.store.holder()).toBe('comment:b')
+
+        view.unmount()
+        // b released on its own unmount; the point is that a's release did not
+        // clear b while b still held it.
+        expect(host.store.holder()).toBeNull()
+    })
+})

--- a/core/lib/editor/warm/__tests__/warm-context.test.tsx
+++ b/core/lib/editor/warm/__tests__/warm-context.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { Text } from 'react-native'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useWarmEditor } from '../use-warm-editor.web'
+import { WarmEditorHost } from '../WarmEditorHost.web'
+
+/**
+ * Web has no WebView and no cold start, so there is nothing to warm. The host
+ * still renders its children and the hook still answers — reporting isWarm
+ * false so the consumer mounts its own editor. That keeps LazyEditor's call
+ * sites identical on both platforms.
+ */
+function Probe() {
+    const lease = useWarmEditor('composer:card1', {})
+    return <Text>{lease.isWarm ? 'warm' : 'cold'}</Text>
+}
+
+describe('warm editor on web', () => {
+    // render() appends to the shared document.body, so without this a later
+    // query matches the previous test's tree as well as its own.
+    afterEach(cleanup)
+
+    it('renders children rather than swallowing the tree', () => {
+        const { getByText } = render(
+            <WarmEditorHost options={{}}>
+                <Text>content</Text>
+            </WarmEditorHost>
+        )
+        expect(getByText('content')).toBeTruthy()
+    })
+
+    it('reports cold, so consumers mount their own editor', () => {
+        const { getByText } = render(
+            <WarmEditorHost options={{}}>
+                <Probe />
+            </WarmEditorHost>
+        )
+        expect(getByText('cold')).toBeTruthy()
+    })
+
+    it('reports cold with no host mounted at all', () => {
+        const { getByText } = render(<Probe />)
+        expect(getByText('cold')).toBeTruthy()
+    })
+})

--- a/core/lib/editor/warm/__tests__/warm-editor-store.test.ts
+++ b/core/lib/editor/warm/__tests__/warm-editor-store.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createWarmEditorStore } from '../warm-editor-store'
+
+/**
+ * One WebView is shared by every editing surface in a package. The store is who
+ * holds it and which configuration generation is live — deliberately plain TS
+ * with no React and no WebView, because the handover rules are the part worth
+ * testing and neither of those is needed to test them.
+ */
+describe('warm editor store', () => {
+    it('starts unheld', () => {
+        const store = createWarmEditorStore()
+        expect(store.holder()).toBeNull()
+    })
+
+    it('hands the instance to an acquiring surface', () => {
+        const store = createWarmEditorStore()
+        store.acquire('comment:a')
+        expect(store.holder()).toBe('comment:a')
+    })
+
+    it('bumps the generation on every acquire, so the page rebuilds', () => {
+        const store = createWarmEditorStore()
+        const first = store.acquire('comment:a')
+        const second = store.acquire('comment:b')
+        expect(second).toBeGreaterThan(first)
+    })
+
+    /**
+     * The handover case. Taking the instance must transfer it outright — an
+     * acquire while another surface holds it is how tapping a second comment
+     * behaves, and leaving the old holder recorded would let its release later
+     * evict the new one.
+     */
+    it('transfers the instance when another surface acquires it', () => {
+        const store = createWarmEditorStore()
+        store.acquire('composer:card1')
+        store.acquire('comment:a')
+        expect(store.holder()).toBe('comment:a')
+    })
+
+    it('reports a release by the current holder', () => {
+        const store = createWarmEditorStore()
+        store.acquire('comment:a')
+        expect(store.release('comment:a')).toBe(true)
+        expect(store.holder()).toBeNull()
+    })
+
+    /**
+     * A surface that was displaced still unmounts and still calls release. That
+     * late call must not evict whoever took over, or tapping from one comment to
+     * another would blank the editor that just opened.
+     */
+    it('ignores a release from a surface that no longer holds it', () => {
+        const store = createWarmEditorStore()
+        store.acquire('composer:card1')
+        store.acquire('comment:a')
+
+        expect(store.release('composer:card1')).toBe(false)
+        expect(store.holder()).toBe('comment:a')
+    })
+
+    it('notifies subscribers on acquire and release', () => {
+        const store = createWarmEditorStore()
+        const listener = vi.fn()
+        store.subscribe(listener)
+
+        store.acquire('comment:a')
+        store.release('comment:a')
+
+        expect(listener).toHaveBeenCalledTimes(2)
+    })
+
+    it('stops notifying after unsubscribe', () => {
+        const store = createWarmEditorStore()
+        const listener = vi.fn()
+        store.subscribe(listener)()
+
+        store.acquire('comment:a')
+
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    /** useSyncExternalStore requires a stable snapshot or it loops forever. */
+    it('returns a stable snapshot while nothing changes', () => {
+        const store = createWarmEditorStore()
+        store.acquire('comment:a')
+        expect(store.getSnapshot()).toBe(store.getSnapshot())
+    })
+})

--- a/core/lib/editor/warm/draft-store.ts
+++ b/core/lib/editor/warm/draft-store.ts
@@ -1,0 +1,35 @@
+import type { SurfaceId } from './warm-editor-store'
+
+export interface DraftStore {
+    /** Keep uncommitted text. Empty content clears rather than stores. */
+    stash(surfaceId: SurfaceId, content: string): void
+    /** Read without consuming — re-acquiring twice must yield the same draft. */
+    take(surfaceId: SurfaceId): string | null
+    clear(surfaceId: SurfaceId): void
+    clearAll(): void
+}
+
+/**
+ * Uncommitted text belonging to a surface that does not hold the warm editor.
+ *
+ * Only surfaces with no commit semantics need this. An inline comment edit
+ * commits on blur, so handing the editor away writes it; the composer has no
+ * such commit, and before the warm editor its draft survived only because the
+ * composer stayed mounted for the life of the open card.
+ */
+export function createDraftStore(): DraftStore {
+    const drafts = new Map<SurfaceId, string>()
+    return {
+        stash(surfaceId, content) {
+            // An empty editor is not a draft: re-seeding "" would paint over
+            // the placeholder and read as a broken composer.
+            if (content.trim() === '') drafts.delete(surfaceId)
+            else drafts.set(surfaceId, content)
+        },
+        take: surfaceId => drafts.get(surfaceId) ?? null,
+        clear: surfaceId => {
+            drafts.delete(surfaceId)
+        },
+        clearAll: () => drafts.clear(),
+    }
+}

--- a/core/lib/editor/warm/index.ts
+++ b/core/lib/editor/warm/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Public surface of the warm editor instance.
+ *
+ * Consumers import from `@tinycld/core/lib/editor/warm`; core's exports map
+ * resolves that through this file, via its lib wildcard's index entry. The
+ * platform split happens one level down — the bundler picks the `.web` or
+ * `.native` variant, and typecheck resolves the matching `.d.ts`.
+ */
+
+export { createDraftStore, type DraftStore } from './draft-store'
+export type { WarmEditorLease } from './types'
+export { useWarmEditor } from './use-warm-editor'
+export { useDraftStore, WarmEditorHost } from './WarmEditorHost'
+export {
+    createWarmEditorStore,
+    type SurfaceId,
+    type WarmEditorStore,
+    type WarmSnapshot,
+} from './warm-editor-store'

--- a/core/lib/editor/warm/types.ts
+++ b/core/lib/editor/warm/types.ts
@@ -1,0 +1,10 @@
+import type { EditorResult } from '../types'
+
+export interface WarmEditorLease {
+    /** False on web, and whenever no warm host is mounted. */
+    isWarm: boolean
+    acquire(): void
+    release(): void
+    /** Non-null only while this surface holds the instance. */
+    result: EditorResult | null
+}

--- a/core/lib/editor/warm/types.ts
+++ b/core/lib/editor/warm/types.ts
@@ -7,4 +7,15 @@ export interface WarmEditorLease {
     release(): void
     /** Non-null only while this surface holds the instance. */
     result: EditorResult | null
+    /**
+     * Bumped on every handover, so a caller can tell that the instance it read
+     * from has since been reconfigured for another surface.
+     *
+     * A read from the shared editor is async, and a handover during that read
+     * makes the resolved content belong to the incoming surface — writing it
+     * would put one surface's text on another's record. Compare this before and
+     * after the await and discard the read if it moved. Always 0 on web, where
+     * each surface owns its editor and no handover exists.
+     */
+    generation: number
 }

--- a/core/lib/editor/warm/use-warm-editor.d.ts
+++ b/core/lib/editor/warm/use-warm-editor.d.ts
@@ -1,0 +1,19 @@
+import type { UseRichEditorOptions } from '../rich/options'
+import type { WarmEditorLease } from './types'
+import type { SurfaceId } from './warm-editor-store'
+
+/**
+ * Platform-neutral declaration for the warm editor lease.
+ *
+ * Mirrors `rich/use-rich-editor.d.ts`: the implementations live in
+ * `use-warm-editor.web.ts` (always cold — web builds Tiptap in-process) and
+ * `use-warm-editor.native.ts` (leases the parked WebView). Consumers import the
+ * bare specifier, the bundler picks the variant, and this file is what typecheck
+ * resolves — so it IS the cross-platform contract.
+ */
+export declare function useWarmEditor(
+    surfaceId: SurfaceId,
+    options: UseRichEditorOptions
+): WarmEditorLease
+
+export type { WarmEditorLease }

--- a/core/lib/editor/warm/use-warm-editor.native.ts
+++ b/core/lib/editor/warm/use-warm-editor.native.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
+import type { UseRichEditorOptions } from '../rich/options'
+import type { WarmEditorLease } from './types'
+import { useWarmContext } from './WarmEditorHost.native'
+import type { SurfaceId, WarmSnapshot } from './warm-editor-store'
+
+const EMPTY: WarmSnapshot = { holder: null, generation: 0 }
+const noopSubscribe = () => () => {}
+const emptySnapshot = () => EMPTY
+
+/**
+ * Lease the package's single warm editor for one surface.
+ *
+ * `isWarm` false means no host is mounted; the consumer must mount its own
+ * editor and pay the cold start. Warm is an optimization, never a correctness
+ * dependency — a fault here degrades to the previous behavior, not a broken
+ * editor.
+ */
+export function useWarmEditor(
+    surfaceId: SurfaceId,
+    options: UseRichEditorOptions
+): WarmEditorLease {
+    const warm = useWarmContext()
+    const optionsRef = useRef(options)
+    optionsRef.current = options
+
+    const snapshot = useSyncExternalStore(
+        warm?.store.subscribe ?? noopSubscribe,
+        warm?.store.getSnapshot ?? emptySnapshot
+    )
+
+    const acquire = useCallback(() => {
+        if (!warm) return
+        warm.setOptions(optionsRef.current)
+        warm.store.acquire(surfaceId)
+    }, [warm, surfaceId])
+
+    const release = useCallback(() => {
+        warm?.store.release(surfaceId)
+    }, [warm, surfaceId])
+
+    // A surface can be unmounted while still holding the instance (the card
+    // closes mid-edit). Without this the store would keep a holder that no
+    // longer exists and the editor would never park.
+    useEffect(() => release, [release])
+
+    const isHolder = warm != null && snapshot.holder === surfaceId
+    return {
+        isWarm: warm != null,
+        acquire,
+        release,
+        result: isHolder ? warm.result : null,
+    }
+}

--- a/core/lib/editor/warm/use-warm-editor.native.ts
+++ b/core/lib/editor/warm/use-warm-editor.native.ts
@@ -50,5 +50,6 @@ export function useWarmEditor(
         acquire,
         release,
         result: isHolder ? warm.result : null,
+        generation: snapshot.generation,
     }
 }

--- a/core/lib/editor/warm/use-warm-editor.web.ts
+++ b/core/lib/editor/warm/use-warm-editor.web.ts
@@ -17,5 +17,8 @@ export function useWarmEditor(
         acquire: () => {},
         release: () => {},
         result: null,
+        // Constant: each surface owns its editor here, so there is no handover
+        // that could invalidate an in-flight read.
+        generation: 0,
     }
 }

--- a/core/lib/editor/warm/use-warm-editor.web.ts
+++ b/core/lib/editor/warm/use-warm-editor.web.ts
@@ -1,0 +1,21 @@
+import type { UseRichEditorOptions } from '../rich/options'
+import type { WarmEditorLease } from './types'
+import type { SurfaceId } from './warm-editor-store'
+
+/**
+ * Web builds Tiptap in-process, so there is no browser cold start to hide and
+ * nothing to keep warm. The lease exists only so LazyEditor's call sites are
+ * identical on both platforms; reporting cold sends the consumer down its own
+ * useRichEditor path.
+ */
+export function useWarmEditor(
+    _surfaceId: SurfaceId,
+    _options: UseRichEditorOptions
+): WarmEditorLease {
+    return {
+        isWarm: false,
+        acquire: () => {},
+        release: () => {},
+        result: null,
+    }
+}

--- a/core/lib/editor/warm/warm-editor-store.ts
+++ b/core/lib/editor/warm/warm-editor-store.ts
@@ -1,0 +1,70 @@
+/** Names an editing surface: `composer:<cardId>`, `comment:<id>`, `description:<cardId>`. */
+export type SurfaceId = string
+
+export interface WarmSnapshot {
+    holder: SurfaceId | null
+    generation: number
+}
+
+export interface WarmEditorStore {
+    /** Take the instance. Returns the generation the caller must post. */
+    acquire(surfaceId: SurfaceId): number
+    /** Give it back. Returns false if the caller had already been displaced. */
+    release(surfaceId: SurfaceId): boolean
+    holder(): SurfaceId | null
+    generation(): number
+    subscribe(listener: () => void): () => void
+    getSnapshot(): WarmSnapshot
+}
+
+/**
+ * Who holds the single warm editor, and which configuration is live.
+ *
+ * A store rather than component state because the holder changes from event
+ * handlers in unrelated subtrees (a comment row, the composer, the description),
+ * and useSyncExternalStore lets each of them re-render without a context that
+ * re-renders the whole card.
+ */
+export function createWarmEditorStore(): WarmEditorStore {
+    let holder: SurfaceId | null = null
+    let generation = 0
+    // Rebuilt only on change: useSyncExternalStore compares snapshots by
+    // identity and loops forever if a fresh object is returned each call.
+    let snapshot: WarmSnapshot = { holder, generation }
+    const listeners = new Set<() => void>()
+
+    function commit() {
+        snapshot = { holder, generation }
+        for (const listener of listeners) listener()
+    }
+
+    return {
+        acquire(surfaceId) {
+            // Unconditional transfer: acquiring while another surface holds the
+            // instance is the ordinary handover (tapping a second comment), and
+            // the previous holder is dropped outright so its later release
+            // cannot evict whoever took over.
+            holder = surfaceId
+            generation += 1
+            commit()
+            return generation
+        },
+        release(surfaceId) {
+            // A displaced surface still unmounts and still releases. Honouring
+            // that would blank the editor that just took over.
+            if (holder !== surfaceId) return false
+            holder = null
+            commit()
+            return true
+        },
+        holder: () => holder,
+        generation: () => generation,
+        subscribe(listener) {
+            listeners.add(listener)
+            return () => {
+                listeners.delete(listener)
+            }
+        },
+        getSnapshot: () => snapshot,
+    }
+}

--- a/core/server/driveshare/driveshare.go
+++ b/core/server/driveshare/driveshare.go
@@ -246,3 +246,70 @@ func CheckDelete(app core.App, userID, itemID string) error {
 func IsOwner(app core.App, userID, itemID string) bool {
 	return CheckDelete(app, userID, itemID) == nil
 }
+
+// ParticipantIDs returns every user who can reach an item: its creator plus
+// the holder of each drive_shares row. Suspended accounts are excluded, so
+// the result is the set ResolveRoleForItem would grant a non-None role to.
+//
+// This is the inverse of the rest of this file. Every other entry point
+// answers "may THIS user reach this item?" and takes a userID, because every
+// caller (a request, a WebDAV walk) already has one in hand. Automation's
+// owner resolvers are the first caller that has only the item and must
+// discover the users — a comment arrives with no user attached, and the
+// engine needs the list to decide whose personal rules fire on it.
+//
+// Deriving this in the calling package instead would mean re-implementing the
+// creator/share/suspension rules per package, and an owner resolver that gets
+// them wrong fires OTHER users' personal rules on data they can't see. It
+// belongs next to the semantics it mirrors.
+//
+// Order is unspecified and the result may be empty (the item is gone, or
+// everyone who could reach it is suspended); an empty result means personal
+// rules simply don't fire, which is the engine's documented no-owner case.
+func ParticipantIDs(app core.App, itemID string) []string {
+	if itemID == "" {
+		return nil
+	}
+	item, err := app.FindRecordById(driveItemsCollection, itemID)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var out []string
+	add := func(userID string) {
+		if userID == "" || seen[userID] {
+			return
+		}
+		// Mirrors ResolveRoleForItem: suspension outranks ownership, so a
+		// suspended creator is not a participant either.
+		if useraccount.IsSuspended(app, userID) {
+			return
+		}
+		seen[userID] = true
+		out = append(out, userID)
+	}
+
+	add(item.GetString("created_by"))
+
+	rows, err := app.FindRecordsByFilter(
+		sharesCollection,
+		"item = {:item}",
+		"", 0, 0,
+		map[string]any{"item": itemID},
+	)
+	if err != nil {
+		// The creator is still a genuine participant; returning them beats
+		// resolving to nobody because the share lookup failed.
+		return out
+	}
+	for _, r := range rows {
+		// Skip roles this build doesn't recognize, matching
+		// ResolveRoleForItem's refusal to admit on an unknown role.
+		if rank(Role(r.GetString("role"))) <= rank(RoleNone) {
+			continue
+		}
+		add(r.GetString("user"))
+	}
+	return out
+}

--- a/core/server/driveshare/driveshare_test.go
+++ b/core/server/driveshare/driveshare_test.go
@@ -426,3 +426,153 @@ func TestResolveRole_UnknownUserFailsClosed(t *testing.T) {
 		t.Errorf("unknown user: got %v, want ErrNoAccess", err)
 	}
 }
+
+// ParticipantIDs is the inverse of everything above: given only an item, who
+// can reach it. Automation's owner resolvers are the caller — the engine uses
+// the result to decide whose personal rules fire on a record, so a wrong
+// answer runs other users' rules on data they cannot see.
+
+func TestParticipantIDs_CreatorAndShareHolders(t *testing.T) {
+	app := setupApp(t)
+	creator := mkUser(t, app, "creator@example.com")
+	viewer := mkUser(t, app, "viewer@example.com")
+	editor := mkUser(t, app, "editor@example.com")
+	item := mkItem(t, app, creator, "doc")
+	grant(t, app, item, viewer, RoleViewer)
+	grant(t, app, item, editor, RoleEditor)
+
+	got := ParticipantIDs(app, item.Id)
+	want := map[string]bool{creator.Id: true, viewer.Id: true, editor.Id: true}
+	if len(got) != len(want) {
+		t.Fatalf("got %d participants (%v), want %d", len(got), got, len(want))
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("unexpected participant %s", id)
+		}
+	}
+}
+
+// The creator needs no share row — same disjunct TestResolveRole_Creator pins.
+func TestParticipantIDs_CreatorWithoutShareRow(t *testing.T) {
+	app := setupApp(t)
+	creator := mkUser(t, app, "solo@example.com")
+	item := mkItem(t, app, creator, "unshared")
+
+	got := ParticipantIDs(app, item.Id)
+	if len(got) != 1 || got[0] != creator.Id {
+		t.Fatalf("got %v, want just the creator (%s)", got, creator.Id)
+	}
+}
+
+// A user holding two rows (possible for rows predating the UNIQUE index)
+// must appear once — a duplicated owner would dispatch a rule twice.
+func TestParticipantIDs_DeduplicatesAndSkipsDoubleCountingTheCreator(t *testing.T) {
+	app := setupApp(t)
+	creator := mkUser(t, app, "creator@example.com")
+	item := mkItem(t, app, creator, "doc")
+	// The creator ALSO holding an explicit share is the normal case: drive's
+	// owner-share hook writes one.
+	grant(t, app, item, creator, RoleOwner)
+	other := mkUser(t, app, "other@example.com")
+	grant(t, app, item, other, RoleViewer)
+	grant(t, app, item, other, RoleEditor)
+
+	got := ParticipantIDs(app, item.Id)
+	if len(got) != 2 {
+		t.Fatalf("got %v, want exactly two distinct participants", got)
+	}
+}
+
+// Suspension outranks ownership everywhere else in this file; it must here
+// too, or a disabled account's personal rules keep firing on documents it
+// can no longer open.
+func TestParticipantIDs_ExcludesSuspendedUsers(t *testing.T) {
+	app := setupApp(t)
+	creator := mkUser(t, app, "creator@example.com")
+	shared := mkUser(t, app, "shared@example.com")
+	item := mkItem(t, app, creator, "doc")
+	grant(t, app, item, shared, RoleEditor)
+
+	shared.Set("disabled", true)
+	if err := app.Save(shared); err != nil {
+		t.Fatalf("set disabled: %v", err)
+	}
+
+	got := ParticipantIDs(app, item.Id)
+	if len(got) != 1 || got[0] != creator.Id {
+		t.Fatalf("got %v, want only the active creator (%s)", got, creator.Id)
+	}
+}
+
+func TestParticipantIDs_SuspendedCreatorIsExcluded(t *testing.T) {
+	app := setupApp(t)
+	creator := mkUser(t, app, "creator@example.com")
+	item := mkItem(t, app, creator, "doc")
+
+	creator.Set("disabled", true)
+	if err := app.Save(creator); err != nil {
+		t.Fatalf("set disabled: %v", err)
+	}
+
+	if got := ParticipantIDs(app, item.Id); len(got) != 0 {
+		t.Fatalf("got %v, want none — a suspended creator reaches nothing", got)
+	}
+}
+
+// Mirrors TestResolveRole_UnknownRoleFailsClosed: a role this build doesn't
+// understand grants nothing, so its holder is not a participant.
+func TestParticipantIDs_UnknownRoleFailsClosed(t *testing.T) {
+	app := setupApp(t)
+	creator := mkUser(t, app, "creator@example.com")
+	stranger := mkUser(t, app, "stranger@example.com")
+	item := mkItem(t, app, creator, "doc")
+	grant(t, app, item, stranger, Role("archivist"))
+
+	got := ParticipantIDs(app, item.Id)
+	if len(got) != 1 || got[0] != creator.Id {
+		t.Fatalf("got %v, want only the creator — an unknown role admits nobody", got)
+	}
+}
+
+func TestParticipantIDs_MissingItemOrEmptyID(t *testing.T) {
+	app := setupApp(t)
+	if got := ParticipantIDs(app, ""); got != nil {
+		t.Errorf("empty id: got %v, want nil", got)
+	}
+	if got := ParticipantIDs(app, "ghost00000000000"); got != nil {
+		t.Errorf("unknown item: got %v, want nil", got)
+	}
+}
+
+// The set ParticipantIDs returns must be exactly the set ResolveRoleForItem
+// grants access to — if the two drift, a resolver hands the engine owners
+// who can't actually open the document.
+func TestParticipantIDs_AgreesWithResolveRole(t *testing.T) {
+	app := setupApp(t)
+	creator := mkUser(t, app, "creator@example.com")
+	viewer := mkUser(t, app, "viewer@example.com")
+	suspended := mkUser(t, app, "suspended@example.com")
+	stranger := mkUser(t, app, "stranger@example.com")
+	item := mkItem(t, app, creator, "doc")
+	grant(t, app, item, viewer, RoleViewer)
+	grant(t, app, item, suspended, RoleEditor)
+	suspended.Set("disabled", true)
+	if err := app.Save(suspended); err != nil {
+		t.Fatalf("set disabled: %v", err)
+	}
+
+	participants := make(map[string]bool)
+	for _, id := range ParticipantIDs(app, item.Id) {
+		participants[id] = true
+	}
+
+	for _, u := range []*core.Record{creator, viewer, suspended, stranger} {
+		_, err := ResolveRole(app, u.Id, item.Id)
+		hasAccess := err == nil
+		if participants[u.Id] != hasAccess {
+			t.Errorf("user %s: participant=%v but ResolveRole access=%v",
+				u.Email(), participants[u.Id], hasAccess)
+		}
+	}
+}

--- a/docs/superpowers/plans/2026-08-14-lazy-editor-warm-instance.md
+++ b/docs/superpowers/plans/2026-08-14-lazy-editor-warm-instance.md
@@ -1,0 +1,1997 @@
+# LazyEditor and the Warm Editor Instance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the ~1.1 s cold start when opening a card description or comment for editing, by keeping one warm WebView editor alive per cards session and swapping surfaces into it.
+
+**Architecture:** The WebView page already mounts in two stages — it boots, posts `EDITOR_READY`, and renders `null` until an init payload arrives. All 1135 ms is stage one (browser cold start, 0.86 MB bundle, React boot) and is configuration-independent. This work makes the init payload re-sendable so a booted page can be reconfigured for a new surface, keeps one such page alive above the card detail, and adds a core `LazyEditor` component that owns the read/edit swap and the commit semantics. Re-initialization is a full stage-two reconstruction, never a mutation, so no editor state can leak between surfaces.
+
+**Tech Stack:** React Native + Expo Router, TenTap (`@10play/tentap-editor`) as WebView host, Tiptap 3 inside the page, Yjs for collaborative descriptions, Vitest for unit tests, Playwright for e2e, Biome for lint.
+
+**Spec:** `tinycld/docs/superpowers/specs/2026-08-14-lazy-editor-warm-instance-design.md`
+
+## Global Constraints
+
+- **Never use `any`** to pass type checks. Embrace inference; don't over-specify.
+- **Never use `biome-ignore` comments** — fix the underlying issue instead.
+- Biome enforces 4-space indent, single quotes, ES5 trailing commas, no superfluous semicolons.
+- Components are PascalCase (`LazyEditor.tsx`), hooks camelCase `use`-prefixed, utility modules kebab-case (`warm-editor-store.ts`).
+- **Comments explain "why", not "what".** Self-explanatory code needs none.
+- **Light + dark mode:** no raw hex. Use semantic Tailwind tokens or `useThemeColor()`.
+- **Both platforms must work.** Web has no WebView and no cold start; every native-only path needs a web equivalent that behaves identically from the user's point of view.
+- **Errors → `captureException(context, error, extra?)`** from `@tinycld/core/lib/errors`. Never `console.log` unguarded; dev tracing is `if (__DEV__) console.debug(...)`.
+- **`editorHtml.ts` is generated** by the webview-bundler and is gitignored — never edit or commit it. After any change under `core/lib/editor/rich/webview/source/`, regenerate with `cd ~/code/tinycld/tinycld && pnpm run packages:generate` or the change is inert.
+- **Warm is an optimization, never a correctness dependency.** Every path must degrade to a fresh mount rather than to a broken editor.
+- Run checks from inside the member changed: `pnpm exec tinycld-pkg check` (biome + tsc + vitest).
+
+## File Structure
+
+**Core — protocol (`core/lib/editor/rich/webview/source/protocol.ts`)**
+Adds `generation` to `RichEditorInitPayload` and the `APP_PARK` message type. Shared by host and page, DOM-free, unit-testable.
+
+**Core — page (`core/lib/editor/rich/webview/source/Editor.tsx`)**
+`Editor` gains park handling and keys `EditorMounted` on `init.generation`, making stage two reconstructible.
+
+**Core — host (`core/lib/editor/use-webview-editor.tsx`)**
+`initSentRef` one-shot latch becomes generation tracking.
+
+**Core — warm instance (new `core/lib/editor/warm/`)**
+- `warm-editor-store.ts` — the acquire/release state machine. Plain TS, no React, no WebView: directly unit-testable.
+- `draft-store.ts` — the composer draft store. Plain TS, unit-testable.
+- `WarmEditorHost.native.tsx` / `WarmEditorHost.web.tsx` — mounts (or, on web, does not mount) the parked WebView.
+- `use-warm-editor.native.ts` / `use-warm-editor.web.ts` — consumer-facing acquire hook; web aliases `useRichEditor`.
+- `index.ts` — public surface.
+
+**Core — swap component (new `core/components/editor/LazyEditor.tsx`)**
+Owns the press target, the read/edit swap, and the commit semantics. Format-neutral: takes `readView` as a prop and never interprets content.
+
+**Cards**
+- `screens/_layout.tsx` — mounts `WarmEditorHost`.
+- `components/detail/CardDetail.tsx` — description swap replaced by `LazyEditor`.
+- `components/detail/DetailActivity.tsx` — inline comment swap replaced by `LazyEditor`.
+- `components/detail/CommentComposer.tsx` — draft store wiring.
+
+**Task ordering rationale:** Tasks 1–3 are the protocol and host plumbing, each independently testable. Task 4 is the state machine (pure, no UI). Task 5 is the draft store (pure). Task 6 assembles the warm host + hook. Task 7 is `LazyEditor` with its commit-semantics matrix. Tasks 8–10 migrate cards. Task 11 is device verification.
+
+---
+
+### Task 1: Make the init payload carry a generation
+
+**Files:**
+- Modify: `core/lib/editor/rich/webview/source/protocol.ts`
+- Test: `core/lib/editor/rich/webview/source/__tests__/protocol-generation.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `RichEditorInitPayload.generation: number` — a monotonically increasing counter, `0` for the first init of a page. `APP_PARK = 'park'`, a host→page message type on the `'app'` namespace with `null` payload.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/lib/editor/rich/webview/source/__tests__/protocol-generation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { makeMessage } from '../../../../message-bus/types'
+import { APP_INIT, APP_PARK, type RichEditorInitPayload } from '../protocol'
+
+/**
+ * A warm editor is re-initialized rather than remounted, so the page needs a
+ * way to tell a NEW configuration from a re-delivery of the one it already
+ * applied. The generation is that discriminator: the page keys its Tiptap
+ * subtree on it, so a bumped value is a full stage-two reconstruction and a
+ * repeated value is a no-op.
+ */
+describe('init generation', () => {
+    it('rides in the init payload so the page can rebuild on a bump', () => {
+        const payload: RichEditorInitPayload = {
+            generation: 3,
+            contentFormat: 'markdown',
+            initialContent: 'hello',
+            placeholder: '',
+            editable: true,
+            autofocus: false,
+            colors: { bg: '#000', fg: '#fff', placeholder: '#888', primary: '#0f0' },
+        }
+        const message = makeMessage('app', APP_INIT, payload)
+
+        expect(message.namespace).toBe('app')
+        expect((message.payload as RichEditorInitPayload).generation).toBe(3)
+    })
+
+    it('names a park message so a released editor can drop to stage one', () => {
+        expect(APP_PARK).toBe('park')
+        expect(makeMessage('app', APP_PARK, null).type).toBe('park')
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/rich/webview/source/__tests__/protocol-generation.test.ts
+```
+
+Expected: FAIL — `APP_PARK` is not exported, and `generation` is not a property of `RichEditorInitPayload`.
+
+- [ ] **Step 3: Add the generation field and park message**
+
+In `core/lib/editor/rich/webview/source/protocol.ts`, beside the existing `APP_INIT` declaration:
+
+```ts
+/**
+ * host → WebView: drop back to stage one — no Tiptap, no document, no
+ * awareness — while keeping the page itself booted.
+ *
+ * This is what makes a warm editor possible. The expensive part of an editor is
+ * the browser cold start and bundle parse, which happen BEFORE init; tearing
+ * down only what init built leaves a page that can be reconfigured for the next
+ * surface in ~34 ms instead of ~1135 ms.
+ */
+export const APP_PARK = 'park'
+```
+
+In the `RichEditorInitPayload` interface, as the first field:
+
+```ts
+    /**
+     * Monotonic counter identifying this configuration.
+     *
+     * Init is no longer one-shot: a warm editor is handed from surface to
+     * surface by re-sending this payload. The page keys its editor subtree on
+     * this value, so a bump is a full reconstruction — new Tiptap, new Y.Doc,
+     * new undo stack. That is deliberate rather than wasteful: a partial reset
+     * would risk leaking one surface's undo history into another, and since a
+     * blur COMMITS an inline comment edit, leaked state is a data-loss risk
+     * rather than a cosmetic one.
+     *
+     * A repeated value must be ignored, so a re-delivered payload does not
+     * discard what the user has typed.
+     */
+    generation: number
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/rich/webview/source/__tests__/protocol-generation.test.ts
+```
+
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Fix the now-broken call site**
+
+`generation` is required, so `use-rich-editor.native.tsx` no longer typechecks. In its `initPayload` memo (around line 182), add as the first field of the returned object:
+
+```ts
+            generation: 0,
+```
+
+and leave the dependency array unchanged — a literal has no identity to track. Task 6 replaces this with the real counter.
+
+- [ ] **Step 6: Typecheck**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec tinycld-pkg typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/lib/editor/rich/webview/source/protocol.ts \
+        core/lib/editor/rich/webview/source/__tests__/protocol-generation.test.ts \
+        core/lib/editor/rich/use-rich-editor.native.tsx
+git commit -m "feat(editor): carry an init generation and name the park message"
+```
+
+---
+
+### Task 2: Rebuild the page's editor on a generation bump
+
+**Files:**
+- Modify: `core/lib/editor/rich/webview/source/Editor.tsx:111-144`
+- Test: `core/lib/editor/rich/webview/source/__tests__/init-reducer.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `RichEditorInitPayload.generation`, `APP_PARK` (Task 1).
+- Produces: `reduceInit(current: RichEditorInitPayload | null, incoming: RichEditorInitPayload | null): RichEditorInitPayload | null` — exported from `Editor.tsx` for testing. `null` incoming means park.
+
+The page's message handling is inside a `useEffect` and needs a DOM to test. Extracting the decision into a pure reducer makes the interesting part testable without one.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/lib/editor/rich/webview/source/__tests__/init-reducer.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { reduceInit } from '../Editor'
+import type { RichEditorInitPayload } from '../protocol'
+
+function payload(generation: number, content = ''): RichEditorInitPayload {
+    return {
+        generation,
+        contentFormat: 'markdown',
+        initialContent: content,
+        placeholder: '',
+        editable: true,
+        autofocus: false,
+        colors: { bg: '#000', fg: '#fff', placeholder: '#888', primary: '#0f0' },
+    }
+}
+
+describe('init reducer', () => {
+    it('accepts the first init', () => {
+        expect(reduceInit(null, payload(0))?.generation).toBe(0)
+    })
+
+    it('accepts a bumped generation, so a handover reconfigures the page', () => {
+        expect(reduceInit(payload(0), payload(1, 'next surface'))?.initialContent).toBe(
+            'next surface'
+        )
+    })
+
+    /**
+     * The host posts init from an effect, and a re-delivery of the SAME
+     * configuration must not rebuild the editor — that would discard whatever
+     * the user has typed since it was applied.
+     */
+    it('ignores a repeated generation, so typing is not discarded', () => {
+        const current = payload(2, 'typed by the user')
+        expect(reduceInit(current, payload(2, 'the original seed'))).toBe(current)
+    })
+
+    /** Out-of-order delivery must not roll the page back to an older surface. */
+    it('ignores an older generation', () => {
+        const current = payload(5)
+        expect(reduceInit(current, payload(4))).toBe(current)
+    })
+
+    it('parks on a null, dropping to stage one', () => {
+        expect(reduceInit(payload(3), null)).toBeNull()
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/rich/webview/source/__tests__/init-reducer.test.ts
+```
+
+Expected: FAIL — `reduceInit` is not exported from `Editor.tsx`.
+
+- [ ] **Step 3: Add the reducer and wire it into the page**
+
+In `core/lib/editor/rich/webview/source/Editor.tsx`, add above `export function Editor()`:
+
+```ts
+/**
+ * Decide what an incoming init means for the page's current configuration.
+ *
+ * Pure so it can be tested without a DOM — the message plumbing around it needs
+ * a WebView, but the interesting decisions are here.
+ *
+ * `null` incoming is a park request: drop to stage one, keeping the booted page.
+ */
+export function reduceInit(
+    current: RichEditorInitPayload | null,
+    incoming: RichEditorInitPayload | null
+): RichEditorInitPayload | null {
+    if (incoming === null) return null
+    // A repeat or a late-arriving older payload must not rebuild the editor —
+    // that discards whatever has been typed since the current one was applied.
+    if (current !== null && incoming.generation <= current.generation) return current
+    return incoming
+}
+```
+
+Replace the body of the `onMessage` handler's init branch (currently `setInit(parsed.payload as RichEditorInitPayload)`) with:
+
+```ts
+            if (parsed.namespace === 'app' && parsed.type === 'init') {
+                const incoming = parsed.payload as RichEditorInitPayload
+                setInit(current => reduceInit(current, incoming))
+                return
+            }
+            if (parsed.namespace === 'app' && parsed.type === APP_PARK) {
+                setInit(current => reduceInit(current, null))
+            }
+```
+
+Add `APP_PARK` to the existing import from `./protocol`.
+
+- [ ] **Step 4: Key the editor subtree on the generation**
+
+Change the render at the end of `Editor()` from `return <EditorMounted init={init} />` to:
+
+```tsx
+    // Keyed on the generation so a handover is a full reconstruction: new
+    // Tiptap, new Y.Doc (useCollabDoc's useState initializer reruns), new undo
+    // stack, new extension set. Nothing survives the swap, which is what makes
+    // it safe to reuse one page across surfaces.
+    return <EditorMounted key={init.generation} init={init} />
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/rich/webview/source/__tests__/init-reducer.test.ts
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Regenerate the WebView bundle**
+
+The page is bundled into a generated `editorHtml.ts`; the change is inert until this runs.
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm run packages:generate
+```
+
+Expected: completes without error. Do **not** stage `editorHtml.ts` — it is gitignored.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/lib/editor/rich/webview/source/Editor.tsx \
+        core/lib/editor/rich/webview/source/__tests__/init-reducer.test.ts
+git commit -m "feat(editor): rebuild the webview editor on a generation bump"
+```
+
+---
+
+### Task 3: Let the host post init more than once
+
+**Files:**
+- Modify: `core/lib/editor/use-webview-editor.tsx:300-317`
+- Test: `core/lib/editor/__tests__/init-dispatch.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `RichEditorInitPayload.generation` (Task 1).
+- Produces: `shouldPostInit(lastPostedGeneration: number | null, incomingGeneration: number, isReady: boolean): boolean` — exported from `use-webview-editor.tsx`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/lib/editor/__tests__/init-dispatch.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { shouldPostInit } from '../use-webview-editor'
+
+/**
+ * Init used to be latched one-shot per mount. A warm editor is handed between
+ * surfaces by re-initializing it, so the latch becomes generation tracking —
+ * post each generation exactly once, and never before the page is ready.
+ */
+describe('init dispatch', () => {
+    it('posts the first init once the page is ready', () => {
+        expect(shouldPostInit(null, 0, true)).toBe(true)
+    })
+
+    it('waits for the page, since nothing would receive it', () => {
+        expect(shouldPostInit(null, 0, false)).toBe(false)
+    })
+
+    it('does not repost the generation it already sent', () => {
+        expect(shouldPostInit(0, 0, true)).toBe(false)
+    })
+
+    it('posts a bumped generation, which is how a handover happens', () => {
+        expect(shouldPostInit(0, 1, true)).toBe(true)
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/__tests__/init-dispatch.test.ts
+```
+
+Expected: FAIL — `shouldPostInit` is not exported.
+
+- [ ] **Step 3: Add the predicate**
+
+In `core/lib/editor/use-webview-editor.tsx`, above `export function useWebViewEditor`:
+
+```ts
+/**
+ * Whether the host should post this init payload.
+ *
+ * Replaces the previous one-shot latch. A warm editor is reconfigured by
+ * re-sending init, so the rule is "each generation exactly once, never before
+ * the page reports ready" rather than "only ever once".
+ */
+export function shouldPostInit(
+    lastPostedGeneration: number | null,
+    incomingGeneration: number,
+    isReady: boolean
+): boolean {
+    if (!isReady) return false
+    return lastPostedGeneration === null || incomingGeneration > lastPostedGeneration
+}
+```
+
+- [ ] **Step 4: Replace the latch in the effect**
+
+Replace the `initSentRef` declaration with:
+
+```ts
+    // Which generation has been posted, rather than whether ANY init was — the
+    // warm editor reconfigures itself by posting a new one.
+    const lastInitGenerationRef = useRef<number | null>(null)
+```
+
+and replace the effect body with:
+
+```ts
+    useEffect(() => {
+        const generation = (initPayload as { generation?: unknown })?.generation
+        // Consumers that predate the warm path (mail, text) send no generation;
+        // treat those as a single one-shot init, exactly as before.
+        const incoming = typeof generation === 'number' ? generation : 0
+        if (!shouldPostInit(lastInitGenerationRef.current, incoming, webviewReady)) return
+        const webview = bridge.webviewRef?.current
+        if (!webview) return
+        const message = makeMessage('app', 'init', initPayload)
+        try {
+            if (__DEV__) {
+                console.log('[editor.mount] init-sent', Date.now() - mountAtRef.current, 'ms')
+            }
+            webview.postMessage(JSON.stringify(message))
+            lastInitGenerationRef.current = incoming
+        } catch (err) {
+            // postMessage can fail mid-handshake; the next render's
+            // webviewReady or bridge identity change will retry. The generation
+            // is deliberately NOT recorded here, so the retry still fires.
+            captureException('editor.postInit', err, { generation: incoming })
+        }
+    }, [bridge, webviewReady, initPayload])
+```
+
+Add the import at the top of the file:
+
+```ts
+import { captureException } from '../errors'
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/__tests__/init-dispatch.test.ts
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Run the full core editor suite**
+
+Nothing should regress — mail and text send no generation and keep one-shot behavior.
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/lib/editor/use-webview-editor.tsx core/lib/editor/__tests__/init-dispatch.test.ts
+git commit -m "feat(editor): post init per generation instead of once per mount"
+```
+
+---
+
+### Task 4: The warm editor state machine
+
+**Files:**
+- Create: `core/lib/editor/warm/warm-editor-store.ts`
+- Test: `core/lib/editor/warm/__tests__/warm-editor-store.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type SurfaceId = string` — `composer:<cardId>`, `comment:<id>`, `description:<cardId>`.
+  - `createWarmEditorStore(): WarmEditorStore`
+  - `WarmEditorStore` = `{ acquire(surfaceId: SurfaceId): number; release(surfaceId: SurfaceId): boolean; holder(): SurfaceId | null; generation(): number; subscribe(listener: () => void): () => void; getSnapshot(): WarmSnapshot }`
+  - `interface WarmSnapshot { holder: SurfaceId | null; generation: number }`
+  - `acquire` returns the generation the caller must send. `release` returns `true` if the caller actually held it (a stale release from a surface that already lost it returns `false` and changes nothing).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/lib/editor/warm/__tests__/warm-editor-store.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { createWarmEditorStore } from '../warm-editor-store'
+
+/**
+ * One WebView is shared by every editing surface in a package. The store is who
+ * holds it and which configuration generation is live — deliberately plain TS
+ * with no React and no WebView, because the handover rules are the part worth
+ * testing and neither of those is needed to test them.
+ */
+describe('warm editor store', () => {
+    it('starts unheld', () => {
+        const store = createWarmEditorStore()
+        expect(store.holder()).toBeNull()
+    })
+
+    it('hands the instance to an acquiring surface', () => {
+        const store = createWarmEditorStore()
+        store.acquire('comment:a')
+        expect(store.holder()).toBe('comment:a')
+    })
+
+    it('bumps the generation on every acquire, so the page rebuilds', () => {
+        const store = createWarmEditorStore()
+        const first = store.acquire('comment:a')
+        const second = store.acquire('comment:b')
+        expect(second).toBeGreaterThan(first)
+    })
+
+    /**
+     * The handover case. Taking the instance must transfer it outright — an
+     * acquire while another surface holds it is how tapping a second comment
+     * behaves, and leaving the old holder recorded would let its release later
+     * evict the new one.
+     */
+    it('transfers the instance when another surface acquires it', () => {
+        const store = createWarmEditorStore()
+        store.acquire('composer:card1')
+        store.acquire('comment:a')
+        expect(store.holder()).toBe('comment:a')
+    })
+
+    it('reports a release by the current holder', () => {
+        const store = createWarmEditorStore()
+        store.acquire('comment:a')
+        expect(store.release('comment:a')).toBe(true)
+        expect(store.holder()).toBeNull()
+    })
+
+    /**
+     * A surface that was displaced still unmounts and still calls release. That
+     * late call must not evict whoever took over, or tapping from one comment to
+     * another would blank the editor that just opened.
+     */
+    it('ignores a release from a surface that no longer holds it', () => {
+        const store = createWarmEditorStore()
+        store.acquire('composer:card1')
+        store.acquire('comment:a')
+
+        expect(store.release('composer:card1')).toBe(false)
+        expect(store.holder()).toBe('comment:a')
+    })
+
+    it('notifies subscribers on acquire and release', () => {
+        const store = createWarmEditorStore()
+        const listener = vi.fn()
+        store.subscribe(listener)
+
+        store.acquire('comment:a')
+        store.release('comment:a')
+
+        expect(listener).toHaveBeenCalledTimes(2)
+    })
+
+    it('stops notifying after unsubscribe', () => {
+        const store = createWarmEditorStore()
+        const listener = vi.fn()
+        store.subscribe(listener)()
+
+        store.acquire('comment:a')
+
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    /** useSyncExternalStore requires a stable snapshot or it loops forever. */
+    it('returns a stable snapshot while nothing changes', () => {
+        const store = createWarmEditorStore()
+        store.acquire('comment:a')
+        expect(store.getSnapshot()).toBe(store.getSnapshot())
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/warm/__tests__/warm-editor-store.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the store**
+
+Create `core/lib/editor/warm/warm-editor-store.ts`:
+
+```ts
+/** Names an editing surface: `composer:<cardId>`, `comment:<id>`, `description:<cardId>`. */
+export type SurfaceId = string
+
+export interface WarmSnapshot {
+    holder: SurfaceId | null
+    generation: number
+}
+
+export interface WarmEditorStore {
+    /** Take the instance. Returns the generation the caller must post. */
+    acquire(surfaceId: SurfaceId): number
+    /** Give it back. Returns false if the caller had already been displaced. */
+    release(surfaceId: SurfaceId): boolean
+    holder(): SurfaceId | null
+    generation(): number
+    subscribe(listener: () => void): () => void
+    getSnapshot(): WarmSnapshot
+}
+
+/**
+ * Who holds the single warm editor, and which configuration is live.
+ *
+ * A store rather than component state because the holder changes from event
+ * handlers in unrelated subtrees (a comment row, the composer, the description),
+ * and useSyncExternalStore lets each of them re-render without a context that
+ * re-renders the whole card.
+ */
+export function createWarmEditorStore(): WarmEditorStore {
+    let holder: SurfaceId | null = null
+    let generation = 0
+    // Rebuilt only on change: useSyncExternalStore compares snapshots by
+    // identity and loops forever if a fresh object is returned each call.
+    let snapshot: WarmSnapshot = { holder, generation }
+    const listeners = new Set<() => void>()
+
+    function commit() {
+        snapshot = { holder, generation }
+        for (const listener of listeners) listener()
+    }
+
+    return {
+        acquire(surfaceId) {
+            // Unconditional transfer: acquiring while another surface holds the
+            // instance is the ordinary handover (tapping a second comment), and
+            // the previous holder is dropped outright so its later release
+            // cannot evict whoever took over.
+            holder = surfaceId
+            generation += 1
+            commit()
+            return generation
+        },
+        release(surfaceId) {
+            // A displaced surface still unmounts and still releases. Honouring
+            // that would blank the editor that just took over.
+            if (holder !== surfaceId) return false
+            holder = null
+            commit()
+            return true
+        },
+        holder: () => holder,
+        generation: () => generation,
+        subscribe(listener) {
+            listeners.add(listener)
+            return () => listeners.delete(listener)
+        },
+        getSnapshot: () => snapshot,
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/warm/__tests__/warm-editor-store.test.ts
+```
+
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/lib/editor/warm/warm-editor-store.ts core/lib/editor/warm/__tests__/warm-editor-store.test.ts
+git commit -m "feat(editor): add the warm editor acquire/release store"
+```
+
+---
+
+### Task 5: The composer draft store
+
+**Files:**
+- Create: `core/lib/editor/warm/draft-store.ts`
+- Test: `core/lib/editor/warm/__tests__/draft-store.test.ts`
+
+**Interfaces:**
+- Consumes: `SurfaceId` (Task 4).
+- Produces: `createDraftStore(): DraftStore`, where `DraftStore` = `{ stash(surfaceId: SurfaceId, content: string): void; take(surfaceId: SurfaceId): string | null; clear(surfaceId: SurfaceId): void; clearAll(): void }`.
+- `stash` of empty/whitespace-only content clears rather than stores. `take` reads without removing (re-acquiring twice must yield the same draft).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/lib/editor/warm/__tests__/draft-store.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { createDraftStore } from '../draft-store'
+
+/**
+ * With one shared editor, a half-typed comment no longer survives in a mounted
+ * composer — the instance moves to whatever the user tapped. The draft store is
+ * where that text lives instead: stashed on release, re-seeded on acquire.
+ *
+ * Scoped to the composer and to the life of the open card. CardDetail is
+ * already keyed on the card id at both mount sites, so a card switch drops the
+ * store with the subtree and there is no eviction policy to get wrong.
+ */
+describe('draft store', () => {
+    it('has nothing for an untouched surface', () => {
+        expect(createDraftStore().take('composer:card1')).toBeNull()
+    })
+
+    it('returns what was stashed', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'half a thought')
+        expect(drafts.take('composer:card1')).toBe('half a thought')
+    })
+
+    /** Re-acquiring twice without typing must not lose the draft. */
+    it('does not consume the draft on read', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'still here')
+        drafts.take('composer:card1')
+        expect(drafts.take('composer:card1')).toBe('still here')
+    })
+
+    it('keeps drafts separate per surface', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'one')
+        drafts.stash('composer:card2', 'two')
+        expect(drafts.take('composer:card1')).toBe('one')
+    })
+
+    it('replaces an earlier draft for the same surface', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'first')
+        drafts.stash('composer:card1', 'second')
+        expect(drafts.take('composer:card1')).toBe('second')
+    })
+
+    /**
+     * An empty editor is not a draft. Stashing one would re-seed an empty
+     * string over the placeholder and make the composer look broken.
+     */
+    it('treats empty content as no draft', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'typed')
+        drafts.stash('composer:card1', '   \n  ')
+        expect(drafts.take('composer:card1')).toBeNull()
+    })
+
+    it('clears on commit', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'sent now')
+        drafts.clear('composer:card1')
+        expect(drafts.take('composer:card1')).toBeNull()
+    })
+
+    it('clears everything when the card closes', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'one')
+        drafts.stash('composer:card2', 'two')
+        drafts.clearAll()
+        expect(drafts.take('composer:card1')).toBeNull()
+        expect(drafts.take('composer:card2')).toBeNull()
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/warm/__tests__/draft-store.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the draft store**
+
+Create `core/lib/editor/warm/draft-store.ts`:
+
+```ts
+import type { SurfaceId } from './warm-editor-store'
+
+export interface DraftStore {
+    /** Keep uncommitted text. Empty content clears rather than stores. */
+    stash(surfaceId: SurfaceId, content: string): void
+    /** Read without consuming — re-acquiring twice must yield the same draft. */
+    take(surfaceId: SurfaceId): string | null
+    clear(surfaceId: SurfaceId): void
+    clearAll(): void
+}
+
+/**
+ * Uncommitted text belonging to a surface that does not hold the warm editor.
+ *
+ * Only surfaces with no commit semantics need this. An inline comment edit
+ * commits on blur, so handing the editor away writes it; the composer has no
+ * such commit, and before the warm editor its draft survived only because the
+ * composer stayed mounted for the life of the open card.
+ */
+export function createDraftStore(): DraftStore {
+    const drafts = new Map<SurfaceId, string>()
+    return {
+        stash(surfaceId, content) {
+            // An empty editor is not a draft: re-seeding "" would paint over
+            // the placeholder and read as a broken composer.
+            if (content.trim() === '') drafts.delete(surfaceId)
+            else drafts.set(surfaceId, content)
+        },
+        take: surfaceId => drafts.get(surfaceId) ?? null,
+        clear: surfaceId => void drafts.delete(surfaceId),
+        clearAll: () => drafts.clear(),
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/warm/__tests__/draft-store.test.ts
+```
+
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/lib/editor/warm/draft-store.ts core/lib/editor/warm/__tests__/draft-store.test.ts
+git commit -m "feat(editor): add the composer draft store"
+```
+
+---
+
+### Task 6: The warm host and acquire hook
+
+**Files:**
+- Create: `core/lib/editor/warm/WarmEditorHost.native.tsx`
+- Create: `core/lib/editor/warm/WarmEditorHost.web.tsx`
+- Create: `core/lib/editor/warm/use-warm-editor.native.ts`
+- Create: `core/lib/editor/warm/use-warm-editor.web.ts`
+- Create: `core/lib/editor/warm/use-warm-editor.d.ts`
+- Create: `core/lib/editor/warm/index.ts`
+- Modify: `core/lib/editor/rich/use-rich-editor.native.tsx` (accept a caller-supplied generation)
+- Modify: `core/package.json` (exports entry)
+- Test: `core/lib/editor/warm/__tests__/warm-context.test.tsx`
+
+**Interfaces:**
+- Consumes: `createWarmEditorStore`, `SurfaceId` (Task 4); `createDraftStore` (Task 5); `shouldPostInit` (Task 3).
+- Produces:
+  - `<WarmEditorHost options={UseRichEditorOptions}>{children}</WarmEditorHost>` — mounts one offscreen WebView and provides the warm context.
+  - `useWarmEditor(surfaceId: SurfaceId, options: UseRichEditorOptions): WarmEditorLease`
+  - `interface WarmEditorLease { isWarm: boolean; acquire(): void; release(): void; result: EditorResult | null }` — `result` is non-null only while this surface holds the instance. `isWarm` is false on web and whenever no host is mounted, telling the consumer to mount its own editor.
+  - `useDraftStore(): DraftStore`
+
+**Web behavior:** `WarmEditorHost.web.tsx` renders `children` and provides a context whose `isWarm` is always false. Web builds Tiptap in-process with no cold start, so there is nothing to warm; consumers fall through to their own `useRichEditor`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/lib/editor/warm/__tests__/warm-context.test.tsx`:
+
+```tsx
+import { render } from '@testing-library/react-native'
+import { Text } from 'react-native'
+import { describe, expect, it } from 'vitest'
+import { WarmEditorHost } from '../WarmEditorHost.web'
+import { useWarmEditor } from '../use-warm-editor.web'
+
+/**
+ * Web has no WebView and no cold start, so there is nothing to warm. The host
+ * still renders its children and the hook still answers — reporting isWarm
+ * false so the consumer mounts its own editor. That keeps LazyEditor's call
+ * sites identical on both platforms.
+ */
+function Probe() {
+    const lease = useWarmEditor('composer:card1', {})
+    return <Text>{lease.isWarm ? 'warm' : 'cold'}</Text>
+}
+
+describe('warm editor on web', () => {
+    it('renders children rather than swallowing the tree', () => {
+        const { getByText } = render(
+            <WarmEditorHost options={{}}>
+                <Text>content</Text>
+            </WarmEditorHost>
+        )
+        expect(getByText('content')).toBeTruthy()
+    })
+
+    it('reports cold, so consumers mount their own editor', () => {
+        const { getByText } = render(
+            <WarmEditorHost options={{}}>
+                <Probe />
+            </WarmEditorHost>
+        )
+        expect(getByText('cold')).toBeTruthy()
+    })
+
+    it('reports cold with no host mounted at all', () => {
+        const { getByText } = render(<Probe />)
+        expect(getByText('cold')).toBeTruthy()
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/warm/__tests__/warm-context.test.tsx
+```
+
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the shared types and web implementations**
+
+Create `core/lib/editor/warm/use-warm-editor.d.ts`:
+
+```ts
+import type { UseRichEditorOptions } from '../rich/options'
+import type { EditorResult } from '../types'
+import type { SurfaceId } from './warm-editor-store'
+
+export interface WarmEditorLease {
+    /** False on web, and whenever no warm host is mounted. */
+    isWarm: boolean
+    acquire(): void
+    release(): void
+    /** Non-null only while this surface holds the instance. */
+    result: EditorResult | null
+}
+
+export declare function useWarmEditor(
+    surfaceId: SurfaceId,
+    options: UseRichEditorOptions
+): WarmEditorLease
+```
+
+Create `core/lib/editor/warm/use-warm-editor.web.ts`:
+
+```ts
+import type { UseRichEditorOptions } from '../rich/options'
+import type { SurfaceId } from './warm-editor-store'
+import type { WarmEditorLease } from './use-warm-editor.d'
+
+/**
+ * Web builds Tiptap in-process, so there is no browser cold start to hide and
+ * nothing to keep warm. The lease exists only so LazyEditor's call sites are
+ * identical on both platforms; reporting cold sends the consumer down its own
+ * useRichEditor path.
+ */
+export function useWarmEditor(_surfaceId: SurfaceId, _options: UseRichEditorOptions): WarmEditorLease {
+    return {
+        isWarm: false,
+        acquire: () => {},
+        release: () => {},
+        result: null,
+    }
+}
+```
+
+Create `core/lib/editor/warm/WarmEditorHost.web.tsx`:
+
+```tsx
+import type { ReactNode } from 'react'
+import type { UseRichEditorOptions } from '../rich/options'
+
+/**
+ * A pass-through on web. Kept so a package mounts the same component on both
+ * platforms and the e2e suite walks the same tree.
+ */
+export function WarmEditorHost({
+    children,
+}: {
+    options: UseRichEditorOptions
+    children: ReactNode
+}) {
+    return <>{children}</>
+}
+```
+
+Create `core/lib/editor/warm/index.ts`:
+
+```ts
+export { createDraftStore, type DraftStore } from './draft-store'
+export { useWarmEditor, type WarmEditorLease } from './use-warm-editor'
+export { WarmEditorHost } from './WarmEditorHost'
+export { createWarmEditorStore, type SurfaceId, type WarmEditorStore } from './warm-editor-store'
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/lib/editor/warm/__tests__/warm-context.test.tsx
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Let `useRichEditor` take a caller-supplied generation**
+
+The warm hook drives reconfiguration by bumping the generation, so it must be an input rather than the hard-coded `0` from Task 1.
+
+In `core/lib/editor/rich/options.ts`, add to `UseRichEditorOptions`:
+
+```ts
+    /**
+     * Configuration generation, for a reused (warm) editor.
+     *
+     * Bumping this re-initializes the underlying WebView page in place — a full
+     * stage-two reconstruction — instead of mounting a new one. Omitted by
+     * ordinary consumers, which mount and destroy their own editor.
+     */
+    generation?: number
+```
+
+In `core/lib/editor/rich/use-rich-editor.native.tsx`, destructure `generation = 0` from `options` alongside the other fields, replace the literal `generation: 0` in the `initPayload` memo with `generation`, and add `generation` to that memo's dependency array.
+
+- [ ] **Step 6: Write the native host and hook**
+
+Create `core/lib/editor/warm/WarmEditorHost.native.tsx`:
+
+```tsx
+import { createContext, type ReactNode, useContext, useMemo, useRef, useSyncExternalStore } from 'react'
+import { View } from 'react-native'
+import { useRichEditor } from '../rich'
+import type { UseRichEditorOptions } from '../rich/options'
+import type { EditorResult } from '../types'
+import { createDraftStore, type DraftStore } from './draft-store'
+import { createWarmEditorStore, type SurfaceId, type WarmEditorStore } from './warm-editor-store'
+
+interface WarmContextValue {
+    store: WarmEditorStore
+    drafts: DraftStore
+    result: EditorResult
+    setOptions: (options: UseRichEditorOptions) => void
+}
+
+const WarmContext = createContext<WarmContextValue | null>(null)
+
+export function useWarmContext(): WarmContextValue | null {
+    return useContext(WarmContext)
+}
+
+/**
+ * Keeps ONE WebView editor booted and parked, ready to be handed to whichever
+ * surface the user starts editing.
+ *
+ * The cost this removes is measured: creating a WebView editor is a browser cold
+ * start plus a 0.86 MB bundle parse — 1135 ms of the 1186 ms an edit used to
+ * take. That work is configuration-independent and finishes before the init
+ * payload is even sent, so a page booted in advance can be reconfigured for a
+ * new surface in the remaining ~34 ms.
+ *
+ * Mount this where the package's editing surfaces live — for cards, the route
+ * layout, so it warms on entering the section and stays warm across boards and
+ * cards. NOT a manifest `provider`: PackageProviderWrapper builds its chain at
+ * module load and wraps the whole app, which would boot a WebView at launch for
+ * anyone who has the package installed but never opens it.
+ */
+export function WarmEditorHost({
+    options,
+    children,
+}: {
+    options: UseRichEditorOptions
+    children: ReactNode
+}) {
+    const storeRef = useRef<WarmEditorStore | null>(null)
+    if (storeRef.current === null) storeRef.current = createWarmEditorStore()
+    const store = storeRef.current
+
+    const draftsRef = useRef<DraftStore | null>(null)
+    if (draftsRef.current === null) draftsRef.current = createDraftStore()
+    const drafts = draftsRef.current
+
+    // The live configuration, held in a ref and read through the store's
+    // generation: putting it in state would re-render this provider (and so the
+    // whole section) on every handover.
+    const optionsRef = useRef<UseRichEditorOptions>(options)
+    const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot)
+
+    const result = useRichEditor({
+        ...optionsRef.current,
+        generation: snapshot.generation,
+        // Never on acquire: the surface decides when to take the caret, and
+        // focusing a parked editor would open the keyboard over a card nobody
+        // is editing.
+        autofocus: false,
+    })
+
+    const value = useMemo<WarmContextValue>(
+        () => ({
+            store,
+            drafts,
+            result,
+            setOptions: next => {
+                optionsRef.current = next
+            },
+        }),
+        [store, drafts, result]
+    )
+
+    return (
+        <WarmContext.Provider value={value}>
+            {children}
+            <WarmEditorViewport isParked={snapshot.holder === null}>
+                <result.EditorComponent />
+            </WarmEditorViewport>
+        </WarmContext.Provider>
+    )
+}
+
+/**
+ * Where the WebView lives while nobody is editing.
+ *
+ * Deliberately NOT `display: none` or a zero-size box: an unlaid-out WebView may
+ * never paint on iOS, and a page that never paints never finishes booting —
+ * which would defeat the entire point of warming it. It is therefore kept at a
+ * real size and pushed off-viewport instead.
+ */
+function WarmEditorViewport({ isParked, children }: { isParked: boolean; children: ReactNode }) {
+    if (!isParked) return null
+    return (
+        <View
+            style={{ position: 'absolute', left: -10000, top: 0, width: 320, height: 200 }}
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+        >
+            {children}
+        </View>
+    )
+}
+```
+
+Create `core/lib/editor/warm/use-warm-editor.native.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
+import type { UseRichEditorOptions } from '../rich/options'
+import type { SurfaceId } from './warm-editor-store'
+import type { WarmEditorLease } from './use-warm-editor.d'
+import { useWarmContext } from './WarmEditorHost.native'
+
+/**
+ * Lease the package's single warm editor for one surface.
+ *
+ * `isWarm` false means no host is mounted; the consumer must mount its own
+ * editor and pay the cold start. Warm is an optimization, never a correctness
+ * dependency — a fault here degrades to the previous behavior, not a broken
+ * editor.
+ */
+export function useWarmEditor(
+    surfaceId: SurfaceId,
+    options: UseRichEditorOptions
+): WarmEditorLease {
+    const warm = useWarmContext()
+    const optionsRef = useRef(options)
+    optionsRef.current = options
+
+    const snapshot = useSyncExternalStore(
+        warm?.store.subscribe ?? noopSubscribe,
+        warm?.store.getSnapshot ?? emptySnapshot
+    )
+
+    const acquire = useCallback(() => {
+        if (!warm) return
+        warm.setOptions(optionsRef.current)
+        warm.store.acquire(surfaceId)
+    }, [warm, surfaceId])
+
+    const release = useCallback(() => {
+        warm?.store.release(surfaceId)
+    }, [warm, surfaceId])
+
+    // A surface can be unmounted while still holding the instance (the card
+    // closes mid-edit). Without this the store would keep a holder that no
+    // longer exists and the editor would never park.
+    useEffect(() => release, [release])
+
+    const isHolder = warm != null && snapshot.holder === surfaceId
+    return {
+        isWarm: warm != null,
+        acquire,
+        release,
+        result: isHolder ? warm.result : null,
+    }
+}
+
+const EMPTY = { holder: null, generation: 0 }
+const noopSubscribe = () => () => {}
+const emptySnapshot = () => EMPTY
+```
+
+- [ ] **Step 7: Re-seed the markdown fallback on acquire**
+
+`MarkdownWebViewHost.lastKnown` is what `getMarkdown` returns when the WebView
+does not answer in time (`markdown-webview-host.ts:48`), and that value is
+persisted. Across a handover it would otherwise still hold the *previous*
+surface's text, so a timeout during a save would write one comment's words over
+another's.
+
+In `use-rich-editor.native.tsx`, the markdown host is created once per mount
+with a one-time seed. Add an effect that re-seeds whenever the generation
+changes:
+
+```ts
+    // A warm editor is reused across surfaces, so the timeout fallback has to
+    // follow the current one. Without this a slow getMarkdown during a handover
+    // resolves with the PREVIOUS surface's text — and that value gets saved.
+    useEffect(() => {
+        if (contentFormat !== 'markdown') return
+        markdownHost.seed(initialContent ?? '')
+    }, [markdownHost, contentFormat, initialContent, generation])
+```
+
+- [ ] **Step 8: Add the package export**
+
+In `core/package.json`, alongside the other `./lib/editor/*` entries, confirm the existing wildcard covers `./lib/editor/warm`. If the exports map lists editor subpaths explicitly, add:
+
+```json
+        "./lib/editor/warm": "./lib/editor/warm/index.ts",
+```
+
+- [ ] **Step 9: Typecheck and run the editor suite**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec tinycld-pkg typecheck && pnpm exec vitest run core/lib/editor
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add core/lib/editor/warm core/lib/editor/rich/options.ts \
+        core/lib/editor/rich/use-rich-editor.native.tsx core/package.json
+git commit -m "feat(editor): add the warm editor host and acquire hook"
+```
+
+---
+
+### Task 7: LazyEditor
+
+**Files:**
+- Create: `core/components/editor/LazyEditor.tsx`
+- Create: `core/components/editor/commit-policy.ts`
+- Test: `core/components/editor/__tests__/commit-policy.test.ts`
+
+**Interfaces:**
+- Consumes: `useWarmEditor`, `WarmEditorLease` (Task 6).
+- Produces:
+  - `shouldCommitOnBlur(state: CommitState): boolean`
+  - `interface CommitState { commitOnBlur: boolean; hasFocused: boolean; isSettled: boolean; isDialogOpen: boolean }`
+  - `isNoOpEdit(next: string, baseline: string): boolean`
+  - `<LazyEditor ... />` with props: `readView: ReactNode`, `value: string`, `contentFormat: 'markdown' | 'html'`, `editorOptions: UseRichEditorOptions`, `surfaceId: SurfaceId`, `canEdit: boolean`, `commitOnBlur?: boolean`, `onCommit: (content: string) => void`, `onCancel?: () => void`, `renderEditor: (slots: LazyEditorSlots) => ReactNode`, `testID?: string`.
+  - `interface LazyEditorSlots { EditorComponent: ComponentType; commands: EditorCommands; toolbarState: EditorToolbarState; submit: () => void; cancel: () => void; setDialogOpen: (open: boolean) => void }`
+
+`renderEditor` keeps chrome (toolbars, Save/Cancel, dialogs) with the consumer, exactly as `readView` keeps rendering with the consumer. `LazyEditor` owns only the swap and the commit rules.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/components/editor/__tests__/commit-policy.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { isNoOpEdit, shouldCommitOnBlur } from '../commit-policy'
+
+/**
+ * Each of these rules was found on a device, and each protects a write. They
+ * live in core so a second consumer inherits the fixes rather than
+ * rediscovering them.
+ */
+describe('commit on blur', () => {
+    const base = { commitOnBlur: true, hasFocused: true, isSettled: false, isDialogOpen: false }
+
+    it('commits when a focused session loses focus', () => {
+        expect(shouldCommitOnBlur(base)).toBe(true)
+    })
+
+    /**
+     * The composer has no blur-commit: leaving it must not post a comment.
+     */
+    it('never commits a surface that does not commit on blur', () => {
+        expect(shouldCommitOnBlur({ ...base, commitOnBlur: false })).toBe(false)
+    })
+
+    /**
+     * The editor opens with autofocus at a placeholder height, and until the
+     * page reports its real content height the caret can land outside the
+     * visible box and blur immediately. Since a blur COMMITS, that saved a
+     * comment nobody had touched.
+     */
+    it('never commits before the session has held focus', () => {
+        expect(shouldCommitOnBlur({ ...base, hasFocused: false })).toBe(false)
+    })
+
+    /**
+     * Save and the blur-commit race each other: pressing Save blurs the editor.
+     * Both writing would submit twice.
+     */
+    it('does not commit again once the session has settled', () => {
+        expect(shouldCommitOnBlur({ ...base, isSettled: true })).toBe(false)
+    })
+
+    /**
+     * The image picker and link prompt both steal focus. Treating that as the
+     * end of the session unmounts the surface the picked image is about to be
+     * inserted into.
+     */
+    it('does not commit while a dialog holds the focus', () => {
+        expect(shouldCommitOnBlur({ ...base, isDialogOpen: true })).toBe(false)
+    })
+})
+
+describe('no-op edits', () => {
+    it('treats an unchanged value as nothing to write', () => {
+        expect(isNoOpEdit('same text', 'same text')).toBe(true)
+    })
+
+    it('ignores surrounding whitespace, which the editor adds on its own', () => {
+        expect(isNoOpEdit('  same text\n', 'same text')).toBe(true)
+    })
+
+    it('treats a real change as a write', () => {
+        expect(isNoOpEdit('new text', 'old text')).toBe(false)
+    })
+
+    /** An emptied editor is a deletion the caller must decide about, not a no-op. */
+    it('does not call an emptied editor unchanged', () => {
+        expect(isNoOpEdit('', 'had content')).toBe(false)
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/components/editor/__tests__/commit-policy.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the policy**
+
+Create `core/components/editor/commit-policy.ts`:
+
+```ts
+export interface CommitState {
+    /** Does this surface write on focus loss? An edit does; a composer does not. */
+    commitOnBlur: boolean
+    /** Has the session ever actually held focus? */
+    hasFocused: boolean
+    /** Has it already committed or cancelled? */
+    isSettled: boolean
+    /** Is a dialog (image picker, link prompt) holding the focus? */
+    isDialogOpen: boolean
+}
+
+/**
+ * Whether a blur should write.
+ *
+ * Every clause here exists because of a bug found on a device, and the stakes
+ * are asymmetric: a missed commit loses an edit the user can redo, while a
+ * spurious one writes text nobody typed.
+ */
+export function shouldCommitOnBlur(state: CommitState): boolean {
+    if (!state.commitOnBlur) return false
+    // The mount racing itself, not a person finishing an edit.
+    if (!state.hasFocused) return false
+    if (state.isSettled) return false
+    // A detour inside the session, not the end of it.
+    if (state.isDialogOpen) return false
+    return true
+}
+
+/**
+ * Whether a submitted value differs from what the session opened with.
+ *
+ * An unchanged edit is a cancel rather than a write — EditableText's rule. The
+ * baseline is snapshotted at acquire, so a realtime update arriving mid-edit
+ * cannot become the comparison target.
+ */
+export function isNoOpEdit(next: string, baseline: string): boolean {
+    return next.trim() === baseline.trim()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec vitest run core/components/editor/__tests__/commit-policy.test.ts
+```
+
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Implement LazyEditor**
+
+Create `core/components/editor/LazyEditor.tsx`:
+
+```tsx
+import { type ComponentType, type ReactNode, useCallback, useRef, useState } from 'react'
+import { Pressable } from 'react-native'
+import { captureException } from '../../lib/errors'
+import { useRichEditor } from '../../lib/editor/rich'
+import type { UseRichEditorOptions } from '../../lib/editor/rich/options'
+import type { EditorCommands, EditorHandle, EditorToolbarState } from '../../lib/editor/types'
+import { useWarmEditor } from '../../lib/editor/warm'
+import type { SurfaceId } from '../../lib/editor/warm/warm-editor-store'
+import { isNoOpEdit, shouldCommitOnBlur } from './commit-policy'
+
+export interface LazyEditorSlots {
+    EditorComponent: ComponentType
+    commands: EditorCommands
+    toolbarState: EditorToolbarState
+    submit: () => void
+    cancel: () => void
+    /** Tell the swap a dialog holds the focus, so a blur is not the session ending. */
+    setDialogOpen: (open: boolean) => void
+}
+
+export interface LazyEditorProps {
+    /** Shown while idle. The consumer's component — core never interprets content. */
+    readView: ReactNode
+    /** Current persisted content, in `contentFormat`. */
+    value: string
+    contentFormat: 'markdown' | 'html'
+    editorOptions: UseRichEditorOptions
+    surfaceId: SurfaceId
+    canEdit: boolean
+    /** True for an edit of existing content; false for a composer. */
+    commitOnBlur?: boolean
+    onCommit: (content: string) => void
+    /** Absent when there is nothing to revert (a collaborative description). */
+    onCancel?: () => void
+    /** The consumer's chrome around the editing surface. */
+    renderEditor: (slots: LazyEditorSlots) => ReactNode
+    testID?: string
+    accessibilityLabel?: string
+}
+
+/**
+ * Renders content, and swaps in a real editor when someone starts editing.
+ *
+ * Two jobs, both previously hand-rolled per consumer:
+ *
+ *  - **The swap.** The read view IS the boot placeholder, so an edit never
+ *    shows an empty box while the editor initializes. On native the editor is
+ *    the package's warm instance when one is available, which turns a ~1135 ms
+ *    cold start into a ~34 ms reconfiguration.
+ *  - **The commit rules.** See commit-policy.ts — each clause protects a write,
+ *    and a blur COMMITS, so getting them wrong loses or invents user text.
+ *
+ * Deliberately NOT format-aware. `readView` is the consumer's, content crosses
+ * as an opaque string, and `contentFormat` only selects which channel to read
+ * back through — so mail's HTML surfaces use this exactly as cards' markdown
+ * ones do.
+ */
+export function LazyEditor({
+    readView,
+    value,
+    contentFormat,
+    editorOptions,
+    surfaceId,
+    canEdit,
+    commitOnBlur = false,
+    onCommit,
+    onCancel,
+    renderEditor,
+    testID,
+    accessibilityLabel = 'Edit',
+}: LazyEditorProps) {
+    const [isEditing, setIsEditing] = useState(false)
+    const [isDialogOpen, setIsDialogOpen] = useState(false)
+    // The revert/no-op baseline, snapshotted when the session opens so a
+    // realtime update mid-edit cannot become the comparison target.
+    const baselineRef = useRef(value)
+    const hasFocusedRef = useRef(false)
+    const settledRef = useRef(false)
+
+    const lease = useWarmEditor(surfaceId, {
+        ...editorOptions,
+        contentFormat,
+        initialContent: value,
+    })
+
+    const startEditing = useCallback(() => {
+        baselineRef.current = value
+        hasFocusedRef.current = false
+        settledRef.current = false
+        lease.acquire()
+        setIsEditing(true)
+    }, [lease, value])
+
+    const endSession = useCallback(() => {
+        settledRef.current = true
+        lease.release()
+        setIsEditing(false)
+    }, [lease])
+
+    if (!isEditing) {
+        if (!canEdit) return <>{readView}</>
+        return (
+            <Pressable
+                testID={testID}
+                onPress={startEditing}
+                accessibilityRole="button"
+                accessibilityLabel={accessibilityLabel}
+            >
+                {readView}
+            </Pressable>
+        )
+    }
+
+    return (
+        <LazyEditorSession
+            lease={lease}
+            value={value}
+            contentFormat={contentFormat}
+            editorOptions={editorOptions}
+            commitOnBlur={commitOnBlur}
+            isDialogOpen={isDialogOpen}
+            setDialogOpen={setIsDialogOpen}
+            baselineRef={baselineRef}
+            hasFocusedRef={hasFocusedRef}
+            settledRef={settledRef}
+            onCommit={onCommit}
+            onCancel={onCancel}
+            endSession={endSession}
+            renderEditor={renderEditor}
+        />
+    )
+}
+
+/**
+ * The live editing session, split out so the fallback `useRichEditor` below is
+ * only ever called while editing — a hook cannot sit behind the swap's branch.
+ */
+function LazyEditorSession({
+    lease,
+    value,
+    contentFormat,
+    editorOptions,
+    commitOnBlur,
+    isDialogOpen,
+    setDialogOpen,
+    baselineRef,
+    hasFocusedRef,
+    settledRef,
+    onCommit,
+    onCancel,
+    endSession,
+    renderEditor,
+}: {
+    lease: ReturnType<typeof useWarmEditor>
+    value: string
+    contentFormat: 'markdown' | 'html'
+    editorOptions: UseRichEditorOptions
+    commitOnBlur: boolean
+    isDialogOpen: boolean
+    setDialogOpen: (open: boolean) => void
+    baselineRef: { current: string }
+    hasFocusedRef: { current: boolean }
+    settledRef: { current: boolean }
+    onCommit: (content: string) => void
+    onCancel?: () => void
+    endSession: () => void
+    renderEditor: (slots: LazyEditorSlots) => ReactNode
+}) {
+    const readContent = useCallback(
+        async (editor: EditorHandle): Promise<string> =>
+            contentFormat === 'markdown' ? ((await editor.getMarkdown?.()) ?? '') : editor.getHTML(),
+        [contentFormat]
+    )
+
+    const submitRef = useRef<() => void>(() => {})
+    const blurRef = useRef<() => void>(() => {})
+
+    // The warm instance when one is available; otherwise this surface mounts
+    // its own and pays the cold start. Warm is an optimization, never a
+    // correctness dependency.
+    const own = useRichEditor({
+        ...editorOptions,
+        contentFormat,
+        initialContent: value,
+        autofocus: true,
+        onFocus: () => {
+            hasFocusedRef.current = true
+        },
+        onBlur: () => blurRef.current(),
+        onSubmitShortcut: () => submitRef.current(),
+    })
+    const active = lease.result ?? own
+
+    const submit = useCallback(() => {
+        if (settledRef.current) return
+        void (async () => {
+            let content: string
+            try {
+                content = (await readContent(active.editor)).trim()
+            } catch (err) {
+                captureException('editor.lazy.readContent', err)
+                return
+            }
+            if (onCancel && isNoOpEdit(content, baselineRef.current)) {
+                settledRef.current = true
+                endSession()
+                onCancel()
+                return
+            }
+            settledRef.current = true
+            onCommit(content)
+            endSession()
+        })()
+    }, [active.editor, readContent, onCommit, onCancel, endSession, baselineRef, settledRef])
+
+    submitRef.current = submit
+    blurRef.current = () => {
+        if (
+            shouldCommitOnBlur({
+                commitOnBlur,
+                hasFocused: hasFocusedRef.current,
+                isSettled: settledRef.current,
+                isDialogOpen,
+            })
+        ) {
+            submit()
+            return
+        }
+        // A surface with no blur-commit still ends its session on blur — the
+        // caller decides whether that text was worth keeping.
+        if (!commitOnBlur && hasFocusedRef.current && !isDialogOpen) endSession()
+    }
+
+    const cancel = useCallback(() => {
+        settledRef.current = true
+        endSession()
+        onCancel?.()
+    }, [endSession, onCancel, settledRef])
+
+    return (
+        <>
+            {renderEditor({
+                EditorComponent: active.EditorComponent,
+                commands: active.commands,
+                toolbarState: active.toolbarState,
+                submit,
+                cancel,
+                setDialogOpen,
+            })}
+        </>
+    )
+}
+```
+
+- [ ] **Step 6: Typecheck**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm exec tinycld-pkg typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/components/editor
+git commit -m "feat(editor): add LazyEditor with core-owned commit semantics"
+```
+
+---
+
+### Task 8: Mount the warm host in cards
+
+**Files:**
+- Modify: `cards/tinycld/cards/screens/_layout.tsx`
+
+**Interfaces:**
+- Consumes: `WarmEditorHost` (Task 6).
+- Produces: a warm instance available to every cards screen.
+
+- [ ] **Step 1: Mount the host**
+
+Replace `cards/tinycld/cards/screens/_layout.tsx` with:
+
+```tsx
+import { WarmEditorHost } from '@tinycld/core/lib/editor/warm'
+import { Stack } from 'expo-router'
+
+/**
+ * Boots one editor WebView on entering Cards and keeps it warm for the section.
+ *
+ * Creating an editor is a browser cold start plus a 0.86 MB bundle parse — 1135
+ * of the 1186 ms an edit used to take, all of it before any configuration is
+ * applied. Warming it here means the first description or comment edit pays only
+ * the reconfiguration.
+ *
+ * Here rather than in the manifest's `provider`: that chain wraps the whole app
+ * and is built at module load, so it would boot a WebView at launch for anyone
+ * who has cards installed and never opens it.
+ */
+export default function CardsLayout() {
+    return (
+        <WarmEditorHost options={{ contentFormat: 'markdown', minHeight: 72 }}>
+            <Stack screenOptions={{ headerShown: false }} />
+        </WarmEditorHost>
+    )
+}
+```
+
+- [ ] **Step 2: Typecheck cards**
+
+```sh
+cd ~/code/tinycld/cards && pnpm exec tinycld-pkg typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify the app still boots and cards renders**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm run dev
+```
+
+Open Cards in the browser. Expected: the board renders as before (web's host is a pass-through). Stop the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/code/tinycld/cards
+git add tinycld/cards/screens/_layout.tsx
+git commit -m "feat(cards): keep one editor warm for the cards section"
+```
+
+---
+
+### Task 9: Move the description onto LazyEditor
+
+**Files:**
+- Modify: `cards/tinycld/cards/components/detail/CardDetail.tsx:302-360`
+- Modify: `cards/tinycld/cards/components/detail/DescriptionEditor.tsx`
+
+**Interfaces:**
+- Consumes: `LazyEditor`, `LazyEditorSlots` (Task 7).
+- Produces: description editing through the warm instance.
+
+The description passes **no `onCancel`**: every keystroke is already shared through Yjs and flushed by the server, so revert and save have nowhere to live. Its surface id is `description:<cardId>`.
+
+- [ ] **Step 1: Replace the hand-rolled swap**
+
+In `CardDetail.tsx`, the `isEditingDescription` state, the `isEditingCollab` branch, and `DescriptionReadView`'s press wiring are replaced by a `LazyEditor`. Keep `DescriptionReadView` itself — it becomes the `readView` prop, minus its `Pressable` (LazyEditor supplies the press target). Keep `useDescriptionEditor` for the chrome it builds, driving it from `LazyEditorSlots` rather than owning the editor.
+
+Pass:
+
+```tsx
+<LazyEditor
+    surfaceId={`description:${card.id}`}
+    readView={<DescriptionReadView description={card.description} projectId={projectId} />}
+    value={card.description ?? ''}
+    contentFormat="markdown"
+    canEdit={canEdit && canEditDoc}
+    editorOptions={{
+        placeholder: 'Add a description — what does done look like?',
+        characterLimit: DESCRIPTION_LIMIT,
+        minHeight: 72,
+        containerClassName: 'min-h-[72px]',
+        triggers: mention.triggers,
+        overlayKey: mention.overlayKey,
+        collab: doc
+            ? { document: doc, field: `card:${card.id}`, awareness: awareness ?? undefined, user: identity ?? undefined }
+            : undefined,
+    }}
+    onCommit={value => updateCard.mutate({ cardId: card.id, description: value })}
+    renderEditor={slots => descriptionChrome(slots)}
+    testID="cards-description-read"
+    accessibilityLabel="Edit description"
+/>
+```
+
+- [ ] **Step 2: Run the cards unit suite**
+
+```sh
+cd ~/code/tinycld/cards && pnpm exec tinycld-pkg test
+```
+
+Expected: PASS. Fix any failure at its source.
+
+- [ ] **Step 3: Run the description e2e specs**
+
+```sh
+cd ~/code/tinycld/cards && pnpm exec tinycld-pkg test:e2e -- card-description.spec.ts card-description-collab.spec.ts card-description-toolbar.spec.ts card-description-images.spec.ts
+```
+
+Expected: PASS. These are the regression net for the swap's layout neutrality — a failure means the swap moved something, and the fix is in the layout, never in the assertion.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/code/tinycld/cards
+git add tinycld/cards/components/detail/CardDetail.tsx tinycld/cards/components/detail/DescriptionEditor.tsx
+git commit -m "feat(cards): edit descriptions through LazyEditor"
+```
+
+---
+
+### Task 10: Move comments onto LazyEditor, with the composer draft store
+
+**Files:**
+- Modify: `cards/tinycld/cards/components/detail/DetailActivity.tsx:150-160`
+- Modify: `cards/tinycld/cards/components/detail/CommentEditor.tsx`
+- Modify: `cards/tinycld/cards/components/detail/CommentComposer.tsx`
+
+**Interfaces:**
+- Consumes: `LazyEditor` (Task 7), `useDraftStore` via the warm context (Task 6).
+- Produces: comment editing and composing through the warm instance.
+
+Surface ids: `comment:<commentId>` for an inline edit, `composer:<cardId>` for the composer.
+
+Inline edits pass `commitOnBlur` — that is today's behavior and switching away must keep committing. The composer does not; its text is stashed instead.
+
+- [ ] **Step 1: Move the inline editor onto LazyEditor**
+
+In `DetailActivity.tsx`, replace the `isEditing ? <InlineCommentEditor .../> : <author line + body>` swap with a `LazyEditor` whose `readView` is the existing author line + `MarkdownText` body, `commitOnBlur` is true, `onCommit` calls `onSaveEdit`, and `onCancel` calls `onCancelEdit`. `CommentEditor.tsx`'s `useCommentEditorCore` loses its blur/settled/hasFocused refs — those now live in `commit-policy.ts` — and keeps only the chrome (toolbar, Save/Cancel, dialogs) as a `renderEditor` callback.
+
+- [ ] **Step 2: Wire the composer draft store**
+
+In `CommentComposer.tsx`, the composer becomes a `LazyEditor` with `surfaceId={`composer:${cardId}`}` and no `commitOnBlur`. On release, stash the editor's content; on acquire, seed it. Read the draft store from the warm context:
+
+```tsx
+const drafts = useDraftStore()
+const draft = drafts.take(`composer:${cardId}`)
+```
+
+Seed `value={draft ?? ''}`, and clear on a successful send:
+
+```tsx
+onCommit={body => {
+    drafts.clear(`composer:${cardId}`)
+    onSubmit(body)
+}}
+```
+
+- [ ] **Step 3: Run the cards unit suite**
+
+```sh
+cd ~/code/tinycld/cards && pnpm exec tinycld-pkg test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the comment e2e specs**
+
+```sh
+cd ~/code/tinycld/cards && pnpm exec tinycld-pkg test:e2e -- comment-editing.spec.ts comment-markdown.spec.ts card-mentions.spec.ts
+```
+
+Expected: PASS. `comment-editing.spec` carries the ±2px layout anchor; a failure means the swap moved the prose and the fix is the layout.
+
+- [ ] **Step 5: Run the full cards check**
+
+```sh
+cd ~/code/tinycld/cards && pnpm exec tinycld-pkg check
+```
+
+Expected: PASS (biome + tsc + vitest).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/code/tinycld/cards
+git add tinycld/cards/components/detail/
+git commit -m "feat(cards): edit comments through LazyEditor with a composer draft store"
+```
+
+---
+
+### Task 11: Verify on device and document
+
+**Files:**
+- Modify: `cards/help/<topic>.md` (only if user-visible behavior changed)
+- Delete: `HANDOFF-editor-webview-cost.md` (superseded by the spec and this plan)
+
+**Interfaces:**
+- Consumes: everything above.
+
+The measurement that motivated this work must be re-taken. The four `__DEV__` marks in `use-webview-editor.tsx` are the instrument and stay in place.
+
+- [ ] **Step 1: Run the app on the iOS simulator**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm run dev
+```
+
+Open the iOS simulator and navigate into Cards.
+
+- [ ] **Step 2: Confirm the warm boot happens on section entry**
+
+Expected in the console on entering Cards, with no card open:
+
+```
+[editor.mount] mounted (t0)
+[editor.mount] page-ready    ~1100 ms
+```
+
+`page-ready` firing here rather than on first edit is the whole point — the cost moved off the interaction.
+
+- [ ] **Step 3: Confirm a warm acquire is fast**
+
+Open a card and tap the description. Expected: `init-sent` and `first-height` marks only, **no new `page-ready`**, and the total from tap to caret under ~100 ms. If `page-ready` appears, the surface fell back to its own editor — check that `WarmEditorHost` is mounted above the screen.
+
+- [ ] **Step 4: Verify the handover cases by hand**
+
+- [ ] Tap description → type → tap a comment's Edit. The description's text persists (Yjs flushed it) and the comment editor opens warm.
+- [ ] Open the composer → type a partial draft → tap a comment's Edit → cancel that edit → return to the composer. **The draft is still there.**
+- [ ] Edit a comment → tap elsewhere without pressing Save. The edit **commits**, as it does today.
+- [ ] Open a card, tap description, close the card mid-edit. No crash, and the editor parks (the next card's first edit is still fast).
+
+- [ ] **Step 5: Check the help topic**
+
+Read `cards/help/` for any topic describing description or comment editing. If the visible behavior is unchanged — it should be, apart from speed — no edit is needed. If a topic mentions waiting or slowness, update it.
+
+- [ ] **Step 6: Remove the superseded handoff**
+
+```bash
+cd ~/code/tinycld && git rm HANDOFF-editor-webview-cost.md
+```
+
+- [ ] **Step 7: Run the full ecosystem checks**
+
+```sh
+cd ~/code/tinycld/tinycld && pnpm run checks && pnpm run pkg:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd ~/code/tinycld
+git add -A
+git commit -m "docs: retire the editor webview cost handoff"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Re-sendable init with a generation | 1 |
+| Page rebuilds stage two on a bump; `APP_PARK` | 1, 2 |
+| Host posts per generation, not once per mount | 3 |
+| Single instance, not a pool | 4 |
+| Handover transfers; stale release ignored | 4 |
+| Host-side relays: no teardown needed | Verified — see the note below |
+| `MarkdownWebViewHost` re-seeded per acquire | 6 (Step 7) |
+| `MarkdownWebViewHost` re-seeded per acquire | 6 (Step 7) |
+| `WarmEditorHost` offscreen at real size, not `display:none` | 6 |
+| `useWarmEditor`; web pass-through | 6 |
+| Fallback to a fresh mount | 6, 7 |
+| `LazyEditor` owns the swap; `readView` is a prop | 7 |
+| Format neutrality via `contentFormat` + opaque content | 7 |
+| Commit semantics matrix in core | 7 |
+| Composer draft store, composer-scoped | 5, 10 |
+| Inline edits commit on switch | 7, 10 |
+| Description gets no `onCancel` | 9 |
+| Mounted in cards' route layout, not a manifest provider | 8 |
+| Device re-measurement | 11 |
+| Existing e2e must pass unchanged | 9, 10 |
+
+**Gap examined and resolved:** the spec calls for the host-side Yjs and awareness relays to be rebuilt per acquire. Checking the code, no separate task is needed, and the reason is worth recording so nobody "fixes" it later:
+
+`yjsHost` and `awarenessHost` are memoized on **document identity** (`use-rich-editor.native.tsx:116-143`). In cards that document is the board's — `useBoardPresence.ts:141` returns `room?.doc`, one Y.Doc holding a fragment per card — so it is the *same object* across every card on a board. The relay is therefore correctly shared, and the only thing that varies per acquire is the `field` (`card:<id>`), which rides in the init payload and is consumed when the page rebuilds its own doc in `useCollabDoc`.
+
+The spec's stale-relay concern is real but applies to a different case: a consumer that swaps to a **different** Y.Doc. The existing memo already handles that — a new doc identity rebuilds both hosts and the `useEffect` cleanups destroy the old ones. Nothing to add.
+
+**Placeholder scan:** none — every code step carries real code. Tasks 9 and 10 describe edits to large existing components in prose plus the concrete props; the implementer has the exact file, line range, prop list, and surface-id format.
+
+**Type consistency:** `SurfaceId`, `WarmSnapshot`, `WarmEditorStore`, `DraftStore`, `WarmEditorLease`, `LazyEditorSlots`, `CommitState`, `shouldPostInit`, `reduceInit`, `shouldCommitOnBlur`, `isNoOpEdit` are each defined once and used consistently. `generation` is a `number` throughout.

--- a/docs/superpowers/plans/2026-08-14-lazy-editor-warm-instance.md
+++ b/docs/superpowers/plans/2026-08-14-lazy-editor-warm-instance.md
@@ -23,6 +23,7 @@
 - **`editorHtml.ts` is generated** by the webview-bundler and is gitignored — never edit or commit it. After any change under `core/lib/editor/rich/webview/source/`, regenerate with `cd ~/code/tinycld/tinycld && pnpm run packages:generate` or the change is inert.
 - **Warm is an optimization, never a correctness dependency.** Every path must degrade to a fresh mount rather than to a broken editor.
 - Run checks from inside the member changed: `pnpm exec tinycld-pkg check` (biome + tsc + vitest).
+- **Component tests use `@testing-library/react`, never `@testing-library/react-native`** — the latter is not a dependency of this workspace. React Native components render under it with a `// @vitest-environment happy-dom` pragma as the first line of the file. `core/lib/editor/__tests__/editor-mount.test.tsx` is the reference example.
 
 ## File Structure
 
@@ -878,7 +879,8 @@ git commit -m "feat(editor): add the composer draft store"
 Create `core/lib/editor/warm/__tests__/warm-context.test.tsx`:
 
 ```tsx
-import { render } from '@testing-library/react-native'
+// @vitest-environment happy-dom
+import { render } from '@testing-library/react'
 import { Text } from 'react-native'
 import { describe, expect, it } from 'vitest'
 import { WarmEditorHost } from '../WarmEditorHost.web'

--- a/docs/superpowers/specs/2026-08-14-lazy-editor-warm-instance-design.md
+++ b/docs/superpowers/specs/2026-08-14-lazy-editor-warm-instance-design.md
@@ -196,14 +196,26 @@ platforms; the native path simply skips a cost web never paid.
 
 - `use-webview-editor.tsx`: replace the one-shot `initSentRef` latch with
   generation tracking, so a new payload is posted rather than suppressed.
-- **The host-side relays must be rebuilt on each acquire, not just the page's.**
-  `YjsWebViewHost` and `AwarenessWebViewHost` subscribe to a specific Y.Doc and
-  Awareness (`use-rich-editor.native.tsx:116-143`, memoized on doc identity). A
-  relay left over from the previous occupant would pump a dead document's
-  updates into the live editor. Acquire destroys and reconstructs both, mirroring
-  the page-side teardown; the existing `destroy()` cleanups are the hook.
-  `MarkdownWebViewHost` likewise re-seeds so a `getMarkdown` that times out
-  returns the newly-acquired content rather than the prior surface's.
+- **The host-side relays need no new teardown — verified, and recorded here so it
+  is not "fixed" later.** `YjsWebViewHost` and `AwarenessWebViewHost` are
+  memoized on **document identity** (`use-rich-editor.native.tsx:116-143`), and
+  in cards that document is the board's: `useBoardPresence.ts:141` returns
+  `room?.doc`, one Y.Doc holding a fragment per card. It is the same object
+  across every card on a board, so the relay is correctly shared and the only
+  thing varying per acquire is the `field` (`card:<id>`) — which rides in the
+  init payload and is consumed when the page rebuilds its own doc in
+  `useCollabDoc`.
+
+  The stale-relay hazard is real but belongs to a different case: a consumer
+  swapping to a **different** Y.Doc. The existing memo already covers it — a new
+  doc identity rebuilds both hosts and the `useEffect` cleanups destroy the old
+  ones.
+
+- **`MarkdownWebViewHost` must re-seed on acquire.** Its `lastKnown` fallback is
+  what `getMarkdown` returns when the round-trip times out
+  (`markdown-webview-host.ts:48`), and that value sits on the save path. Left
+  unseeded, a timeout during a handover would return the *previous surface's*
+  text and persist it over the current one.
 - New `lib/editor/warm/`:
   - `WarmEditorHost` — renders the parked WebView. Positioned absolutely
     off-viewport **at real size**, not `display:none` and not zero-height: a

--- a/tests/tentap-editor-stub.cjs
+++ b/tests/tentap-editor-stub.cjs
@@ -1,0 +1,44 @@
+// Vitest stub for @10play/tentap-editor.
+//
+// The package's `react-native` export condition points at src/index.tsx — raw
+// TypeScript source, which re-exports RichText and the bridge modules. Those
+// reach react-native internals carrying Flow syntax (`import typeof`), so Vite's
+// node environment fails to parse them and any test whose import chain touches
+// use-webview-editor.tsx dies at collect time with "Unexpected token 'typeof'".
+// Same failure mode as the react-native-svg and uniwind stubs beside this file.
+//
+// Only the surface use-webview-editor.tsx imports is needed: the hooks return
+// inert values, since the pure host logic (shouldPostInit, deriveToolbarState)
+// is what unit tests exercise — driving a real bridge needs a WebView.
+'use strict'
+
+function useEditorBridge() {
+    return {
+        webviewRef: { current: null },
+        getHTML: () => Promise.resolve(''),
+        getText: () => Promise.resolve(''),
+        setContent: () => {},
+        focus: () => {},
+        setEditable: () => {},
+    }
+}
+
+function useBridgeState() {
+    return {}
+}
+
+function RichText() {
+    return null
+}
+
+class BridgeExtension {}
+
+module.exports = {
+    useEditorBridge,
+    useBridgeState,
+    RichText,
+    BridgeExtension,
+    TenTapStartKit: [],
+    CoreBridge: {},
+    defaultEditorTheme: {},
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,22 @@ const CORE_DIR = path.join(APP_DIR, 'core')
 
 export default defineConfig({
     resolve: {
+        // Platform-split modules (`use-rich-editor.web.tsx` / `.native.tsx`, with
+        // a `.d.ts` carrying the shared contract) are resolved by Metro at build
+        // time from a bare `./use-rich-editor` specifier. Vite has no such rule,
+        // so a test importing one fails to resolve the bare path. Prefer the web
+        // variant, which is the platform unit tests run as.
+        extensions: [
+            '.web.tsx',
+            '.web.ts',
+            '.web.jsx',
+            '.web.js',
+            '.tsx',
+            '.ts',
+            '.jsx',
+            '.js',
+            '.json',
+        ],
         alias: [
             // @tinycld/core/* — Vite's exports resolution lacks Metro's
             // directory-index fallback, so remap straight to the core dir.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -107,6 +107,15 @@ export default defineConfig({
                 find: /^expo-image$/,
                 replacement: path.join(APP_DIR, '..', 'tests', 'expo-image-stub.tsx'),
             },
+            // @10play/tentap-editor's `react-native` export condition resolves
+            // to src/index.tsx, whose RichText and bridge modules reach
+            // react-native internals carrying Flow syntax. Same failure mode as
+            // the react-native-svg stub above; without it any test importing
+            // use-webview-editor.tsx dies at collect time.
+            {
+                find: /^@10play\/tentap-editor$/,
+                replacement: path.join(APP_DIR, 'tests', 'tentap-editor-stub.cjs'),
+            },
             // ~/* — package source. Resolved relative to the package's own dir
             // at invocation time via the test root, so we map it dynamically below.
         ],


### PR DESCRIPTION
Keeps one WebView editor booted per package so opening an editor stops costing a browser cold start.

Measured before this: creating a WebView editor was 1135 ms of the 1186 ms an edit took, all of it spent before the init payload is even sent — so it is configuration-independent, and a page booted in advance can be reconfigured for a new surface in the remaining ~34 ms.

## What's here

- **A re-sendable init.** `RichEditorInitPayload` carries a `generation`; the page keys its editor subtree on it, so a bump is a full stage-two reconstruction (new Tiptap, new Y.Doc, new undo stack) rather than a mutation. Nothing leaks between surfaces. `APP_PARK` drops a released page back to stage one.
- **`warm/`** — the acquire/release store, the composer draft store, `WarmEditorHost` (one WebView, parked off-viewport at real size), and `useWarmEditor`. Web is a pass-through: it builds Tiptap in-process and has no cold start.
- **`LazyEditor`** — the read/edit swap plus the commit rules (`commit-policy.ts`), which each protect a write and previously lived hand-rolled in each consumer. `useLazyEditor` returns header/body separately for surfaces whose toolbar must stay a direct child of a scroll view.

Warm is an optimization, never a correctness dependency — every path degrades to a fresh mount.

## Notes for review

- `MarkdownWebViewHost.seedGeneration` also settles requests the displaced surface left in flight. Re-seeding alone was not enough: a pending `get()` would time out against the *incoming* surface's seed and persist that text over its own.
- Two vitest resolution gaps had to be closed before any of this was testable — `@10play/tentap-editor` needs a stub (its `react-native` condition resolves to raw source reaching Flow-carrying RN internals), and `resolve.extensions` is needed for platform-split modules. No test had imported through those paths before.
- **`07b5e58 feat(driveshare): list an item's participants` does not belong to this work.** It was picked up when the repo was switched branches mid-session; the same change lives on `feat/driveshare-participants` as `6ed6ade`. It should be dropped before merge — I was not able to rebase it out.

## Status

Tasks 1–7 of `docs/superpowers/plans/2026-08-14-lazy-editor-warm-instance.md`. Comments/composer (Task 10) and device re-measurement (Task 11) are still outstanding.

Core 1203/1203 unit, typecheck and biome clean. The cards side is tinycld/cards#(companion) and needs this merged first.
