### PR TITLE
feat: central logging facility (client logger + Go slog fan-out)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -176,6 +176,7 @@
             "includes": [
                 "**/core/lib/nav-perf.ts",
                 "**/core/lib/sentry.ts",
+                "**/core/lib/logger.ts",
                 "**/core/lib/debug-trace.ts",
                 "**/core/lib/editor/use-webview-editor.tsx",
                 "**/core/lib/editor/webview-bundler/build.ts",

--- a/biome.json
+++ b/biome.json
@@ -174,17 +174,11 @@
         },
         {
             "includes": [
-                "**/core/lib/nav-perf.ts",
                 "**/core/lib/sentry.ts",
                 "**/core/lib/logger.ts",
                 "**/core/lib/debug-trace.ts",
-                "**/core/lib/editor/use-webview-editor.tsx",
                 "**/core/lib/editor/webview-bundler/build.ts",
-                "**/core/lib/editor/rich/use-rich-editor.web.tsx",
-                "**/core/components/workspace/LazySidebarBoundary.tsx",
-                "**/core/components/AppErrorBoundary.tsx",
-                "**/lib/use-server-address-gate.ts",
-                "**/lib/diagnose-regexp.ts"
+                "**/core/components/AppErrorBoundary.tsx"
             ],
             "linter": {
                 "rules": {

--- a/biome.json
+++ b/biome.json
@@ -129,7 +129,7 @@
             },
             "suspicious": {
                 "noDebugger": "error",
-                "noConsole": "warn",
+                "noConsole": "error",
                 "noVar": "error",
                 "noExplicitAny": "error"
             },

--- a/core/components/AppErrorBoundary.tsx
+++ b/core/components/AppErrorBoundary.tsx
@@ -33,13 +33,17 @@ export function AppErrorBoundary({ error, retry }: ErrorBoundaryProps) {
         if (!error.stack) return
         symbolicateStack(error.stack)
             .then(clean => {
-                // Load-bearing in ALL builds: the browser never applies
-                // sourcemaps to error.stack at runtime (only DevTools/Sentry do),
-                // so this is the ONLY place the readable, source-mapped crash
-                // stack surfaces in a production web build. sourcemaps.spec.ts
-                // asserts this line fires and names the original source. The file
-                // is exempt from noConsole in biome.json (diagnostic-modules
-                // override).
+                // Deliberately NOT routed through `log` — this is the one console
+                // call in client code that must survive a release build. The
+                // browser never applies sourcemaps to error.stack at runtime (only
+                // DevTools/Sentry do), so this is the ONLY place the readable,
+                // source-mapped crash stack surfaces in a production web build,
+                // and sourcemaps.spec.ts reads it off the console of an
+                // `expo export` bundle. `log.*` writes to the console only under
+                // __DEV__, so migrating this line would silence it exactly where
+                // it is needed. Sentry already has the error itself via the
+                // captureException above; this is the human-readable companion.
+                // The file is exempt from noConsole in biome.json.
                 console.log(`[error-boundary] ${clean}`)
             })
             .catch(() => {

--- a/core/components/workspace/LazySidebarBoundary.tsx
+++ b/core/components/workspace/LazySidebarBoundary.tsx
@@ -1,4 +1,5 @@
 import { captureException } from '@tinycld/core/lib/errors'
+import { log } from '@tinycld/core/lib/logger'
 import {
     Component,
     type ErrorInfo,
@@ -14,15 +15,13 @@ import { nextAttempt, shouldRetryOnTimeout } from './lazy-sidebar-retry'
 // Copious logging around sidebar-mount failures: when this boundary has to
 // recover, the next person debugging CI (or a user report) needs to see exactly
 // what happened — which slug, which failure mode, which attempt — not a silent
-// retry. `pkgSlug` is threaded in so every line names the package.
+// retry. `slug` is threaded in so every line names the package.
 function logSidebar(slug: string | undefined, msg: string, extra?: Record<string, unknown>) {
-    // __DEV__-guarded per house rule (no unguarded console). CI runs the dev
-    // bundle (Development-level warnings: ON), so these lines DO surface in CI
-    // failure logs — which is exactly where a wedged sidebar gets diagnosed.
-    // Production reporting goes through captureException at the call sites.
-    if (!__DEV__) return
-    const tag = `[sidebar-boundary${slug ? `:${slug}` : ''}]`
-    console.warn(tag, msg, extra ?? '')
+    // debug, not warn: each of these lines narrates one step of a retry the
+    // boundary is designed to absorb, so on its own none is worth paging for.
+    // They ride along as breadcrumbs on whatever event does fire — the terminal
+    // "gave up" case reports separately via captureException at the call site.
+    log.debug('core.workspace.sidebar-boundary', msg, { ...extra, slug })
 }
 
 interface LazySidebarBoundaryProps {

--- a/core/lib/__tests__/core-config.test.ts
+++ b/core/lib/__tests__/core-config.test.ts
@@ -60,4 +60,20 @@ describe('core-config', () => {
         configureCore({ brandName: 'Second', serverShortcuts: {} })
         expect(getCoreConfigOptional()?.brandName).toBe('Second')
     })
+
+    it('accepts a logLevel and returns it verbatim', async () => {
+        const { configureCore, getCoreConfig } = await importFresh()
+        configureCore({
+            brandName: 'TinyCld',
+            serverShortcuts: {},
+            logLevel: 'info',
+        })
+        expect(getCoreConfig().logLevel).toBe('info')
+    })
+
+    it('leaves logLevel undefined when not supplied', async () => {
+        const { configureCore, getCoreConfig } = await importFresh()
+        configureCore({ brandName: 'TinyCld', serverShortcuts: {} })
+        expect(getCoreConfig().logLevel).toBeUndefined()
+    })
 })

--- a/core/lib/__tests__/handle-mutation-errors.test.ts
+++ b/core/lib/__tests__/handle-mutation-errors.test.ts
@@ -66,3 +66,19 @@ describe('handleMutationErrorsWithForm', () => {
         expect(useToastStore.getState().toasts).toHaveLength(1)
     })
 })
+
+describe('captureException', () => {
+    it('captureException delegates to log.error', async () => {
+        const spy = vi.fn()
+        vi.doMock('../logger', () => ({
+            log: { error: spy, debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+        }))
+        vi.resetModules()
+
+        const { captureException } = await import('../errors')
+        const err = new Error('boom')
+        captureException('example.create', err, { id: '1' })
+
+        expect(spy).toHaveBeenCalledWith('example.create', err, { id: '1' })
+    })
+})

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { __resetCoreConfigForTests, configureCore } from '../core-config'
+
+const captureException = vi.fn()
+const captureMessage = vi.fn()
+const addBreadcrumb = vi.fn()
+
+vi.mock('../sentry', () => ({
+    captureExceptionToSentry: (...args: unknown[]) => captureException(...args),
+    captureMessageToSentry: (...args: unknown[]) => captureMessage(...args),
+    addBreadcrumbToSentry: (...args: unknown[]) => addBreadcrumb(...args),
+}))
+
+describe('log', () => {
+    beforeEach(() => {
+        __resetCoreConfigForTests()
+        captureException.mockClear()
+        captureMessage.mockClear()
+        addBreadcrumb.mockClear()
+        // logger.ts reads the RN global __DEV__ (console gating). Nothing
+        // defines it under vitest — stub it the same way use-saved-servers.test.ts
+        // does for debug-trace's read of the same global.
+        vi.stubGlobal('__DEV__', false)
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('breadcrumbs a below-threshold call without raising an event', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
+        const { log } = await import('../logger')
+
+        log.debug('mail.compose', 'draft saved', { draftId: '1' })
+
+        expect(addBreadcrumb).toHaveBeenCalledWith('mail.compose', 'debug', 'draft saved', {
+            draftId: '1',
+        })
+        expect(captureMessage).not.toHaveBeenCalled()
+        expect(captureException).not.toHaveBeenCalled()
+    })
+
+    it('breadcrumbs AND raises an event at the threshold', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
+        const { log } = await import('../logger')
+
+        log.warn('mail.imap', 'reconnect attempt', { attempt: 2 })
+
+        expect(addBreadcrumb).toHaveBeenCalledTimes(1)
+        expect(captureMessage).toHaveBeenCalledWith('mail.imap', 'reconnect attempt', {
+            attempt: 2,
+        })
+    })
+
+    it('routes log.error through captureException', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
+        const { log } = await import('../logger')
+        const err = new Error('boom')
+
+        log.error('mail.send', err, { messageId: 'm1' })
+
+        expect(captureException).toHaveBeenCalledWith('mail.send', err, { messageId: 'm1' })
+    })
+
+    it('treats an above-threshold info call as an event when level is debug', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'debug' })
+        const { log } = await import('../logger')
+
+        log.info('app.boot', 'ready')
+
+        expect(captureMessage).toHaveBeenCalledWith('app.boot', 'ready', undefined)
+    })
+})

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -32,19 +32,22 @@ describe('log', () => {
         expect(captureException).not.toHaveBeenCalled()
     })
 
