### PR TITLE
Add the text and calc OAuth scopes; label every scope on the consent screen

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -33,6 +33,8 @@ var cliScopes = []string{
 	"contacts:read", "contacts:write",
 	"calendar:read", "calendar:write",
 	"cards:read", "cards:write",
+	"text:read", "text:write",
+	"calc:read", "calc:write",
 }
 
 // contextTokenStore adapts the keychain to client.TokenStore for one context.

--- a/core/components/oauth/ScopeList.tsx
+++ b/core/components/oauth/ScopeList.tsx
@@ -2,7 +2,13 @@ import { Text, View } from 'react-native'
 
 // Human-readable copy for each scope. The consent screen must say what access
 // means in plain language — "mail:read" tells a user nothing.
-const SCOPE_LABELS: Record<string, string> = {
+//
+// EVERY scope in oauth.AllScopes needs an entry. A missing one is not a
+// cosmetic gap: the fallback below renders the raw scope string, so the
+// consent screen asks a person to approve "cards:write". scope-labels.test.ts
+// reads the Go constant and fails when the two drift, which is how the cards
+// scopes were found to have been unlabeled since they shipped.
+export const SCOPE_LABELS: Record<string, string> = {
     profile: 'See your name and email address',
     'mail:read': 'Read your email',
     'mail:send': 'Send email on your behalf',
@@ -12,6 +18,12 @@ const SCOPE_LABELS: Record<string, string> = {
     'contacts:write': 'Create and modify your contacts',
     'calendar:read': 'Read your calendar',
     'calendar:write': 'Create and modify calendar events',
+    'cards:read': 'Read your boards and cards',
+    'cards:write': 'Create and modify your boards and cards',
+    'text:read': 'Read comments on your documents',
+    'text:write': 'Add and resolve comments on your documents',
+    'calc:read': 'Read comments on your spreadsheets',
+    'calc:write': 'Add and resolve comments on your spreadsheets',
 }
 
 interface ScopeListProps {

--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -138,6 +138,18 @@ var collectionScopes = map[string]collectionAccess{
 	// had already built on, so start closed.
 	"cards_project_members": {read: scopeRule{ScopeCardsRead}},
 	"cards_share_links":     {read: scopeRule{ScopeCardsRead}},
+
+	// text and calc own ONLY their comment collections; the documents and
+	// spreadsheets they comment on are drive_items, governed by drive:*.
+	//
+	// A grant here widens which rows a token may touch not at all: both rules
+	// reach through `drive_item` and admit only the document's creator or
+	// someone it is shared with, and create additionally demands the caller be
+	// the comment's own author. So this decides whether an OAuth caller may use
+	// the collection at all, on top of the document access the rules demand —
+	// which in practice means a useful token also holds drive:read.
+	"text_comments": {read: scopeRule{ScopeTextRead}, write: scopeRule{ScopeTextWrite}},
+	"calc_comments": {read: scopeRule{ScopeCalcRead}, write: scopeRule{ScopeCalcWrite}},
 }
 
 // endpointScopes maps a bespoke Go endpoint to its required scope.

--- a/core/server/oauth/middleware_test.go
+++ b/core/server/oauth/middleware_test.go
@@ -474,6 +474,14 @@ func TestScopeForRouteNewCollectionsAndEndpoints(t *testing.T) {
 		// separating a read grant from a write one.
 		{"GET", "/api/contacts/export", ScopeContactsRead},
 		{"POST", "/api/contacts/import", ScopeContactsWrite},
+		// text and calc own only their comment collections. Unclassified,
+		// these default-denied, so `tinycld text comments` could not run at
+		// all — the same hole cards:* fell into before the first live smoke
+		// test found it.
+		{"GET", "/api/collections/text_comments/records", ScopeTextRead},
+		{"POST", "/api/collections/text_comments/records", ScopeTextWrite},
+		{"GET", "/api/collections/calc_comments/records", ScopeCalcRead},
+		{"POST", "/api/collections/calc_comments/records", ScopeCalcWrite},
 	}
 	for _, r := range reachable {
 		if got := ScopeForRoute(r.method, r.path); !onlyScope(got, r.scope) {

--- a/core/server/oauth/oauth.go
+++ b/core/server/oauth/oauth.go
@@ -44,6 +44,15 @@ const (
 	ScopeCalendarWrite = "calendar:write"
 	ScopeCardsRead     = "cards:read"
 	ScopeCardsWrite    = "cards:write"
+	// text and calc own only their comment collections — the documents and
+	// spreadsheets themselves are drive_items, governed by drive:*. So these
+	// scopes are narrower than they look, and a token that can do anything
+	// useful with them holds drive:read too: a comment is unreachable without
+	// access to the item it hangs off (the rules reach through drive_item).
+	ScopeTextRead  = "text:read"
+	ScopeTextWrite = "text:write"
+	ScopeCalcRead  = "calc:read"
+	ScopeCalcWrite = "calc:write"
 )
 
 // AllScopes is the full catalog, used to validate a requested scope string and
@@ -55,6 +64,8 @@ var AllScopes = []string{
 	ScopeContactsRead, ScopeContactsWrite,
 	ScopeCalendarRead, ScopeCalendarWrite,
 	ScopeCardsRead, ScopeCardsWrite,
+	ScopeTextRead, ScopeTextWrite,
+	ScopeCalcRead, ScopeCalcWrite,
 }
 
 var (

--- a/core/server/oauth/route_classification_test.go
+++ b/core/server/oauth/route_classification_test.go
@@ -44,6 +44,14 @@ func TestEveryRegisteredRouteIsClassified(t *testing.T) {
 		{"DELETE", "/api/drive/share-link/abc123", "drive link revoke"},
 		{"POST", "/api/drive/versions/restore", "drive versions --restore"},
 		{"POST", "/api/drive/versions/snapshot", "drive versions --snapshot"},
+		// text and calc contribute only comment commands — the documents
+		// themselves are drive_items, reached through the drive scopes above.
+		{"GET", "/api/collections/text_comments/records", "text comments list"},
+		{"POST", "/api/collections/text_comments/records", "text comments --add"},
+		{"PATCH", "/api/collections/text_comments/records/abc123", "text comments --resolve"},
+		{"GET", "/api/collections/calc_comments/records", "calc comments list"},
+		{"POST", "/api/collections/calc_comments/records", "calc comments --add"},
+		{"PATCH", "/api/collections/calc_comments/records/abc123", "calc comments --resolve"},
 	}
 	for _, r := range reachable {
 		if len(ScopeForRoute(r.method, r.path)) == 0 {

--- a/core/server/pb_migrations/1985000001_seed_cli_oauth_client.js
+++ b/core/server/pb_migrations/1985000001_seed_cli_oauth_client.js
@@ -26,7 +26,7 @@ migrate(
             'scopes',
             'profile mail:read mail:send drive:read drive:write ' +
                 'contacts:read contacts:write calendar:read calendar:write ' +
-                'cards:read cards:write'
+                'cards:read cards:write text:read text:write calc:read calc:write'
         )
         app.save(cli)
     },

--- a/core/server/pb_migrations/2000000002_cli_client_text_calc_scopes.js
+++ b/core/server/pb_migrations/2000000002_cli_client_text_calc_scopes.js
@@ -1,0 +1,55 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Add the text and calc scopes to the seeded tinycld-cli client.
+//
+// Same shape, and the same reason, as 2000000001 did for cards: the CLI client
+// row is a hard ceiling (ValidateClientScopes rejects any scope it does not
+// name), so a scope missing there fails the LOGIN outright, while one missing
+// from the CLI's own cliScopes list fails later and quietly — the grant is
+// issued without it and the command 403s.
+//
+// Appended rather than folded into 1985000001 (or 2000000001) because
+// PocketBase never re-runs an applied migration: editing either file would fix
+// only databases created after the edit and silently leave every existing one
+// broken.
+//
+// Rewrites the whole scope string from the current catalog rather than
+// appending to whatever is there, so a row that already has the scopes (a DB
+// seeded after this ships) converges instead of accumulating duplicates.
+const CLI_SCOPES =
+    'profile mail:read mail:send drive:read drive:write ' +
+    'contacts:read contacts:write calendar:read calendar:write ' +
+    'cards:read cards:write text:read text:write calc:read calc:write'
+
+const CLI_SCOPES_BEFORE =
+    'profile mail:read mail:send drive:read drive:write ' +
+    'contacts:read contacts:write calendar:read calendar:write ' +
+    'cards:read cards:write'
+
+migrate(
+    app => {
+        let cli
+        try {
+            cli = app.findFirstRecordByFilter('oauth_clients', 'client_id = {:id}', {
+                id: 'tinycld-cli',
+            })
+        } catch {
+            // No CLI client on this deployment (the seed was rolled back, or
+            // the operator deleted it). Nothing to widen — a fresh seed will
+            // carry the current scope list.
+            return
+        }
+        cli.set('scopes', CLI_SCOPES)
+        app.save(cli)
+    },
+    app => {
+        try {
+            const cli = app.findFirstRecordByFilter('oauth_clients', 'client_id = {:id}', {
+                id: 'tinycld-cli',
+            })
+            cli.set('scopes', CLI_SCOPES_BEFORE)
+            app.save(cli)
+        } catch {
+            // Already gone — nothing to undo.
+        }
+    }
+)

--- a/core/tests/unit/scope-labels.test.ts
+++ b/core/tests/unit/scope-labels.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { SCOPE_LABELS } from '../../components/oauth/ScopeList'
+
+// The consent screen renders SCOPE_LABELS[scope] ?? scope, so a scope with no
+// label asks a person to approve the raw string — "cards:write" instead of
+// "Create and modify your boards and cards". That is exactly what shipped: the
+// cards scopes went out unlabeled and nothing caught it, because the label map
+// and the scope catalog live in different languages.
+//
+// This reads the Go catalog as the source of truth rather than restating it,
+// so adding a scope in oauth.go without a label turns this red.
+const OAUTH_GO = join(__dirname, '../../server/oauth/oauth.go')
+
+// Scope constants are declared as `ScopeMailRead = "mail:read"`. Reading the
+// literals (rather than the AllScopes identifier list) keeps this immune to
+// how that slice is formatted.
+function scopesFromGo(): string[] {
+    const source = readFileSync(OAUTH_GO, 'utf8')
+    const start = source.indexOf('var AllScopes = []string{')
+    // Skip the declaration line itself, whose `AllScopes` identifier would
+    // otherwise match the constant pattern below.
+    const body = source.slice(source.indexOf('\n', start), source.indexOf('}', start))
+    const names = [...new Set([...body.matchAll(/\bScope[A-Za-z]+\b/g)].map(m => m[0]))]
+    return names.map(name => {
+        const declared = source.match(new RegExp(`${name}\\s*=\\s*"([^"]+)"`))
+        if (!declared) throw new Error(`no string literal found for ${name} in oauth.go`)
+        return declared[1]
+    })
+}
+
+describe('OAuth consent scope labels', () => {
+    it('finds the Go scope catalog', () => {
+        const scopes = scopesFromGo()
+        // A parse failure would otherwise make the next test vacuously pass.
+        expect(scopes.length).toBeGreaterThanOrEqual(11)
+        expect(scopes).toContain('mail:read')
+    })
+
+    it('labels every scope the server can grant', () => {
+        const unlabeled = scopesFromGo().filter(scope => !SCOPE_LABELS[scope])
+        expect(unlabeled).toEqual([])
+    })
+
+    it('labels nothing the server cannot grant', () => {
+        // A stale label is a smaller problem than a missing one, but it still
+        // means the map and the catalog disagree about what exists.
+        const known = new Set(scopesFromGo())
+        expect(Object.keys(SCOPE_LABELS).filter(scope => !known.has(scope))).toEqual([])
+    })
+
+    it('writes labels as plain language, not the scope string', () => {
+        for (const [scope, label] of Object.entries(SCOPE_LABELS)) {
+            expect(label, `${scope} should read as a sentence`).not.toContain(':')
+        }
+    })
+})


### PR DESCRIPTION
Prerequisite for the text and calc CLI command groups.

### The scopes

`text` and `calc` own only their comment collections — the documents themselves are `drive_items`, governed by `drive:*`. Both collections were **absent from the scope table entirely**, so an OAuth token default-denied on each and the CLI groups could not have run at all. Same hole `cards:*` fell into, which the first live smoke test caught only at runtime.

All four hand-maintained lists are updated together, because a scope missing from any one fails differently and none of them check each other:

| List | Failure if missing |
|---|---|
| `oauth.go` `AllScopes` | scope rejected as unknown |
| collection scope table | default-deny 403 on the collection |
| CLI `cliScopes` | grant issued without it; command 403s later, quietly |
| seeded client row | hard ceiling — login fails outright |

The client row is widened by an **appended** migration (`2000000002`), following the precedent of `2000000001`: PocketBase never re-runs an applied migration, so editing the seed alone would fix only databases created afterwards. The seed is updated too, for fresh installs.

### A pre-existing bug this turned up

The consent screen renders `SCOPE_LABELS[scope] ?? scope`, so a scope with no label asks a person to approve the raw string. `cards:read` / `cards:write` shipped with no labels — so that is literally what the consent screen has been showing since cards launched.

Labels added for cards, text, and calc, plus a test that parses the Go catalog and fails when the map and the catalog drift. That turns "someone forgot a label" from an invisible UX bug into a red test.

Verification: oauth suite, CLI suite, 1410 app unit tests, typecheck — all pass.