### PR TITLE
Core rules: send-email action and user-added trigger

### DIFF
--- a/core/help/rules.md
+++ b/core/help/rules.md
@@ -37,6 +37,22 @@ Select **Save** when you're done. If something's missing — no name, no
 trigger, no action — the builder lists exactly what to fix before it will
 save.
 
+## What every workspace can do
+
+Three things are always available, whichever packages are installed:
+
+- **A user joins** — a trigger for onboarding: welcome someone, add them to a
+  board, create a contact for them. Make it an organization rule; a new user
+  doesn't belong to anyone, so personal rules never match it.
+- **Send me a notification** — the in-app bell.
+- **Send an email** — sends to any address, with a subject and body you write.
+  Both accept `{{ }}` placeholders, so the mail can describe whatever started
+  the rule.
+
+A rule that sends email is capped at 20 messages an hour so an exchange with
+someone else's auto-responder can't run away. Hitting the cap is recorded in
+the rule's run history.
+
 ## Personal vs. organization rules
 
 Settings → Rules has two segments:

--- a/core/lib/automation/__tests__/core-defs.test.ts
+++ b/core/lib/automation/__tests__/core-defs.test.ts
@@ -12,8 +12,25 @@ describe('CORE_AUTOMATION', () => {
     it('declares the built-in triggers and actions from the spec', () => {
         const triggerIds = (CORE_AUTOMATION.triggers ?? []).map(t => t.id)
         const actionIds = (CORE_AUTOMATION.actions ?? []).map(a => a.id)
-        expect(triggerIds).toEqual(['schedule', 'manual'])
-        expect(actionIds).toEqual(['apply-label', 'notify'])
+        expect(triggerIds).toEqual(['schedule', 'manual', 'user-added'])
+        expect(actionIds).toEqual(['apply-label', 'notify', 'send-email'])
+    })
+
+    // users carries password and tokenKey. The engine's exposure rules filter
+    // both out everywhere regardless, but this trigger's allowlist must never
+    // name them in the first place — the filter is a backstop, not the
+    // statement of intent.
+    it('user-added exposes no credential columns', () => {
+        const userAdded = (CORE_AUTOMATION.triggers ?? []).find(t => t.id === 'user-added')
+        expect(userAdded).toMatchObject({ collection: 'users', on: 'create' })
+
+        const fieldKeys = (
+            (userAdded as { fields?: (string | { key: string })[] }).fields ?? []
+        ).map(f => (typeof f === 'string' ? f : f.key))
+        expect(fieldKeys).toEqual(['name', 'username', 'email', 'role'])
+        for (const secret of ['password', 'tokenKey', 'metadata']) {
+            expect(fieldKeys).not.toContain(secret)
+        }
     })
 
     it('apply-label writes a polymorphic label_assignments record from context', () => {

--- a/core/lib/automation/core-defs.ts
+++ b/core/lib/automation/core-defs.ts
@@ -9,6 +9,26 @@ export const CORE_AUTOMATION: AutomationDefinitions = {
     triggers: [
         { id: 'schedule', label: 'On a schedule', synthetic: 'schedule' },
         { id: 'manual', label: 'Run manually', synthetic: 'manual' },
+        {
+            // Onboarding recipes: welcome mail, add to a board, create a
+            // contact. Core-owned rather than a package's, because "a person
+            // joined" is not any one feature's event.
+            //
+            // The field list is curated deliberately. `users` carries
+            // password and tokenKey, which the engine's exposure rules filter
+            // out everywhere — but an allowlist that never names them is the
+            // honest way to say what a rule may read, rather than relying on
+            // that filter as the only guard.
+            //
+            // No ownerField: a new user is not "owned" by anyone, so personal
+            // rules never match this. Org rules are the sensible scope for
+            // onboarding, and they fire regardless of owner resolution.
+            id: 'user-added',
+            label: 'A user joins',
+            collection: 'users',
+            on: 'create',
+            fields: ['name', 'username', 'email', { key: 'role', label: 'Role' }],
+        },
     ],
     actions: [
         {
@@ -35,6 +55,24 @@ export const CORE_AUTOMATION: AutomationDefinitions = {
                 { key: 'title', type: 'text' },
                 { key: 'body', type: 'text' },
                 { key: 'url', type: 'text', label: 'Link (optional)' },
+            ],
+        },
+        {
+            // The universal "email me / the team when X". Native, but native
+            // IN CORE — which is the point: a multi-org tenant links no
+            // feature package's Go, so mail:send-message is unavailable
+            // there while this is not.
+            //
+            // Backed by the same core mailer every transactional email uses,
+            // so it inherits the deployment's configured provider rather
+            // than introducing a second outbound path.
+            id: 'send-email',
+            label: 'Send an email',
+            kind: 'native',
+            params: [
+                { key: 'to', type: 'text', label: 'To' },
+                { key: 'subject', type: 'text', label: 'Subject' },
+                { key: 'body', type: 'text', label: 'Body' },
             ],
         },
     ],

--- a/core/server/automation/actions_email.go
+++ b/core/server/automation/actions_email.go
@@ -1,0 +1,138 @@
+package automation
+
+import (
+	"context"
+	"fmt"
+	netmail "net/mail"
+	"strings"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/types"
+
+	"tinycld.org/core/mailer"
+)
+
+// maxEmailsPerRulePerHour caps how much mail one rule may emit.
+//
+// The engine's depth cap stops a rule re-triggering itself inside one
+// dispatch, but it cannot see across dispatches — an auto-reply answering
+// another system's auto-responder is two systems each doing one hop, forever.
+// A per-rule hourly ceiling bounds that without stopping legitimate bursts.
+//
+// Mail's send actions cap per MAILBOX because several rules share one outbox;
+// core has no mailbox to key on, so the rule is the unit.
+const maxEmailsPerRulePerHour = 20
+
+// sendEmailNow is the seam tests replace. Production sends through the same
+// core mailer every transactional email uses, so a rule inherits the
+// deployment's configured provider rather than opening a second outbound path.
+var sendEmailNow = func(ctx context.Context, msg *mailer.Message) error {
+	return mailer.DefaultSender().Send(ctx, msg)
+}
+
+// registerCoreEmailAction installs core:send-email.
+//
+// Native, but native IN CORE, which is the whole point: a multi-org tenant
+// links no feature package's Go, so mail:send-message is unavailable there
+// while this is not. It is the universal "email me when X".
+func registerCoreEmailAction() {
+	RegisterAction("core:send-email", actionSendEmail)
+}
+
+// actionSendEmail sends one email on behalf of a rule.
+//
+// Native handlers are not pkgaccess-gated — the engine hands them a superuser
+// app — so this validates its own inputs. The `to` param arrives after
+// template substitution, meaning its value is only as trustworthy as the
+// record that triggered the rule: {{sender_email}} is a documented recipe, so
+// whoever can create that record chooses this string.
+func actionSendEmail(app core.App, req ActionRequest) error {
+	recipient, err := emailRecipient(req.Params["to"])
+	if err != nil {
+		return fmt.Errorf("core:send-email: %w", err)
+	}
+
+	if err := checkEmailRateLimit(app, req); err != nil {
+		return fmt.Errorf("core:send-email: %w", err)
+	}
+
+	subject := strings.TrimSpace(req.Params["subject"])
+	if subject == "" {
+		subject = "(no subject)"
+	}
+
+	msg := &mailer.Message{
+		To:      []mailer.Recipient{{Email: recipient}},
+		Subject: subject,
+		Text:    req.Params["body"],
+	}
+
+	if err := sendEmailNow(context.Background(), msg); err != nil {
+		return fmt.Errorf("core:send-email: %w", err)
+	}
+	return nil
+}
+
+// emailRecipient validates the rule-supplied address.
+//
+// ParseAddress rejects the header-injection shapes a raw string could carry
+// (embedded newlines, a bare comma-separated list) and normalizes a
+// "Name <addr>" form down to the address. Exactly one recipient: a list here
+// would let one templated value fan out to arbitrarily many.
+func emailRecipient(to string) (string, error) {
+	raw := strings.TrimSpace(to)
+	if raw == "" {
+		return "", fmt.Errorf("no recipient")
+	}
+	parsed, err := netmail.ParseAddress(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid recipient %q: %w", raw, err)
+	}
+	return parsed.Address, nil
+}
+
+// checkEmailRateLimit reports whether the rule has room to send.
+//
+// Counts this rule's matched runs in the last hour from rule_runs — the same
+// durable log the run-history UI reads, so a restart doesn't reset the ceiling
+// the way an in-memory counter would.
+//
+// Fails OPEN on a query error: a broken count should not silently stop a
+// user's mail. That is the opposite of mail's per-mailbox limiter, which fails
+// closed — there, an unresolvable mailbox means an unverifiable self-send,
+// which is the loop being guarded. Here there is no self-send to verify, so
+// the risk of blocking legitimate mail outweighs one uncounted send.
+func checkEmailRateLimit(app core.App, req ActionRequest) error {
+	if req.Rule == nil {
+		return nil
+	}
+
+	// types.DateTime, not an RFC3339 string: PocketBase persists dates as
+	// "2006-01-02 15:04:05.000Z" and compares them as text, so an RFC3339
+	// literal sorts above every stored value and the filter would silently
+	// match nothing — the cap would never engage.
+	since := types.NowDateTime().Add(-time.Hour)
+
+	runs, err := app.FindRecordsByFilter(
+		"rule_runs",
+		"rule = {:rule} && matched = true && fired_at >= {:since}",
+		"",
+		maxEmailsPerRulePerHour+1,
+		0,
+		map[string]any{"rule": req.Rule.Id, "since": since},
+	)
+	if err != nil {
+		app.Logger().Warn("automation: email rate-limit check failed, allowing send",
+			"rule", req.Rule.Id, "error", err)
+		return nil
+	}
+
+	if len(runs) >= maxEmailsPerRulePerHour {
+		return fmt.Errorf(
+			"rule %s reached its hourly email limit (%d) — skipping to break a possible loop",
+			req.Rule.Id, maxEmailsPerRulePerHour,
+		)
+	}
+	return nil
+}

--- a/core/server/automation/actions_email_test.go
+++ b/core/server/automation/actions_email_test.go
@@ -1,0 +1,208 @@
+package automation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/types"
+
+	"tinycld.org/core/mailer"
+)
+
+// actions_email_test.go covers core:send-email. The send itself goes through
+// the sendEmailNow seam so these never touch a real provider.
+
+// captureEmails swaps the send seam for the duration of a test and returns the
+// slice the handler writes into.
+func captureEmails(t *testing.T) *[]*mailer.Message {
+	t.Helper()
+	sent := &[]*mailer.Message{}
+	original := sendEmailNow
+	sendEmailNow = func(_ context.Context, msg *mailer.Message) error {
+		*sent = append(*sent, msg)
+		return nil
+	}
+	t.Cleanup(func() { sendEmailNow = original })
+	return sent
+}
+
+func TestActionSendEmail_SendsThroughTheCoreMailer(t *testing.T) {
+	app, rule := runsApp(t)
+	sent := captureEmails(t)
+
+	err := actionSendEmail(app, ActionRequest{
+		Rule: rule,
+		Params: map[string]string{
+			"to":      "someone@example.com",
+			"subject": "Invoice received",
+			"body":    "An invoice arrived.",
+		},
+	})
+	if err != nil {
+		t.Fatalf("actionSendEmail: %v", err)
+	}
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent %d emails, want 1", len(*sent))
+	}
+	msg := (*sent)[0]
+	if len(msg.To) != 1 || msg.To[0].Email != "someone@example.com" {
+		t.Errorf("To = %v, want someone@example.com", msg.To)
+	}
+	if msg.Subject != "Invoice received" {
+		t.Errorf("Subject = %q", msg.Subject)
+	}
+	if msg.Text != "An invoice arrived." {
+		t.Errorf("Text = %q", msg.Text)
+	}
+}
+
+// The `to` param arrives after template substitution, so its value is only as
+// trustworthy as the record that triggered the rule — {{sender_email}} is a
+// documented recipe, which means whoever can create that record chooses this
+// string.
+func TestActionSendEmail_RejectsUnusableRecipients(t *testing.T) {
+	app, rule := runsApp(t)
+	sent := captureEmails(t)
+
+	bad := []struct {
+		name string
+		to   string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"not an address", "not-an-address"},
+		// Header injection: a newline in a recipient would split the header.
+		{"embedded newline", "a@example.com\nBcc: victim@example.com"},
+		// One templated value must not fan out to many recipients.
+		{"address list", "a@example.com, b@example.com"},
+	}
+
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			err := actionSendEmail(app, ActionRequest{
+				Rule:   rule,
+				Params: map[string]string{"to": tc.to, "subject": "s", "body": "b"},
+			})
+			if err == nil {
+				t.Errorf("recipient %q was accepted, want rejection", tc.to)
+			}
+		})
+	}
+
+	if len(*sent) != 0 {
+		t.Fatalf("sent %d emails despite every recipient being invalid", len(*sent))
+	}
+}
+
+// "Name <addr>" is a legitimate form a template could produce; the address is
+// what reaches the mailer.
+func TestActionSendEmail_NormalizesADisplayNameAddress(t *testing.T) {
+	app, rule := runsApp(t)
+	sent := captureEmails(t)
+
+	err := actionSendEmail(app, ActionRequest{
+		Rule:   rule,
+		Params: map[string]string{"to": "Ada Lovelace <ada@example.com>", "subject": "s", "body": "b"},
+	})
+	if err != nil {
+		t.Fatalf("actionSendEmail: %v", err)
+	}
+	if len(*sent) != 1 || (*sent)[0].To[0].Email != "ada@example.com" {
+		t.Fatalf("To = %v, want the bare address", (*sent)[0].To)
+	}
+}
+
+func TestActionSendEmail_EmptySubjectGetsAPlaceholder(t *testing.T) {
+	app, rule := runsApp(t)
+	sent := captureEmails(t)
+
+	if err := actionSendEmail(app, ActionRequest{
+		Rule:   rule,
+		Params: map[string]string{"to": "a@example.com", "body": "b"},
+	}); err != nil {
+		t.Fatalf("actionSendEmail: %v", err)
+	}
+	if (*sent)[0].Subject != "(no subject)" {
+		t.Errorf("Subject = %q, want the placeholder", (*sent)[0].Subject)
+	}
+}
+
+// The engine's depth cap stops a rule re-triggering itself within one
+// dispatch; it cannot see an exchange with another system's auto-responder.
+func TestCheckEmailRateLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		recentRuns int
+		age        time.Duration
+		wantErr    bool
+	}{
+		{name: "no history sends", recentRuns: 0, age: time.Minute},
+		{name: "under the cap sends", recentRuns: maxEmailsPerRulePerHour - 1, age: time.Minute},
+		{name: "at the cap is blocked", recentRuns: maxEmailsPerRulePerHour, age: time.Minute, wantErr: true},
+		{
+			// A rolling hour, not a lifetime total: yesterday's burst must not
+			// stop today's mail.
+			name: "old runs fall outside the window", recentRuns: maxEmailsPerRulePerHour + 5,
+			age: 2 * time.Hour,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app, rule := runsApp(t)
+			col, err := app.FindCollectionByNameOrId("rule_runs")
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < tc.recentRuns; i++ {
+				r := core.NewRecord(col)
+				r.Set("rule", rule.Id)
+				r.Set("matched", true)
+				r.Set("fired_at", types.NowDateTime().Add(-tc.age))
+				if err := app.Save(r); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			err = checkEmailRateLimit(app, ActionRequest{Rule: rule})
+			if tc.wantErr && err == nil {
+				t.Error("expected the send to be blocked, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected the send to be allowed, got %v", err)
+			}
+		})
+	}
+}
+
+// A manual or scheduled rule with no rule record still sends: there is
+// nothing to count against, and refusing would break "run now".
+func TestCheckEmailRateLimit_NoRuleIsAllowed(t *testing.T) {
+	app, _ := runsApp(t)
+	if err := checkEmailRateLimit(app, ActionRequest{}); err != nil {
+		t.Errorf("a request with no rule must be allowed: %v", err)
+	}
+}
+
+// A failing send must surface as an action error so the run is recorded as
+// failed and auto-disable can see a rule that never delivers.
+func TestActionSendEmail_SurfacesSendFailures(t *testing.T) {
+	app, rule := runsApp(t)
+	original := sendEmailNow
+	sendEmailNow = func(_ context.Context, _ *mailer.Message) error {
+		return fmt.Errorf("provider refused")
+	}
+	t.Cleanup(func() { sendEmailNow = original })
+
+	err := actionSendEmail(app, ActionRequest{
+		Rule:   rule,
+		Params: map[string]string{"to": "a@example.com", "subject": "s", "body": "b"},
+	})
+	if err == nil {
+		t.Fatal("a provider failure must surface as an action error")
+	}
+}

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -44,6 +44,8 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 // action refs. Factored out of Register so a test can install them without
 // the full app-bootstrap path (LoadDefs + OnServe binding).
 func registerCoreNativeActions() {
+	registerCoreEmailAction()
+
 	// core:notify is fire-and-forget: the handler returns nil immediately and
 	// the actual push happens on a detached goroutine. The engine records this
 	// action's ActionResult as "ok" the instant the handler returns, before

--- a/scripts/__tests__/gen-automation.test.ts
+++ b/scripts/__tests__/gen-automation.test.ts
@@ -92,7 +92,13 @@ describe('mergeAutomationDefs', () => {
             },
         ])
         expect(merged.packages[0].slug).toBe('core')
