### PR TITLE
test(e2e): seed a collaborator fixture and harden the login retry

### DIFF
--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -94,6 +94,35 @@ const TEST_DEFAULTS = {
     userName: 'Test User',
 }
 
+// A SECOND ordinary member, seeded ready-to-use so a spec that needs "another
+// person on the board" can just sign them in.
+//
+// Before this existed the only way to get a second account was
+// createInvitedUser(), which drives the whole invite arc through the UI: owner
+// → Settings → Members → Invite → extract token → NEW browser context →
+// /accept-invite → set password → wait for the shell. Measured, that is ~4.4s
+// on a fast dev machine, and it strands the owner's page on Settings so every
+// caller then pays another ~1.4s login() to get back. ~5.8s of setup before a
+// single assertion — which is why seven cards specs carried test.slow(), and
+// why all of them timed out on CI once the slower, contended runner multiplied
+// that baseline. The marker was the symptom; this fixture is the cause.
+//
+// Seeding it is not a rules bypass: provisioning fixtures is exactly the seed
+// layer's job (the fixture owner and each package's demo data arrive the same
+// way). The invite FLOW keeps its own dedicated coverage in
+// tests/e2e/invite-flow.spec.ts, and specs that genuinely need to mint a
+// throwaway account (change-password, password-reset, admin-role-access) still
+// call createInvitedUser.
+//
+// role is 'member', deliberately NOT 'owner': a second owner would silently
+// weaken every last-owner and role-gate assertion that relies on the fixture
+// owner being the only one.
+const COLLABORATOR_DEFAULTS = {
+    email: process.env.TEST_COLLABORATOR_LOGIN || 'collaborator@tinycld.org',
+    username: process.env.TEST_COLLABORATOR_USERNAME || 'collaborator',
+    name: 'Collaborator Tester',
+}
+
 // These mirror the singleton constants in
 // core/server/coreserver/demo_start.go. Keep in sync.
 // REVIEW_DEMO_EMAIL overrides userEmail at runtime; if you set it to
@@ -403,6 +432,73 @@ async function ensureAdminAppUser(pb: PocketBase, config: SeedConfig): Promise<v
     }
 }
 
