### PR TITLE
Help: list every package's CLI group; fix editor complexity lint

### DIFF
--- a/core/help/command-line.md
+++ b/core/help/command-line.md
@@ -75,3 +75,14 @@ Each installed package contributes its own command group:
   `search`, `export`, …)
 - [Cards from the command line](help://cards:command-line) — boards, lists,
   and cards (`tinycld cards board list`, `card view`, …)
+- [Calendar from the command line](help://calendar:command-line) — your
+  agenda, events, and RSVPs, including iCalendar export and import
+  (`tinycld calendar agenda`, `add`, `rsvp`, …)
+- [Text from the command line](help://text:command-line) — comments on your
+  documents (`tinycld text comments`)
+- [Calc from the command line](help://calc:command-line) — comments on your
+  spreadsheets (`tinycld calc comments`)
+
+Documents and spreadsheets are Drive files, so creating, listing, and
+downloading them are `drive` commands — the `text` and `calc` groups cover
+their comments.

--- a/core/help/command-line.md
+++ b/core/help/command-line.md
@@ -64,8 +64,14 @@ Every command accepts `--json` for scripting, and prompts are skipped with
 
 ## Package commands
 
-Each installed package contributes its own command group. See
-[Drive from the command line](help://drive:command-line) for working with
-files (`tinycld drive ls`, `put`, `get`, …) and
-[Mail from the command line](help://mail:command-line) for searching,
-reading, and sending mail (`tinycld mail search`, `read`, `send`, …).
+Each installed package contributes its own command group:
+
+- [Drive from the command line](help://drive:command-line) — working with
+  files (`tinycld drive ls`, `put`, `get`, …)
+- [Mail from the command line](help://mail:command-line) — searching,
+  reading, and sending mail (`tinycld mail search`, `read`, `send`, …)
+- [Contacts from the command line](help://contacts:command-line) — your
+  address book, including vCard export and import (`tinycld contacts list`,
+  `search`, `export`, …)
+- [Cards from the command line](help://cards:command-line) — boards, lists,
+  and cards (`tinycld cards board list`, `card view`, …)

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -377,6 +377,22 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     // posts from a window-level scroll listener; we fan it out to
     // onScroll(...) instead of forwarding to onUiMessage so consumers
     // can take it without writing a switch over message.type.
+    // The page measured itself. A WebView has no intrinsic height, so this is
+    // the only way the container can track its content — without it the editor
+    // is clipped to a guess (or, inside a ScrollView where flex resolves to
+    // zero, invisible).
+    const applyContentHeight = useCallback(
+        (payload: unknown) => {
+            const height = (payload as { height?: unknown } | undefined)?.height
+            if (typeof height !== 'number' || height <= 0) return
+            if (__DEV__) {
+                console.debug('[editor.mount] first-height', Date.now() - mountAtRef.current, 'ms')
+            }
+            setContentHeight(height)
+        },
+        [setContentHeight]
+    )
+
     const onWebViewMessage = useMemo(
         () => (event: WebViewMessageEvent) => {
             const data = event?.nativeEvent?.data
@@ -409,23 +425,8 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
                     onScrollRef.current?.()
                     return
                 }
-                // The page measured itself. A WebView has no intrinsic
-                // height, so this is the only way the container can track
-                // its content — without it the editor is clipped to a
-                // guess (or, inside a ScrollView where flex resolves to
-                // zero, invisible).
                 if (parsed.type === 'content-height') {
-                    const height = (parsed.payload as { height?: unknown } | undefined)?.height
-                    if (typeof height === 'number' && height > 0) {
-                        if (__DEV__) {
-                            console.debug(
-                                '[editor.mount] first-height',
-                                Date.now() - mountAtRef.current,
-                                'ms'
-                            )
-                        }
-                        setContentHeight(height)
-                    }
+                    applyContentHeight(parsed.payload)
                     return
                 }
                 onUiMessageRef.current?.(parsed)
@@ -457,9 +458,10 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
                 onMessageRef.current?.(parsed)
             }
         },
-        // Everything else is read through a ref; setContentHeight comes from a
-        // store created once per mount, so this list never changes in practice.
-        [setContentHeight]
+        // Everything else is read through a ref; applyContentHeight is itself
+        // memoized on a store setter created once per mount, so this list never
+        // changes in practice.
+        [applyContentHeight]
     )
 
     // The anchor host overlays measure against.


### PR DESCRIPTION
Two small, independent changes.

**Help cross-links.** The "Package commands" section of `core/help/command-line.md` named only drive and mail. `cards` shipped a command group without ever being added, and contacts now has one too ([tinycld/contacts#31](https://github.com/tinycld/contacts/pull/31)). Turned the prose into a list so the next group is an appended line rather than a rewrite.

**Editor complexity.** `onWebViewMessage` had grown past the cognitive-complexity ceiling (49 vs. a max of 45), failing `pnpm run lint`. Extracted the content-height branch into its own memoized handler — the fix the rule is asking for, and consistent with keeping processing out of the dispatch body. No behavior change.

Verification: lint clean (2030 files), typecheck clean, 1406 unit tests passing.