-        expect(merged.packages[0].triggers.map(t => t.id)).toEqual(['schedule', 'manual'])
+        // The assertion is the ORDER — core first — not core's catalog, which
+        // grows. Pin the two synthetic triggers that make core special (a
+        // feature package may not declare them; see the test below) rather
+        // than the whole list.
+        expect(merged.packages[0].triggers.map(t => t.id)).toEqual(
+            expect.arrayContaining(['schedule', 'manual'])
+        )
         expect(merged.packages[1].slug).toBe('mail')
     })
 


### PR DESCRIPTION
Step 8's safe two. **`core:webhook` is deliberately not here** — it's new outbound-HTTP capability needing SSRF guards, and the rollout plan itself suggests deferring it. It belongs in its own reviewed change.

### `core:send-email`

Native, but native **in core** — which is the point. A multi-org tenant links no feature package's Go, so `mail:send-message` is unavailable there while this is not. It's the universal "email me when X".

Sends through the same core mailer every transactional email uses (`mailer.DefaultSender()`), so a rule inherits the deployment's configured provider rather than opening a second outbound path.

**Recipient validation is load-bearing.** The `to` param arrives after template substitution, so its value is only as trustworthy as the record that triggered the rule — `{{sender_email}}` is a documented recipe, which means whoever can create that record chooses the string. `ParseAddress` rejects embedded newlines (header injection) and comma-separated lists (one templated value fanning out to many recipients). Both are tested.

**Hourly cap** mirrors mail's, keyed on the *rule* rather than a mailbox since core has no outbox to key on. It fails **open** on a count error — deliberately the opposite of mail's limiter, which fails closed because there an unresolvable mailbox means an unverifiable self-send. Here there's no self-send to verify, so blocking legitimate mail is the worse outcome.

### `core:user-added`

`users` on create, enabling onboarding recipes — welcome mail, add to a board, create a contact.

Exposes `name` / `username` / `email` / `role` only. The engine filters `password` and `tokenKey` everywhere regardless, but an allowlist that never names them states the intent rather than relying on that filter as the only guard. No `ownerField`: a new user isn't owned by anyone, so this is org-scoped by nature.

### Verification

15 new tests (send path, recipient rejection incl. header injection, display-name normalization, rate limit, failure surfacing) · full `core/automation` Go suite green · `packages:generate` validates.

**Note:** `tinycld-pkg check` currently reports two typecheck errors in `cards`, not in this change — cards is on `feat/app-singleton-editor` and expects editor APIs (`useEditorNeeded`, `startOpen`) that aren't on core `main` yet. Unrelated to this PR.