-    it('breadcrumbs AND raises an event at the threshold', async () => {
+    it('breadcrumbs AND raises an event at the threshold, tagged with the call level', async () => {
         configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
         const { log } = await import('../logger')
 
         log.warn('mail.imap', 'reconnect attempt', { attempt: 2 })
 
         expect(addBreadcrumb).toHaveBeenCalledTimes(1)
-        expect(captureMessage).toHaveBeenCalledWith('mail.imap', 'reconnect attempt', {
+        expect(addBreadcrumb).toHaveBeenCalledWith('mail.imap', 'warn', 'reconnect attempt', {
+            attempt: 2,
+        })
+        expect(captureMessage).toHaveBeenCalledWith('mail.imap', 'warn', 'reconnect attempt', {
             attempt: 2,
         })
     })
 
-    it('routes log.error through captureException', async () => {
+    it('routes log.error through captureException without also breadcrumbing itself', async () => {
         configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
         const { log } = await import('../logger')
         const err = new Error('boom')
@@ -52,6 +55,7 @@ describe('log', () => {
         log.error('mail.send', err, { messageId: 'm1' })
 
         expect(captureException).toHaveBeenCalledWith('mail.send', err, { messageId: 'm1' })
+        expect(addBreadcrumb).not.toHaveBeenCalled()
     })
 
     it('treats an above-threshold info call as an event when level is debug', async () => {
@@ -60,6 +64,6 @@ describe('log', () => {
 
         log.info('app.boot', 'ready')
 
-        expect(captureMessage).toHaveBeenCalledWith('app.boot', 'ready', undefined)
+        expect(captureMessage).toHaveBeenCalledWith('app.boot', 'info', 'ready', undefined)
     })
 })

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { __resetCoreConfigForTests, configureCore } from '../core-config'
 
 const captureException = vi.fn()

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -17,14 +17,6 @@ describe('log', () => {
         captureException.mockClear()
         captureMessage.mockClear()
         addBreadcrumb.mockClear()
-        // logger.ts reads the RN global __DEV__ (console gating). Nothing
-        // defines it under vitest — stub it the same way use-saved-servers.test.ts
-        // does for debug-trace's read of the same global.
-        vi.stubGlobal('__DEV__', false)
-    })
-
-    afterEach(() => {
-        vi.unstubAllGlobals()
     })
 
     it('breadcrumbs a below-threshold call without raising an event', async () => {

--- a/core/lib/__tests__/mutations.test.tsx
+++ b/core/lib/__tests__/mutations.test.tsx
@@ -27,7 +27,6 @@ vi.mock('@tinycld/core/lib/notifications', () => ({
 vi.mock('@tinycld/core/lib/sentry', () => ({
     captureExceptionToSentry: vi.fn(),
     addBreadcrumbToSentry: vi.fn(),
-    captureMessageToSentry: vi.fn(),
 }))
 
 function wrapper() {

--- a/core/lib/__tests__/mutations.test.tsx
+++ b/core/lib/__tests__/mutations.test.tsx
@@ -26,6 +26,8 @@ vi.mock('@tinycld/core/lib/notifications', () => ({
 }))
 vi.mock('@tinycld/core/lib/sentry', () => ({
     captureExceptionToSentry: vi.fn(),
+    addBreadcrumbToSentry: vi.fn(),
+    captureMessageToSentry: vi.fn(),
 }))
 
 function wrapper() {

--- a/core/lib/core-config.ts
+++ b/core/lib/core-config.ts
@@ -1,4 +1,11 @@
 /**
+ * Severity ordering used by `@tinycld/core/lib/logger`. Everything becomes a
+ * Sentry breadcrumb; only calls at or above the configured level additionally
+ * become Sentry events.
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/**
  * Runtime configuration that the app shell hands to `@tinycld/core` at
  * startup. Moves per-app details — branding, server
  * shortcuts, Sentry DSN, review-mode flags — out of hard-coded env reads
@@ -40,6 +47,11 @@ export interface CoreConfig {
     environment?: string
     /** Sentry release tag (maps to EXPO_PUBLIC_GIT_COMMIT). */
     release?: string
+    /**
+     * Minimum level that escalates a log call from a breadcrumb to a Sentry
+     * event. Defaults to 'warn' in release builds and 'debug' in __DEV__.
+     */
+    logLevel?: LogLevel
     /** When true, the app is an App Store review build. */
     reviewMode?: boolean
     /** Demo password auto-filled in review builds. */

--- a/core/lib/editor/rich/use-rich-editor.web.tsx
+++ b/core/lib/editor/rich/use-rich-editor.web.tsx
@@ -1,6 +1,7 @@
 import { EditorContent, ReactNodeViewRenderer, useEditor } from '@tiptap/react'
 import { useEffect, useMemo, useRef } from 'react'
 import { View } from 'react-native'
+import { log } from '../../logger'
 import { useThemeColor } from '../../use-app-theme'
 import type { EditorCommands, EditorHandle, EditorResult, EditorToolbarState } from '../types'
 import { AuthedImageView } from './AuthedImageView.web'
@@ -309,10 +310,14 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         // return a destroyed instance during a remount. Touching `.commands` in
         // that window throws, so every imperative call is gated.
         const isLive = () => !!tiptapEditor && !tiptapEditor.isDestroyed
+        // debug, not warn: this catches a developer calling the wrong API, which
+        // is a coding mistake to read in the console — not a production incident
+        // worth an event.
         const warnIfCollab = (method: string) => {
-            if (collab && __DEV__) {
-                console.warn(
-                    `[editor] ${method} is a no-op under collaboration — seed the shared document instead`
+            if (collab) {
+                log.debug(
+                    'core.editor.rich',
+                    `${method} is a no-op under collaboration — seed the shared document instead`
                 )
             }
             return !!collab

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { View } from 'react-native'
 import type { WebViewMessageEvent } from 'react-native-webview'
 import { captureException } from '../errors'
+import { log } from '../logger'
 import { deriveToolbarState } from './derive-toolbar-state'
 import { createHeightStore, type HeightStore } from './height-store'
 import { type EditorMessage, makeMessage } from './message-bus/types'
@@ -279,18 +280,18 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     // when the WebView sends a `stateUpdate`, which our custom Editor
     // only sends after init arrives — chicken-and-egg.
     const [webviewReady, setWebviewReady] = useState(false)
-    // Mount timestamp for the dev-only phase timings below. A WebView editor is
-    // an expensive thing to create — a browser cold start plus a bundle — and
-    // the three marks (page-ready, init-sent, first-height) are what tell you
-    // WHICH of those phases a slow open actually spent its time in.
+    // Mount timestamp for the phase timings below. A WebView editor is an
+    // expensive thing to create — a browser cold start plus a bundle — and the
+    // three marks (page-ready, init-sent, first-height) are what tell you WHICH
+    // of those phases a slow open actually spent its time in.
     const mountAtRef = useRef(Date.now())
     // t0. Logged once per editor so the marks below have a visible origin —
     // without it a slow open is indistinguishable from an editor that mounted
     // late for reasons upstream of this hook.
     const loggedMountRef = useRef(false)
-    if (__DEV__ && !loggedMountRef.current) {
+    if (!loggedMountRef.current) {
         loggedMountRef.current = true
-        console.debug('[editor.mount] mounted (t0)')
+        log.debug('core.editor.webview', 'mounted (t0)')
     }
 
     // Height the page reported for its own content, held in a tiny store
@@ -321,9 +322,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         if (!webview) return
         const message = makeMessage('app', 'init', initPayload)
         try {
-            if (__DEV__) {
-                console.debug('[editor.mount] init-sent', Date.now() - mountAtRef.current, 'ms')
-            }
+            log.debug('core.editor.webview', 'init-sent', {
+                sinceMountMs: Date.now() - mountAtRef.current,
+            })
             webview.postMessage(JSON.stringify(message))
             lastInitGenerationRef.current = incoming
         } catch (err) {
@@ -385,9 +386,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         (payload: unknown) => {
             const height = (payload as { height?: unknown } | undefined)?.height
             if (typeof height !== 'number' || height <= 0) return
-            if (__DEV__) {
-                console.debug('[editor.mount] first-height', Date.now() - mountAtRef.current, 'ms')
-            }
+            log.debug('core.editor.webview', 'first-height', {
+                sinceMountMs: Date.now() - mountAtRef.current,
+            })
             setContentHeight(height)
         },
         [setContentHeight]
@@ -410,13 +411,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
             // alongside its dispatch), but it doesn't flip any
             // bridgeState flag from it.
             if (parsed.type === 'editor-ready') {
-                if (__DEV__) {
-                    console.debug(
-                        '[editor.mount] page-ready',
-                        Date.now() - mountAtRef.current,
-                        'ms'
-                    )
-                }
+                log.debug('core.editor.webview', 'page-ready', {
+                    sinceMountMs: Date.now() - mountAtRef.current,
+                })
                 setWebviewReady(true)
                 return
             }

--- a/core/lib/errors.ts
+++ b/core/lib/errors.ts
@@ -1,6 +1,6 @@
 import { notify } from '@tinycld/core/lib/notify/dispatcher'
 import type { FieldValues, Path, UseFormSetError } from 'react-hook-form'
-import { captureExceptionToSentry } from './sentry'
+import { log } from './logger'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === 'object' && value !== null
@@ -159,6 +159,10 @@ export function handleMutationErrorsWithForm<T extends FieldValues = FieldValues
     }
 }
 
+/**
+ * Retained for the many existing call sites; `log.error` is the same thing and
+ * is what new code should use.
+ */
 export function captureException(context: string, error: unknown, extra?: Record<string, unknown>) {
-    captureExceptionToSentry(context, error, extra)
+    log.error(context, error, extra)
 }

--- a/core/lib/logger.ts
+++ b/core/lib/logger.ts
@@ -42,7 +42,7 @@ function emit(
     consoleLine(level, context, message, extra)
     addBreadcrumbToSentry(context, level, message, extra)
     if (SEVERITY[level] < SEVERITY[resolveLogLevel()]) return
-    captureMessageToSentry(context, message, extra)
+    captureMessageToSentry(context, level, message, extra)
 }
 
 /**
@@ -67,12 +67,15 @@ export const log = {
     },
     /**
      * Errors always route through captureException so Sentry gets the real
-     * stack, never a stringified message.
+     * stack, never a stringified message. Deliberately skips
+     * addBreadcrumbToSentry: unlike debug/info/warn, an error call always
+     * produces its own Sentry event, so breadcrumbing it too would just
+     * restate the event as its own trailing context and evict one slot of
+     * actually-preceding history from the ring buffer.
      */
     error(context: string, error: unknown, extra?: Record<string, unknown>): void {
         const message = error instanceof Error ? error.message : String(error)
         consoleLine('error', context, message, extra)
-        addBreadcrumbToSentry(context, 'error', message, extra)
         captureExceptionToSentry(context, error, extra)
     },
 }

--- a/core/lib/logger.ts
+++ b/core/lib/logger.ts
@@ -1,0 +1,78 @@
+declare const __DEV__: boolean
+
+import { getCoreConfigOptional, type LogLevel } from './core-config'
+import { addBreadcrumbToSentry, captureExceptionToSentry, captureMessageToSentry } from './sentry'
+
+const SEVERITY: Record<LogLevel, number> = {
+    debug: 10,
+    info: 20,
+    warn: 30,
+    error: 40,
+}
+
+/**
+ * The level at or above which a log call also becomes a Sentry event. Release
+ * builds default to 'warn' so a production warning surfaces before it escalates
+ * into an exception; __DEV__ defaults to 'debug' (Sentry is inert there anyway,
+ * since initSentry early-returns on __DEV__).
+ */
+export function resolveLogLevel(): LogLevel {
+    const configured = getCoreConfigOptional()?.logLevel
+    if (configured) return configured
+    return __DEV__ ? 'debug' : 'warn'
+}
+
+function consoleLine(
+    level: LogLevel,
+    context: string,
+    message: string,
+    extra?: Record<string, unknown>
+): void {
+    if (!__DEV__) return
+    const method = level === 'debug' ? 'debug' : level === 'error' ? 'error' : level
+    console[method](`[${context}] ${message}`, extra ?? '')
+}
+
+function emit(
+    level: LogLevel,
+    context: string,
+    message: string,
+    extra?: Record<string, unknown>
+): void {
+    consoleLine(level, context, message, extra)
+    addBreadcrumbToSentry(context, level, message, extra)
+    if (SEVERITY[level] < SEVERITY[resolveLogLevel()]) return
+    captureMessageToSentry(context, message, extra)
+}
+
+/**
+ * The one blessed logging API for client code.
+ *
+ *     log.debug('mail.compose', 'draft saved', { draftId })
+ *     log.error('mail.send', err, { messageId })
+ *
+ * `context` is a short stable dotted string Sentry groups on; `extra` is the
+ * variable detail. Every call becomes a breadcrumb; calls at or above the
+ * configured level additionally become Sentry events.
+ */
+export const log = {
+    debug(context: string, message: string, extra?: Record<string, unknown>): void {
+        emit('debug', context, message, extra)
+    },
+    info(context: string, message: string, extra?: Record<string, unknown>): void {
+        emit('info', context, message, extra)
+    },
+    warn(context: string, message: string, extra?: Record<string, unknown>): void {
+        emit('warn', context, message, extra)
+    },
+    /**
+     * Errors always route through captureException so Sentry gets the real
+     * stack, never a stringified message.
+     */
+    error(context: string, error: unknown, extra?: Record<string, unknown>): void {
+        const message = error instanceof Error ? error.message : String(error)
+        consoleLine('error', context, message, extra)
+        addBreadcrumbToSentry(context, 'error', message, extra)
+        captureExceptionToSentry(context, error, extra)
+    },
+}

--- a/core/lib/nav-perf.ts
+++ b/core/lib/nav-perf.ts
@@ -1,3 +1,5 @@
+import { log } from './logger'
+
 /**
  * Navigation timing. Marks the moment a tab is pressed and logs the elapsed
  * time at later milestones (first paint of the target screen, query settled)
@@ -8,12 +10,11 @@
  * Call sites guard their argument construction with NAV_PERF too; the helpers
  * also short-circuit internally so a stray call is still cheap.
  *
- * Default OFF. To capture production first-mount timings: set NAV_PERF = true
- * AND switch the console.debug calls below to console.log (so they surface in
- * logcat from a Release build), then `expo run:android --variant release
- * --no-bundler`, kill Metro, launch from the embedded bundle, and
- * `adb logcat | grep '[nav-perf]'`. Leave NAV_PERF = false on any shipped
- * build — these must not run on the navigation hot path in production.
+ * Default OFF. The marks route through `log.debug`, so with NAV_PERF = true they
+ * land in the dev console and as Sentry breadcrumbs on the enclosing event —
+ * which is how a production first-mount timing gets read back without a logcat
+ * round-trip. Leave NAV_PERF = false on any shipped build; these must not run on
+ * the navigation hot path in production.
  */
 export const NAV_PERF = false
 
@@ -24,12 +25,12 @@ export function markNavPress(slug: string) {
     if (!NAV_PERF) return
     pressedSlug = slug
     pressedAt = performance.now()
-    console.debug(`[nav-perf] press → ${slug} @ t0`)
+    log.debug('core.nav-perf', 'press (t0)', { slug })
 }
 
 export function markNavMilestone(slug: string, label: string) {
     if (!NAV_PERF) return
     if (slug !== pressedSlug || pressedAt === 0) return
     const ms = Math.round(performance.now() - pressedAt)
-    console.debug(`[nav-perf] ${slug} · ${label} +${ms}ms`)
+    log.debug('core.nav-perf', 'milestone', { slug, label, ms })
 }

--- a/core/lib/sentry.ts
+++ b/core/lib/sentry.ts
@@ -2,7 +2,7 @@ declare const __DEV__: boolean
 
 import * as Sentry from '@sentry/react-native'
 import { Platform } from 'react-native'
-import { getCoreConfigOptional } from './core-config'
+import { getCoreConfigOptional, type LogLevel } from './core-config'
 import { scrubPII } from './sentry-scrub'
 
 let initialized = false
@@ -107,22 +107,34 @@ export function initSentry(): void {
 }
 
 /**
- * Lightweight breadcrumb-style log line that goes to Sentry as a "info" message
- * AND to the browser console. Use sparingly — for tracing intermittent prod
- * issues where you need to see a sequence of events. Remove the call sites once
- * the bug is found.
+ * Maps our LogLevel to the Sentry severity used for both breadcrumbs and
+ * captured events — shared so a `log.warn` sorts/filters/alerts the same way
+ * whichever path it took to get to Sentry.
+ */
+const SENTRY_LEVEL: Record<LogLevel, Sentry.SeverityLevel> = {
+    debug: 'debug',
+    info: 'info',
+    warn: 'warning',
+    error: 'error',
+}
+
+/**
+ * Sentry event for a non-error log call. `logger.ts` is the sole caller — its
+ * own `__DEV__`-gated `consoleLine()` owns console output, so this stays
+ * console-silent to avoid double-printing (and printing unconditionally in
+ * release, which is exactly the bug this replaced).
  */
 export function captureMessageToSentry(
     context: string,
+    level: LogLevel,
     message: string,
     extra?: Record<string, unknown>
 ): void {
-    const scrubbedExtra = extra ? scrubPII(extra) : undefined
-    console.info(`[trace:${context}] ${message}`, scrubbedExtra ?? '')
     if (!initialized) return
+    const scrubbedExtra = extra ? scrubPII(extra) : undefined
     Sentry.withScope(scope => {
         scope.setTag('context', context)
-        scope.setLevel('info')
+        scope.setLevel(SENTRY_LEVEL[level])
         if (scrubbedExtra) scope.setExtras(scrubbedExtra)
         Sentry.captureMessage(message)
     })
@@ -144,13 +156,6 @@ export function captureExceptionToSentry(
     })
 }
 
-const SENTRY_BREADCRUMB_LEVEL: Record<string, Sentry.SeverityLevel> = {
-    debug: 'debug',
-    info: 'info',
-    warn: 'warning',
-    error: 'error',
-}
-
 /**
  * Record a log line as a Sentry breadcrumb. Breadcrumbs are an in-memory ring
  * buffer — no network — and are attached automatically to whatever event fires
@@ -161,7 +166,7 @@ const SENTRY_BREADCRUMB_LEVEL: Record<string, Sentry.SeverityLevel> = {
  */
 export function addBreadcrumbToSentry(
     context: string,
-    level: string,
+    level: LogLevel,
     message: string,
     extra?: Record<string, unknown>
 ): void {
@@ -169,7 +174,7 @@ export function addBreadcrumbToSentry(
     Sentry.addBreadcrumb({
         category: context,
         message,
-        level: SENTRY_BREADCRUMB_LEVEL[level] ?? 'info',
+        level: SENTRY_LEVEL[level],
         data: extra,
     })
 }

--- a/core/lib/sentry.ts
+++ b/core/lib/sentry.ts
@@ -143,3 +143,33 @@ export function captureExceptionToSentry(
         Sentry.captureException(error)
     })
 }
+
+const SENTRY_BREADCRUMB_LEVEL: Record<string, Sentry.SeverityLevel> = {
+    debug: 'debug',
+    info: 'info',
+    warn: 'warning',
+    error: 'error',
+}
+
+/**
+ * Record a log line as a Sentry breadcrumb. Breadcrumbs are an in-memory ring
+ * buffer — no network — and are attached automatically to whatever event fires
+ * next, which is what gives an error its preceding context.
+ *
+ * PII scrubbing is handled by the `beforeBreadcrumb` hook registered in
+ * `initSentry`; do not scrub here or the data gets filtered twice.
+ */
+export function addBreadcrumbToSentry(
+    context: string,
+    level: string,
+    message: string,
+    extra?: Record<string, unknown>
+): void {
+    if (!initialized) return
+    Sentry.addBreadcrumb({
+        category: context,
+        message,
+        level: SENTRY_BREADCRUMB_LEVEL[level] ?? 'info',
+        data: extra,
+    })
+}

--- a/core/server/coreserver/logging_bootstrap_test.go
+++ b/core/server/coreserver/logging_bootstrap_test.go
@@ -1,0 +1,75 @@
+package coreserver
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase"
+)
+
+// TestLoggerInstallDoesNotHangDuringBootstrap pins the ordering bug fixed
+// alongside this test: logging.Install must run from an app.OnBootstrap()
+// hook, AFTER e.Next(), not directly inside Register/registerSharedEarly.
+//
+// Before bootstrap, app.Logger() falls back to slog.Default() (see
+// pocketbase/core/base.go). If Install were called with that fallback
+// handler, the fan-out it installs as the new default would contain a
+// handler that resolves back into itself — and the first log call
+// (registerSharedCore reaches automation.Register's slog.Info) recurses
+// forever. That is exactly what happened when the install lived directly
+// in Register: go test ./coreserver/ -run
+// TestTenantCompositionMatchesHostMinusRecordedExceptions hung until its
+// 150s timeout.
+//
+// Registering a full app (Register/RegisterTenant) is the only way to
+// reach registerSharedEarly's hook binding, so this lives in coreserver
+// rather than the logging package, which can't see that wiring.
+//
+// The run happens in a goroutine with a bounded timeout: if the ordering
+// regresses, the bug is a deadlock, not a returned error, so nothing short
+// of a timeout will turn it into a clean test failure.
+func TestLoggerInstallDoesNotHangDuringBootstrap(t *testing.T) {
+	preBootstrapHandler := slog.Default().Handler()
+	t.Cleanup(func() { slog.SetDefault(slog.New(preBootstrapHandler)) })
+
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: t.TempDir()})
+	Register(app, Options{
+		HooksDir:      t.TempDir(),
+		MigrationsDir: t.TempDir(),
+		TypesDir:      t.TempDir(),
+		PublicDir:     t.TempDir(),
+		HooksPoolSize: 1,
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		if err := app.Bootstrap(); err != nil {
+			done <- err
+			return
+		}
+		// The path that previously recursed: a plain slog.Info on the
+		// process-wide default, taken right after bootstrap completes —
+		// the same point automation.Register logs from during
+		// registerSharedCore.
+		slog.Info("post-bootstrap log reaches the installed fan-out")
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Bootstrap failed: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Bootstrap + log call did not complete within 10s — logging.Install likely wired the default logger to itself before bootstrap")
+	}
+
+	// Install replaces slog's default handler with the fan-out; confirming
+	// it changed (rather than asserting the unexported fanout type, which
+	// this package can't see) is what proves Install actually ran here
+	// rather than being skipped or silently no-op'd.
+	if slog.Default().Handler() == preBootstrapHandler {
+		t.Fatal("slog.Default() handler is unchanged after Bootstrap — logging.Install did not run")
+	}
+}

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -122,14 +122,6 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 
 	registerSharedEarly(app)
 
-	// Install the process-wide logger before features register, so their
-	// package loggers and any boot-time logging reach every destination.
-	//
-	// app.Logger().Handler() is resolved HERE and handed to Install, never
-	// resolved inside the fan-out: app.Logger() falls back to slog.Default()
-	// pre-bootstrap, so a lazy lookup inside the default handler would recurse.
-	logging.Install(app.Logger().Handler())
-
 	// Feature packages register BEFORE jsvm, and the order is load-bearing:
 	// jsvm.Register executes the hook files synchronously (its registerHooks
 	// call, not deferred to OnBootstrap), so any `$`-binding or loader binding
@@ -245,6 +237,28 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 // multi-org/docs/FINDING-tenant-composition-gap.md for what silent divergence
 // cost.
 func registerSharedEarly(app *pocketbase.PocketBase) {
+	// Install the process-wide logger once PocketBase has bootstrapped, not
+	// here in Register/RegisterTenant. app.Logger() falls back to
+	// slog.Default() until PocketBase's own initLogger() runs during
+	// bootstrap (pocketbase/core/base.go), so resolving it any earlier would
+	// hand Install the fan-out's own future default handler — wiring the
+	// fan-out to itself and recursing on the first log call. Waiting for
+	// e.Next() to complete first is also why the DB write works: the PB
+	// handler batches records into the _logs table, and there is no usable
+	// DB before bootstrap finishes.
+	//
+	// Anything logged between Register/RegisterTenant and this point (e.g.
+	// registerFlags, jsvm/migratecmd setup) falls through to Go's default
+	// slog handler (stderr) instead of the fan-out. That's deliberate, not a
+	// gap: those calls have no _logs table to reach yet regardless.
+	app.OnBootstrap().BindFunc(func(e *core.BootstrapEvent) error {
+		if err := e.Next(); err != nil {
+			return err
+		}
+		logging.Install(app.Logger().Handler())
+		return nil
+	})
+
 	// Sentry must register first so its router middleware sees every route.
 	// Middleware bound after a route is added does not apply retroactively.
 	// The client only initializes when a DSN exists in system_settings, so in

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/hook"
 
 	"tinycld.org/core/automation"
+	"tinycld.org/core/logging"
 	"tinycld.org/core/notify"
 	"tinycld.org/core/oauth"
 	"tinycld.org/core/offboard"
@@ -120,6 +121,14 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 	_ = app.RootCmd.ParseFlags(os.Args[1:])
 
 	registerSharedEarly(app)
+
+	// Install the process-wide logger before features register, so their
+	// package loggers and any boot-time logging reach every destination.
+	//
+	// app.Logger().Handler() is resolved HERE and handed to Install, never
+	// resolved inside the fan-out: app.Logger() falls back to slog.Default()
+	// pre-bootstrap, so a lazy lookup inside the default handler would recurse.
+	logging.Install(app.Logger().Handler())
 
 	// Feature packages register BEFORE jsvm, and the order is load-bearing:
 	// jsvm.Register executes the hook files synchronously (its registerHooks

--- a/core/server/logging/fanout.go
+++ b/core/server/logging/fanout.go
@@ -1,0 +1,72 @@
+// Package logging installs the process-wide slog handler for TinyCld servers.
+//
+// Call sites declare what happened (level + message + attrs); this package
+// decides where it goes. That separation is the point: before it, the function
+// you called silently picked the destination (slog → stderr, app.Logger() →
+// the _logs table, sentry.CaptureException → Sentry).
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+// fanout forwards each record to every child handler that accepts it, so a
+// single call site can reach stderr, the _logs table, and Sentry at once with
+// independent per-destination levels.
+type fanout struct {
+	handlers []slog.Handler
+}
+
+// NewFanout returns a handler that forwards to each of handlers.
+func NewFanout(handlers ...slog.Handler) slog.Handler {
+	return &fanout{handlers: handlers}
+}
+
+// Enabled reports whether ANY child would accept the level. Returning false
+// only when every child declines is what lets a quiet stderr handler coexist
+// with a chatty Sentry one without either suppressing the other.
+func (f *fanout) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, h := range f.handlers {
+		if h.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle re-checks Enabled per child, because the parent's Enabled is an OR
+// across all of them — without this a debug record aimed at stderr would also
+// be written to the error-level Sentry handler.
+//
+// A child returning an error must not stop the others: losing a stderr line
+// should never also lose the Sentry event. The last error is returned for the
+// caller's benefit and otherwise ignored.
+func (f *fanout) Handle(ctx context.Context, r slog.Record) error {
+	var lastErr error
+	for _, h := range f.handlers {
+		if !h.Enabled(ctx, r.Level) {
+			continue
+		}
+		if err := h.Handle(ctx, r.Clone()); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (f *fanout) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Handler, len(f.handlers))
+	for i, h := range f.handlers {
+		next[i] = h.WithAttrs(attrs)
+	}
+	return &fanout{handlers: next}
+}
+
+func (f *fanout) WithGroup(name string) slog.Handler {
+	next := make([]slog.Handler, len(f.handlers))
+	for i, h := range f.handlers {
+		next[i] = h.WithGroup(name)
+	}
+	return &fanout{handlers: next}
+}

--- a/core/server/logging/fanout_test.go
+++ b/core/server/logging/fanout_test.go
@@ -1,0 +1,62 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestFanoutWritesToEveryEnabledHandler(t *testing.T) {
+	var a, b bytes.Buffer
+	h := NewFanout(
+		slog.NewTextHandler(&a, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		slog.NewTextHandler(&b, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+	slog.New(h).Info("hello", "k", "v")
+
+	if !strings.Contains(a.String(), "hello") {
+		t.Errorf("handler a missing record: %q", a.String())
+	}
+	if !strings.Contains(b.String(), "hello") {
+		t.Errorf("handler b missing record: %q", b.String())
+	}
+}
+
+func TestFanoutRespectsPerHandlerLevel(t *testing.T) {
+	var chatty, quiet bytes.Buffer
+	h := NewFanout(
+		slog.NewTextHandler(&chatty, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		slog.NewTextHandler(&quiet, &slog.HandlerOptions{Level: slog.LevelError}),
+	)
+	slog.New(h).Info("only-chatty")
+
+	if !strings.Contains(chatty.String(), "only-chatty") {
+		t.Errorf("debug handler should have received the record")
+	}
+	if quiet.Len() != 0 {
+		t.Errorf("error-level handler should have dropped the record, got %q", quiet.String())
+	}
+}
+
+func TestFanoutEnabledIsTrueIfAnyChildIsEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewFanout(
+		slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}),
+		slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+	if !h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("fanout should be enabled when any child is enabled")
+	}
+}
+
+func TestFanoutPropagatesAttrsToChildren(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewFanout(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.New(h).With("pkg", "cards").Info("msg")
+
+	if !strings.Contains(buf.String(), "pkg=cards") {
+		t.Errorf("WithAttrs did not reach the child handler: %q", buf.String())
+	}
+}

--- a/core/server/logging/logging.go
+++ b/core/server/logging/logging.go
@@ -8,12 +8,16 @@ import (
 // Destination levels. Independent by design: stderr and the DB-backed _logs
 // table are for operators reading history, while Sentry is for paging someone.
 //
-// _logs sits at Info deliberately. It is a database table, and routing all of
-// the codebase's slog calls there at Debug would write far more than the
-// app.Logger() calls it receives today.
+// _logs has no level constant here — pbHandler (app.Logger().Handler(), the
+// caller-supplied destination below) already gates itself on PocketBase's own
+// admin-configurable Settings.Logs.MinLevel (Info by default). Wrapping it in
+// a second, hardcoded filter would either duplicate that gate or silently
+// override an admin who lowered MinLevel to Debug to troubleshoot — and
+// _logs must keep receiving records unconditionally: the OTA e2e harness
+// polls it for an "app-boot: rendered" beacon to confirm a promoted bundle
+// booted on a device.
 const (
 	StderrLevel = slog.LevelInfo
-	LogsLevel   = slog.LevelInfo
 	SentryLevel = slog.LevelWarn
 )
 

--- a/core/server/logging/logging.go
+++ b/core/server/logging/logging.go
@@ -1,0 +1,48 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Destination levels. Independent by design: stderr and the DB-backed _logs
+// table are for operators reading history, while Sentry is for paging someone.
+//
+// _logs sits at Info deliberately. It is a database table, and routing all of
+// the codebase's slog calls there at Debug would write far more than the
+// app.Logger() calls it receives today.
+const (
+	StderrLevel = slog.LevelInfo
+	LogsLevel   = slog.LevelInfo
+	SentryLevel = slog.LevelWarn
+)
+
+// Install sets the process-wide default logger to a fan-out over stderr, the
+// PocketBase _logs table, and Sentry.
+//
+// pbHandler is the caller-resolved handler for the _logs table — normally
+// app.Logger().Handler(). It is passed in rather than resolved here because
+// app.Logger() falls back to slog.Default() before bootstrap; resolving it
+// inside the handler we are installing AS the default would recurse.
+//
+// Pass nil for pbHandler to skip the _logs destination (useful in tests and in
+// binaries with no PocketBase app).
+func Install(pbHandler slog.Handler) {
+	handlers := []slog.Handler{
+		slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: StderrLevel}),
+		NewSentryHandler(SentryLevel),
+	}
+	if pbHandler != nil {
+		handlers = append(handlers, pbHandler)
+	}
+	slog.SetDefault(slog.New(NewFanout(handlers...)))
+}
+
+// ForPackage returns a logger stamped with a pkg attribute, replacing the old
+// hand-written "cards: " message prefixes with a queryable structured field.
+//
+//	log := logging.ForPackage("cards")
+//	log.WarnContext(ctx, "refusing to flush a card from another board", "cardID", id)
+func ForPackage(name string) *slog.Logger {
+	return slog.Default().With("pkg", name)
+}

--- a/core/server/logging/logging_test.go
+++ b/core/server/logging/logging_test.go
@@ -1,0 +1,36 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestForPackageStampsThePkgAttr(t *testing.T) {
+	var buf bytes.Buffer
+	Install(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))) })
+
+	ForPackage("cards").Warn("refusing to flush")
+
+	out := buf.String()
+	if !strings.Contains(out, "pkg=cards") {
+		t.Errorf("expected pkg=cards, got %q", out)
+	}
+	if !strings.Contains(out, "refusing to flush") {
+		t.Errorf("expected the message, got %q", out)
+	}
+}
+
+func TestInstallSetsTheDefaultLogger(t *testing.T) {
+	var buf bytes.Buffer
+	Install(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))) })
+
+	slog.Info("via the package-level default")
+
+	if !strings.Contains(buf.String(), "via the package-level default") {
+		t.Errorf("slog.Default was not installed: %q", buf.String())
+	}
+}

--- a/core/server/logging/sentry_handler.go
+++ b/core/server/logging/sentry_handler.go
@@ -1,0 +1,75 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/getsentry/sentry-go"
+)
+
+var sentryLevel = map[slog.Level]sentry.Level{
+	slog.LevelDebug: sentry.LevelDebug,
+	slog.LevelInfo:  sentry.LevelInfo,
+	slog.LevelWarn:  sentry.LevelWarning,
+	slog.LevelError: sentry.LevelError,
+}
+
+// sentryHandler turns log records at or above minLevel into Sentry events.
+//
+// User attribution is inherited, not plumbed: the per-request middleware in
+// coreserver/sentry.go already puts a hub carrying sentry.User{ID: …} on the
+// request context, so a *Context log call picks it up automatically. Calls
+// without a ctx (tickers, startup, background goroutines) fall back to the
+// current hub and produce an unattributed event — which is correct, because
+// there genuinely is no user in those paths.
+type sentryHandler struct {
+	minLevel slog.Level
+	attrs    []slog.Attr
+	groups   []string
+}
+
+// NewSentryHandler returns a handler capturing records at or above minLevel.
+func NewSentryHandler(minLevel slog.Level) slog.Handler {
+	return &sentryHandler{minLevel: minLevel}
+}
+
+func (h *sentryHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.minLevel
+}
+
+func (h *sentryHandler) Handle(ctx context.Context, r slog.Record) error {
+	hub := sentry.GetHubFromContext(ctx)
+	if hub == nil {
+		hub = sentry.CurrentHub()
+	}
+
+	extra := make(map[string]any, len(h.attrs)+r.NumAttrs())
+	for _, a := range h.attrs {
+		extra[a.Key] = a.Value.Any()
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		extra[a.Key] = a.Value.Any()
+		return true
+	})
+
+	hub.WithScope(func(scope *sentry.Scope) {
+		scope.SetLevel(sentryLevel[r.Level])
+		scope.SetExtras(extra)
+		hub.CaptureMessage(r.Message)
+	})
+	return nil
+}
+
+func (h *sentryHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	next = append(next, h.attrs...)
+	next = append(next, attrs...)
+	return &sentryHandler{minLevel: h.minLevel, attrs: next, groups: h.groups}
+}
+
+func (h *sentryHandler) WithGroup(name string) slog.Handler {
+	next := make([]string, 0, len(h.groups)+1)
+	next = append(next, h.groups...)
+	next = append(next, name)
+	return &sentryHandler{minLevel: h.minLevel, attrs: h.attrs, groups: next}
+}

--- a/core/server/logging/sentry_handler.go
+++ b/core/server/logging/sentry_handler.go
@@ -54,7 +54,11 @@ func (h *sentryHandler) Handle(ctx context.Context, r slog.Record) error {
 
 	hub.WithScope(func(scope *sentry.Scope) {
 		scope.SetLevel(sentryLevel[r.Level])
-		scope.SetExtras(extra)
+		// SetContext (not the deprecated SetExtras/SetAttributes) so the
+		// record's attrs attach to the event itself — SetAttributes is
+		// documented to be dropped for error events, and this handler exists
+		// specifically to capture events.
+		scope.SetContext("log", extra)
 		hub.CaptureMessage(r.Message)
 	})
 	return nil

--- a/core/server/logging/sentry_handler_test.go
+++ b/core/server/logging/sentry_handler_test.go
@@ -65,7 +65,7 @@ func TestSentryHandlerCapturesWithoutAHubOnContext(t *testing.T) {
 	logger.Warn("no ctx here")
 }
 
-func TestSentryHandlerAttachesAttrsAsExtra(t *testing.T) {
+func TestSentryHandlerAttachesAttrsAsContext(t *testing.T) {
 	hub, tr := newTestHub(t)
 	ctx := sentry.SetHubOnContext(context.Background(), hub)
 
@@ -75,11 +75,14 @@ func TestSentryHandlerAttachesAttrsAsExtra(t *testing.T) {
 	if len(tr.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(tr.events))
 	}
-	extra := tr.events[0].Extra
-	if extra["pkg"] != "cards" {
-		t.Errorf("expected pkg=cards in extra, got %v", extra["pkg"])
+	logCtx, ok := tr.events[0].Contexts["log"]
+	if !ok {
+		t.Fatalf("expected a %q context on the event, got %v", "log", tr.events[0].Contexts)
 	}
-	if extra["boardID"] != "b1" {
-		t.Errorf("expected boardID=b1 in extra, got %v", extra["boardID"])
+	if logCtx["pkg"] != "cards" {
+		t.Errorf("expected pkg=cards in log context, got %v", logCtx["pkg"])
+	}
+	if logCtx["boardID"] != "b1" {
+		t.Errorf("expected boardID=b1 in log context, got %v", logCtx["boardID"])
 	}
 }

--- a/core/server/logging/sentry_handler_test.go
+++ b/core/server/logging/sentry_handler_test.go
@@ -1,0 +1,85 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// captureTransport records events instead of sending them.
+type captureTransport struct {
+	events []*sentry.Event
+}
+
+func (t *captureTransport) Configure(sentry.ClientOptions)        {}
+func (t *captureTransport) SendEvent(e *sentry.Event)             { t.events = append(t.events, e) }
+func (t *captureTransport) Flush(time.Duration) bool              { return true }
+func (t *captureTransport) FlushWithContext(context.Context) bool { return true }
+func (t *captureTransport) Close()                                {}
+
+func newTestHub(t *testing.T) (*sentry.Hub, *captureTransport) {
+	t.Helper()
+	tr := &captureTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{Dsn: "", Transport: tr})
+	if err != nil {
+		t.Fatalf("sentry.NewClient: %v", err)
+	}
+	return sentry.NewHub(client, sentry.NewScope()), tr
+}
+
+func TestSentryHandlerCapturesAtOrAboveLevel(t *testing.T) {
+	hub, tr := newTestHub(t)
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	logger := slog.New(NewSentryHandler(slog.LevelWarn))
+	logger.WarnContext(ctx, "reconnect failed", "attempt", 3)
+
+	if len(tr.events) != 1 {
+		t.Fatalf("expected 1 captured event, got %d", len(tr.events))
+	}
+	if tr.events[0].Message != "reconnect failed" {
+		t.Errorf("unexpected message: %q", tr.events[0].Message)
+	}
+}
+
+func TestSentryHandlerIgnoresBelowLevel(t *testing.T) {
+	hub, tr := newTestHub(t)
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	logger := slog.New(NewSentryHandler(slog.LevelWarn))
+	logger.InfoContext(ctx, "just fyi")
+
+	if len(tr.events) != 0 {
+		t.Fatalf("expected no events, got %d", len(tr.events))
+	}
+}
+
+// A call site with no ctx (tickers, startup, background goroutines) must still
+// produce an event — the user id is enrichment, never a gate.
+func TestSentryHandlerCapturesWithoutAHubOnContext(t *testing.T) {
+	logger := slog.New(NewSentryHandler(slog.LevelWarn))
+	// Must not panic with no hub on the context.
+	logger.Warn("no ctx here")
+}
+
+func TestSentryHandlerAttachesAttrsAsExtra(t *testing.T) {
+	hub, tr := newTestHub(t)
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	logger := slog.New(NewSentryHandler(slog.LevelWarn)).With("pkg", "cards")
+	logger.ErrorContext(ctx, "flush failed", "boardID", "b1")
+
+	if len(tr.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(tr.events))
+	}
+	extra := tr.events[0].Extra
+	if extra["pkg"] != "cards" {
+		t.Errorf("expected pkg=cards in extra, got %v", extra["pkg"])
+	}
+	if extra["boardID"] != "b1" {
+		t.Errorf("expected boardID=b1 in extra, got %v", extra["boardID"])
+	}
+}

--- a/lib/use-server-address-gate.ts
+++ b/lib/use-server-address-gate.ts
@@ -1,3 +1,4 @@
+import { log } from '@tinycld/core/lib/logger'
 import {
     DEMO_SERVER,
     getResolvedAddress,
@@ -72,7 +73,7 @@ export function useServerAddressGate(pathname: string): GateState {
                 // diagnostic UI.
                 if (cancelled) return
                 const message = err instanceof Error ? err.message : String(err)
-                console.error('[layout-gate] failed to resolve providers:', err)
+                log.error('core.layout-gate.resolve-providers', err)
                 setState({ status: 'failed', error: message })
             }
         }

--- a/tests/unit-setup.ts
+++ b/tests/unit-setup.ts
@@ -4,6 +4,12 @@
 // Add vi.mock() calls here for modules that cannot be handled by resolve.alias.
 import { vi } from 'vitest'
 
+// Metro injects __DEV__ at build time; vitest runs in Node, so declare it here.
+declare global {
+    const __DEV__: boolean
+}
+globalThis.__DEV__ = true
+
 // Mock the generated config to empty. This is REQUIRED to break an import
 // cycle: the real tinycld.config.ts imports each package's provider, some of
 // which (calc, text) eagerly import @tinycld/core/file-viewer components that

--- a/tests/unit-setup.ts
+++ b/tests/unit-setup.ts
@@ -4,13 +4,13 @@
 // Add vi.mock() calls here for modules that cannot be handled by resolve.alias.
 import { vi } from 'vitest'
 
-// Metro injects __DEV__ at build time; vitest runs in Node, so declare it here.
+// Metro injects __DEV__ at build time; vitest runs in Node, so seed it here.
+// react-native's globals.d.ts already declares the global as `const __DEV__`, so
+// this file must not redeclare it (that is a block-scoped collision) — it only
+// needs to install the value, which the cast through globalThis does.
 // Tests exercise the production default (__DEV__ = false) unless they opt into dev
 // behavior with a per-test vi.stubGlobal override (see logger.test.ts for examples).
-declare global {
-    const __DEV__: boolean
-}
-globalThis.__DEV__ = false
+;(globalThis as unknown as { __DEV__: boolean }).__DEV__ = false
 
 // Mock the generated config to empty. This is REQUIRED to break an import
 // cycle: the real tinycld.config.ts imports each package's provider, some of

--- a/tests/unit-setup.ts
+++ b/tests/unit-setup.ts
@@ -5,10 +5,12 @@
 import { vi } from 'vitest'
 
 // Metro injects __DEV__ at build time; vitest runs in Node, so declare it here.
+// Tests exercise the production default (__DEV__ = false) unless they opt into dev
+// behavior with a per-test vi.stubGlobal override (see logger.test.ts for examples).
 declare global {
     const __DEV__: boolean
 }
-globalThis.__DEV__ = true
+globalThis.__DEV__ = false
 
 // Mock the generated config to empty. This is REQUIRED to break an import
 // cycle: the real tinycld.config.ts imports each package's provider, some of


### PR DESCRIPTION
Replaces five ad-hoc logging paths with one blessed API per language.

**Client** — new `@tinycld/core/lib/logger`:
```ts
log.debug('mail.compose', 'draft saved', { draftId })
log.error('mail.send', err, { messageId })
```
Every call becomes a Sentry breadcrumb; calls at or above `coreConfig.logLevel` (default `warn` in release, `debug` in dev) also become events. Routing through the SDK means the existing `scrubPII` hooks apply automatically. `captureException` still works and is now an alias for `log.error`.

**Server** — a fan-out `slog.Handler` writing to stderr (`info`+), PocketBase `_logs` (`info`+), and Sentry (`warn`+), installed as `slog.Default()` on bootstrap. User attribution is inherited from the per-request Sentry hub, so `*Context` calls get it for free and calls without a `ctx` still log, just unattributed.

`noConsole` is now a biome error. Nine runtime files migrated, each `warn`/`error` site audited for whether it should page someone in production.

### Notes for review

- **Must land with tinycld/mail#63** — this changes `captureMessageToSentry`'s signature and `mail` has two call sites.
- Install is bound to `OnBootstrap`, not `Register`. Doing it earlier wires the fan-out to itself (`app.Logger()` falls back to `slog.Default()` pre-bootstrap) and hangs the suite; `TestLoggerInstallDoesNotHangDuringBootstrap` pins that invariant.
- `_logs` delivery is preserved — the OTA e2e harness polls it for the boot beacon.
- Three deliberate `console.*` exemptions remain: `sentry.ts` (pre-init), `logger.ts` (owns console), `AppErrorBoundary.tsx` (`sourcemaps.spec.ts` asserts on it in a release web export).

The ~830-site Go call-site migration is **out of scope** — it needs this released plus per-member `peerVersions` bumps.

Tests: `tinycld-pkg check` 1421/1421 · `go test ./coreserver/... ./logging/...` both ok · lint clean across 2040 files.