### PR TITLE
Replace acquireToken with an imperative handle

### DIFF
--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -1,4 +1,14 @@
-import { type ComponentType, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import {
+    type ComponentType,
+    forwardRef,
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState,
+} from 'react'
 import { Pressable } from 'react-native'
 import type { UseRichEditorOptions } from '../../lib/editor/rich/options'
 import type { EditorCommands, EditorHandle, EditorToolbarState } from '../../lib/editor/types'
@@ -24,11 +34,47 @@ export interface LazyEditorHeaderState {
     slots: LazyEditorSlots | null
 }
 
+/**
+ * Drive the surface from OUTSIDE its own chrome.
+ *
+ * For a caller that decides elsewhere that this surface should be editing: a
+ * comment composer whose Reply button lives in the activity list, a keyboard
+ * shortcut registered by the screen. `slots` already carries submit/cancel, but
+ * only while editing — and the whole point here is to reach a surface that is
+ * not.
+ *
+ * Stable across renders, so it is safe to hold in a ref or a dependency array.
+ */
+export interface LazyEditorHandle {
+    /**
+     * Start editing: take the shared instance, and put the caret in it.
+     *
+     * The imperative form of pressing the read view. Idempotent — calling it on
+     * a session that is already open reclaims the editor without resetting the
+     * revert baseline, so a repeated press cannot turn half-typed text into the
+     * thing Escape reverts to.
+     */
+    edit: () => void
+    /** Commit through the ordinary path, guards and all. */
+    submit: () => void
+    /** Discard and end the session, as Escape does. */
+    cancel: () => void
+    /**
+     * Whether this surface is editing AND holds a usable editor.
+     *
+     * A method rather than a field because the handle outlives the render that
+     * produced it; a boolean would be a snapshot that silently went stale.
+     */
+    isEditing: () => boolean
+}
+
 export interface LazyEditorRenderSlots {
     /** The row above the surface, or null when no `renderHeader` was given. */
     header: ReactNode
     /** The read view, or the editing surface once a session opens. */
     body: ReactNode
+    /** Drive the surface from outside its chrome. See {@link LazyEditorHandle}. */
+    handle: LazyEditorHandle
 }
 
 export interface LazyEditorProps {
@@ -99,16 +145,6 @@ export interface LazyEditorProps {
      */
     startOpen?: boolean
     /**
-     * Change this to say "the caret belongs in this surface now".
-     *
-     * Only meaningful with `startOpen`. Such a session stays open when another
-     * surface steals the editor, so the caller needs a way to claim it back on
-     * an explicit user action — a comment composer keys this on its reply
-     * target, so pressing Reply on a comment brings the editor back to the
-     * composer that the reply will be written in.
-     */
-    acquireToken?: string | number
-    /**
      * Keep the session open after a commit, clearing the editor instead.
      *
      * A composer sends and stays — the next comment goes in the same box, and
@@ -161,9 +197,14 @@ export interface LazyEditorProps {
  * back through — so mail's HTML surfaces use this exactly as cards' markdown
  * ones do.
  */
-export function LazyEditor(props: LazyEditorProps) {
-    return <>{useLazyEditor(props).body}</>
-}
+export const LazyEditor = forwardRef<LazyEditorHandle, LazyEditorProps>(
+    function LazyEditor(props, ref) {
+        const { body, handle } = useLazyEditor(props)
+        // The SAME object the hook returns, so the two forms cannot drift.
+        useImperativeHandle(ref, () => handle, [handle])
+        return <>{body}</>
+    }
+)
 
 /**
  * The slot-returning form of {@link LazyEditor}.
@@ -185,7 +226,6 @@ export function useLazyEditor({
     onRelease,
     isDialogOpen: dialogOpenProp,
     startOpen = false,
-    acquireToken,
     stayOpenOnCommit = false,
     renderEditor,
     renderHeader,
@@ -248,13 +288,27 @@ export function useLazyEditor({
     const activeRef = useRef(active)
     activeRef.current = active
 
-    const startEditing = useCallback(() => {
+    // Opening a session and RECLAIMING the instance for one already open are
+    // different things, and only the first may touch the guards.
+    //
+    // `baselineRef` is the revert target, snapshotted when the session opens so
+    // a realtime update mid-edit cannot become it. Re-snapshotting on a surface
+    // that is already editing would capture the user's half-typed text instead,
+    // and a later Escape would "revert" to that rather than to what was
+    // persisted — so the reclaim path leaves all three alone.
+    const openSession = useCallback(() => {
         baselineRef.current = value
         hasFocusedRef.current = false
         settledRef.current = false
         lease.acquire()
         setIsEditing(true)
     }, [lease, value])
+
+    // Take the instance back without disturbing a session in progress. Focus
+    // follows from the generation effect below, which fires on every acquire.
+    const reclaim = useCallback(() => {
+        lease.acquire()
+    }, [lease])
 
     // A session that opened on mount still has to TAKE the instance. Without
     // this it renders an editing surface while holding no lease, so `result` is
@@ -268,25 +322,14 @@ export function useLazyEditor({
     // composer on a freshly opened card — would otherwise acquire once against
     // a provider that had no editor yet and never try again, leaving it stuck
     // on its read view for the life of the card.
-    // `acquireToken` re-runs it on demand. A parent-owned session survives a
-    // steal (#193), so a composer can be open while another surface holds the
-    // editor; when the parent does something that means "the caret belongs here
-    // now" — pressing Reply, which targets THIS composer — it changes the token
-    // and the instance comes back. Without it the composer stays open with no
-    // editor in it and no way in but a tap.
-    //
-    // Deliberately caller-driven rather than a blanket "reclaim whenever idle":
-    // the editor falls idle for a moment during every ordinary handover, and
-    // grabbing it there would rip it out of the surface the user just clicked.
+    // A parent-owned session that LOSES the instance to a steal does not get it
+    // back here — that is `handle.edit()`, driven by the caller, because the
+    // editor falls idle for a moment during every ordinary handover and
+    // reclaiming on idle would rip it out of the surface the user just clicked.
     const acquire = lease.acquire
-    // Null when this surface should not claim the instance at all, and a NEW
-    // value each time the caller says the caret belongs here again. Reading it
-    // in the effect makes it a genuine dependency rather than one the linter can
-    // prove does nothing — the token IS the trigger.
-    const claim = startOpen ? `${surfaceId}:${acquireToken ?? ''}` : null
     useEffect(() => {
-        if (claim) acquire()
-    }, [claim, acquire])
+        if (startOpen) acquire()
+    }, [startOpen, acquire])
 
     // The warm instance parks with autofocus off — focusing a parked editor
     // would open the keyboard over a card nobody is editing — so the surface
@@ -465,6 +508,55 @@ export function useLazyEditor({
         onCancel?.()
     }, [endSession, onCancel])
 
+    // Everything the handle calls, read at call time rather than captured.
+    //
+    // A handle is HELD across renders — a keyboard shortcut registered once, a
+    // parent effect that fires much later — so a captured closure would call
+    // into a stale render's state. The object identity below therefore stays
+    // fixed while its behavior stays current, which is what lets a caller put it
+    // in a dependency array without re-running on every keystroke.
+    const handleFnsRef = useRef({
+        openSession,
+        reclaim,
+        submit,
+        cancel,
+        isEditing: false,
+        isSessionOpen: false,
+    })
+    handleFnsRef.current = {
+        openSession,
+        reclaim,
+        submit,
+        cancel,
+        // What a CALLER means by "is it editing": holding a usable editor. A
+        // displaced surface whose session is still open has nothing to type
+        // into, so it reads false.
+        isEditing: isEditing && active != null,
+        // Whether a session exists at all, displaced or not. Distinct from the
+        // above, and the one `edit()` must branch on — a displaced session is
+        // still a session, and re-opening it would reset its revert baseline.
+        isSessionOpen: isEditing,
+    }
+
+    const handle = useMemo<LazyEditorHandle>(
+        () => ({
+            edit: () => {
+                const fns = handleFnsRef.current
+                // A session already open — INCLUDING one displaced by a steal,
+                // which is the case this exists for — only takes the instance
+                // back. Re-opening would snapshot the user's half-typed text as
+                // the thing Escape reverts to, and clear the settled guard on a
+                // surface that may have already committed.
+                if (fns.isSessionOpen) fns.reclaim()
+                else fns.openSession()
+            },
+            submit: () => handleFnsRef.current.submit(),
+            cancel: () => handleFnsRef.current.cancel(),
+            isEditing: () => handleFnsRef.current.isEditing,
+        }),
+        []
+    )
+
     submitRef.current = submit
     blurRef.current = () => {
         if (
@@ -513,7 +605,11 @@ export function useLazyEditor({
             body: canEdit ? (
                 <Pressable
                     testID={testID}
-                    onPress={startEditing}
+                    // Through the handle, not openSession: a DISPLACED session
+                    // renders this branch too, and it must reclaim the instance
+                    // rather than re-open — otherwise tapping back into a
+                    // composer would make its half-typed draft the revert target.
+                    onPress={handle.edit}
                     accessibilityRole="button"
                     accessibilityLabel={accessibilityLabel}
                 >
@@ -522,6 +618,7 @@ export function useLazyEditor({
             ) : (
                 readView
             ),
+            handle,
         }
     }
 
@@ -539,5 +636,6 @@ export function useLazyEditor({
     return {
         header: renderHeader?.({ isEditing: true, slots }) ?? null,
         body: renderEditor(slots),
+        handle,
     }
 }

--- a/core/components/editor/__tests__/lazy-editor-handle.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-handle.test.tsx
@@ -1,0 +1,270 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import { useRef } from 'react'
+import { Text, View } from 'react-native'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EditorResult } from '../../../lib/editor/types'
+import type { WarmEditorLease } from '../../../lib/editor/warm/types'
+
+/**
+ * The imperative handle: how a caller drives a surface from OUTSIDE its own
+ * chrome. A comment composer's Reply button lives in the activity list, and a
+ * keyboard shortcut lives on the screen — neither can reach `slots`, which
+ * exists only while the surface is already editing.
+ *
+ * The load-bearing rule is that `edit()` is IDEMPOTENT. A session that is
+ * already open (including one displaced by a steal, which is the case this
+ * exists for) must reclaim the editor without re-snapshotting the revert
+ * baseline — otherwise the user's half-typed text becomes the thing Escape
+ * reverts to.
+ */
+
+const editorHandle = {
+    getHTML: vi.fn(async () => '<p>held</p>'),
+    getText: vi.fn(async () => 'held'),
+    getMarkdown: vi.fn(async () => 'typed by the user'),
+    setContent: vi.fn(),
+    setMarkdown: vi.fn(),
+    focus: vi.fn(),
+    clear: vi.fn(),
+    getSelection: vi.fn(async () => null),
+}
+
+const heldResult = {
+    editor: editorHandle,
+    EditorComponent: () => <Text>EDITOR</Text>,
+    commands: {},
+    toolbarState: {},
+} as unknown as EditorResult
+
+let leaseState: { result: EditorResult | null } = { result: heldResult }
+const acquire = vi.fn()
+const release = vi.fn()
+
+function currentLease(): WarmEditorLease {
+    return {
+        isWarm: true,
+        acquire,
+        release,
+        generation: 1,
+        ready: true,
+        holder: leaseState.result ? 'comment:a' : null,
+        result: leaseState.result,
+    }
+}
+
+// Built per call rather than closed over a module-level const: vi.mock factories
+// are hoisted above these declarations, so capturing one directly would read it
+// in its temporal dead zone.
+vi.mock('../../../lib/editor/warm', () => ({
+    useWarmEditor: () => currentLease(),
+}))
+
+const { useLazyEditor, LazyEditor } = await import('../LazyEditor')
+type Handle = import('../LazyEditor').LazyEditorHandle
+
+/** The handle from the most recent render, for the test to drive. */
+let handle: Handle | null = null
+
+function Probe({
+    startOpen = false,
+    value = 'persisted',
+    onCommit = vi.fn(),
+    onCancel,
+}: {
+    startOpen?: boolean
+    value?: string
+    onCommit?: (content: string) => void
+    onCancel?: () => void
+}) {
+    const slots = useLazyEditor({
+        readView: <Text>READ VIEW</Text>,
+        value,
+        contentFormat: 'markdown',
+        editorOptions: {},
+        surfaceId: 'comment:a',
+        canEdit: true,
+        startOpen,
+        onCommit,
+        onCancel,
+        renderEditor: () => <Text>EDITOR</Text>,
+    })
+    handle = slots.handle
+    return <View>{slots.body}</View>
+}
+
+beforeEach(() => {
+    leaseState = { result: heldResult }
+    handle = null
+    vi.clearAllMocks()
+    // Restored explicitly: one test overrides it, and clearAllMocks resets call
+    // history without restoring an implementation.
+    editorHandle.getMarkdown.mockResolvedValue('typed by the user')
+})
+
+afterEach(cleanup)
+
+describe('the LazyEditor handle', () => {
+    it('opens a session and takes the instance', () => {
+        const { getByText, queryByText } = render(<Probe />)
+        expect(getByText('READ VIEW')).toBeTruthy()
+
+        act(() => handle?.edit())
+
+        expect(acquire).toHaveBeenCalled()
+        expect(getByText('EDITOR')).toBeTruthy()
+        expect(queryByText('READ VIEW')).toBeNull()
+    })
+
+    /**
+     * The regression this split exists to prevent.
+     *
+     * `edit()` on an open session must NOT re-run the guard reset. Doing so
+     * re-snapshots `baselineRef` against the CURRENT `value` prop, and the
+     * baseline is what the no-op rule compares against — so an edit that
+     * genuinely reverted the user's text back to the persisted value would stop
+     * reading as a no-op and would be written instead of cancelled.
+     *
+     * Detecting that needs the editor's content to EQUAL the persisted value:
+     * with a correct baseline ('persisted') the submit is a no-op and cancels;
+     * with a reset one it would still be 'persisted' — so the value prop has to
+     * differ from the baseline the reset would capture. The prop is changed
+     * between the two edit() calls to make the two cases distinguishable.
+     */
+    it('reclaims without resetting the baseline when already editing', async () => {
+        const onCommit = vi.fn()
+        const onCancel = vi.fn()
+        // The editor reads back exactly the value the session STARTED with.
+        editorHandle.getMarkdown.mockResolvedValue('original')
+
+        const { rerender } = render(
+            <Probe value="original" onCommit={onCommit} onCancel={onCancel} />
+        )
+
+        act(() => handle?.edit())
+        acquire.mockClear()
+
+        // A realtime update lands mid-session: the persisted value moves on,
+        // but the revert target must stay what the session opened with.
+        rerender(<Probe value="changed by someone else" onCommit={onCommit} onCancel={onCancel} />)
+
+        // The parent says "the caret belongs here" again, mid-session.
+        act(() => handle?.edit())
+
+        // It took the instance back...
+        expect(acquire).toHaveBeenCalled()
+
+        // ...without moving the baseline. The content still equals what the
+        // session opened with, so this is a no-op edit: cancel, never commit.
+        // Had edit() re-opened, the baseline would now be 'changed by someone
+        // else' and this same content would be written over the record.
+        await act(async () => handle?.submit())
+
+        expect(onCancel).toHaveBeenCalled()
+        expect(onCommit).not.toHaveBeenCalled()
+    })
+
+    /**
+     * A displaced surface is still a session. `startOpen` keeps it open through
+     * a steal (#193), so `edit()` there must reclaim rather than re-open — the
+     * same baseline hazard, reached by the path the composer actually takes.
+     */
+    it('treats a displaced session as open, not as idle', () => {
+        const { rerender, getByText } = render(<Probe startOpen />)
+        expect(getByText('EDITOR')).toBeTruthy()
+
+        // Another surface takes the editor.
+        leaseState = { result: null }
+        rerender(<Probe startOpen />)
+        expect(getByText('READ VIEW')).toBeTruthy()
+        expect(handle?.isEditing()).toBe(false)
+
+        acquire.mockClear()
+        act(() => handle?.edit())
+
+        // Reclaimed. The session was never closed, so this is not a re-open.
+        expect(acquire).toHaveBeenCalled()
+    })
+
+    it('reports isEditing only while holding a usable editor', () => {
+        const { rerender } = render(<Probe />)
+        expect(handle?.isEditing()).toBe(false)
+
+        act(() => handle?.edit())
+        expect(handle?.isEditing()).toBe(true)
+
+        // Displaced: the session is open but there is nothing to type into.
+        leaseState = { result: null }
+        rerender(<Probe />)
+        expect(handle?.isEditing()).toBe(false)
+    })
+
+    it('submits and cancels through the handle', async () => {
+        const onCommit = vi.fn()
+        render(<Probe onCommit={onCommit} />)
+
+        act(() => handle?.edit())
+        await act(async () => handle?.submit())
+
+        expect(onCommit).toHaveBeenCalledWith('typed by the user')
+    })
+
+    it('cancel ends the session', () => {
+        const onCancel = vi.fn()
+        const { getByText } = render(<Probe onCancel={onCancel} />)
+
+        act(() => handle?.edit())
+        act(() => handle?.cancel())
+
+        expect(onCancel).toHaveBeenCalled()
+        expect(getByText('READ VIEW')).toBeTruthy()
+    })
+
+    /**
+     * A handle is HELD — a shortcut registered once, a parent effect that fires
+     * much later — so its identity must not churn, and the object captured on
+     * the first render must still drive the current one.
+     */
+    it('keeps one stable object across renders', () => {
+        const { rerender } = render(<Probe />)
+        const first = handle
+
+        rerender(<Probe />)
+        expect(handle).toBe(first)
+
+        // And the captured object still works after the re-render.
+        act(() => first?.edit())
+        expect(acquire).toHaveBeenCalled()
+    })
+
+    it('exposes the same handle through the component ref', () => {
+        let fromRef: Handle | null = null
+
+        function ComponentProbe() {
+            const ref = useRef<Handle>(null)
+            // Published during render for the assertion below; the ref is
+            // populated by useImperativeHandle before this runs on re-render.
+            fromRef = ref.current
+            return (
+                <LazyEditor
+                    ref={ref}
+                    readView={<Text>READ VIEW</Text>}
+                    value="persisted"
+                    contentFormat="markdown"
+                    editorOptions={{}}
+                    surfaceId="comment:a"
+                    canEdit
+                    onCommit={vi.fn()}
+                    renderEditor={() => <Text>EDITOR</Text>}
+                />
+            )
+        }
+
+        const { rerender } = render(<ComponentProbe />)
+        rerender(<ComponentProbe />)
+
+        expect(fromRef).not.toBeNull()
+        act(() => fromRef?.edit())
+        expect(acquire).toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Follow-up to #194 (merged). Pairs with tinycld/cards#30, which moves cards onto this.

`acquireToken` was a value whose content meant nothing and whose only job was to change — hard to name, harder to read. `useLazyEditor` now returns a handle:

```ts
export interface LazyEditorHandle {
    edit: () => void        // take the shared instance, put the caret in it
    submit: () => void
    cancel: () => void
    isEditing: () => boolean
}
```

The component forwards a `ref` to the same object. Every current caller uses the **hook** — the description's toolbar must stay a direct child of its `ScrollView` for `stickyHeaderIndices` to pin it, so header and body can't be one tree — which is why the hook's return is the primary API. This follows `EditableTextHandle`, whose doc comment makes the same argument against a controlled prop.

## The idempotence rule is load-bearing

`startEditing` resets the revert baseline and the commit guards. That's right when *opening* a session and wrong when reclaiming one already open: it would re-snapshot the baseline against the user's half-typed text, so a later Escape would "revert" to that instead of to what was persisted. The two halves are now separate, and `edit()` branches on whether a session exists — **including a displaced one**, since a parent-owned session stays open through a steal (#193).

The read view's press goes through the handle for the same reason: a displaced session renders that branch too.

`isEditing` is a method, not a field — a handle outlives the render that produced it, so a boolean would be a snapshot that silently went stale.

## Verification

- 1406 unit tests green on top of current `main`, clean typecheck and lint (one pre-existing complexity warning in `use-webview-editor.tsx`).
- 8 new tests in `lazy-editor-handle.test.tsx`. The idempotence test was confirmed to **fail** when the fix is reverted — it detects a reset baseline via the no-op-edit rule, which needed the editor's content to equal the session's opening value to be observable at all.
- Cards e2e 10/11, including "the reply flow survives its own save" — the test `acquireToken` existed to fix.

The one failing e2e (`an edited comment gains the (edited) marker`) fails identically on the parent branch with these changes stashed, so it is not caused by this work. It wants a look on its own.