### PR TITLE
lint: exempt cards' membership visibility sync from the raw-pb-access ban

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -83,7 +83,8 @@
                 "!**/core/lib/expo-push.ts",
                 "!**/core/lib/use-push-subscription.ts",
                 "!**/core/lib/stores/auth-store.ts",
-                "!**/core/lib/editor/use-share-visitor-role.tsx"
+                "!**/core/lib/editor/use-share-visitor-role.tsx",
+                "!**/cards/hooks/useMembershipVisibilitySync.ts"
             ]
         },
         {


### PR DESCRIPTION
cards' new useMembershipVisibilitySync (tinycld/cards#31) fetches a just-granted project's rows and upserts them through pbtsdb's own write utils — sync infrastructure, not a store bypass. Joins the plugin's existing exception list beside core's sync-layer files. cards CI lints against this canonical config, so its PR needs this on main to go green.