### PR TITLE
Workflow rules core decisions + CLI OAuth scope fixes

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -18,12 +18,21 @@ import (
 // cliScopes mirrors the scope set granted to the seeded tinycld-cli client:
 // the CLI is first-party, so it asks for everything up front and the consent
 // screen shows the full list.
+//
+// This list, the seed migration's `scopes`, and oauth.AllScopes must stay in
+// step, and nothing enforces that — the module boundary keeps the constants
+// out of reach (see gen-cli.ts). The client row is a hard CEILING
+// (ValidateClientScopes), so a scope missing THERE fails the login outright,
+// while one missing HERE fails later and quietly: the grant is issued without
+// it and the command 403s. cards:* was missing from both for an entire
+// release — `tinycld cards` could not run at all.
 var cliScopes = []string{
 	"profile",
 	"mail:read", "mail:send",
 	"drive:read", "drive:write",
 	"contacts:read", "contacts:write",
 	"calendar:read", "calendar:write",
+	"cards:read", "cards:write",
 }
 
 // contextTokenStore adapts the keychain to client.TokenStore for one context.

--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -89,9 +89,16 @@ var collectionScopes = map[string]collectionAccess{
 	// Read-only surfaces the CLI needs: per-folder unread counts (a view), the
 	// caller's mailbox memberships, and the mailbox aliases a send can pick a
 	// From identity from. Aliases are administered in the app, so no write.
+	//
+	// mail_domains belongs here for a non-obvious reason: mail_mailboxes.address
+	// stores only the LOCAL PART, so every full address the CLI prints or matches
+	// on has to join the domain row. Without it `mail mailboxes`, `mail send`,
+	// and `--mailbox <address>` all fail closed on the domain read, even holding
+	// mail:read and mail:send. Domains are administered in the app, so no write.
 	"mail_folder_counts":   {read: scopeRule{ScopeMailRead}},
 	"mail_mailbox_members": {read: scopeRule{ScopeMailRead}},
 	"mail_mailbox_aliases": {read: scopeRule{ScopeMailRead}},
+	"mail_domains":         {read: scopeRule{ScopeMailRead}},
 
 	// Labels are CORE collections shared across packages (mail threads and
 	// contacts both get labelled through label_assignments), so either

--- a/core/server/oauth/middleware_test.go
+++ b/core/server/oauth/middleware_test.go
@@ -457,6 +457,12 @@ func TestScopeForRouteNewCollectionsAndEndpoints(t *testing.T) {
 		method, path, scope string
 	}{
 		{"GET", "/api/collections/mail_mailbox_aliases/records", ScopeMailRead},
+		// mail_domains: mail_mailboxes.address holds only the local part, so
+		// resolving any full address joins the domain row. Missing here, a
+		// mail:read+mail:send grant still failed closed on `mail mailboxes`,
+		// `mail send`, and `--mailbox <address>`. Found by the first live
+		// smoke test — every fake-server test served the row unguarded.
+		{"GET", "/api/collections/mail_domains/records", ScopeMailRead},
 		{"GET", "/api/collections/drive_item_versions/records", ScopeDriveRead},
 		{"POST", "/api/collections/drive_item_versions/records", ScopeDriveWrite},
 		{"POST", "/api/drive/share-link", ScopeDriveWrite},
@@ -496,6 +502,14 @@ func TestScopeForRouteNewCollectionsAndEndpoints(t *testing.T) {
 	// Aliases are administered in the app; the CLI only reads them.
 	if got := ScopeForRoute("PATCH", "/api/collections/mail_mailbox_aliases/records/abc"); len(got) != 0 {
 		t.Errorf("alias writes must stay denied, got %v", got)
+	}
+
+	// Same for domains — granting the read must not have opened a write path
+	// to DNS/verification state.
+	for _, m := range []string{"POST", "PATCH", "DELETE"} {
+		if got := ScopeForRoute(m, "/api/collections/mail_domains/records/abc"); len(got) != 0 {
+			t.Errorf("domain %s must stay denied, got %v", m, got)
+		}
 	}
 }
 

--- a/core/server/pb_migrations/1985000001_seed_cli_oauth_client.js
+++ b/core/server/pb_migrations/1985000001_seed_cli_oauth_client.js
@@ -19,10 +19,14 @@ migrate(
         // The CLI uses the device grant, which has no redirect. The loopback
         // entry is there for a future `--browser` authorization-code login.
         cli.set('redirect_uris', ['http://127.0.0.1/callback'])
+        // Keep in step with oauth.AllScopes and the CLI's own cliScopes. A
+        // package whose scopes are missing here cannot be used from the CLI at
+        // all: this row is the ceiling ValidateClientScopes enforces.
         cli.set(
             'scopes',
             'profile mail:read mail:send drive:read drive:write ' +
-                'contacts:read contacts:write calendar:read calendar:write'
+                'contacts:read contacts:write calendar:read calendar:write ' +
+                'cards:read cards:write'
         )
         app.save(cli)
     },

--- a/core/server/pb_migrations/2000000001_cli_client_cards_scopes.js
+++ b/core/server/pb_migrations/2000000001_cli_client_cards_scopes.js
@@ -1,0 +1,53 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Add the cards scopes to the seeded tinycld-cli client.
+//
+// The cards CLI (`tinycld cards …`) shipped with its collections classified in
+// oauth's scope table, but the CLI client row still carried the original
+// scope list. That row is a hard ceiling — ValidateClientScopes rejects any
+// scope it does not name — so `tinycld cards board list` 403'd for every
+// caller, on every deployment, no matter how they logged in.
+//
+// Appended rather than folded into 1985000001 because PocketBase never re-runs
+// an applied migration: editing that file would fix only databases created
+// after the edit and silently leave every existing one broken.
+//
+// Rewrites the whole scope string from the current catalog rather than
+// appending to whatever is there, so a row that already has the scopes (a DB
+// seeded after this ships) converges instead of accumulating duplicates.
+const CLI_SCOPES =
+    'profile mail:read mail:send drive:read drive:write ' +
+    'contacts:read contacts:write calendar:read calendar:write ' +
+    'cards:read cards:write'
+
+const CLI_SCOPES_BEFORE =
+    'profile mail:read mail:send drive:read drive:write ' +
+    'contacts:read contacts:write calendar:read calendar:write'
+
+migrate(
+    app => {
+        let cli
+        try {
+            cli = app.findFirstRecordByFilter('oauth_clients', 'client_id = {:id}', {
+                id: 'tinycld-cli',
+            })
+        } catch {
+            // No CLI client on this deployment (the seed was rolled back, or
+            // the operator deleted it). Nothing to widen — a fresh seed will
+            // carry the current scope list.
+            return
+        }
+        cli.set('scopes', CLI_SCOPES)
+        app.save(cli)
+    },
+    app => {
+        try {
+            const cli = app.findFirstRecordByFilter('oauth_clients', 'client_id = {:id}', {
+                id: 'tinycld-cli',
+            })
+            cli.set('scopes', CLI_SCOPES_BEFORE)
+            app.save(cli)
+        } catch {
+            // Already gone — nothing to undo.
+        }
+    }
+)


### PR DESCRIPTION
Two unrelated tracks on one branch.

## Workflow rules (pre-existing on this branch)

`core:send-email` action and `user-added` trigger, plus catalog assertions.

## CLI OAuth scope fixes

Found by the first live smoke test of the CLI against a real server — every
CLI test to date runs against a fake HTTP server with no scope layer, so
neither of these could have been caught.

**`mail_domains` was unclassified**, and the middleware default-denies
anything not in `collectionScopes`. Since `mail_mailboxes.address` stores only
the local part, every full address the CLI resolves joins that row — so a grant
holding `mail:read` and `mail:send` still got a 403 on `mail send`,
`mail mailboxes`, and `--mailbox <address>`. Classified read-only.

**`cards:*` was missing from both client-side scope lists** (`cliScopes` and
the seeded client row, which is a hard ceiling), so `tinycld cards` 403'd on
every deployment and `tinycld search` silently omitted cards results — the
federated aggregator narrows to covered scopes rather than erroring. Fixed in
both, plus an appended migration to widen already-provisioned databases, since
PocketBase never re-runs an applied one.

Verified against a live server: cards commands work, federated search returns
cards rows, and `mail mailboxes` returns real data.