### PR TITLE
Let a caller pass isDialogOpen to LazyEditor instead of echoing it back

### DIFF
--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -46,6 +46,19 @@ export interface LazyEditorProps {
     onCommit: (content: string) => void
     /** Absent when there is nothing to revert (a collaborative description). */
     onCancel?: () => void
+    /**
+     * True while a dialog the editor opened holds the focus, so a blur is not
+     * the session ending — the editor must survive until the picked image or
+     * link lands in it.
+     *
+     * Two ways to say this, and a caller should pick one. `slots.setDialogOpen`
+     * suits a caller that learns about the dialog from inside the rendered
+     * chrome. This prop suits one that already knows: a card description owns
+     * both dialogs' open state itself, and pushing it back up through an effect
+     * only to receive it again is the useState+useEffect pairing the style
+     * guide names as the signal to switch primitives. When supplied, this wins.
+     */
+    isDialogOpen?: boolean
     /** The consumer's chrome around the editing surface. */
     renderEditor: (slots: LazyEditorSlots) => ReactNode
     /**
@@ -100,13 +113,17 @@ export function useLazyEditor({
     commitOnBlur = false,
     onCommit,
     onCancel,
+    isDialogOpen: dialogOpenProp,
     renderEditor,
     renderHeader,
     testID,
     accessibilityLabel = 'Edit',
 }: LazyEditorProps): LazyEditorRenderSlots {
     const [isEditing, setIsEditing] = useState(false)
-    const [isDialogOpen, setIsDialogOpen] = useState(false)
+    const [dialogOpenState, setIsDialogOpen] = useState(false)
+    // The prop wins when given, so a caller that already owns the dialog state
+    // does not have to echo it back through setDialogOpen.
+    const isDialogOpen = dialogOpenProp ?? dialogOpenState
     // The revert/no-op baseline, snapshotted when the session opens so a
     // realtime update mid-edit cannot become the comparison target.
     const baselineRef = useRef(value)

--- a/core/components/editor/__tests__/lazy-editor-dialog.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-dialog.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import { isValidElement } from 'react'
+import { Text, View } from 'react-native'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UseRichEditorOptions } from '../../../lib/editor/rich/options'
+
+/**
+ * A blur while a dialog the editor opened holds the focus must NOT end the
+ * session — the editor has to survive until the picked image or link lands in
+ * it.
+ *
+ * There are two ways for a caller to say a dialog is open. `slots.setDialogOpen`
+ * suits chrome that learns about it while rendering; the `isDialogOpen` prop
+ * suits a caller that already owns the state, which otherwise has to push it
+ * back up through a useEffect — the useState+useEffect pairing the style guide
+ * names as the signal to switch primitives.
+ */
+
+// Captures the options LazyEditor hands the editor, so the test can fire the
+// blur the same way the real editor would.
+let captured: UseRichEditorOptions | null = null
+
+vi.mock('../../../lib/editor/warm', () => ({
+    useWarmEditor: () => ({
+        isWarm: false,
+        acquire: vi.fn(),
+        release: vi.fn(),
+        result: null,
+        generation: 0,
+    }),
+}))
+
+vi.mock('../../../lib/editor/rich', () => ({
+    useRichEditor: (options: UseRichEditorOptions) => {
+        captured = options
+        return {
+            editor: {
+                getHTML: vi.fn(async () => '<p>x</p>'),
+                getText: vi.fn(async () => 'x'),
+                getMarkdown: vi.fn(async () => 'typed'),
+                setContent: vi.fn(),
+                focus: vi.fn(),
+                clear: vi.fn(),
+                getSelection: vi.fn(async () => null),
+            },
+            EditorComponent: () => null,
+            commands: {},
+            toolbarState: {},
+        }
+    },
+}))
+
+const { useLazyEditor } = await import('../LazyEditor')
+
+let startEditing: (() => void) | null = null
+let setDialogOpen: ((open: boolean) => void) | null = null
+let isEditing = false
+
+function Probe({ isDialogOpen }: { isDialogOpen?: boolean }) {
+    const slots = useLazyEditor({
+        readView: <Text>read view</Text>,
+        value: 'persisted',
+        contentFormat: 'markdown',
+        editorOptions: {},
+        surfaceId: 'description:card1',
+        canEdit: true,
+        isDialogOpen,
+        onCommit: () => {},
+        renderEditor: s => {
+            setDialogOpen = s.setDialogOpen
+            return <Text>editing surface</Text>
+        },
+        renderHeader: state => {
+            isEditing = state.isEditing
+            return null
+        },
+        testID: 'probe',
+    })
+    startEditing =
+        (isValidElement<{ onPress?: () => void }>(slots.body) ? slots.body.props.onPress : null) ??
+        null
+    return <View>{slots.body}</View>
+}
+
+/** Focus then blur, the way the real editor drives the handlers. */
+function focusThenBlur() {
+    act(() => captured?.onFocus?.())
+    act(() => captured?.onBlur?.())
+}
+
+beforeEach(() => {
+    captured = null
+    startEditing = null
+    setDialogOpen = null
+    isEditing = false
+    vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('LazyEditor dialog handling', () => {
+    it('ends the session on blur when no dialog is open', () => {
+        render(<Probe />)
+        act(() => startEditing?.())
+        expect(isEditing).toBe(true)
+
+        focusThenBlur()
+
+        expect(isEditing).toBe(false)
+    })
+
+    it('keeps the session alive on blur while the isDialogOpen prop is true', () => {
+        render(<Probe isDialogOpen />)
+        act(() => startEditing?.())
+
+        focusThenBlur()
+
+        expect(isEditing).toBe(true)
+    })
+
+    it('keeps the session alive on blur after slots.setDialogOpen(true)', () => {
+        render(<Probe />)
+        act(() => startEditing?.())
+        act(() => setDialogOpen?.(true))
+
+        focusThenBlur()
+
+        expect(isEditing).toBe(true)
+    })
+
+    // The prop is authoritative when supplied, so a caller that owns the state
+    // cannot be contradicted by a stale setDialogOpen call.
+    it('lets the prop win over setDialogOpen', () => {
+        render(<Probe isDialogOpen />)
+        act(() => startEditing?.())
+        act(() => setDialogOpen?.(false))
+
+        focusThenBlur()
+
+        expect(isEditing).toBe(true)
+    })
+})


### PR DESCRIPTION
A blur while a dialog the editor opened holds the focus must not end the session — the editor has to survive until the picked image or link lands in it.

`slots.setDialogOpen` says that, and suits chrome that learns about the dialog while rendering. It does not suit a caller that already owns the state: a card description owns both dialogs' open flags itself, so saying this meant pushing the value back up through a `useEffect` purely to receive it again — the `useState`+`useEffect` pairing CLAUDE.md names as the signal to switch primitives.

Adds an optional `isDialogOpen` prop that wins when supplied. Both routes stay supported; the setter is still right for a caller with no other way to know.

Unblocks cards#29, which drops its effect (and its last `useEffect`) in favour of the prop.