+/**
+ * The collaborator's password, resolved the same way the fixture user's is.
+ *
+ * TEST_COLLABORATOR_PW wins so CI can set it; otherwise the collaborator shares
+ * the fixture user's password. Falling back to the SAME literal the e2e helper
+ * hardcodes is what makes a clean checkout work at all — playwright.config.ts
+ * never loads .env, so seed and helper can only meet at a shared constant.
+ */
+function collaboratorPassword(config: SeedConfig): string {
+    return (
+        process.env.TEST_COLLABORATOR_PW ||
+        (config.userPasswordExplicit ? config.userPassword : TEST_USER_DEFAULT_PASSWORD)
+    )
+}
+
+/**
+ * Find-or-create the seeded collaborator (see COLLABORATOR_DEFAULTS).
+ *
+ * Runs BEFORE seedForUser so package seeds that look for a "teammate" (cards'
+ * seed resolves its `teammate` rows from the other users in the deployment)
+ * find a real one, rather than collapsing those rows onto the seeded owner.
+ *
+ * Idempotent in the same shape as ensureAdminAppUser: an existing row keeps its
+ * id but has its password reset to the known fixture value, because a
+ * re-seeded DB must be signable-into with the credential the e2e helper
+ * hardcodes — a row left with an unknown password would fail every
+ * signInAsCollaborator() with no clue why.
+ */
+async function ensureCollaboratorUser(pb: PocketBase, password: string): Promise<void> {
+    let existing: { id: string } | null = null
+    try {
+        existing = await pb
+            .collection('users')
+            .getFirstListItem(`username = "${COLLABORATOR_DEFAULTS.username}"`)
+    } catch (err) {
+        if (!isNotFoundError(err)) throw err
+    }
+
+    if (existing) {
+        log('Found existing collaborator user:', COLLABORATOR_DEFAULTS.username)
+        await pb.collection('users').update(existing.id, {
+            email: COLLABORATOR_DEFAULTS.email,
+            name: COLLABORATOR_DEFAULTS.name,
+            password,
+            passwordConfirm: password,
+            role: 'member',
+        })
+        return
+    }
+
+    log('Creating collaborator user:', COLLABORATOR_DEFAULTS.username)
+    await pb.collection('users').create({
+        username: COLLABORATOR_DEFAULTS.username,
+        email: COLLABORATOR_DEFAULTS.email,
+        password,
+        passwordConfirm: password,
+        name: COLLABORATOR_DEFAULTS.name,
+        // The share dialog searches people by email; a collaborator whose email
+        // is hidden cannot be found and added through the real UI.
+        emailVisibility: true,
+        verified: true,
+        // `role` is required (1940000000_backfill_and_require_users_role) and
+        // must be set on the create itself.
+        role: 'member',
+    })
+}
+
 export async function authSuperuser(config: {
     url: string
     adminEmail: string
@@ -473,6 +569,13 @@ async function main() {
     const pb = await authSuperuser(config)
     await seedAppName(pb)
     await ensureAdminAppUser(pb, config)
+    // Before seedForUser: package seeds resolve their "teammate" rows from the
+    // other users present, so the collaborator has to exist by then.
+    // Demo mode is a single-visitor tour — a second signed-in member there
+    // would show up in rosters and pickers as a stranger.
+    if (!config.isDemo) {
+        await ensureCollaboratorUser(pb, collaboratorPassword(config))
+    }
     const login = await seedForUser(pb, config)
     log('Seeding complete!')
     printLoginSummary(config, login)

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -132,7 +132,18 @@ export async function login(page: Page) {
     // unusable in any mobile-viewport spec — it waited out the full timeout for
     // an element that layout never renders. Accept either.
     const shellReady = appShell(page)
-    const authError = page.getByText('Failed to authenticate', { exact: false })
+    // Match EITHER message the sign-in form can render for a failed attempt.
+    // 'Failed to authenticate' is the clean credential rejection; 'Something
+    // went wrong' is the generic fallback in core/lib/errors.ts, which is what
+    // a TRANSIENT failure under parallel load actually produces. Watching only
+    // the first meant the common case never retried: the race below resolved
+    // 'timeout' after 15s, fell through to a final 15s wait, and blew the 30s
+    // test budget in beforeEach — taking every worker that hit the same moment
+    // with it (three at once, in the run that surfaced this).
+    const authError = page
+        .getByText('Failed to authenticate', { exact: false })
+        .or(page.getByText('Something went wrong', { exact: false }))
+        .first()
     const maxAttempts = 3
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         await page.getByText('Sign in', { exact: true }).last().click()
@@ -148,7 +159,14 @@ export async function login(page: Page) {
                 .catch(() => 'timeout' as const),
         ])
         if (outcome === 'ok') return
-        if (outcome === 'error' && attempt < maxAttempts) continue
+        if (outcome === 'error' && attempt < maxAttempts) {
+            // Wait out the visible error before re-clicking. It stays on screen
+            // after a failed attempt, so an immediate retry would race the
+            // banner it just saw and resolve 'error' again instantly, burning
+            // every attempt in a few milliseconds without a real retry.
+            await authError.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {})
+            continue
+        }
         // Timed out with no shell and no error banner, or exhausted retries: one
         // last direct wait so the failure surfaces with a clear message + screenshot.
         await shellReady.waitFor({ state: 'visible', timeout: 15_000 })
@@ -160,6 +178,60 @@ export interface InvitedUser {
     username: string
     email: string
     password: string
+}
+
+// The second member the seed provisions ready-to-use (scripts/seed-db.ts,
+// COLLABORATOR_DEFAULTS). These MUST match that file: playwright.config.ts
+// never loads .env, so on a clean checkout the seed and this helper can only
+// agree via a shared literal. The env vars are the CI override for both sides.
+export const TEST_COLLABORATOR_EMAIL =
+    process.env.TEST_COLLABORATOR_LOGIN || 'collaborator@tinycld.org'
+export const TEST_COLLABORATOR_USERNAME = process.env.TEST_COLLABORATOR_USERNAME || 'collaborator'
+// The DISPLAY name, which is what collaborative UI (presence avatars, caret
+// labels) actually renders — so specs assert against this rather than a literal.
+export const TEST_COLLABORATOR_NAME = 'Collaborator Tester'
+export const TEST_COLLABORATOR_PASSWORD =
+    process.env.TEST_COLLABORATOR_PW || process.env.TEST_USER_PW || TEST_USER_PASSWORD
+
+/**
+ * A SECOND signed-in person, in their own browser context.
+ *
+ * Use this whenever a spec needs "somebody else" — a viewer to gate, a
+ * collaborator to see a live edit, a non-member to refuse. It signs in the
+ * pre-seeded collaborator account, which costs ONE login (~1.4s) against
+ * createInvitedUser's ~5.8s: that helper drives the entire invite arc through
+ * the UI (two full app boots) and leaves the owner's page stranded on Settings,
+ * forcing every caller into a second login() just to get back to their board.
+ * That setup cost — not the assertions — is what made seven cards specs carry
+ * test.slow() and then time out on CI.
+ *
+ * Reach for createInvitedUser instead ONLY when the invite flow itself is under
+ * test, or when the spec MUTATES the account's credentials (change-password,
+ * password-reset): this account is shared across the run, so changing its
+ * password would break every later spec that signs in with it.
+ *
+ * The caller's own `page` is untouched — no re-login needed afterwards.
+ *
+ *     const { page: bobPage, user: bob, close } = await signInAsCollaborator(page)
+ *     try { ... } finally { await close() }
+ */
+export async function signInAsCollaborator(page: Page): Promise<{
+    page: Page
+    user: InvitedUser
+    close: () => Promise<void>
+}> {
+    const context = await page.context().browser()!.newContext()
+    const collaboratorPage = await context.newPage()
+    await loginAs(collaboratorPage, TEST_COLLABORATOR_EMAIL, TEST_COLLABORATOR_PASSWORD)
+    return {
+        page: collaboratorPage,
+        user: {
+            username: TEST_COLLABORATOR_USERNAME,
+            email: TEST_COLLABORATOR_EMAIL,
+            password: TEST_COLLABORATOR_PASSWORD,
+        },
+        close: () => context.close(),
+    }
 }
 
 // Provision a fresh org member via the invite flow, in an isolated browser


### PR DESCRIPTION
Unblocks cards#31, whose specs already call `signInAsCollaborator` — the
member side of that migration is merged, but the core side that provides it
was never landed, so cards' E2E has nine specs timing out against a core
that has neither the helper nor the seeded account.

Specs needing a second person on a board drove the whole invite arc through
the UI (~4.4s), and stranded the owner's page on Settings so every caller
paid another ~1.4s `login()` to get back. ~5.8s of setup before a single
assertion — which is why seven cards specs carried `test.slow()`, and why
they timed out once a contended runner multiplied that baseline.

Seeds a second ordinary member and exposes `signInAsCollaborator()`. Role is
`member`, not `owner`, so last-owner and role-gate assertions still mean
something. Runs before `seedForUser` so package seeds resolving a "teammate"
find a real one. Skipped in demo mode. The invite flow keeps its own coverage
in `invite-flow.spec.ts`.

Also matches the generic "Something went wrong" alongside "Failed to
authenticate" in `login()`'s retry — watching only the latter meant the
common transient failure never actually retried, blowing the 30s `beforeEach`
budget and taking every worker that hit the same moment with it.