### PR TITLE
feat(automation): gate relation params behind a view-rule floor and a required authorizer

### DIFF
--- a/core/lib/automation/__tests__/schemas.test.ts
+++ b/core/lib/automation/__tests__/schemas.test.ts
@@ -186,4 +186,74 @@ describe('validateDefinitions', () => {
         }
         expect(validateDefinitions('mail', bad).some(e => e.includes('missing'))).toBe(true)
     })
+
+    // A typed relation param with no target reaches the UI as a picker over
+    // nothing — the failure that stayed silent until runtime before this rule.
+    it('rejects a typed relation param without a relationTarget', () => {
+        const bad: AutomationDefinitions = {
+            actions: [
+                {
+                    id: 'add-assignee',
+                    label: 'Add an assignee',
+                    kind: 'native',
+                    params: [{ key: 'user', type: 'relation' }],
+                },
+            ],
+        }
+        expect(validateDefinitions('cards', bad).some(e => e.includes('no relationTarget'))).toBe(
+            true
+        )
+    })
+
+    it('rejects a relationTarget on a non-relation typed param', () => {
+        const bad: AutomationDefinitions = {
+            actions: [
+                {
+                    id: 'add-assignee',
+                    label: 'Add an assignee',
+                    kind: 'native',
+                    params: [{ key: 'note', type: 'text', relationTarget: 'users' }],
+                },
+            ],
+        }
+        expect(
+            validateDefinitions('cards', bad).some(e => e.includes('declares relationTarget'))
+        ).toBe(true)
+    })
+
+    it('accepts a typed relation param that names its target', () => {
+        const good: AutomationDefinitions = {
+            actions: [
+                {
+                    id: 'add-assignee',
+                    label: 'Add an assignee',
+                    kind: 'native',
+                    params: [{ key: 'user', type: 'relation', relationTarget: 'users' }],
+                },
+            ],
+        }
+        expect(validateDefinitions('cards', good)).toEqual([])
+    })
+
+    // Column params inherit the column's target; declaring one is not the
+    // authoring mistake the typed-param rule guards against.
+    it('leaves column-referencing params out of the relation checks', () => {
+        const good: AutomationDefinitions = {
+            actions: [
+                {
+                    id: 'move',
+                    label: 'Move',
+                    kind: 'record-op',
+                    collection: 'c',
+                    op: {
+                        type: 'update',
+                        target: 'trigger-record',
+                        set: { folder: { param: 'folder' } },
+                    },
+                    params: [{ key: 'folder', field: 'folder' }],
+                },
+            ],
+        }
+        expect(validateDefinitions('mail', good)).toEqual([])
+    })
 })

--- a/core/lib/automation/core-defs.ts
+++ b/core/lib/automation/core-defs.ts
@@ -59,9 +59,10 @@ export const CORE_AUTOMATION: AutomationDefinitions = {
         },
         {
             // The universal "email me / the team when X". Native, but native
-            // IN CORE — which is the point: a multi-org tenant links no
-            // feature package's Go, so mail:send-message is unavailable
-            // there while this is not.
+            // IN CORE — which is the point: it ships in every build
+            // regardless of which feature packages an org installed, so an
+            // org without mail (whose build links no mail Go, hence no
+            // mail:send-message) still has it.
             //
             // Backed by the same core mailer every transactional email uses,
             // so it inherits the deployment's configured provider rather

--- a/core/lib/automation/schemas.ts
+++ b/core/lib/automation/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { ALL_OPS, NO_VALUE_OPS } from './helpers'
-import type { AutomationDefinitions, ConditionOp } from './types'
+import type { AutomationDefinitions, ConditionOp, ParamDef } from './types'
 
 const ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
 const REF_RE = /^[a-z0-9-]+:[a-z0-9-]+$/
@@ -47,6 +47,35 @@ function checkId(errors: string[], pkgSlug: string, what: string, id: string, se
     seen.add(id)
 }
 
+/** Per-action param checks; returns the declared keys for the `set` cross-check. */
+function checkActionParams(
+    errors: string[],
+    pkgSlug: string,
+    action: { id: string; params?: ParamDef[] }
+): Set<string> {
+    const paramKeys = new Set<string>()
+    for (const p of action.params ?? []) {
+        if (paramKeys.has(p.key))
+            errors.push(`${pkgSlug}: action '${action.id}' duplicate param '${p.key}'`)
+        paramKeys.add(p.key)
+        // Column params inherit their relation target from the column; a
+        // typed relation param without a declared target reaches the UI as a
+        // picker over nothing — fail the generate instead.
+        if ('field' in p) continue
+        if (p.type === 'relation' && !p.relationTarget) {
+            errors.push(
+                `${pkgSlug}: action '${action.id}' param '${p.key}' is type 'relation' but declares no relationTarget`
+            )
+        }
+        if (p.type !== 'relation' && p.relationTarget) {
+            errors.push(
+                `${pkgSlug}: action '${action.id}' param '${p.key}' declares relationTarget but is type '${p.type}'`
+            )
+        }
+    }
+    return paramKeys
+}
+
 /**
  * Structural validation of a package's automation definitions. Collection and
  * column EXISTENCE is not checked here — the package's own typecheck enforces
@@ -86,12 +115,7 @@ export function validateDefinitions(
     const actionIds = new Set<string>()
     for (const a of defs.actions ?? []) {
         checkId(errors, pkgSlug, 'action', a.id, actionIds)
-        const paramKeys = new Set<string>()
-        for (const p of a.params ?? []) {
-            if (paramKeys.has(p.key))
-                errors.push(`${pkgSlug}: action '${a.id}' duplicate param '${p.key}'`)
-            paramKeys.add(p.key)
-        }
+        const paramKeys = checkActionParams(errors, pkgSlug, a)
         if (a.kind === 'record-op') {
             if (!a.collection)
                 errors.push(`${pkgSlug}: record-op action '${a.id}' has no collection`)

--- a/core/lib/automation/types.ts
+++ b/core/lib/automation/types.ts
@@ -92,6 +92,14 @@ export interface TypedParamDef {
     type: FieldType
     label?: string
     options?: string[]
+    /**
+     * Required when `type` is 'relation' (validateDefinitions enforces both
+     * directions): the target collection NAME the record picker lists. A
+     * column-referencing param inherits its target from the column instead;
+     * this field exists so native actions — which reference no collection —
+     * can offer a picker at all.
+     */
+    relationTarget?: string
 }
 
 export type ParamDef<F extends string = string> = ColumnParamDef<F> | TypedParamDef

--- a/core/server/automation/actions.go
+++ b/core/server/automation/actions.go
@@ -32,7 +32,7 @@ func takeEngineWrite(recordID string) (engineWrite, bool) {
 	return v.(engineWrite), true
 }
 
