### PR TITLE
Scope the calendar iCalendar file routes

### DIFF
--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -157,6 +157,8 @@ var endpointScopes = map[string]scopeRule{
 	"POST /api/drive/versions/snapshot": {ScopeDriveWrite},
 	"GET /api/contacts/export":          {ScopeContactsRead},
 	"POST /api/contacts/import":         {ScopeContactsWrite},
+	"GET /api/calendar/export":          {ScopeCalendarRead},
+	"POST /api/calendar/import":         {ScopeCalendarWrite},
 	"GET /api/cards/search":             {ScopeCardsRead},
 
 	// The federated search narrows itself: it drops the sources a caller's

--- a/core/server/oauth/middleware_test.go
+++ b/core/server/oauth/middleware_test.go
@@ -474,6 +474,9 @@ func TestScopeForRouteNewCollectionsAndEndpoints(t *testing.T) {
 		// separating a read grant from a write one.
 		{"GET", "/api/contacts/export", ScopeContactsRead},
 		{"POST", "/api/contacts/import", ScopeContactsWrite},
+		// iCalendar file transfer, same reasoning as the vCard pair above.
+		{"GET", "/api/calendar/export", ScopeCalendarRead},
+		{"POST", "/api/calendar/import", ScopeCalendarWrite},
 	}
 	for _, r := range reachable {
 		if got := ScopeForRoute(r.method, r.path); !onlyScope(got, r.scope) {
@@ -489,6 +492,16 @@ func TestScopeForRouteNewCollectionsAndEndpoints(t *testing.T) {
 	}
 	if ScopeForRoute("POST", "/api/contacts/import").satisfiedBy([]string{ScopeContactsRead}) {
 		t.Error("contacts import must NOT be satisfied by contacts:read alone")
+	}
+
+	// Same asymmetry for calendar. It matters more here than for contacts:
+	// calendar read access is membership in ANY role, so a viewer legitimately
+	// holds calendar:read — and must still not be able to import.
+	if ScopeForRoute("GET", "/api/calendar/export").satisfiedBy([]string{ScopeCalendarWrite}) {
+		t.Error("calendar export must NOT be satisfied by calendar:write alone")
+	}
+	if ScopeForRoute("POST", "/api/calendar/import").satisfiedBy([]string{ScopeCalendarRead}) {
+		t.Error("calendar import must NOT be satisfied by calendar:read alone")
 	}
 
 	// GET /api/contacts/search is not mounted — contacts registers fts index


### PR DESCRIPTION
Adds the route→scope entries for `GET /api/calendar/export` and `POST /api/calendar/import`, the two raw routes added in [tinycld/calendar#…](https://github.com/tinycld/calendar) for the CLI's `calendar export` / `import`.

These are raw Go routes, so PocketBase's collection rules never run on them — this table is the only thing separating a read grant from a write one, and an unlisted route default-denies (the failure mode that broke `mail send` and `tinycld cards` in the first live CLI smoke test).

The read/write asymmetry matters more here than for contacts: calendar read access is membership in **any** role, so a viewer legitimately holds `calendar:read` and must still not be able to import. The test asserts both directions rather than just the mapping.

**Merge before** the calendar member PR — the endpoints are unreachable without these entries.