-func substituteParams(defs ActionDef, raw map[string]any, record *core.Record, trigger TriggerDef) map[string]string {
+func substituteParams(defs ActionDef, raw map[string]any, record *core.Record, trigger TriggerDef, relationKeys map[string]bool) map[string]string {
 	out := map[string]string{}
 	for _, p := range defs.Params {
 		v, ok := raw[p.Key]
@@ -40,9 +40,106 @@ func substituteParams(defs ActionDef, raw map[string]any, record *core.Record, t
 			continue
 		}
 		s := normalize(v)
+		// A relation param carries a picker-chosen record id. Substituting
+		// {{templates}} in it would let trigger-record CONTENT choose which
+		// record the action touches — ids pass verbatim.
+		if relationKeys[p.Key] {
+			out[p.Key] = s
+			continue
+		}
 		out[p.Key] = SubstituteTemplates(s, record, trigger)
 	}
 	return out
+}
+
+// relationParamTarget classifies one param: is it relation-typed, and which
+// collection does it pick from. A typed param declares both; a column param
+// inherits the column's. An empty target with isRelation=true means the
+// declaration cannot resolve in this deployment — callers must fail closed,
+// mirroring resolveAction greying the action out in the catalog.
+func relationParamTarget(app core.App, action ActionDef, p ParamDef) (target string, isRelation bool) {
+	if p.Field == "" {
+		if p.Type != "relation" {
+			return "", false
+		}
+		if p.RelationTarget == "" {
+			return "", true
+		}
+		if col, err := app.FindCachedCollectionByNameOrId(p.RelationTarget); err == nil {
+			return col.Name, true
+		}
+		return "", true
+	}
+	col, err := app.FindCachedCollectionByNameOrId(action.Collection)
+	if err != nil {
+		return "", false
+	}
+	rel, ok := col.Fields.GetByName(p.Field).(*core.RelationField)
+	if !ok {
+		return "", false
+	}
+	if targetCol, err := app.FindCachedCollectionByNameOrId(rel.CollectionId); err == nil {
+		return targetCol.Name, true
+	}
+	return "", true
+}
+
+// authorizeRelationParams gates every caller-supplied record id before an
+// action of either kind runs. Two layers, both fail-closed:
+//
+//  1. The FLOOR, engine-owned and generic: the rule owner must pass the
+//     target collection's own view rule for the referenced record
+//     (CanAccessRecord as the owner). This is pure data — collection rules
+//     travel in migrations — so it holds in every deployment, but it only
+//     proves the owner may SEE the record. A rule whose disjuncts need
+//     request context beyond auth (e.g. cards' share-link token header)
+//     correctly evaluates those branches false: automation acts as the
+//     owner, never as an anonymous link holder.
+//  2. The package's registered RelationAuthorizer, which owns the
+//     write-level question (membership, role, ownership). Declaring a
+//     relation param without registering its authorizer is refused outright
+//     — the rollout's real bugs were all which-record bugs, and this turns
+//     that question from a review-time convention into a contract.
+func authorizeRelationParams(app core.App, ref string, action ActionDef, req ActionRequest) error {
+	var owner *core.Record
+	for _, p := range action.Params {
+		target, isRelation := relationParamTarget(app, action, p)
+		if !isRelation {
+			continue
+		}
+		id := req.Params[p.Key]
+		if id == "" {
+			continue
+		}
+		if target == "" {
+			return fmt.Errorf("relation param %q has no resolvable target collection — refusing", p.Key)
+		}
+		rec, err := app.FindRecordById(target, id)
+		if err != nil {
+			return fmt.Errorf("relation param %q: no %s record %q", p.Key, target, id)
+		}
+		if owner == nil {
+			owner, err = app.FindRecordById("users", req.OwnerID)
+			if err != nil {
+				return fmt.Errorf("relation param %q: rule owner lookup: %w", p.Key, err)
+			}
+		}
+		info := &core.RequestInfo{Auth: owner}
+		if ok, err := app.CanAccessRecord(rec, info, rec.Collection().ViewRule); err != nil || !ok {
+			return fmt.Errorf("relation param %q: rule owner may not use %s record %q", p.Key, target, id)
+		}
+		authorize, registered := relationAuthorizer(ref, p.Key)
+		if !registered {
+			return fmt.Errorf(
+				"action %q relation param %q has no registered authorizer — the owning package must RegisterRelationAuthorizer for it",
+				ref, p.Key,
+			)
+		}
+		if err := authorize(app, req, id); err != nil {
+			return fmt.Errorf("relation param %q: %w", p.Key, err)
+		}
+	}
+	return nil
 }
 
 func resolveSetValue(sv SetValue, params map[string]string, record *core.Record, ownerID string) (any, error) {
@@ -95,14 +192,28 @@ func ExecuteAction(app core.App, defs *Defs, ref string, rawParams map[string]an
 		return fmt.Errorf("unknown action %q (package uninstalled?)", ref)
 	}
 	ownerID := rule.GetString("owner")
-	params := substituteParams(action, rawParams, record, trigger)
+	relationKeys := map[string]bool{}
+	for _, p := range action.Params {
+		if _, isRelation := relationParamTarget(app, action, p); isRelation {
+			relationKeys[p.Key] = true
+		}
+	}
+	params := substituteParams(action, rawParams, record, trigger, relationKeys)
+	req := ActionRequest{Rule: rule, OwnerID: ownerID, Params: params, Record: record}
+
+	// Both kinds pass the relation-id gates: a record-op's superuser Save
+	// bypasses collection rules just as thoroughly as a native handler's
+	// superuser app does.
+	if err := authorizeRelationParams(app, ref, action, req); err != nil {
+		return err
+	}
 
 	if action.Kind == "native" {
 		h, ok := actionHandler(ref)
 		if !ok {
 			return fmt.Errorf("native action %q has no registered handler (package Go not linked?)", ref)
 		}
-		return h(app, ActionRequest{Rule: rule, OwnerID: ownerID, Params: params, Record: record})
+		return h(app, req)
 	}
 
 	if err := checkPersonalAccess(app, rule, pkg); err != nil {

--- a/core/server/automation/actions_email.go
+++ b/core/server/automation/actions_email.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	netmail "net/mail"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pocketbase/pocketbase/core"
-	"github.com/pocketbase/pocketbase/tools/types"
 
 	"tinycld.org/core/mailer"
 )
@@ -17,11 +17,14 @@ import (
 //
 // The engine's depth cap stops a rule re-triggering itself inside one
 // dispatch, but it cannot see across dispatches — an auto-reply answering
-// another system's auto-responder is two systems each doing one hop, forever.
-// A per-rule hourly ceiling bounds that without stopping legitimate bursts.
+// another system's auto-responder returns as genuinely new inbound mail at
+// depth 0, so two systems each doing one hop can loop forever. This ceiling
+// is the only control bounding that exchange.
 //
 // Mail's send actions cap per MAILBOX because several rules share one outbox;
-// core has no mailbox to key on, so the rule is the unit.
+// core has no mailbox to key on, so the rule is the unit. Per-recipient was
+// considered and rejected: a rule replying to N distinct senders would evade
+// it, while an address-pair loop always recurs through the same rule.
 const maxEmailsPerRulePerHour = 20
 
 // sendEmailNow is the seam tests replace. Production sends through the same
@@ -33,9 +36,9 @@ var sendEmailNow = func(ctx context.Context, msg *mailer.Message) error {
 
 // registerCoreEmailAction installs core:send-email.
 //
-// Native, but native IN CORE, which is the whole point: a multi-org tenant
-// links no feature package's Go, so mail:send-message is unavailable there
-// while this is not. It is the universal "email me when X".
+// Native, but native IN CORE, which is the point: it ships in every build
+// regardless of which feature packages an org installed, so an org without
+// mail still gets the universal "email me when X".
 func registerCoreEmailAction() {
 	RegisterAction("core:send-email", actionSendEmail)
 }
@@ -53,8 +56,12 @@ func actionSendEmail(app core.App, req ActionRequest) error {
 		return fmt.Errorf("core:send-email: %w", err)
 	}
 
-	if err := checkEmailRateLimit(app, req); err != nil {
-		return fmt.Errorf("core:send-email: %w", err)
+	// A request with no rule (a dry-run style invocation) has nothing to
+	// count against; every engine path supplies the rule.
+	if req.Rule != nil {
+		if err := reserveEmailSend(req.Rule.Id, time.Now()); err != nil {
+			return fmt.Errorf("core:send-email: %w", err)
+		}
 	}
 
 	subject := strings.TrimSpace(req.Params["subject"])
@@ -92,47 +99,51 @@ func emailRecipient(to string) (string, error) {
 	return parsed.Address, nil
 }
 
-// checkEmailRateLimit reports whether the rule has room to send.
+// emailSendLedger tracks each rule's sends inside the rolling hour, in memory.
 //
-// Counts this rule's matched runs in the last hour from rule_runs — the same
-// durable log the run-history UI reads, so a restart doesn't reset the ceiling
-// the way an in-memory counter would.
+// In-memory is deliberate (the failureStreaks precedent): there is no query
+// that can fail, so the cap cannot fail open — this ceiling is the only
+// control bounding a cross-dispatch mail loop, and an unavailable count must
+// never be read as permission to send. It also cannot be pruned out from
+// under itself the way a rule_runs-based count was (pruneRuns deletes the
+// rows such a count relies on).
 //
-// Fails OPEN on a query error: a broken count should not silently stop a
-// user's mail. That is the opposite of mail's per-mailbox limiter, which fails
-// closed — there, an unresolvable mailbox means an unverifiable self-send,
-// which is the loop being guarded. Here there is no self-send to verify, so
-// the risk of blocking legitimate mail outweighs one uncounted send.
-func checkEmailRateLimit(app core.App, req ActionRequest) error {
-	if req.Rule == nil {
-		return nil
+// A new process starts with an empty ledger. That is acceptable because the
+// processes involved do not recycle mid-loop: a single-tenant server restarts
+// when an operator says so, and a multi-org tenant is evicted only after 30
+// idle minutes with zero connections — a state an active mail loop never
+// reaches.
+var emailSendLedger = struct {
+	sync.Mutex
+	sends map[string][]time.Time
+}{sends: map[string][]time.Time{}}
+
+// reserveEmailSend claims one send slot for the rule, or reports the rule is
+// over its hourly ceiling.
+//
+// The slot is claimed BEFORE the send so the in-flight message is part of its
+// own hour (a rule with several send actions is metered per message, and a
+// concurrent dispatch cannot slip past the ceiling). A claimed slot stays
+// consumed even if the send then fails or is abandoned by the action timeout
+// — over-counting is the safe direction for a loop guard.
+func reserveEmailSend(ruleID string, now time.Time) error {
+	emailSendLedger.Lock()
+	defer emailSendLedger.Unlock()
+
+	cutoff := now.Add(-time.Hour)
+	kept := emailSendLedger.sends[ruleID][:0]
+	for _, t := range emailSendLedger.sends[ruleID] {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
 	}
-
-	// types.DateTime, not an RFC3339 string: PocketBase persists dates as
-	// "2006-01-02 15:04:05.000Z" and compares them as text, so an RFC3339
-	// literal sorts above every stored value and the filter would silently
-	// match nothing — the cap would never engage.
-	since := types.NowDateTime().Add(-time.Hour)
-
-	runs, err := app.FindRecordsByFilter(
-		"rule_runs",
-		"rule = {:rule} && matched = true && fired_at >= {:since}",
-		"",
-		maxEmailsPerRulePerHour+1,
-		0,
-		map[string]any{"rule": req.Rule.Id, "since": since},
-	)
-	if err != nil {
-		app.Logger().Warn("automation: email rate-limit check failed, allowing send",
-			"rule", req.Rule.Id, "error", err)
-		return nil
-	}
-
-	if len(runs) >= maxEmailsPerRulePerHour {
+	if len(kept) >= maxEmailsPerRulePerHour {
+		emailSendLedger.sends[ruleID] = kept
 		return fmt.Errorf(
 			"rule %s reached its hourly email limit (%d) — skipping to break a possible loop",
-			req.Rule.Id, maxEmailsPerRulePerHour,
+			ruleID, maxEmailsPerRulePerHour,
 		)
 	}
+	emailSendLedger.sends[ruleID] = append(kept, now)
 	return nil
 }

--- a/core/server/automation/actions_email_test.go
+++ b/core/server/automation/actions_email_test.go
@@ -3,11 +3,11 @@ package automation
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/pocketbase/pocketbase/core"
-	"github.com/pocketbase/pocketbase/tools/types"
 
 	"tinycld.org/core/mailer"
 )
@@ -133,58 +133,135 @@ func TestActionSendEmail_EmptySubjectGetsAPlaceholder(t *testing.T) {
 
 // The engine's depth cap stops a rule re-triggering itself within one
 // dispatch; it cannot see an exchange with another system's auto-responder.
-func TestCheckEmailRateLimit(t *testing.T) {
+// The ledger counts SENDS, not matched runs: an earlier rule_runs-based count
+// let a rule with N send actions emit N× the ceiling.
+func TestReserveEmailSend(t *testing.T) {
 	tests := []struct {
-		name       string
-		recentRuns int
-		age        time.Duration
-		wantErr    bool
+		name      string
+		prior     int
+		age       time.Duration
+		wantBlock bool
 	}{
-		{name: "no history sends", recentRuns: 0, age: time.Minute},
-		{name: "under the cap sends", recentRuns: maxEmailsPerRulePerHour - 1, age: time.Minute},
-		{name: "at the cap is blocked", recentRuns: maxEmailsPerRulePerHour, age: time.Minute, wantErr: true},
+		{name: "no history sends", prior: 0, age: time.Minute},
+		{name: "under the cap sends", prior: maxEmailsPerRulePerHour - 1, age: time.Minute},
+		{name: "at the cap is blocked", prior: maxEmailsPerRulePerHour, age: time.Minute, wantBlock: true},
 		{
 			// A rolling hour, not a lifetime total: yesterday's burst must not
 			// stop today's mail.
-			name: "old runs fall outside the window", recentRuns: maxEmailsPerRulePerHour + 5,
+			name: "old sends fall outside the window", prior: maxEmailsPerRulePerHour + 5,
 			age: 2 * time.Hour,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			app, rule := runsApp(t)
-			col, err := app.FindCollectionByNameOrId("rule_runs")
-			if err != nil {
-				t.Fatal(err)
+			t.Cleanup(ResetRunStateForTest)
+			now := time.Now()
+			emailSendLedger.Lock()
+			for i := 0; i < tc.prior; i++ {
+				emailSendLedger.sends["rule-a"] = append(emailSendLedger.sends["rule-a"], now.Add(-tc.age))
 			}
-			for i := 0; i < tc.recentRuns; i++ {
-				r := core.NewRecord(col)
-				r.Set("rule", rule.Id)
-				r.Set("matched", true)
-				r.Set("fired_at", types.NowDateTime().Add(-tc.age))
-				if err := app.Save(r); err != nil {
-					t.Fatal(err)
-				}
-			}
+			emailSendLedger.Unlock()
 
-			err = checkEmailRateLimit(app, ActionRequest{Rule: rule})
-			if tc.wantErr && err == nil {
+			err := reserveEmailSend("rule-a", now)
+			if tc.wantBlock && err == nil {
 				t.Error("expected the send to be blocked, got nil")
 			}
-			if !tc.wantErr && err != nil {
+			if !tc.wantBlock && err != nil {
 				t.Errorf("expected the send to be allowed, got %v", err)
 			}
 		})
 	}
 }
 
-// A manual or scheduled rule with no rule record still sends: there is
-// nothing to count against, and refusing would break "run now".
-func TestCheckEmailRateLimit_NoRuleIsAllowed(t *testing.T) {
+// The slot is claimed before the send and stays consumed on failure, so the
+// in-flight message is inside its own hour (no off-by-one) and a rule whose
+// sends all fail still cannot spin: 20 failed attempts exhaust the budget.
+func TestReserveEmailSend_FailedSendsStillConsumeBudget(t *testing.T) {
+	app, rule := runsApp(t)
+	original := sendEmailNow
+	sendEmailNow = func(_ context.Context, _ *mailer.Message) error {
+		return fmt.Errorf("provider refused")
+	}
+	t.Cleanup(func() { sendEmailNow = original })
+
+	req := ActionRequest{
+		Rule:   rule,
+		Params: map[string]string{"to": "a@example.com", "subject": "s", "body": "b"},
+	}
+	for i := 0; i < maxEmailsPerRulePerHour; i++ {
+		if err := actionSendEmail(app, req); err == nil {
+			t.Fatalf("send %d: provider failure must surface", i)
+		}
+	}
+
+	err := actionSendEmail(app, req)
+	if err == nil || !strings.Contains(err.Error(), "hourly email limit") {
+		t.Fatalf("send %d must be blocked by the ledger, got %v", maxEmailsPerRulePerHour+1, err)
+	}
+}
+
+// One ledger, many workers: the reservation must hand out exactly the cap.
+func TestReserveEmailSend_ConcurrentReservationsRespectTheCap(t *testing.T) {
+	t.Cleanup(ResetRunStateForTest)
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	var allowed atomic.Int32
+	for i := 0; i < 2*maxEmailsPerRulePerHour; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if reserveEmailSend("rule-a", now) == nil {
+				allowed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := allowed.Load(); got != maxEmailsPerRulePerHour {
+		t.Fatalf("allowed %d concurrent sends, want exactly %d", got, maxEmailsPerRulePerHour)
+	}
+}
+
+// End to end through the handler: the 21st delivery attempt within the hour
+// is refused and never reaches the mailer.
+func TestActionSendEmail_MetersPerSend(t *testing.T) {
+	app, rule := runsApp(t)
+	sent := captureEmails(t)
+
+	req := ActionRequest{
+		Rule:   rule,
+		Params: map[string]string{"to": "a@example.com", "subject": "s", "body": "b"},
+	}
+	for i := 0; i < maxEmailsPerRulePerHour; i++ {
+		if err := actionSendEmail(app, req); err != nil {
+			t.Fatalf("send %d: %v", i, err)
+		}
+	}
+
+	err := actionSendEmail(app, req)
+	if err == nil || !strings.Contains(err.Error(), "hourly email limit") {
+		t.Fatalf("want the ledger to block the send, got %v", err)
+	}
+	if len(*sent) != maxEmailsPerRulePerHour {
+		t.Fatalf("mailer saw %d messages, want %d", len(*sent), maxEmailsPerRulePerHour)
+	}
+}
+
+// A request with no rule record has nothing to count against, and refusing
+// would break "run now"-style invocations.
+func TestActionSendEmail_NoRuleIsNotMetered(t *testing.T) {
 	app, _ := runsApp(t)
-	if err := checkEmailRateLimit(app, ActionRequest{}); err != nil {
-		t.Errorf("a request with no rule must be allowed: %v", err)
+	sent := captureEmails(t)
+
+	if err := actionSendEmail(app, ActionRequest{
+		Params: map[string]string{"to": "a@example.com", "subject": "s", "body": "b"},
+	}); err != nil {
+		t.Errorf("a request with no rule must send: %v", err)
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("mailer saw %d messages, want 1", len(*sent))
 	}
 }
 

--- a/core/server/automation/actions_test.go
+++ b/core/server/automation/actions_test.go
@@ -2,6 +2,7 @@
 package automation
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -357,4 +358,200 @@ func TestPersonalScopePkgaccess(t *testing.T) {
 	if err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0); err != nil {
 		t.Fatalf("personal rule with full pkgaccess must succeed: %v", err)
 	}
+}
+
+// relationGateApp builds the fixture the relation-param gates need: two
+// users, a per-user-visible target collection (boxes, view rule
+// `owner = @request.auth.id`), a LOCKED target collection (vaults, nil view
+// rule), a source collection whose record-op param names a relation column,
+// and native actions declaring typed relation params against both targets.
+func relationGateApp(t *testing.T) (app *tests.TestApp, u1, u2, rule, crate, box1, box2, vault *core.Record, defs *Defs) {
+	t.Helper()
+	t.Cleanup(ResetRegistriesForTest)
+	testApp, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { testApp.Cleanup() })
+	app = testApp
+	users, _ := app.FindCollectionByNameOrId("users")
+
+	newUser := func(email string) *core.Record {
+		r := core.NewRecord(users)
+		r.SetEmail(email)
+		r.SetPassword("Password123!")
+		r.SetVerified(true)
+		if err := app.Save(r); err != nil {
+			t.Fatal(err)
+		}
+		return r
+	}
+	u1, u2 = newUser("gate-owner@test.local"), newUser("gate-other@test.local")
+
+	boxes := core.NewBaseCollection("boxes")
+	boxes.Fields.Add(&core.TextField{Name: "name"})
+	boxes.Fields.Add(&core.RelationField{Name: "owner", CollectionId: users.Id, MaxSelect: 1})
+	boxes.ViewRule = types.Pointer("owner = @request.auth.id")
+	if err := app.Save(boxes); err != nil {
+		t.Fatal(err)
+	}
+	vaults := core.NewBaseCollection("vaults")
+	vaults.Fields.Add(&core.TextField{Name: "name"})
+	if err := app.Save(vaults); err != nil {
+		t.Fatal(err)
+	}
+	crates := core.NewBaseCollection("crates")
+	crates.Fields.Add(&core.TextField{Name: "title"})
+	crates.Fields.Add(&core.RelationField{Name: "box", CollectionId: boxes.Id, MaxSelect: 1})
+	if err := app.Save(crates); err != nil {
+		t.Fatal(err)
+	}
+	rulesCol := core.NewBaseCollection("fake_rules")
+	rulesCol.Fields.Add(&core.TextField{Name: "scope"})
+	rulesCol.Fields.Add(&core.TextField{Name: "owner"})
+	if err := app.Save(rulesCol); err != nil {
+		t.Fatal(err)
+	}
+
+	mkBox := func(owner *core.Record) *core.Record {
+		r := core.NewRecord(boxes)
+		r.Set("name", "box of "+owner.Email())
+		r.Set("owner", owner.Id)
+		if err := app.Save(r); err != nil {
+			t.Fatal(err)
+		}
+		return r
+	}
+	box1, box2 = mkBox(u1), mkBox(u2)
+	vault = core.NewRecord(vaults)
+	vault.Set("name", "locked")
+	if err := app.Save(vault); err != nil {
+		t.Fatal(err)
+	}
+
+	crate = core.NewRecord(crates)
+	// The title deliberately holds a REAL box id: if a relation param were
+	// template-substituted, "{{title}}" would resolve to it and succeed —
+	// the no-substitution test relies on it failing verbatim instead.
+	crate.Set("title", box1.Id)
+	if err := app.Save(crate); err != nil {
+		t.Fatal(err)
+	}
+
+	rule = core.NewRecord(rulesCol)
+	rule.Set("scope", "org")
+	rule.Set("owner", u1.Id)
+	if err := app.Save(rule); err != nil {
+		t.Fatal(err)
+	}
+
+	defs = &Defs{Packages: []PackageDefs{{
+		Slug: "crates",
+		Actions: []ActionDef{
+			{
+				ID: "file", Kind: "record-op", Collection: "crates",
+				Op:     RecordOp{Type: "update", Target: "trigger-record", Set: map[string]SetValue{"box": {Param: "box"}}},
+				Params: []ParamDef{{Key: "box", Field: "box"}},
+			},
+			{ID: "file-native", Kind: "native",
+				Params: []ParamDef{{Key: "box", Type: "relation", RelationTarget: "boxes"}}},
+			{ID: "vault-native", Kind: "native",
+				Params: []ParamDef{{Key: "vault", Type: "relation", RelationTarget: "vaults"}}},
+		},
+	}}}
+	return app, u1, u2, rule, crate, box1, box2, vault, defs
+}
+
+var crateTrigger = TriggerDef{Collection: "crates", On: "create"}
+
+func allowRelation(ref, key string) {
+	RegisterRelationAuthorizer(ref, key, func(core.App, ActionRequest, string) error { return nil })
+}
+
+func TestRelationParamGates(t *testing.T) {
+	app, _, _, rule, crate, box1, box2, vault, defs := relationGateApp(t)
+
+	t.Run("no authorizer refuses even the owner's own record", func(t *testing.T) {
+		err := ExecuteAction(app, defs, "crates:file", map[string]any{"box": box1.Id}, rule, crateTrigger, crate, 0)
+		if err == nil || !strings.Contains(err.Error(), "no registered authorizer") {
+			t.Fatalf("want the missing-authorizer refusal, got %v", err)
+		}
+	})
+
+	allowRelation("crates:file", "box")
+	allowRelation("crates:file-native", "box")
+	allowRelation("crates:vault-native", "vault")
+
+	t.Run("owner-visible record passes", func(t *testing.T) {
+		if err := ExecuteAction(app, defs, "crates:file", map[string]any{"box": box1.Id}, rule, crateTrigger, crate, 0); err != nil {
+			t.Fatalf("owner's own box must pass: %v", err)
+		}
+		fresh, _ := app.FindRecordById("crates", crate.Id)
+		if fresh.GetString("box") != box1.Id {
+			t.Fatalf("box = %q, want %q", fresh.GetString("box"), box1.Id)
+		}
+	})
+
+	t.Run("floor blocks a record the owner cannot view", func(t *testing.T) {
+		err := ExecuteAction(app, defs, "crates:file", map[string]any{"box": box2.Id}, rule, crateTrigger, crate, 0)
+		if err == nil || !strings.Contains(err.Error(), "may not use") {
+			t.Fatalf("want the floor denial, got %v", err)
+		}
+	})
+
+	t.Run("missing record is refused", func(t *testing.T) {
+		err := ExecuteAction(app, defs, "crates:file", map[string]any{"box": "nope12345"}, rule, crateTrigger, crate, 0)
+		if err == nil || !strings.Contains(err.Error(), "no boxes record") {
+			t.Fatalf("want the missing-record refusal, got %v", err)
+		}
+	})
+
+	t.Run("relation params are never template-substituted", func(t *testing.T) {
+		// crate.title IS box1's id — substitution would resolve and succeed.
+		err := ExecuteAction(app, defs, "crates:file", map[string]any{"box": "{{title}}"}, rule, crateTrigger, crate, 0)
+		if err == nil || !strings.Contains(err.Error(), "no boxes record") {
+			t.Fatalf("a templated relation param must fail verbatim, got %v", err)
+		}
+	})
+
+	t.Run("empty value skips the gates", func(t *testing.T) {
+		if err := ExecuteAction(app, defs, "crates:file", map[string]any{"box": ""}, rule, crateTrigger, crate, 0); err != nil {
+			t.Fatalf("an empty relation value has nothing to authorize: %v", err)
+		}
+	})
+
+	t.Run("locked target collection blocks via the floor", func(t *testing.T) {
+		RegisterAction("crates:vault-native", func(core.App, ActionRequest) error { return nil })
+		err := ExecuteAction(app, defs, "crates:vault-native", map[string]any{"vault": vault.Id}, rule, crateTrigger, crate, 0)
+		if err == nil || !strings.Contains(err.Error(), "may not use") {
+			t.Fatalf("a nil view rule must fail closed, got %v", err)
+		}
+	})
+
+	t.Run("native handler runs only after the gates", func(t *testing.T) {
+		got := ""
+		RegisterAction("crates:file-native", func(_ core.App, req ActionRequest) error {
+			got = req.Params["box"]
+			return nil
+		})
+		if err := ExecuteAction(app, defs, "crates:file-native", map[string]any{"box": box1.Id}, rule, crateTrigger, crate, 0); err != nil {
+			t.Fatalf("gated native must run: %v", err)
+		}
+		if got != box1.Id {
+			t.Fatalf("handler saw %q, want %q", got, box1.Id)
+		}
+		if err := ExecuteAction(app, defs, "crates:file-native", map[string]any{"box": box2.Id}, rule, crateTrigger, crate, 0); err == nil {
+			t.Fatal("native handler must not run for a floor-blocked id")
+		}
+	})
+
+	t.Run("authorizer veto fails the action", func(t *testing.T) {
+		RegisterRelationAuthorizer("crates:file", "box", func(core.App, ActionRequest, string) error {
+			return fmt.Errorf("destination is read-only for this user")
+		})
+		err := ExecuteAction(app, defs, "crates:file", map[string]any{"box": box1.Id}, rule, crateTrigger, crate, 0)
+		if err == nil || !strings.Contains(err.Error(), "read-only for this user") {
+			t.Fatalf("want the authorizer's veto, got %v", err)
+		}
+	})
 }

--- a/core/server/automation/catalog.go
+++ b/core/server/automation/catalog.go
@@ -238,6 +238,16 @@ func resolveParam(app core.App, col *core.Collection, p ParamDef) catalogParam {
 		}
 	} else {
 		out.Field = catalogField{Key: p.Key, Label: out.Label, Type: p.Type, Options: p.Options}
+		// A typed relation param names its target collection directly (a
+		// column param inherits the column's instead). Resolution fails when
+		// the target's package is absent from this deployment — the empty
+		// target then flips the action unavailable in resolveAction.
+		if p.Type == "relation" && p.RelationTarget != "" {
+			if target, err := app.FindCachedCollectionByNameOrId(p.RelationTarget); err == nil {
+				out.Field.RelationTarget = target.Name
+				out.Field.DisplayField = displayFieldFor(target)
+			}
+		}
 	}
 	out.Template = out.Field.Type == "text"
 	return out
@@ -271,6 +281,22 @@ func resolveAction(app core.App, pkg string, a ActionDef) catalogAction {
 	out.Params = make([]catalogParam, 0, len(a.Params))
 	for _, p := range a.Params {
 		out.Params = append(out.Params, resolveParam(app, col, p))
+	}
+	// A relation param that resolved no target would render a picker over
+	// nothing — authorable but permanently broken. Whatever the cause (typed
+	// param whose declared target is absent from this deployment, column
+	// param whose relation points at an uninstalled package's collection, or
+	// defs that skipped generate-time validation), grey the action out. The
+	// same goes for a relation param with no registered authorizer: the
+	// engine refuses to execute it (authorizeRelationParams), so offering it
+	// in the builder would only author rules that always fail.
+	for _, cp := range out.Params {
+		if cp.Field.Type != "relation" {
+			continue
+		}
+		if cp.Field.RelationTarget == "" || !hasRelationAuthorizer(out.Ref, cp.Key) {
+			out.Available = false
+		}
 	}
 	return out
 }

--- a/core/server/automation/catalog_test.go
+++ b/core/server/automation/catalog_test.go
@@ -113,11 +113,59 @@ func TestCatalogActionAvailability(t *testing.T) {
 		t.Fatal("registered native action must be available")
 	}
 	sf := get("cat:set-folder")
-	if !sf.Available || sf.OpTarget != "trigger-record" || sf.Params[0].Field.RelationTarget != "cat_folders" {
+	if sf.OpTarget != "trigger-record" || sf.Params[0].Field.RelationTarget != "cat_folders" {
 		t.Fatalf("record-op resolution: %+v", sf)
 	}
 	if sf.Params[0].Template {
 		t.Fatalf("relation-typed param must not be marked templatable: %+v", sf.Params[0])
+	}
+	// The engine refuses relation params with no registered authorizer, so
+	// the catalog must grey the action out until the package registers one.
+	if sf.Available {
+		t.Fatal("a relation param without an authorizer must leave the action unavailable")
+	}
+	RegisterRelationAuthorizer("cat:set-folder", "folder", func(core.App, ActionRequest, string) error { return nil })
+	rebuilt := eng.buildCatalog(app)
+	if !rebuilt.Actions[actionIndex(rebuilt.Actions, "cat:set-folder")].Available {
+		t.Fatal("record-op with a resolvable target and an authorizer must be available")
+	}
+}
+
+// A typed relation param names its target collection directly — the native
+// action case, where there is no column to inherit from. An unresolvable
+// target must grey the action out rather than ship a picker over nothing.
+func TestCatalogTypedRelationParams(t *testing.T) {
+	app, _ := catalogApp(t)
+	defs := &Defs{Packages: []PackageDefs{{
+		Slug: "cat",
+		Actions: []ActionDef{
+			{ID: "file-into", Label: "File into", Kind: "native",
+				Params: []ParamDef{{Key: "folder", Type: "relation", RelationTarget: "cat_folders"}}},
+			{ID: "file-into-void", Label: "File into the void", Kind: "native",
+				Params: []ParamDef{{Key: "folder", Type: "relation", RelationTarget: "not_installed_here"}}},
+		},
+	}}}
+	for _, ref := range []string{"cat:file-into", "cat:file-into-void"} {
+		RegisterAction(ref, func(core.App, ActionRequest) error { return nil })
+		RegisterRelationAuthorizer(ref, "folder", func(core.App, ActionRequest, string) error { return nil })
+	}
+	res := NewEngine(app, defs).buildCatalog(app)
+
+	ok := res.Actions[actionIndex(res.Actions, "cat:file-into")]
+	f := ok.Params[0].Field
+	if f.Type != "relation" || f.RelationTarget != "cat_folders" || f.DisplayField != "name" {
+		t.Fatalf("declared target must resolve like a column's: %+v", f)
+	}
+	if !ok.Available {
+		t.Fatal("native action with handler + authorizer + resolvable target must be available")
+	}
+
+	void := res.Actions[actionIndex(res.Actions, "cat:file-into-void")]
+	if void.Params[0].Field.RelationTarget != "" {
+		t.Fatalf("absent target must resolve empty: %+v", void.Params[0].Field)
+	}
+	if void.Available {
+		t.Fatal("native action whose relation target is absent must be unavailable")
 	}
 }
 

--- a/core/server/automation/defs.go
+++ b/core/server/automation/defs.go
@@ -79,6 +79,9 @@ type ParamDef struct {
 	Type    string   `json:"type"`
 	Label   string   `json:"label"`
 	Options []string `json:"options"`
+	// RelationTarget names the collection a typed relation param picks from.
+	// Column params leave it empty — their target resolves from the column.
+	RelationTarget string `json:"relationTarget"`
 }
 
 type ActionDef struct {

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -46,6 +46,17 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 func registerCoreNativeActions() {
 	registerCoreEmailAction()
 
+	// core:apply-label's `label` param is a caller-supplied record id, so it
+	// needs a registered authorizer like any other relation param. The check
+	// itself is deliberately a pass: labels are org-wide by design — any
+	// non-guest may view, apply, and edit any label (the labels collection's
+	// own rules say so, and the engine's floor has already held the rule
+	// owner to them). If labels ever become per-user, this is the line that
+	// changes.
+	RegisterRelationAuthorizer("core:apply-label", "label", func(core.App, ActionRequest, string) error {
+		return nil
+	})
+
 	// core:notify is fire-and-forget: the handler returns nil immediately and
 	// the actual push happens on a detached goroutine. The engine records this
 	// action's ActionResult as "ok" the instant the handler returns, before

--- a/core/server/automation/registry.go
+++ b/core/server/automation/registry.go
@@ -1,10 +1,9 @@
 // Package automation's registries (actionHandlers, ownerResolvers,
-// triggerFilters below) are process-global vars, not per-app state. In
-// multi-org mode one process hosts many tenant apps, each with its own
-// Engine — all of them share these same maps. That's fine in practice: refs
-// are package-qualified ("mail:send", "core:notify", …) and collide only on a
-// 15-char random id, which random-id generation makes negligible. Do not
-// assume a registered handler/resolver/filter is scoped to one tenant.
+// triggerFilters, relationAuthorizers below) are process-global vars, not
+// per-app state. Every deployment shape runs one org per OS process — a
+// multi-org router spawns a per-org build artifact as its own process
+// (multi-org/README.md) — so these maps only ever serve one org's Engine;
+// they are package globals for registration ergonomics, not for sharing.
 package automation
 
 import (
@@ -14,12 +13,17 @@ import (
 )
 
 // ActionRequest is what a native action handler receives. Params are already
-// template-substituted strings; Record is nil for synthetic triggers.
+// template-substituted strings (relation params pass verbatim — ids are
+// picker-chosen, never templated); Record is nil for synthetic triggers.
 //
 // Native handlers run outside the record-op/pkgaccess path (see
 // checkPersonalAccess in actions.go, which only re-applies pkgaccess to
 // record-op actions): a native handler must self-enforce any access control
-// it needs, the engine does not gate it for you.
+// it needs, the engine does not gate it for you. The one exception is
+// relation params, which the engine does gate — a view-rule floor plus the
+// action's registered RelationAuthorizer — because their values are
+// caller-supplied record ids; everything else (recipients, folders named by
+// text, the records a handler looks up itself) remains the handler's job.
 type ActionRequest struct {
 	Rule    *core.Record
 	OwnerID string
@@ -44,11 +48,23 @@ type OwnerResolver func(app core.App, record *core.Record) []string
 // rules.
 type TriggerFilter func(app core.App, record *core.Record) bool
 
+// RelationAuthorizer answers the which-record question for one relation param:
+// may this rule use the record `recordID` names? The engine refuses to run an
+// action whose relation param has no registered authorizer, so declaring the
+// param forces the package to answer — in code, not in a comment. The engine
+// has already applied its own floor (the rule owner passes the target
+// collection's view rule) before calling this; the authorizer adds the
+// package's write-level semantics (membership, roles, ownership). Return nil
+// to allow; a returned error fails the action and lands in run history.
+type RelationAuthorizer func(app core.App, req ActionRequest, recordID string) error
+
 var (
 	registryMu     sync.RWMutex
 	actionHandlers = map[string]ActionHandler{}
 	ownerResolvers = map[string]OwnerResolver{}
 	triggerFilters = map[string]TriggerFilter{}
+	// actionRef -> paramKey -> authorizer
+	relationAuthorizers = map[string]map[string]RelationAuthorizer{}
 )
 
 // RegisterAction installs the Go handler for a native action ref. Packages
@@ -67,6 +83,35 @@ func actionHandler(ref string) (ActionHandler, bool) {
 	defer registryMu.RUnlock()
 	h, ok := actionHandlers[ref]
 	return h, ok
+}
+
+// RegisterRelationAuthorizer installs the which-record check for one relation
+// param of one action. Packages call this next to RegisterAction (or, for a
+// record-op's relation param, next to their other registrations) — an action
+// with an unauthorized relation param is unavailable in the catalog and
+// refused at execution, so this is not optional hardening but part of
+// declaring the param.
+func RegisterRelationAuthorizer(actionRef, paramKey string, a RelationAuthorizer) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	m, ok := relationAuthorizers[actionRef]
+	if !ok {
+		m = map[string]RelationAuthorizer{}
+		relationAuthorizers[actionRef] = m
+	}
+	m[paramKey] = a
+}
+
+func relationAuthorizer(actionRef, paramKey string) (RelationAuthorizer, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	a, ok := relationAuthorizers[actionRef][paramKey]
+	return a, ok
+}
+
+func hasRelationAuthorizer(actionRef, paramKey string) bool {
+	_, ok := relationAuthorizer(actionRef, paramKey)
+	return ok
 }
 
 // RegisterOwnerResolver overrides owner auto-detection for one trigger ref.
@@ -103,6 +148,7 @@ func ResetRegistriesForTest() {
 	actionHandlers = map[string]ActionHandler{}
 	ownerResolvers = map[string]OwnerResolver{}
 	triggerFilters = map[string]TriggerFilter{}
+	relationAuthorizers = map[string]map[string]RelationAuthorizer{}
 }
 
 var autoOwnerFields = []string{"user", "owner", "author"}

--- a/core/server/automation/runs.go
+++ b/core/server/automation/runs.go
@@ -107,6 +107,9 @@ var failureStreaks sync.Map
 
 func ResetRunStateForTest() {
 	failureStreaks = sync.Map{}
+	emailSendLedger.Lock()
+	emailSendLedger.sends = map[string][]time.Time{}
+	emailSendLedger.Unlock()
 }
 
 func recordRunResult(app core.App, rule *core.Record, fullyFailed bool) {

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -124,8 +124,8 @@ rules on this data — treat resolvers as security code.
 ## Actions
 
 Two kinds. **Record-ops** are declarative database writes the core engine
-executes itself — they work in every deployment, including multi-org
-tenants where your package's Go isn't linked:
+executes itself — no handler to register, though a relation param still
+needs its authorizer (see **Record-level authorization** below):
 
 ```ts
 {
@@ -147,9 +147,14 @@ tenants where your package's Go isn't linked:
   a literal.
 - Params with `field: '<column>'` inherit the column's type, relation
   target, and select options; novel params declare `type` (`text`,
-  `number`, `boolean`, `date`, `select`, `relation`). Every text param
-  accepts `{{field}}` placeholders filled from the trigger's exposed fields
-  — no opt-in flag.
+  `number`, `boolean`, `date`, `select`, `relation`). A novel `relation`
+  param must also declare `relationTarget: '<collection>'` — the generator
+  rejects one without it (there is no column to inherit a target from, and
+  a targetless relation param renders a picker over nothing). Every text
+  param accepts `{{field}}` placeholders filled from the trigger's exposed
+  fields — no opt-in flag; relation params are never template-substituted
+  (ids are picker-chosen, and letting trigger content pick the id would be
+  an injection channel).
 
 **Native actions** dispatch to a Go handler you register in `Register(app)`
 (mirrors `$`-binding registration — must run before hooks load):
@@ -169,16 +174,82 @@ automation.RegisterAction("mail:send-message", func(app core.App, req automation
 
 Native-action caveats:
 
-- **Single-tenant only** unless the handler lives in core: a multi-org
-  tenant links no feature Go, so your handler is absent there. The catalog
-  marks the action unavailable and the UI greys it out ("needs <pkg>") —
+- **Available wherever your package's Go is linked.** Every deployment
+  shape links feature Go — a multi-org router builds a per-org artifact
+  from exactly that org's package set (`multi-org/README.md`), so your
+  handler exists wherever your package is installed. The catalog marks an
+  action whose handler is absent (package removed / not installed)
+  unavailable and the UI greys it out ("needs <pkg>") —
   declared-but-unregistered is a supported state, not an error.
-- **Handlers self-enforce access.** The engine applies `pkgaccess` to
-  personal-rule *record-ops* automatically; native handlers receive
-  superuser-powered `app` and must apply their own checks (the rule owner
-  is `req.OwnerID`).
+- **Handlers self-enforce access** — see **Record-level authorization**
+  below for what the engine gates for you (relation params) and what stays
+  your job (everything else).
 - Returning an error records the action as failed in `rule_runs` and
   continues to the rule's later actions (mail-filter semantics).
+
+## Record-level authorization
+
+The engine runs actions with system authority: record-ops write with a
+superuser `Save`, and native handlers receive a superuser-powered `app`.
+PocketBase collection rules therefore do NOT protect anything on this path —
+whatever check a write needs has to happen in engine or package Go. The
+division of labor:
+
+**The engine gates relation params — and only relation params.** A relation
+param's value is a caller-supplied record id (the rule JSON is
+client-authored; the picker is a convenience, not a boundary). Before an
+action of either kind runs, every non-empty relation param passes two
+fail-closed layers:
+
+1. **The floor (engine-owned, generic):** the rule owner must pass the
+   target collection's own `viewRule` for the referenced record, evaluated
+   as the owner (`CanAccessRecord`). Missing record, failed rule, or a
+   locked (nil) rule refuses the action. This proves the owner may *see*
+   the record — nothing more. Rule branches needing request context beyond
+   auth (e.g. a share-link token header) correctly evaluate false:
+   automation acts as the rule owner, never as an anonymous link holder.
+2. **Your registered `RelationAuthorizer` (required):** the write-level
+   question — may this rule file into that folder, assign that user, move
+   to that list — is package semantics the engine cannot know. Declaring a
+   relation param without registering its authorizer is refused at
+   execution and greys the action out in the catalog, so the question gets
+   answered in code, not assumed:
+
+   ```go
+   automation.RegisterRelationAuthorizer("drive:move-to-folder", "parent",
+       func(app core.App, req automation.ActionRequest, id string) error {
+           return destinationWritableBy(app, req.OwnerID, id)
+       })
+   ```
+
+   A deliberate pass is fine when the collection's own model is org-wide —
+   core's `apply-label` authorizer returns nil with a comment saying why
+   (labels are org-wide by design). The point is that the decision is
+   written down where review can see it.
+
+**Everything else stays the handler's job.** The floor+authorizer pair
+covers ids the *engine* hands you; records your handler looks up itself,
+text params that name things (recipients, addresses), and who an action
+acts *as* are still yours to check — `checkPersonalAccess` applies
+`pkgaccess` to personal-rule record-ops only, deliberately: it is a
+package-level floor that answers "may this user write to this package at
+all", never *which record*, and every real bug this system has produced
+was a which-record bug. Reference implementations worth copying:
+
+- `mail/server/automation_actions.go` — `actionAudience`/`applyToAudience`
+  (org rules act on all mailbox members, personal rules only as a
+  still-current member) and `ruleRecipient` (a rule may not mail the
+  mailbox's own addresses — the self-feeding-loop check).
+- `calendar/server/automation.go` — `ownedCalendarFor` +
+  `writableCalendarRoles` (rule-created events land only on a calendar the
+  owner can write, mirroring the collection's create rule the superuser
+  path bypasses).
+- `text/server/automation.go` / `calc/server/automation.go` — delegate to
+  core's `driveshare.ParticipantIDs` rather than re-deriving sharing rules
+  (a second copy would drift, and an over-reporting resolver fires other
+  users' rules on documents they cannot see).
+- `cards/server/automation.go` — `cardOwnerResolver` (project membership
+  scopes which personal rules fire at all).
 
 ## Execution semantics you inherit
 


### PR DESCRIPTION
Automation actions run with system authority — a record-op's `Save` and a native handler's `app` are both superuser — so PocketBase collection rules protect nothing on this path. A relation param's value is a caller-supplied record id (rule JSON is client-authored; the picker is a convenience, not a boundary), which left "which record may this rule touch" unanswered.

## What changed

**Two fail-closed layers on every non-empty relation param**, for both action kinds:

1. **Engine floor (generic):** the rule owner must pass the target collection's own `viewRule` for the referenced record, evaluated as the owner via `CanAccessRecord`. Missing record, failed rule, or a locked (nil) rule refuses the action.
2. **`RelationAuthorizer` (required, package-registered):** the write-level question — may this rule file into that folder, assign that user — is package semantics the engine can't know. Declaring a relation param without registering its authorizer is refused at execution and greys the action out in the catalog.

**Relation params are no longer template-substituted.** Letting trigger-record content choose which record an action touches is an injection channel; ids pass verbatim.

**Typed relation params must declare `relationTarget`.** They have no column to inherit one from, and a targetless relation param renders a picker over nothing. `validateDefinitions` enforces both directions at generate time.

**`core:send-email`'s hourly ceiling moved to an in-memory ledger.** The old `rule_runs` query failed open on error, and `pruneRuns` deletes the rows the count relied on. This cap is the only control bounding a cross-dispatch mail loop, so an unavailable count must not read as permission to send. The slot is claimed before the send, so a concurrent dispatch can't slip past.

`core:apply-label` gets an authorizer that deliberately passes — labels are org-wide by design — with a comment saying so, and a note on what would change if that stops being true.

## Notes

The registry and docs comments about multi-org tenants "linking no feature Go" were wrong and are corrected: a multi-org router builds a per-org artifact from that org's package set, so a package's handler exists wherever the package is installed.

## Checks

`go build ./...` + `go test ./automation/...` pass; `tinycld-pkg check` (biome + tsc + 1259 vitest tests) passes.