### PR TITLE
Report where the credential actually landed on auth login

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -176,6 +176,7 @@
             "includes": [
                 "**/core/lib/nav-perf.ts",
                 "**/core/lib/sentry.ts",
+                "**/core/lib/logger.ts",
                 "**/core/lib/debug-trace.ts",
                 "**/core/lib/editor/use-webview-editor.tsx",
                 "**/core/lib/editor/webview-bundler/build.ts",

--- a/biome.json
+++ b/biome.json
@@ -174,17 +174,11 @@
         },
         {
             "includes": [
-                "**/core/lib/nav-perf.ts",
                 "**/core/lib/sentry.ts",
                 "**/core/lib/logger.ts",
                 "**/core/lib/debug-trace.ts",
-                "**/core/lib/editor/use-webview-editor.tsx",
                 "**/core/lib/editor/webview-bundler/build.ts",
-                "**/core/lib/editor/rich/use-rich-editor.web.tsx",
-                "**/core/components/workspace/LazySidebarBoundary.tsx",
-                "**/core/components/AppErrorBoundary.tsx",
-                "**/lib/use-server-address-gate.ts",
-                "**/lib/diagnose-regexp.ts"
+                "**/core/components/AppErrorBoundary.tsx"
             ],
             "linter": {
                 "rules": {

--- a/biome.json
+++ b/biome.json
@@ -129,7 +129,7 @@
             },
             "suspicious": {
                 "noDebugger": "error",
-                "noConsole": "warn",
+                "noConsole": "error",
                 "noVar": "error",
                 "noExplicitAny": "error"
             },

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -168,7 +168,11 @@ func newAuthLoginCmd(d *deps) *cobra.Command {
 			}
 
 			d.out.Info(cmd.OutOrStdout(), "✓ Authenticated as %s", user.Email)
-			d.out.Info(cmd.OutOrStdout(), "✓ Token saved to keychain")
+			// Report where the credential ACTUALLY landed. The keychain can
+			// pass the read probe and still refuse the write, in which case the
+			// store falls back to a file — and this line used to say "keychain"
+			// anyway, directly under the warning saying that had just failed.
+			d.out.Info(cmd.OutOrStdout(), "✓ Token saved to %s", d.store().Location(host))
 			return nil
 		},
 	}

--- a/cli/internal/keychain/keychain.go
+++ b/cli/internal/keychain/keychain.go
@@ -33,6 +33,16 @@ type Store interface {
 	Set(account, value string) error
 	// Delete is idempotent: removing an absent credential is not an error.
 	Delete(account string) error
+	// Location describes where the LAST Set for this account actually landed,
+	// for a caller that wants to tell the user. A store can degrade per-write
+	// (systemStore falls back to a file when the keychain refuses), so this is
+	// only meaningful after a Set — before one it reports where a write would
+	// be attempted.
+	//
+	// It exists because `auth login` used to print "Token saved to keychain"
+	// unconditionally, directly under the warning saying the keychain write had
+	// just failed. The store knew; it simply had no way to say so.
+	Location(account string) string
 }
 
 // Open returns the OS keychain when one responds, else a file store with a
@@ -57,9 +67,13 @@ func Open(configDir string, warn io.Writer) Store {
 // the keychain refuses a write. Reads consult both places, so a credential
 // keeps working regardless of where an earlier Set landed.
 type systemStore struct {
-	file   fileStore
-	warn   io.Writer
-	warned bool
+	// degraded records, per account, whether the last Set fell back to the
+	// file store. Per-account rather than a single flag because one context can
+	// degrade while another succeeds in the same process.
+	degraded map[string]bool
+	file     fileStore
+	warn     io.Writer
+	warned   bool
 }
 
 func (s *systemStore) Get(account string) (string, error) {
@@ -82,6 +96,7 @@ func (s *systemStore) Set(account, value string) error {
 		// A keychain write supersedes any stale file copy from a degraded
 		// earlier session; drop it so Get cannot resurrect old credentials.
 		s.file.Delete(account)
+		s.setDegraded(account, false)
 		return nil
 	}
 	if !s.warned {
@@ -90,7 +105,28 @@ func (s *systemStore) Set(account, value string) error {
 			"warning: OS keychain write failed (%v); storing credentials in %s (mode 0600)\n",
 			err, s.file.dir)
 	}
-	return s.file.Set(account, value)
+	if ferr := s.file.Set(account, value); ferr != nil {
+		return ferr
+	}
+	s.setDegraded(account, true)
+	return nil
+}
+
+func (s *systemStore) setDegraded(account string, degraded bool) {
+	if s.degraded == nil {
+		s.degraded = map[string]bool{}
+	}
+	s.degraded[account] = degraded
+}
+
+// Location reports the keychain unless this account's last write fell back to
+// the file store — the case the old unconditional "saved to keychain" message
+// got wrong.
+func (s *systemStore) Location(account string) string {
+	if s.degraded[account] {
+		return s.file.Location(account)
+	}
+	return "keychain"
 }
 
 func (s *systemStore) Delete(account string) error {
@@ -110,6 +146,12 @@ type fileStore struct{ dir string }
 func (f fileStore) path(account string) string {
 	// Context names carry ':' (host:port), which Windows filenames reject.
 	return filepath.Join(f.dir, url.PathEscape(account)+".json")
+}
+
+// Location names the actual file, not just the directory: a user told their
+// credential is "in a file" still has to go find it.
+func (f fileStore) Location(account string) string {
+	return f.path(account)
 }
 
 func (f fileStore) Get(account string) (string, error) {
@@ -176,6 +218,8 @@ func (s *MemStore) Delete(account string) error {
 	delete(s.m, account)
 	return nil
 }
+
+func (s *MemStore) Location(string) string { return "memory" }
 
 // GetJSON / SetJSON are conveniences for the token payloads every caller
 // stores — one JSON document per context.

--- a/cli/internal/keychain/keychain_test.go
+++ b/cli/internal/keychain/keychain_test.go
@@ -165,6 +165,17 @@ func TestSystemStoreFallsBackWhenKeychainRefusesWrites(t *testing.T) {
 		t.Fatalf("Get after degraded Set = %q, %v", v, err)
 	}
 
+	// Location must name the FILE, not the keychain. `auth login` prints this,
+	// and it used to say "keychain" unconditionally — directly under the
+	// warning above saying the keychain write had just failed.
+	loc := s.Location("ctx1")
+	if strings.Contains(loc, "keychain") {
+		t.Errorf("Location after a degraded write = %q, must not claim the keychain", loc)
+	}
+	if !strings.Contains(loc, dir) {
+		t.Errorf("Location = %q, want the credential file under %s", loc, dir)
+	}
+
 	// Second write must not warn again.
 	warn.Reset()
 	if err := s.Set("ctx1", `{"t":"v2"}`); err != nil {
@@ -219,8 +230,59 @@ func TestSystemStoreKeychainWriteClearsStaleFileCopy(t *testing.T) {
 	if err := s.Set("ctx1", `{"t":"new"}`); err != nil {
 		t.Fatal(err)
 	}
+
+	// A healthy write really is in the keychain, so Location must say so —
+	// otherwise reporting the truth on the degraded path would just have
+	// traded one wrong message for another.
+	if loc := s.Location("ctx1"); loc != "keychain" {
+		t.Errorf("Location after a successful keychain write = %q, want \"keychain\"", loc)
+	}
+
 	delete(kcMem, "ctx1")
 	if _, err := s.Get("ctx1"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("stale file copy resurrected: err = %v", err)
+	}
+}
+
+// One context degrading must not mislabel another that succeeded — the reason
+// the flag is per-account rather than a single bool on the store.
+func TestSystemStoreLocationIsPerAccount(t *testing.T) {
+	kcMem := map[string]string{}
+	stubKeyring(t,
+		func(_, account string) (string, error) {
+			v, ok := kcMem[account]
+			if !ok {
+				return "", keyring.ErrNotFound
+			}
+			return v, nil
+		},
+		func(_, account, value string) error {
+			// Only this one context is refused.
+			if account == "refused" {
+				return errors.New("exit status 154")
+			}
+			kcMem[account] = value
+			return nil
+		},
+		func(_, account string) error {
+			delete(kcMem, account)
+			return nil
+		},
+	)
+
+	var warn bytes.Buffer
+	s := Open(t.TempDir(), &warn)
+	if err := s.Set("refused", "a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set("accepted", "b"); err != nil {
+		t.Fatal(err)
+	}
+
+	if loc := s.Location("accepted"); loc != "keychain" {
+		t.Errorf("accepted context Location = %q, want \"keychain\"", loc)
+	}
+	if loc := s.Location("refused"); loc == "keychain" {
+		t.Errorf("refused context Location = %q, must not claim the keychain", loc)
 	}
 }

--- a/core/components/AppErrorBoundary.tsx
+++ b/core/components/AppErrorBoundary.tsx
@@ -33,13 +33,17 @@ export function AppErrorBoundary({ error, retry }: ErrorBoundaryProps) {
         if (!error.stack) return
         symbolicateStack(error.stack)
             .then(clean => {
-                // Load-bearing in ALL builds: the browser never applies
-                // sourcemaps to error.stack at runtime (only DevTools/Sentry do),
-                // so this is the ONLY place the readable, source-mapped crash
-                // stack surfaces in a production web build. sourcemaps.spec.ts
-                // asserts this line fires and names the original source. The file
-                // is exempt from noConsole in biome.json (diagnostic-modules
-                // override).
+                // Deliberately NOT routed through `log` — this is the one console
+                // call in client code that must survive a release build. The
+                // browser never applies sourcemaps to error.stack at runtime (only
+                // DevTools/Sentry do), so this is the ONLY place the readable,
+                // source-mapped crash stack surfaces in a production web build,
+                // and sourcemaps.spec.ts reads it off the console of an
+                // `expo export` bundle. `log.*` writes to the console only under
+                // __DEV__, so migrating this line would silence it exactly where
+                // it is needed. Sentry already has the error itself via the
+                // captureException above; this is the human-readable companion.
+                // The file is exempt from noConsole in biome.json.
                 console.log(`[error-boundary] ${clean}`)
             })
             .catch(() => {

--- a/core/components/workspace/LazySidebarBoundary.tsx
+++ b/core/components/workspace/LazySidebarBoundary.tsx
@@ -1,4 +1,5 @@
 import { captureException } from '@tinycld/core/lib/errors'
+import { log } from '@tinycld/core/lib/logger'
 import {
     Component,
     type ErrorInfo,
@@ -14,15 +15,13 @@ import { nextAttempt, shouldRetryOnTimeout } from './lazy-sidebar-retry'
 // Copious logging around sidebar-mount failures: when this boundary has to
 // recover, the next person debugging CI (or a user report) needs to see exactly
 // what happened — which slug, which failure mode, which attempt — not a silent
-// retry. `pkgSlug` is threaded in so every line names the package.
+// retry. `slug` is threaded in so every line names the package.
 function logSidebar(slug: string | undefined, msg: string, extra?: Record<string, unknown>) {
-    // __DEV__-guarded per house rule (no unguarded console). CI runs the dev
-    // bundle (Development-level warnings: ON), so these lines DO surface in CI
-    // failure logs — which is exactly where a wedged sidebar gets diagnosed.
-    // Production reporting goes through captureException at the call sites.
-    if (!__DEV__) return
-    const tag = `[sidebar-boundary${slug ? `:${slug}` : ''}]`
-    console.warn(tag, msg, extra ?? '')
+    // debug, not warn: each of these lines narrates one step of a retry the
+    // boundary is designed to absorb, so on its own none is worth paging for.
+    // They ride along as breadcrumbs on whatever event does fire — the terminal
+    // "gave up" case reports separately via captureException at the call site.
+    log.debug('core.workspace.sidebar-boundary', msg, { ...extra, slug })
 }
 
 interface LazySidebarBoundaryProps {

--- a/core/lib/__tests__/core-config.test.ts
+++ b/core/lib/__tests__/core-config.test.ts
@@ -60,4 +60,20 @@ describe('core-config', () => {
         configureCore({ brandName: 'Second', serverShortcuts: {} })
         expect(getCoreConfigOptional()?.brandName).toBe('Second')
     })
+
+    it('accepts a logLevel and returns it verbatim', async () => {
+        const { configureCore, getCoreConfig } = await importFresh()
+        configureCore({
+            brandName: 'TinyCld',
+            serverShortcuts: {},
+            logLevel: 'info',
+        })
+        expect(getCoreConfig().logLevel).toBe('info')
+    })
+
+    it('leaves logLevel undefined when not supplied', async () => {
+        const { configureCore, getCoreConfig } = await importFresh()
+        configureCore({ brandName: 'TinyCld', serverShortcuts: {} })
+        expect(getCoreConfig().logLevel).toBeUndefined()
+    })
 })

--- a/core/lib/__tests__/handle-mutation-errors.test.ts
+++ b/core/lib/__tests__/handle-mutation-errors.test.ts
@@ -66,3 +66,19 @@ describe('handleMutationErrorsWithForm', () => {
         expect(useToastStore.getState().toasts).toHaveLength(1)
     })
 })
+
+describe('captureException', () => {
+    it('captureException delegates to log.error', async () => {
+        const spy = vi.fn()
+        vi.doMock('../logger', () => ({
+            log: { error: spy, debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+        }))
+        vi.resetModules()
+
+        const { captureException } = await import('../errors')
+        const err = new Error('boom')
+        captureException('example.create', err, { id: '1' })
+
+        expect(spy).toHaveBeenCalledWith('example.create', err, { id: '1' })
+    })
+})

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { __resetCoreConfigForTests, configureCore } from '../core-config'
+
+const captureException = vi.fn()
+const captureMessage = vi.fn()
+const addBreadcrumb = vi.fn()
+
+vi.mock('../sentry', () => ({
+    captureExceptionToSentry: (...args: unknown[]) => captureException(...args),
+    captureMessageToSentry: (...args: unknown[]) => captureMessage(...args),
+    addBreadcrumbToSentry: (...args: unknown[]) => addBreadcrumb(...args),
+}))
+
+describe('log', () => {
+    beforeEach(() => {
+        __resetCoreConfigForTests()
+        captureException.mockClear()
+        captureMessage.mockClear()
+        addBreadcrumb.mockClear()
+        // logger.ts reads the RN global __DEV__ (console gating). Nothing
+        // defines it under vitest — stub it the same way use-saved-servers.test.ts
+        // does for debug-trace's read of the same global.
+        vi.stubGlobal('__DEV__', false)
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('breadcrumbs a below-threshold call without raising an event', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
+        const { log } = await import('../logger')
+
+        log.debug('mail.compose', 'draft saved', { draftId: '1' })
+
+        expect(addBreadcrumb).toHaveBeenCalledWith('mail.compose', 'debug', 'draft saved', {
+            draftId: '1',
+        })
+        expect(captureMessage).not.toHaveBeenCalled()
+        expect(captureException).not.toHaveBeenCalled()
+    })
+
+    it('breadcrumbs AND raises an event at the threshold', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
+        const { log } = await import('../logger')
+
+        log.warn('mail.imap', 'reconnect attempt', { attempt: 2 })
+
+        expect(addBreadcrumb).toHaveBeenCalledTimes(1)
+        expect(captureMessage).toHaveBeenCalledWith('mail.imap', 'reconnect attempt', {
+            attempt: 2,
+        })
+    })
+
+    it('routes log.error through captureException', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
+        const { log } = await import('../logger')
+        const err = new Error('boom')
+
+        log.error('mail.send', err, { messageId: 'm1' })
+
+        expect(captureException).toHaveBeenCalledWith('mail.send', err, { messageId: 'm1' })
+    })
+
+    it('treats an above-threshold info call as an event when level is debug', async () => {
+        configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'debug' })
+        const { log } = await import('../logger')
+
+        log.info('app.boot', 'ready')
+
+        expect(captureMessage).toHaveBeenCalledWith('app.boot', 'ready', undefined)
+    })
+})

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -32,19 +32,22 @@ describe('log', () => {
         expect(captureException).not.toHaveBeenCalled()
     })
 
-    it('breadcrumbs AND raises an event at the threshold', async () => {
+    it('breadcrumbs AND raises an event at the threshold, tagged with the call level', async () => {
         configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
         const { log } = await import('../logger')
 
         log.warn('mail.imap', 'reconnect attempt', { attempt: 2 })
 
         expect(addBreadcrumb).toHaveBeenCalledTimes(1)
-        expect(captureMessage).toHaveBeenCalledWith('mail.imap', 'reconnect attempt', {
+        expect(addBreadcrumb).toHaveBeenCalledWith('mail.imap', 'warn', 'reconnect attempt', {
+            attempt: 2,
+        })
+        expect(captureMessage).toHaveBeenCalledWith('mail.imap', 'warn', 'reconnect attempt', {
             attempt: 2,
         })
     })
 
-    it('routes log.error through captureException', async () => {
+    it('routes log.error through captureException without also breadcrumbing itself', async () => {
         configureCore({ brandName: 'T', serverShortcuts: {}, logLevel: 'warn' })
         const { log } = await import('../logger')
         const err = new Error('boom')
@@ -52,6 +55,7 @@ describe('log', () => {
         log.error('mail.send', err, { messageId: 'm1' })
 
         expect(captureException).toHaveBeenCalledWith('mail.send', err, { messageId: 'm1' })
+        expect(addBreadcrumb).not.toHaveBeenCalled()
     })
 
     it('treats an above-threshold info call as an event when level is debug', async () => {
@@ -60,6 +64,6 @@ describe('log', () => {
 
         log.info('app.boot', 'ready')
 
-        expect(captureMessage).toHaveBeenCalledWith('app.boot', 'ready', undefined)
+        expect(captureMessage).toHaveBeenCalledWith('app.boot', 'info', 'ready', undefined)
     })
 })

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { __resetCoreConfigForTests, configureCore } from '../core-config'
 
 const captureException = vi.fn()

--- a/core/lib/__tests__/logger.test.ts
+++ b/core/lib/__tests__/logger.test.ts
@@ -17,14 +17,6 @@ describe('log', () => {
         captureException.mockClear()
         captureMessage.mockClear()
         addBreadcrumb.mockClear()
-        // logger.ts reads the RN global __DEV__ (console gating). Nothing
-        // defines it under vitest — stub it the same way use-saved-servers.test.ts
-        // does for debug-trace's read of the same global.
-        vi.stubGlobal('__DEV__', false)
-    })
-
-    afterEach(() => {
-        vi.unstubAllGlobals()
     })
 
     it('breadcrumbs a below-threshold call without raising an event', async () => {

--- a/core/lib/__tests__/mutations.test.tsx
+++ b/core/lib/__tests__/mutations.test.tsx
@@ -27,7 +27,6 @@ vi.mock('@tinycld/core/lib/notifications', () => ({
 vi.mock('@tinycld/core/lib/sentry', () => ({
     captureExceptionToSentry: vi.fn(),
     addBreadcrumbToSentry: vi.fn(),
-    captureMessageToSentry: vi.fn(),
 }))
 
 function wrapper() {

--- a/core/lib/__tests__/mutations.test.tsx
+++ b/core/lib/__tests__/mutations.test.tsx
@@ -26,6 +26,8 @@ vi.mock('@tinycld/core/lib/notifications', () => ({
 }))
 vi.mock('@tinycld/core/lib/sentry', () => ({
     captureExceptionToSentry: vi.fn(),
+    addBreadcrumbToSentry: vi.fn(),
+    captureMessageToSentry: vi.fn(),
 }))
 
 function wrapper() {

--- a/core/lib/core-config.ts
+++ b/core/lib/core-config.ts
@@ -1,4 +1,11 @@
 /**
+ * Severity ordering used by `@tinycld/core/lib/logger`. Everything becomes a
+ * Sentry breadcrumb; only calls at or above the configured level additionally
+ * become Sentry events.
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/**
  * Runtime configuration that the app shell hands to `@tinycld/core` at
  * startup. Moves per-app details — branding, server
  * shortcuts, Sentry DSN, review-mode flags — out of hard-coded env reads
@@ -40,6 +47,11 @@ export interface CoreConfig {
     environment?: string
     /** Sentry release tag (maps to EXPO_PUBLIC_GIT_COMMIT). */
     release?: string
+    /**
+     * Minimum level that escalates a log call from a breadcrumb to a Sentry
+     * event. Defaults to 'warn' in release builds and 'debug' in __DEV__.
+     */
+    logLevel?: LogLevel
     /** When true, the app is an App Store review build. */
     reviewMode?: boolean
     /** Demo password auto-filled in review builds. */

--- a/core/lib/editor/rich/use-rich-editor.web.tsx
+++ b/core/lib/editor/rich/use-rich-editor.web.tsx
@@ -1,6 +1,7 @@
 import { EditorContent, ReactNodeViewRenderer, useEditor } from '@tiptap/react'
 import { useEffect, useMemo, useRef } from 'react'
 import { View } from 'react-native'
+import { log } from '../../logger'
 import { useThemeColor } from '../../use-app-theme'
 import type { EditorCommands, EditorHandle, EditorResult, EditorToolbarState } from '../types'
 import { AuthedImageView } from './AuthedImageView.web'
@@ -309,10 +310,14 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         // return a destroyed instance during a remount. Touching `.commands` in
         // that window throws, so every imperative call is gated.
         const isLive = () => !!tiptapEditor && !tiptapEditor.isDestroyed
+        // debug, not warn: this catches a developer calling the wrong API, which
+        // is a coding mistake to read in the console — not a production incident
+        // worth an event.
         const warnIfCollab = (method: string) => {
-            if (collab && __DEV__) {
-                console.warn(
-                    `[editor] ${method} is a no-op under collaboration — seed the shared document instead`
+            if (collab) {
+                log.debug(
+                    'core.editor.rich',
+                    `${method} is a no-op under collaboration — seed the shared document instead`
                 )
             }
             return !!collab

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { View } from 'react-native'
 import type { WebViewMessageEvent } from 'react-native-webview'
 import { captureException } from '../errors'
+import { log } from '../logger'
 import { deriveToolbarState } from './derive-toolbar-state'
 import { createHeightStore, type HeightStore } from './height-store'
 import { type EditorMessage, makeMessage } from './message-bus/types'
@@ -279,18 +280,18 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     // when the WebView sends a `stateUpdate`, which our custom Editor
     // only sends after init arrives — chicken-and-egg.
     const [webviewReady, setWebviewReady] = useState(false)
-    // Mount timestamp for the dev-only phase timings below. A WebView editor is
-    // an expensive thing to create — a browser cold start plus a bundle — and
-    // the three marks (page-ready, init-sent, first-height) are what tell you
-    // WHICH of those phases a slow open actually spent its time in.
+    // Mount timestamp for the phase timings below. A WebView editor is an
+    // expensive thing to create — a browser cold start plus a bundle — and the
+    // three marks (page-ready, init-sent, first-height) are what tell you WHICH
+    // of those phases a slow open actually spent its time in.
     const mountAtRef = useRef(Date.now())
     // t0. Logged once per editor so the marks below have a visible origin —
     // without it a slow open is indistinguishable from an editor that mounted
     // late for reasons upstream of this hook.
     const loggedMountRef = useRef(false)
-    if (__DEV__ && !loggedMountRef.current) {
+    if (!loggedMountRef.current) {
         loggedMountRef.current = true
-        console.debug('[editor.mount] mounted (t0)')
+        log.debug('core.editor.webview', 'mounted (t0)')
     }
 
     // Height the page reported for its own content, held in a tiny store
@@ -321,9 +322,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         if (!webview) return
         const message = makeMessage('app', 'init', initPayload)
         try {
-            if (__DEV__) {
-                console.debug('[editor.mount] init-sent', Date.now() - mountAtRef.current, 'ms')
-            }
+            log.debug('core.editor.webview', 'init-sent', {
+                sinceMountMs: Date.now() - mountAtRef.current,
+            })
             webview.postMessage(JSON.stringify(message))
             lastInitGenerationRef.current = incoming
         } catch (err) {
@@ -385,9 +386,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         (payload: unknown) => {
             const height = (payload as { height?: unknown } | undefined)?.height
             if (typeof height !== 'number' || height <= 0) return
-            if (__DEV__) {
-                console.debug('[editor.mount] first-height', Date.now() - mountAtRef.current, 'ms')
-            }
+            log.debug('core.editor.webview', 'first-height', {
+                sinceMountMs: Date.now() - mountAtRef.current,
+            })
             setContentHeight(height)
         },
         [setContentHeight]
@@ -410,13 +411,9 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
             // alongside its dispatch), but it doesn't flip any
             // bridgeState flag from it.
             if (parsed.type === 'editor-ready') {
-                if (__DEV__) {
-                    console.debug(
-                        '[editor.mount] page-ready',
-                        Date.now() - mountAtRef.current,
-                        'ms'
-                    )
-                }
+                log.debug('core.editor.webview', 'page-ready', {
+                    sinceMountMs: Date.now() - mountAtRef.current,
+                })
                 setWebviewReady(true)
                 return
             }

--- a/core/lib/errors.ts
+++ b/core/lib/errors.ts
@@ -1,6 +1,6 @@
 import { notify } from '@tinycld/core/lib/notify/dispatcher'
 import type { FieldValues, Path, UseFormSetError } from 'react-hook-form'
-import { captureExceptionToSentry } from './sentry'
+import { log } from './logger'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === 'object' && value !== null
@@ -159,6 +159,10 @@ export function handleMutationErrorsWithForm<T extends FieldValues = FieldValues
     }
 }
 
+/**
+ * Retained for the many existing call sites; `log.error` is the same thing and
+ * is what new code should use.
+ */
 export function captureException(context: string, error: unknown, extra?: Record<string, unknown>) {
-    captureExceptionToSentry(context, error, extra)
+    log.error(context, error, extra)
 }

--- a/core/lib/logger.ts
+++ b/core/lib/logger.ts
@@ -42,7 +42,7 @@ function emit(
     consoleLine(level, context, message, extra)
     addBreadcrumbToSentry(context, level, message, extra)
     if (SEVERITY[level] < SEVERITY[resolveLogLevel()]) return
-    captureMessageToSentry(context, message, extra)
+    captureMessageToSentry(context, level, message, extra)
 }
 
 /**
@@ -67,12 +67,15 @@ export const log = {
     },
     /**
      * Errors always route through captureException so Sentry gets the real
-     * stack, never a stringified message.
+     * stack, never a stringified message. Deliberately skips
+     * addBreadcrumbToSentry: unlike debug/info/warn, an error call always
+     * produces its own Sentry event, so breadcrumbing it too would just
+     * restate the event as its own trailing context and evict one slot of
+     * actually-preceding history from the ring buffer.
      */
     error(context: string, error: unknown, extra?: Record<string, unknown>): void {
         const message = error instanceof Error ? error.message : String(error)
         consoleLine('error', context, message, extra)
-        addBreadcrumbToSentry(context, 'error', message, extra)
         captureExceptionToSentry(context, error, extra)
     },
 }

--- a/core/lib/logger.ts
+++ b/core/lib/logger.ts
@@ -1,0 +1,78 @@
+declare const __DEV__: boolean
+
+import { getCoreConfigOptional, type LogLevel } from './core-config'
+import { addBreadcrumbToSentry, captureExceptionToSentry, captureMessageToSentry } from './sentry'
+
+const SEVERITY: Record<LogLevel, number> = {
+    debug: 10,
+    info: 20,
+    warn: 30,
+    error: 40,
+}
+
+/**
+ * The level at or above which a log call also becomes a Sentry event. Release
+ * builds default to 'warn' so a production warning surfaces before it escalates
+ * into an exception; __DEV__ defaults to 'debug' (Sentry is inert there anyway,
+ * since initSentry early-returns on __DEV__).
+ */
+export function resolveLogLevel(): LogLevel {
+    const configured = getCoreConfigOptional()?.logLevel
+    if (configured) return configured
+    return __DEV__ ? 'debug' : 'warn'
+}
+
+function consoleLine(
+    level: LogLevel,
+    context: string,
+    message: string,
+    extra?: Record<string, unknown>
+): void {
+    if (!__DEV__) return
+    const method = level === 'debug' ? 'debug' : level === 'error' ? 'error' : level
+    console[method](`[${context}] ${message}`, extra ?? '')
+}
+
+function emit(
+    level: LogLevel,
+    context: string,
+    message: string,
+    extra?: Record<string, unknown>
+): void {
+    consoleLine(level, context, message, extra)
+    addBreadcrumbToSentry(context, level, message, extra)
+    if (SEVERITY[level] < SEVERITY[resolveLogLevel()]) return
+    captureMessageToSentry(context, message, extra)
+}
+
+/**
+ * The one blessed logging API for client code.
+ *
+ *     log.debug('mail.compose', 'draft saved', { draftId })
+ *     log.error('mail.send', err, { messageId })
+ *
+ * `context` is a short stable dotted string Sentry groups on; `extra` is the
+ * variable detail. Every call becomes a breadcrumb; calls at or above the
+ * configured level additionally become Sentry events.
+ */
+export const log = {
+    debug(context: string, message: string, extra?: Record<string, unknown>): void {
+        emit('debug', context, message, extra)
+    },
+    info(context: string, message: string, extra?: Record<string, unknown>): void {
+        emit('info', context, message, extra)
+    },
+    warn(context: string, message: string, extra?: Record<string, unknown>): void {
+        emit('warn', context, message, extra)
+    },
+    /**
+     * Errors always route through captureException so Sentry gets the real
+     * stack, never a stringified message.
+     */
+    error(context: string, error: unknown, extra?: Record<string, unknown>): void {
+        const message = error instanceof Error ? error.message : String(error)
+        consoleLine('error', context, message, extra)
+        addBreadcrumbToSentry(context, 'error', message, extra)
+        captureExceptionToSentry(context, error, extra)
+    },
+}

--- a/core/lib/nav-perf.ts
+++ b/core/lib/nav-perf.ts
@@ -1,3 +1,5 @@
+import { log } from './logger'
+
 /**
  * Navigation timing. Marks the moment a tab is pressed and logs the elapsed
  * time at later milestones (first paint of the target screen, query settled)
@@ -8,12 +10,11 @@
  * Call sites guard their argument construction with NAV_PERF too; the helpers
  * also short-circuit internally so a stray call is still cheap.
  *
- * Default OFF. To capture production first-mount timings: set NAV_PERF = true
- * AND switch the console.debug calls below to console.log (so they surface in
- * logcat from a Release build), then `expo run:android --variant release
- * --no-bundler`, kill Metro, launch from the embedded bundle, and
- * `adb logcat | grep '[nav-perf]'`. Leave NAV_PERF = false on any shipped
- * build — these must not run on the navigation hot path in production.
+ * Default OFF. The marks route through `log.debug`, so with NAV_PERF = true they
+ * land in the dev console and as Sentry breadcrumbs on the enclosing event —
+ * which is how a production first-mount timing gets read back without a logcat
+ * round-trip. Leave NAV_PERF = false on any shipped build; these must not run on
+ * the navigation hot path in production.
  */
 export const NAV_PERF = false
 
@@ -24,12 +25,12 @@ export function markNavPress(slug: string) {
     if (!NAV_PERF) return
     pressedSlug = slug
     pressedAt = performance.now()
-    console.debug(`[nav-perf] press → ${slug} @ t0`)
+    log.debug('core.nav-perf', 'press (t0)', { slug })
 }
 
 export function markNavMilestone(slug: string, label: string) {
     if (!NAV_PERF) return
     if (slug !== pressedSlug || pressedAt === 0) return
     const ms = Math.round(performance.now() - pressedAt)
-    console.debug(`[nav-perf] ${slug} · ${label} +${ms}ms`)
+    log.debug('core.nav-perf', 'milestone', { slug, label, ms })
 }

--- a/core/lib/sentry.ts
+++ b/core/lib/sentry.ts
@@ -2,7 +2,7 @@ declare const __DEV__: boolean
 
 import * as Sentry from '@sentry/react-native'
 import { Platform } from 'react-native'
-import { getCoreConfigOptional } from './core-config'
+import { getCoreConfigOptional, type LogLevel } from './core-config'
 import { scrubPII } from './sentry-scrub'
 
 let initialized = false
@@ -107,22 +107,34 @@ export function initSentry(): void {
 }
 
 /**
- * Lightweight breadcrumb-style log line that goes to Sentry as a "info" message
- * AND to the browser console. Use sparingly — for tracing intermittent prod
- * issues where you need to see a sequence of events. Remove the call sites once
- * the bug is found.
+ * Maps our LogLevel to the Sentry severity used for both breadcrumbs and
+ * captured events — shared so a `log.warn` sorts/filters/alerts the same way
+ * whichever path it took to get to Sentry.
+ */
+const SENTRY_LEVEL: Record<LogLevel, Sentry.SeverityLevel> = {
+    debug: 'debug',
+    info: 'info',
+    warn: 'warning',
+    error: 'error',
+}
+
+/**
+ * Sentry event for a non-error log call. `logger.ts` is the sole caller — its
+ * own `__DEV__`-gated `consoleLine()` owns console output, so this stays
+ * console-silent to avoid double-printing (and printing unconditionally in
+ * release, which is exactly the bug this replaced).
  */
 export function captureMessageToSentry(
     context: string,
+    level: LogLevel,
     message: string,
     extra?: Record<string, unknown>
 ): void {
-    const scrubbedExtra = extra ? scrubPII(extra) : undefined
-    console.info(`[trace:${context}] ${message}`, scrubbedExtra ?? '')
     if (!initialized) return
+    const scrubbedExtra = extra ? scrubPII(extra) : undefined
     Sentry.withScope(scope => {
         scope.setTag('context', context)
-        scope.setLevel('info')
+        scope.setLevel(SENTRY_LEVEL[level])
         if (scrubbedExtra) scope.setExtras(scrubbedExtra)
         Sentry.captureMessage(message)
     })
@@ -144,13 +156,6 @@ export function captureExceptionToSentry(
     })
 }
 
-const SENTRY_BREADCRUMB_LEVEL: Record<string, Sentry.SeverityLevel> = {
-    debug: 'debug',
-    info: 'info',
-    warn: 'warning',
-    error: 'error',
-}
-
 /**
  * Record a log line as a Sentry breadcrumb. Breadcrumbs are an in-memory ring
  * buffer — no network — and are attached automatically to whatever event fires
@@ -161,7 +166,7 @@ const SENTRY_BREADCRUMB_LEVEL: Record<string, Sentry.SeverityLevel> = {
  */
 export function addBreadcrumbToSentry(
     context: string,
-    level: string,
+    level: LogLevel,
     message: string,
     extra?: Record<string, unknown>
 ): void {
@@ -169,7 +174,7 @@ export function addBreadcrumbToSentry(
     Sentry.addBreadcrumb({
         category: context,
         message,
-        level: SENTRY_BREADCRUMB_LEVEL[level] ?? 'info',
+        level: SENTRY_LEVEL[level],
         data: extra,
     })
 }

--- a/core/lib/sentry.ts
+++ b/core/lib/sentry.ts
@@ -143,3 +143,33 @@ export function captureExceptionToSentry(
         Sentry.captureException(error)
     })
 }
+
+const SENTRY_BREADCRUMB_LEVEL: Record<string, Sentry.SeverityLevel> = {
+    debug: 'debug',
+    info: 'info',
+    warn: 'warning',
+    error: 'error',
+}
+
+/**
+ * Record a log line as a Sentry breadcrumb. Breadcrumbs are an in-memory ring
+ * buffer — no network — and are attached automatically to whatever event fires
+ * next, which is what gives an error its preceding context.
+ *
+ * PII scrubbing is handled by the `beforeBreadcrumb` hook registered in
+ * `initSentry`; do not scrub here or the data gets filtered twice.
+ */
+export function addBreadcrumbToSentry(
+    context: string,
+    level: string,
+    message: string,
+    extra?: Record<string, unknown>
+): void {
+    if (!initialized) return
+    Sentry.addBreadcrumb({
+        category: context,
+        message,
+        level: SENTRY_BREADCRUMB_LEVEL[level] ?? 'info',
+        data: extra,
+    })
+}

--- a/core/server/audit/audit.go
+++ b/core/server/audit/audit.go
@@ -10,12 +10,15 @@ package audit
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("audit")
 
 // LabelExtractor returns a human-readable label for a record.
 type LabelExtractor func(record *core.Record) string
@@ -101,7 +104,7 @@ func logCreate(app core.App, record *core.Record, re *core.RequestEvent, collect
 	setRequestInfo(auditRecord, re)
 
 	if err := app.Save(auditRecord); err != nil {
-		log.Printf("[audit] failed to save audit log for %s/%s: %v", collectionName, record.Id, err)
+		log.Error("failed to save audit log", "collection", collectionName, "recordID", record.Id, "err", err)
 	}
 }
 
@@ -120,7 +123,7 @@ func logUpdate(app core.App, record *core.Record, original *core.Record, re *cor
 	}
 
 	if err := app.Save(auditRecord); err != nil {
-		log.Printf("[audit] failed to save audit log for %s/%s: %v", collectionName, record.Id, err)
+		log.Error("failed to save audit log", "collection", collectionName, "recordID", record.Id, "err", err)
 	}
 }
 
@@ -133,14 +136,14 @@ func logDelete(app core.App, recordID string, label string, snapshot map[string]
 	setRequestInfo(auditRecord, re)
 
 	if err := app.Save(auditRecord); err != nil {
-		log.Printf("[audit] failed to save audit log for %s/%s: %v", collectionName, recordID, err)
+		log.Error("failed to save audit log", "collection", collectionName, "recordID", recordID, "err", err)
 	}
 }
 
 func newAuditRecord(app core.App, action string, resourceType string, resourceID string, label string) *core.Record {
 	auditCollection, err := app.FindCollectionByNameOrId("audit_logs")
 	if err != nil {
-		log.Printf("[audit] could not find audit_logs collection: %v", err)
+		log.Error("could not find audit_logs collection", "err", err)
 		return nil
 	}
 

--- a/core/server/coreserver/logging_bootstrap_test.go
+++ b/core/server/coreserver/logging_bootstrap_test.go
@@ -1,0 +1,75 @@
+package coreserver
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase"
+)
+
+// TestLoggerInstallDoesNotHangDuringBootstrap pins the ordering bug fixed
+// alongside this test: logging.Install must run from an app.OnBootstrap()
+// hook, AFTER e.Next(), not directly inside Register/registerSharedEarly.
+//
+// Before bootstrap, app.Logger() falls back to slog.Default() (see
+// pocketbase/core/base.go). If Install were called with that fallback
+// handler, the fan-out it installs as the new default would contain a
+// handler that resolves back into itself — and the first log call
+// (registerSharedCore reaches automation.Register's slog.Info) recurses
+// forever. That is exactly what happened when the install lived directly
+// in Register: go test ./coreserver/ -run
+// TestTenantCompositionMatchesHostMinusRecordedExceptions hung until its
+// 150s timeout.
+//
+// Registering a full app (Register/RegisterTenant) is the only way to
+// reach registerSharedEarly's hook binding, so this lives in coreserver
+// rather than the logging package, which can't see that wiring.
+//
+// The run happens in a goroutine with a bounded timeout: if the ordering
+// regresses, the bug is a deadlock, not a returned error, so nothing short
+// of a timeout will turn it into a clean test failure.
+func TestLoggerInstallDoesNotHangDuringBootstrap(t *testing.T) {
+	preBootstrapHandler := slog.Default().Handler()
+	t.Cleanup(func() { slog.SetDefault(slog.New(preBootstrapHandler)) })
+
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: t.TempDir()})
+	Register(app, Options{
+		HooksDir:      t.TempDir(),
+		MigrationsDir: t.TempDir(),
+		TypesDir:      t.TempDir(),
+		PublicDir:     t.TempDir(),
+		HooksPoolSize: 1,
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		if err := app.Bootstrap(); err != nil {
+			done <- err
+			return
+		}
+		// The path that previously recursed: a plain slog.Info on the
+		// process-wide default, taken right after bootstrap completes —
+		// the same point automation.Register logs from during
+		// registerSharedCore.
+		slog.Info("post-bootstrap log reaches the installed fan-out")
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Bootstrap failed: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Bootstrap + log call did not complete within 10s — logging.Install likely wired the default logger to itself before bootstrap")
+	}
+
+	// Install replaces slog's default handler with the fan-out; confirming
+	// it changed (rather than asserting the unexported fanout type, which
+	// this package can't see) is what proves Install actually ran here
+	// rather than being skipped or silently no-op'd.
+	if slog.Default().Handler() == preBootstrapHandler {
+		t.Fatal("slog.Default() handler is unchanged after Bootstrap — logging.Install did not run")
+	}
+}

--- a/core/server/coreserver/pkg_build.go
+++ b/core/server/coreserver/pkg_build.go
@@ -3,7 +3,6 @@ package coreserver
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -174,16 +173,16 @@ func SeedBaseBuild(app core.App) {
 	// append-only, so a base revert promotes correctly without re-archiving them).
 	arch := buildArchiveFor(appDir, baseBuildID)
 	if err := os.MkdirAll(arch.root, 0o755); err != nil {
-		log.Printf("pkg_build: base seed — mkdir failed: %v", err)
+		srvLog.Error("base build seed: mkdir failed", "err", err)
 		return
 	}
 	if _, err := runCmd(".", "cp", "-a", binPath, arch.binary); err != nil {
-		log.Printf("pkg_build: base seed — archive binary failed: %v", err)
+		srvLog.Error("base build seed: archive binary failed", "err", err)
 		os.RemoveAll(arch.root)
 		return
 	}
 	if err := copyDir(currentRelease, arch.release); err != nil {
-		log.Printf("pkg_build: base seed — archive release failed: %v", err)
+		srvLog.Error("base build seed: archive release failed", "err", err)
 		os.RemoveAll(arch.root)
 		return
 	}
@@ -191,11 +190,11 @@ func SeedBaseBuild(app core.App) {
 	os.WriteFile(filepath.Join(arch.root, "build.json"), metaJSON, 0o644)
 
 	if _, err := recordBuild(app, fields); err != nil {
-		log.Printf("pkg_build: base seed — record failed: %v", err)
+		srvLog.Error("base build seed: record failed", "err", err)
 		os.RemoveAll(arch.root)
 		return
 	}
-	log.Printf("pkg_build: seeded base build %s (release %s)", baseBuildID, releaseID)
+	srvLog.Info("seeded base build", "buildID", baseBuildID, "releaseID", releaseID)
 }
 
 // readReleaseID reads a release dir's release-id.txt, returning "" if absent.

--- a/core/server/coreserver/pkg_go_build.go
+++ b/core/server/coreserver/pkg_go_build.go
@@ -2,7 +2,6 @@ package coreserver
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +32,7 @@ import (
 // is mid-flight on a background goroutine, no request is being served against
 // these specific writes, and the process restarts moments later anyway.
 func recoverLiveDBAfterExternalWrite(app *pocketbase.PocketBase) error {
-	log.Printf("pkg_install: reconnecting live DB after external WAL access")
+	srvLog.Info("reconnecting live DB after external WAL access")
 	if err := app.Bootstrap(); err != nil {
 		return fmt.Errorf("re-bootstrap app DB after migrate: %w", err)
 	}
@@ -50,7 +49,7 @@ func recoverLiveDBAfterExternalWrite(app *pocketbase.PocketBase) error {
 // every committed write. Best-effort: a checkpoint failure is logged, not fatal.
 func checkpointWAL(app *pocketbase.PocketBase) {
 	if _, err := app.DB().NewQuery("PRAGMA wal_checkpoint(TRUNCATE)").Execute(); err != nil {
-		log.Printf("pkg_install: WAL checkpoint before restart failed: %v", err)
+		srvLog.Error("WAL checkpoint before restart failed", "err", err)
 	}
 }
 
@@ -85,10 +84,10 @@ func armDatabaseBackup(buildID string) {
 		return
 	}
 	if err := os.WriteFile(dbArmedMarkerPath(), []byte(buildID), 0o644); err != nil {
-		log.Printf("[pkg_install] WARNING: failed to arm DB backup marker (rollback still works; SIGKILL-recovery degraded): %v", err)
+		srvLog.Warn("failed to arm DB backup marker (rollback still works; SIGKILL-recovery degraded)", "buildID", buildID, "err", err)
 		return
 	}
-	log.Printf("[pkg_install] DB backup armed for build %s (entrypoint commits on healthy boot, restores on failed probe)", buildID)
+	srvLog.Info("DB backup armed", "buildID", buildID)
 }
 
 // backupDatabase snapshots the live DB and returns a restore closure. The DB
@@ -117,7 +116,7 @@ func backupDatabase(_ string) (rollbackFn func() error, err error) {
 	if fi, statErr := os.Stat(backupPath); statErr == nil {
 		sizeNote = fmt.Sprintf(" (%.1f MB)", float64(fi.Size())/(1024*1024))
 	}
-	log.Printf("[pkg_install] database backed up to %s%s (restore-on-failure armed)", backupPath, sizeNote)
+	srvLog.Info("database backed up (restore-on-failure armed)", "path", backupPath, "sizeNote", sizeNote)
 
 	// In-process restore, used ONLY for PRE-activation failures (migrate/activate
 	// fail before the symlink swaps). It restores the live DB and disarms — both
@@ -128,7 +127,7 @@ func backupDatabase(_ string) (rollbackFn func() error, err error) {
 	// fails its post-restart health probe (the failure happens in a different
 	// process, so it can't be handled here). See entrypoint.sh's rollback branch.
 	rollbackFn = func() error {
-		log.Printf("pkg_go_build: restoring database from backup")
+		srvLog.Info("restoring database from backup")
 		// Use cp for streaming copy to avoid loading entire DB into memory
 		cmd := exec.Command("cp", backupPath, dbPath)
 		if out, err := cmd.CombinedOutput(); err != nil {

--- a/core/server/coreserver/pkg_install.go
+++ b/core/server/coreserver/pkg_install.go
@@ -3,7 +3,6 @@ package coreserver
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -73,7 +72,7 @@ func RegisterPackageInstallEndpoints(app *pocketbase.PocketBase) {
 	// (requestRestart), a different path this guard never sees.
 	app.OnTerminate().BindFunc(func(e *core.TerminateEvent) error {
 		if shouldSuppressRestart(e.IsRestart) {
-			log.Println("pkg_install: suppressing watcher restart — a package operation is in progress")
+			srvLog.Info("suppressing watcher restart — a package operation is in progress")
 			return nil // short-circuit: don't run the execve handler
 		}
 		return e.Next()
@@ -462,7 +461,7 @@ func emitProgress(job *installJob, step string, progress int, message string) {
 	job.Step = step
 	job.Progress = progress
 	job.LogLines = append(job.LogLines, fmt.Sprintf("[%d%%] %s: %s", progress, step, message))
-	log.Printf("[pkg_install] [%s] [%d%%] %s: %s", job.ID, progress, step, message)
+	srvLog.Info("package install progress", "jobID", job.ID, "percent", progress, "step", step, "message", message)
 
 	evt := sseEvent{
 		Event: "progress",
@@ -508,9 +507,9 @@ func emitComplete(job *installJob, status string, errMsg string) {
 	defer job.mu.Unlock()
 
 	if errMsg != "" {
-		log.Printf("[pkg_install] [%s] COMPLETE status=%s error=%s", job.ID, status, errMsg)
+		srvLog.Info("package install complete", "jobID", job.ID, "status", status, "err", errMsg)
 	} else {
-		log.Printf("[pkg_install] [%s] COMPLETE status=%s", job.ID, status)
+		srvLog.Info("package install complete", "jobID", job.ID, "status", status)
 	}
 
 	evt := sseEvent{
@@ -533,7 +532,7 @@ func emitComplete(job *installJob, status string, errMsg string) {
 func createInstallLog(app core.App, job *installJob, action string) *core.Record {
 	collection, err := app.FindCollectionByNameOrId("pkg_install_log")
 	if err != nil {
-		log.Printf("pkg_install: failed to find pkg_install_log collection: %v", err)
+		srvLog.Error("failed to find pkg_install_log collection", "err", err)
 		return nil
 	}
 
@@ -555,7 +554,7 @@ func createInstallLog(app core.App, job *installJob, action string) *core.Record
 	record.Set("started_at", time.Now().UTC().Format("2006-01-02 15:04:05.000Z"))
 
 	if err := app.Save(record); err != nil {
-		log.Printf("pkg_install: failed to create install log: %v", err)
+		srvLog.Error("failed to create install log", "err", err)
 		return nil
 	}
 
@@ -570,7 +569,7 @@ func updateInstallLogSlug(app core.App, record *core.Record, slug string) {
 	}
 	record.Set("pkg_slug", slug)
 	if err := app.Save(record); err != nil {
-		log.Printf("pkg_install: failed to update install log slug: %v", err)
+		srvLog.Warn("failed to update install log slug", "recordID", record.Id, "slug", slug, "err", err)
 	}
 }
 
@@ -585,10 +584,10 @@ func finalizeInstallLog(app core.App, record *core.Record, status string, errMsg
 	record.Set("completed_at", time.Now().UTC().Format("2006-01-02 15:04:05.000Z"))
 
 	if err := app.Save(record); err != nil {
-		log.Printf("pkg_install: failed to finalize install log: %v", err)
+		srvLog.Error("failed to finalize install log", "recordID", record.Id, "status", status, "err", err)
 		return
 	}
-	log.Printf("pkg_install: finalized install log %s -> %s", record.Id, status)
+	srvLog.Info("finalized install log", "recordID", record.Id, "status", status)
 }
 
 // ---------- release staging ----------

--- a/core/server/coreserver/pkg_restart.go
+++ b/core/server/coreserver/pkg_restart.go
@@ -1,7 +1,6 @@
 package coreserver
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,17 +17,17 @@ const restartExitCode = 75
 // persists across the per-build symlink swap rather than in the swapped dir.
 func requestRestart(_ string) {
 	if isDevelopment() {
-		log.Println("pkg_install: restart requested (dev mode — restart manually)")
+		srvLog.Info("restart requested (dev mode — restart manually)")
 		return
 	}
 
 	// Write a restart marker so the entrypoint knows this was intentional
 	markerPath := filepath.Join(statePbDataDir(), ".restart-requested")
 	if err := os.WriteFile(markerPath, []byte("restart"), 0o644); err != nil {
-		log.Printf("pkg_install: failed to write restart marker: %v", err)
+		srvLog.Warn("failed to write restart marker", "path", markerPath, "err", err)
 	}
 
-	log.Println("pkg_install: requesting restart via exit code 75")
+	srvLog.Info("requesting restart via exit code 75")
 	os.Exit(restartExitCode)
 }
 

--- a/core/server/coreserver/pkg_rollback_reconcile.go
+++ b/core/server/coreserver/pkg_rollback_reconcile.go
@@ -1,7 +1,6 @@
 package coreserver
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,7 +56,7 @@ func ReconcileRolledBackInstall(app core.App) {
 	live := currentJob != nil
 	installMu.Unlock()
 	if live {
-		log.Printf("pkg_rollback: .rollback-pending present but a job is in-flight; deferring reconcile")
+		srvLog.Info("rollback-pending marker present but a job is in-flight; deferring reconcile")
 		return
 	}
 
@@ -76,7 +75,7 @@ func ReconcileRolledBackInstall(app core.App) {
 		0,
 	)
 	if fErr != nil {
-		log.Printf("pkg_rollback: query stranded running row failed: %v", fErr)
+		srvLog.Warn("query for stranded running install-log row failed, retrying next boot", "err", fErr)
 		return // keep the marker; retry next boot rather than lose the signal
 	}
 	if len(rows) == 0 {
@@ -96,15 +95,14 @@ func ReconcileRolledBackInstall(app core.App) {
 	row.Set("error", msg)
 	row.Set("completed_at", time.Now().UTC().Format("2006-01-02 15:04:05.000Z"))
 	if sErr := app.Save(row); sErr != nil {
-		log.Printf("pkg_rollback: failed to mark install-log %s rolled_back: %v", row.Id, sErr)
+		srvLog.Warn("failed to mark install-log rolled_back, retrying next boot", "recordID", row.Id, "err", sErr)
 		return // keep the marker; retry next boot
 	}
-	log.Printf("pkg_rollback: marked install-log %s (pkg=%s) rolled_back",
-		row.Id, row.GetString("pkg_slug"))
+	srvLog.Info("marked install-log rolled_back", "recordID", row.Id, "pkgSlug", row.GetString("pkg_slug"))
 
 	// Consume the breadcrumb only after a successful write so a transient failure
 	// retries on the next boot.
 	if rmErr := os.Remove(markerPath); rmErr != nil && !os.IsNotExist(rmErr) {
-		log.Printf("pkg_rollback: WARNING: failed to clear %s: %v", markerPath, rmErr)
+		srvLog.Warn("failed to clear rollback-pending marker", "path", markerPath, "err", rmErr)
 	}
 }

--- a/core/server/coreserver/pkg_seed.go
+++ b/core/server/coreserver/pkg_seed.go
@@ -2,7 +2,6 @@ package coreserver
 
 import (
 	"encoding/json"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -29,25 +28,25 @@ type bundledPackage struct {
 func SyncBundledPackages(app core.App) {
 	jsonPath := findBundledPackagesJSON()
 	if jsonPath == "" {
-		log.Println("pkg_seed: bundled-packages.json not found, skipping sync")
+		srvLog.Info("bundled-packages.json not found, skipping sync")
 		return
 	}
 
 	data, err := os.ReadFile(jsonPath)
 	if err != nil {
-		log.Printf("pkg_seed: failed to read %s: %v", jsonPath, err)
+		srvLog.Error("failed to read bundled-packages.json", "path", jsonPath, "err", err)
 		return
 	}
 
 	var packages []bundledPackage
 	if err := json.Unmarshal(data, &packages); err != nil {
-		log.Printf("pkg_seed: failed to parse bundled-packages.json: %v", err)
+		srvLog.Error("failed to parse bundled-packages.json", "err", err)
 		return
 	}
 
 	collection, err := app.FindCollectionByNameOrId("pkg_registry")
 	if err != nil {
-		log.Printf("pkg_seed: pkg_registry collection not found: %v", err)
+		srvLog.Error("pkg_registry collection not found", "err", err)
 		return
 	}
 
@@ -90,7 +89,7 @@ func SyncBundledPackages(app core.App) {
 				record.Set("manifest_json", pkg.ManifestJSON)
 			}
 			if err := app.Save(record); err != nil {
-				log.Printf("pkg_seed: failed to create %s: %v", pkg.Slug, err)
+				srvLog.Error("failed to create bundled package registry row", "slug", pkg.Slug, "err", err)
 			}
 			continue
 		}
@@ -120,7 +119,7 @@ func SyncBundledPackages(app core.App) {
 			existing.Set("status", "bundled")
 		}
 		if err := app.Save(existing); err != nil {
-			log.Printf("pkg_seed: failed to update %s: %v", pkg.Slug, err)
+			srvLog.Error("failed to update bundled package registry row", "slug", pkg.Slug, "err", err)
 		}
 	}
 
@@ -141,12 +140,12 @@ func SyncBundledPackages(app core.App) {
 		if !bundledSlugs[slug] {
 			record.Set("status", "disabled")
 			if err := app.Save(record); err != nil {
-				log.Printf("pkg_seed: failed to disable %s: %v", slug, err)
+				srvLog.Warn("failed to disable removed bundled package", "slug", slug, "err", err)
 			}
 		}
 	}
 
-	log.Printf("pkg_seed: synced %d bundled packages", len(packages))
+	srvLog.Info("synced bundled packages", "count", len(packages))
 }
 
 func findBundledPackagesJSON() string {

--- a/core/server/coreserver/rebuild.go
+++ b/core/server/coreserver/rebuild.go
@@ -3,7 +3,6 @@ package coreserver
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -202,7 +201,7 @@ func rebuildWith(job *installJob, m RebuildManifest, d rebuildDeps) error {
 func restore(d rebuildDeps) {
 	if d.restoreDB != nil {
 		if err := d.restoreDB(); err != nil {
-			log.Printf("rebuild: DB restore failed: %v", err)
+			srvLog.Error("rebuild: DB restore failed", "err", err)
 			return
 		}
 		// The restore overwrote data.db (and cleared its WAL) underneath the still-
@@ -213,7 +212,7 @@ func restore(d rebuildDeps) {
 		// the entrypoint instead (different process), so this only matters here.
 		if d.recoverDB != nil {
 			if err := d.recoverDB(); err != nil {
-				log.Printf("rebuild: DB reconnect after restore failed: %v", err)
+				srvLog.Error("rebuild: DB reconnect after restore failed", "err", err)
 			}
 		}
 	}
@@ -495,7 +494,7 @@ func commitRegistry(app core.App, m RebuildManifest, buildDir, uninstalledSlug s
 				if err := app.Delete(r); err != nil {
 					return err
 				}
-				log.Printf("[pkg_install] registry: %s -> deleted (uninstalled)", slug)
+				srvLog.Info("registry entry deleted (uninstalled)", "slug", slug)
 				continue
 			}
 			// Absent for another reason (reverted past, etc.) — disable, don't delete.
@@ -504,7 +503,7 @@ func commitRegistry(app core.App, m RebuildManifest, buildDir, uninstalledSlug s
 				if err := app.Save(r); err != nil {
 					return err
 				}
-				log.Printf("[pkg_install] registry: %s -> disabled (absent from build)", slug)
+				srvLog.Info("registry entry disabled (absent from build)", "slug", slug)
 			}
 			continue
 		}
@@ -537,8 +536,7 @@ func commitRegistry(app core.App, m RebuildManifest, buildDir, uninstalledSlug s
 			if err := app.Save(r); err != nil {
 				return err
 			}
-			log.Printf("[pkg_install] registry: %s -> version=%s status=%s",
-				slug, r.GetString("version"), r.GetString("status"))
+			srvLog.Info("registry entry updated", "slug", slug, "version", r.GetString("version"), "status", r.GetString("status"))
 		}
 	}
 	// Create rows for freshly-installed members (no existing row). Parse each
@@ -550,7 +548,7 @@ func commitRegistry(app core.App, m RebuildManifest, buildDir, uninstalledSlug s
 		if err := createRegistryRowFromBuild(app, buildDir, ms); err != nil {
 			return fmt.Errorf("create registry row for %s: %w", ms.Slug, err)
 		}
-		log.Printf("[pkg_install] registry: created %s (newly installed)", regSlug)
+		srvLog.Info("registry entry created", "slug", regSlug)
 	}
 	return nil
 }

--- a/core/server/coreserver/rebuild_activate.go
+++ b/core/server/coreserver/rebuild_activate.go
@@ -1,7 +1,6 @@
 package coreserver
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -37,8 +36,7 @@ func activateBuild(buildID string) error {
 	}
 	// Durable (docker logs) record of the atomic swap + the rollback target the
 	// entrypoint would flip back to on a failed post-restart health probe.
-	log.Printf("[pkg_install] activate: current %s -> %s (rollback target: %s)",
-		orNone(prev), buildID, orNone(prev))
+	srvLog.Info("activate: symlink swapped", "from", orNone(prev), "to", buildID, "rollbackTarget", orNone(prev))
 	return nil
 }
 
@@ -97,8 +95,7 @@ func pruneBuilds(keep int) error {
 		}
 	}
 	if len(pruned) > 0 {
-		log.Printf("[pkg_install] prune: removed %d old build(s): %s (kept current=%s + newest %d)",
-			len(pruned), strings.Join(pruned, ", "), orNone(cur), keep)
+		srvLog.Info("prune: removed old builds", "count", len(pruned), "removed", strings.Join(pruned, ", "), "kept", orNone(cur), "keepCount", keep)
 	}
 	return nil
 }

--- a/core/server/coreserver/rebuild_logging.go
+++ b/core/server/coreserver/rebuild_logging.go
@@ -2,7 +2,6 @@ package coreserver
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -28,14 +27,14 @@ import (
 // emitProgress lines in the recorded log.
 func jobLogf(job *installJob, format string, args ...any) {
 	if job == nil {
-		log.Printf("[pkg_install] "+format, args...)
+		srvLog.Info(fmt.Sprintf(format, args...))
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
 	job.mu.Lock()
 	job.LogLines = append(job.LogLines, "  · "+msg)
 	job.mu.Unlock()
-	log.Printf("[pkg_install] [%s]   · %s", job.ID, msg)
+	srvLog.Info(msg, "jobID", job.ID)
 }
 
 // timeStep brackets a named step: it logs a START detail line, runs fn, then logs

--- a/core/server/coreserver/schema_gen.go
+++ b/core/server/coreserver/schema_gen.go
@@ -2,7 +2,6 @@ package coreserver
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,7 +17,7 @@ import (
 func GenerateSchemas(app core.App, typesDir string) {
 	collections, err := app.FindAllCollections()
 	if err != nil {
-		log.Printf("Schema generation: failed to find collections: %v", err)
+		srvLog.Error("schema generation: failed to find collections", "err", err)
 		return
 	}
 
@@ -37,7 +36,7 @@ func GenerateSchemas(app core.App, typesDir string) {
 	zodSchema := generateZodSchema(filtered)
 
 	if err := os.MkdirAll(typesDir, 0o755); err != nil {
-		log.Printf("Schema generation: failed to create types dir: %v", err)
+		srvLog.Error("schema generation: failed to create types dir", "typesDir", typesDir, "err", err)
 		return
 	}
 
@@ -45,15 +44,15 @@ func GenerateSchemas(app core.App, typesDir string) {
 	zodPath := filepath.Join(typesDir, "pbZodSchema.ts")
 
 	if err := os.WriteFile(tsPath, []byte(tsSchema), 0o644); err != nil {
-		log.Printf("Schema generation: failed to write %s: %v", tsPath, err)
+		srvLog.Error("schema generation: failed to write file", "path", tsPath, "err", err)
 	} else {
-		log.Printf("Schema generation: wrote %s", tsPath)
+		srvLog.Info("schema generation: wrote file", "path", tsPath)
 	}
 
 	if err := os.WriteFile(zodPath, []byte(zodSchema), 0o644); err != nil {
-		log.Printf("Schema generation: failed to write %s: %v", zodPath, err)
+		srvLog.Error("schema generation: failed to write file", "path", zodPath, "err", err)
 	} else {
-		log.Printf("Schema generation: wrote %s", zodPath)
+		srvLog.Info("schema generation: wrote file", "path", zodPath)
 	}
 }
 

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -122,14 +122,6 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 
 	registerSharedEarly(app)
 
-	// Install the process-wide logger before features register, so their
-	// package loggers and any boot-time logging reach every destination.
-	//
-	// app.Logger().Handler() is resolved HERE and handed to Install, never
-	// resolved inside the fan-out: app.Logger() falls back to slog.Default()
-	// pre-bootstrap, so a lazy lookup inside the default handler would recurse.
-	logging.Install(app.Logger().Handler())
-
 	// Feature packages register BEFORE jsvm, and the order is load-bearing:
 	// jsvm.Register executes the hook files synchronously (its registerHooks
 	// call, not deferred to OnBootstrap), so any `$`-binding or loader binding
@@ -245,6 +237,28 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 // multi-org/docs/FINDING-tenant-composition-gap.md for what silent divergence
 // cost.
 func registerSharedEarly(app *pocketbase.PocketBase) {
+	// Install the process-wide logger once PocketBase has bootstrapped, not
+	// here in Register/RegisterTenant. app.Logger() falls back to
+	// slog.Default() until PocketBase's own initLogger() runs during
+	// bootstrap (pocketbase/core/base.go), so resolving it any earlier would
+	// hand Install the fan-out's own future default handler — wiring the
+	// fan-out to itself and recursing on the first log call. Waiting for
+	// e.Next() to complete first is also why the DB write works: the PB
+	// handler batches records into the _logs table, and there is no usable
+	// DB before bootstrap finishes.
+	//
+	// Anything logged between Register/RegisterTenant and this point (e.g.
+	// registerFlags, jsvm/migratecmd setup) falls through to Go's default
+	// slog handler (stderr) instead of the fan-out. That's deliberate, not a
+	// gap: those calls have no _logs table to reach yet regardless.
+	app.OnBootstrap().BindFunc(func(e *core.BootstrapEvent) error {
+		if err := e.Next(); err != nil {
+			return err
+		}
+		logging.Install(app.Logger().Handler())
+		return nil
+	})
+
 	// Sentry must register first so its router middleware sees every route.
 	// Middleware bound after a route is added does not apply retroactively.
 	// The client only initializes when a DSN exists in system_settings, so in

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -26,6 +26,13 @@ import (
 	"tinycld.org/core/sharelink"
 )
 
+// srvLog is the package-wide structured logger for coreserver. Named srvLog
+// rather than the usual "log" because coreserver is one package spanning many
+// files, several of which (this one included, for the log.Fatalf below) still
+// import stdlib "log" — a package-level "log" identifier would shadow/collide
+// with that import everywhere in the package, not just here.
+var srvLog = logging.ForPackage("coreserver")
+
 // Options configure the core server's registered plugins, flags, and wiring.
 // A runnable `main` package builds this struct and calls Register(app, opts).
 type Options struct {

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/hook"
 
 	"tinycld.org/core/automation"
+	"tinycld.org/core/logging"
 	"tinycld.org/core/notify"
 	"tinycld.org/core/oauth"
 	"tinycld.org/core/offboard"
@@ -120,6 +121,14 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 	_ = app.RootCmd.ParseFlags(os.Args[1:])
 
 	registerSharedEarly(app)
+
+	// Install the process-wide logger before features register, so their
+	// package loggers and any boot-time logging reach every destination.
+	//
+	// app.Logger().Handler() is resolved HERE and handed to Install, never
+	// resolved inside the fan-out: app.Logger() falls back to slog.Default()
+	// pre-bootstrap, so a lazy lookup inside the default handler would recurse.
+	logging.Install(app.Logger().Handler())
 
 	// Feature packages register BEFORE jsvm, and the order is load-bearing:
 	// jsvm.Register executes the hook files synchronously (its registerHooks

--- a/core/server/coreserver/setup_bootstrap.go
+++ b/core/server/coreserver/setup_bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -28,7 +27,7 @@ func RegisterSetupBootstrap(app *pocketbase.PocketBase) {
 		if publicURL := strings.TrimRight(os.Getenv("TINYCLD_PUBLIC_URL"), "/"); publicURL != "" {
 			app.Settings().Meta.AppURL = publicURL
 			if err := app.Save(app.Settings()); err != nil {
-				log.Printf("setup bootstrap: failed to persist AppURL from TINYCLD_PUBLIC_URL: %v", err)
+				srvLog.Error("setup bootstrap: failed to persist AppURL from TINYCLD_PUBLIC_URL", "err", err)
 			}
 		}
 
@@ -164,7 +163,7 @@ func handleSetupInit(app *pocketbase.PocketBase, re *core.RequestEvent) error {
 	}
 	if req.AppName != "" || req.AppURL != "" {
 		if err := app.Save(app.Settings()); err != nil {
-			log.Printf("Setup bootstrap: failed to save settings: %v", err)
+			srvLog.Warn("setup bootstrap: failed to save settings", "err", err)
 		}
 	}
 

--- a/core/server/coreserver/tenant_pkg_state.go
+++ b/core/server/coreserver/tenant_pkg_state.go
@@ -3,7 +3,6 @@ package coreserver
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"time"
@@ -46,7 +45,7 @@ func reconcileTenantPackageState(app core.App, orgDir, artifactDir string) {
 	defer tenantPkgStateMu.Unlock()
 	uninstalledSlug := reconcileDeployResult(app, orgDir)
 	if err := reconcileRegistryFromArtifact(app, artifactDir, uninstalledSlug); err != nil {
-		log.Printf("tenant_pkg_state: registry reconcile failed: %v", err)
+		srvLog.Error("tenant registry reconcile failed", "err", err)
 	}
 }
 
@@ -79,7 +78,7 @@ func consumePendingDeployResult(app core.App, orgDir, artifactDir string) {
 func reconcileDeployResult(app core.App, orgDir string) (uninstalledSlug string) {
 	res, ok, err := tenantcfg.LoadDeployResult(orgDir)
 	if err != nil {
-		log.Printf("tenant_pkg_state: unreadable deploy result (leaving for next boot): %v", err)
+		srvLog.Warn("unreadable deploy result, leaving for next boot", "err", err)
 		return ""
 	}
 	if !ok {
@@ -102,7 +101,7 @@ func reconcileDeployResult(app core.App, orgDir string) (uninstalledSlug string)
 			errMsg = "deploy reverted: the proposed build failed to become ready"
 		}
 	default:
-		log.Printf("tenant_pkg_state: deploy result has unknown status %q (consuming)", res.Status)
+		srvLog.Warn("deploy result has unknown status, consuming", "status", res.Status)
 		consumeDeployResult(orgDir)
 		return ""
 	}
@@ -124,11 +123,10 @@ func reconcileDeployResult(app core.App, orgDir string) (uninstalledSlug string)
 		row.Set("error", errMsg)
 		row.Set("completed_at", time.Now().UTC().Format("2006-01-02 15:04:05.000Z"))
 		if err := app.Save(row); err != nil {
-			log.Printf("tenant_pkg_state: could not finalize install-log %s (retrying next boot): %v", row.Id, err)
+			srvLog.Warn("could not finalize install-log, retrying next boot", "recordID", row.Id, "err", err)
 			return ""
 		}
-		log.Printf("tenant_pkg_state: finalized install-log %s (pkg=%s) -> %s",
-			row.Id, row.GetString("pkg_slug"), status)
+		srvLog.Info("finalized install-log", "recordID", row.Id, "pkgSlug", row.GetString("pkg_slug"), "status", status)
 	}
 
 	consumeDeployResult(orgDir)
@@ -140,7 +138,7 @@ func reconcileDeployResult(app core.App, orgDir string) (uninstalledSlug string)
 
 func consumeDeployResult(orgDir string) {
 	if err := tenantcfg.ConsumeDeployResult(orgDir); err != nil {
-		log.Printf("tenant_pkg_state: WARNING: could not consume deploy result: %v", err)
+		srvLog.Warn("could not consume deploy result", "err", err)
 	}
 }
 
@@ -192,7 +190,7 @@ func reconcileRegistryFromArtifact(app core.App, artifactDir, uninstalledSlug st
 			if err := app.Delete(r); err != nil {
 				return err
 			}
-			log.Printf("tenant_pkg_state: registry: %s -> deleted (uninstalled)", slug)
+			srvLog.Info("registry entry deleted (uninstalled)", "slug", slug)
 			continue
 		}
 		if s := r.GetString("status"); s != "disabled" {
@@ -200,7 +198,7 @@ func reconcileRegistryFromArtifact(app core.App, artifactDir, uninstalledSlug st
 			if err := app.Save(r); err != nil {
 				return err
 			}
-			log.Printf("tenant_pkg_state: registry: %s -> disabled (absent from artifact)", slug)
+			srvLog.Info("registry entry disabled (absent from artifact)", "slug", slug)
 		}
 	}
 	return nil

--- a/core/server/coreserver/users_guard.go
+++ b/core/server/coreserver/users_guard.go
@@ -1,7 +1,6 @@
 package coreserver
 
 import (
-	"log"
 	"reflect"
 
 	"github.com/pocketbase/pocketbase"
@@ -94,7 +93,7 @@ func registerUsersDemoAuditHookCore(app core.App) {
 
 		auditCol, err := e.App.FindCollectionByNameOrId("audit_logs")
 		if err != nil {
-			log.Printf("[demo-audit] missing audit_logs collection: %v", err)
+			srvLog.Error("demo-audit: missing audit_logs collection", "err", err)
 			return nil
 		}
 		auditRec := core.NewRecord(auditCol)
@@ -110,7 +109,7 @@ func registerUsersDemoAuditHookCore(app core.App) {
 			auditRec.Set("actor", e.Auth.Id)
 		}
 		if err := e.App.Save(auditRec); err != nil {
-			log.Printf("[demo-audit] failed to write audit entry: %v", err)
+			srvLog.Error("demo-audit: failed to write audit entry", "userID", e.Record.Id, "err", err)
 		}
 		return nil
 	})

--- a/core/server/logging/fanout.go
+++ b/core/server/logging/fanout.go
@@ -1,0 +1,72 @@
+// Package logging installs the process-wide slog handler for TinyCld servers.
+//
+// Call sites declare what happened (level + message + attrs); this package
+// decides where it goes. That separation is the point: before it, the function
+// you called silently picked the destination (slog → stderr, app.Logger() →
+// the _logs table, sentry.CaptureException → Sentry).
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+// fanout forwards each record to every child handler that accepts it, so a
+// single call site can reach stderr, the _logs table, and Sentry at once with
+// independent per-destination levels.
+type fanout struct {
+	handlers []slog.Handler
+}
+
+// NewFanout returns a handler that forwards to each of handlers.
+func NewFanout(handlers ...slog.Handler) slog.Handler {
+	return &fanout{handlers: handlers}
+}
+
+// Enabled reports whether ANY child would accept the level. Returning false
+// only when every child declines is what lets a quiet stderr handler coexist
+// with a chatty Sentry one without either suppressing the other.
+func (f *fanout) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, h := range f.handlers {
+		if h.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle re-checks Enabled per child, because the parent's Enabled is an OR
+// across all of them — without this a debug record aimed at stderr would also
+// be written to the error-level Sentry handler.
+//
+// A child returning an error must not stop the others: losing a stderr line
+// should never also lose the Sentry event. The last error is returned for the
+// caller's benefit and otherwise ignored.
+func (f *fanout) Handle(ctx context.Context, r slog.Record) error {
+	var lastErr error
+	for _, h := range f.handlers {
+		if !h.Enabled(ctx, r.Level) {
+			continue
+		}
+		if err := h.Handle(ctx, r.Clone()); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (f *fanout) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Handler, len(f.handlers))
+	for i, h := range f.handlers {
+		next[i] = h.WithAttrs(attrs)
+	}
+	return &fanout{handlers: next}
+}
+
+func (f *fanout) WithGroup(name string) slog.Handler {
+	next := make([]slog.Handler, len(f.handlers))
+	for i, h := range f.handlers {
+		next[i] = h.WithGroup(name)
+	}
+	return &fanout{handlers: next}
+}

--- a/core/server/logging/fanout_test.go
+++ b/core/server/logging/fanout_test.go
@@ -1,0 +1,62 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestFanoutWritesToEveryEnabledHandler(t *testing.T) {
+	var a, b bytes.Buffer
+	h := NewFanout(
+		slog.NewTextHandler(&a, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		slog.NewTextHandler(&b, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+	slog.New(h).Info("hello", "k", "v")
+
+	if !strings.Contains(a.String(), "hello") {
+		t.Errorf("handler a missing record: %q", a.String())
+	}
+	if !strings.Contains(b.String(), "hello") {
+		t.Errorf("handler b missing record: %q", b.String())
+	}
+}
+
+func TestFanoutRespectsPerHandlerLevel(t *testing.T) {
+	var chatty, quiet bytes.Buffer
+	h := NewFanout(
+		slog.NewTextHandler(&chatty, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		slog.NewTextHandler(&quiet, &slog.HandlerOptions{Level: slog.LevelError}),
+	)
+	slog.New(h).Info("only-chatty")
+
+	if !strings.Contains(chatty.String(), "only-chatty") {
+		t.Errorf("debug handler should have received the record")
+	}
+	if quiet.Len() != 0 {
+		t.Errorf("error-level handler should have dropped the record, got %q", quiet.String())
+	}
+}
+
+func TestFanoutEnabledIsTrueIfAnyChildIsEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewFanout(
+		slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}),
+		slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+	if !h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("fanout should be enabled when any child is enabled")
+	}
+}
+
+func TestFanoutPropagatesAttrsToChildren(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewFanout(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.New(h).With("pkg", "cards").Info("msg")
+
+	if !strings.Contains(buf.String(), "pkg=cards") {
+		t.Errorf("WithAttrs did not reach the child handler: %q", buf.String())
+	}
+}

--- a/core/server/logging/logging.go
+++ b/core/server/logging/logging.go
@@ -8,12 +8,16 @@ import (
 // Destination levels. Independent by design: stderr and the DB-backed _logs
 // table are for operators reading history, while Sentry is for paging someone.
 //
-// _logs sits at Info deliberately. It is a database table, and routing all of
-// the codebase's slog calls there at Debug would write far more than the
-// app.Logger() calls it receives today.
+// _logs has no level constant here — pbHandler (app.Logger().Handler(), the
+// caller-supplied destination below) already gates itself on PocketBase's own
+// admin-configurable Settings.Logs.MinLevel (Info by default). Wrapping it in
+// a second, hardcoded filter would either duplicate that gate or silently
+// override an admin who lowered MinLevel to Debug to troubleshoot — and
+// _logs must keep receiving records unconditionally: the OTA e2e harness
+// polls it for an "app-boot: rendered" beacon to confirm a promoted bundle
+// booted on a device.
 const (
 	StderrLevel = slog.LevelInfo
-	LogsLevel   = slog.LevelInfo
 	SentryLevel = slog.LevelWarn
 )
 

--- a/core/server/logging/logging.go
+++ b/core/server/logging/logging.go
@@ -1,0 +1,48 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Destination levels. Independent by design: stderr and the DB-backed _logs
+// table are for operators reading history, while Sentry is for paging someone.
+//
+// _logs sits at Info deliberately. It is a database table, and routing all of
+// the codebase's slog calls there at Debug would write far more than the
+// app.Logger() calls it receives today.
+const (
+	StderrLevel = slog.LevelInfo
+	LogsLevel   = slog.LevelInfo
+	SentryLevel = slog.LevelWarn
+)
+
+// Install sets the process-wide default logger to a fan-out over stderr, the
+// PocketBase _logs table, and Sentry.
+//
+// pbHandler is the caller-resolved handler for the _logs table — normally
+// app.Logger().Handler(). It is passed in rather than resolved here because
+// app.Logger() falls back to slog.Default() before bootstrap; resolving it
+// inside the handler we are installing AS the default would recurse.
+//
+// Pass nil for pbHandler to skip the _logs destination (useful in tests and in
+// binaries with no PocketBase app).
+func Install(pbHandler slog.Handler) {
+	handlers := []slog.Handler{
+		slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: StderrLevel}),
+		NewSentryHandler(SentryLevel),
+	}
+	if pbHandler != nil {
+		handlers = append(handlers, pbHandler)
+	}
+	slog.SetDefault(slog.New(NewFanout(handlers...)))
+}
+
+// ForPackage returns a logger stamped with a pkg attribute, replacing the old
+// hand-written "cards: " message prefixes with a queryable structured field.
+//
+//	log := logging.ForPackage("cards")
+//	log.WarnContext(ctx, "refusing to flush a card from another board", "cardID", id)
+func ForPackage(name string) *slog.Logger {
+	return slog.Default().With("pkg", name)
+}

--- a/core/server/logging/logging_test.go
+++ b/core/server/logging/logging_test.go
@@ -1,0 +1,36 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestForPackageStampsThePkgAttr(t *testing.T) {
+	var buf bytes.Buffer
+	Install(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))) })
+
+	ForPackage("cards").Warn("refusing to flush")
+
+	out := buf.String()
+	if !strings.Contains(out, "pkg=cards") {
+		t.Errorf("expected pkg=cards, got %q", out)
+	}
+	if !strings.Contains(out, "refusing to flush") {
+		t.Errorf("expected the message, got %q", out)
+	}
+}
+
+func TestInstallSetsTheDefaultLogger(t *testing.T) {
+	var buf bytes.Buffer
+	Install(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))) })
+
+	slog.Info("via the package-level default")
+
+	if !strings.Contains(buf.String(), "via the package-level default") {
+		t.Errorf("slog.Default was not installed: %q", buf.String())
+	}
+}

--- a/core/server/logging/sentry_handler.go
+++ b/core/server/logging/sentry_handler.go
@@ -1,0 +1,75 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/getsentry/sentry-go"
+)
+
+var sentryLevel = map[slog.Level]sentry.Level{
+	slog.LevelDebug: sentry.LevelDebug,
+	slog.LevelInfo:  sentry.LevelInfo,
+	slog.LevelWarn:  sentry.LevelWarning,
+	slog.LevelError: sentry.LevelError,
+}
+
+// sentryHandler turns log records at or above minLevel into Sentry events.
+//
+// User attribution is inherited, not plumbed: the per-request middleware in
+// coreserver/sentry.go already puts a hub carrying sentry.User{ID: …} on the
+// request context, so a *Context log call picks it up automatically. Calls
+// without a ctx (tickers, startup, background goroutines) fall back to the
+// current hub and produce an unattributed event — which is correct, because
+// there genuinely is no user in those paths.
+type sentryHandler struct {
+	minLevel slog.Level
+	attrs    []slog.Attr
+	groups   []string
+}
+
+// NewSentryHandler returns a handler capturing records at or above minLevel.
+func NewSentryHandler(minLevel slog.Level) slog.Handler {
+	return &sentryHandler{minLevel: minLevel}
+}
+
+func (h *sentryHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.minLevel
+}
+
+func (h *sentryHandler) Handle(ctx context.Context, r slog.Record) error {
+	hub := sentry.GetHubFromContext(ctx)
+	if hub == nil {
+		hub = sentry.CurrentHub()
+	}
+
+	extra := make(map[string]any, len(h.attrs)+r.NumAttrs())
+	for _, a := range h.attrs {
+		extra[a.Key] = a.Value.Any()
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		extra[a.Key] = a.Value.Any()
+		return true
+	})
+
+	hub.WithScope(func(scope *sentry.Scope) {
+		scope.SetLevel(sentryLevel[r.Level])
+		scope.SetExtras(extra)
+		hub.CaptureMessage(r.Message)
+	})
+	return nil
+}
+
+func (h *sentryHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	next = append(next, h.attrs...)
+	next = append(next, attrs...)
+	return &sentryHandler{minLevel: h.minLevel, attrs: next, groups: h.groups}
+}
+
+func (h *sentryHandler) WithGroup(name string) slog.Handler {
+	next := make([]string, 0, len(h.groups)+1)
+	next = append(next, h.groups...)
+	next = append(next, name)
+	return &sentryHandler{minLevel: h.minLevel, attrs: h.attrs, groups: next}
+}

--- a/core/server/logging/sentry_handler.go
+++ b/core/server/logging/sentry_handler.go
@@ -54,7 +54,11 @@ func (h *sentryHandler) Handle(ctx context.Context, r slog.Record) error {
 
 	hub.WithScope(func(scope *sentry.Scope) {
 		scope.SetLevel(sentryLevel[r.Level])
-		scope.SetExtras(extra)
+		// SetContext (not the deprecated SetExtras/SetAttributes) so the
+		// record's attrs attach to the event itself — SetAttributes is
+		// documented to be dropped for error events, and this handler exists
+		// specifically to capture events.
+		scope.SetContext("log", extra)
 		hub.CaptureMessage(r.Message)
 	})
 	return nil

--- a/core/server/logging/sentry_handler_test.go
+++ b/core/server/logging/sentry_handler_test.go
@@ -65,7 +65,7 @@ func TestSentryHandlerCapturesWithoutAHubOnContext(t *testing.T) {
 	logger.Warn("no ctx here")
 }
 
-func TestSentryHandlerAttachesAttrsAsExtra(t *testing.T) {
+func TestSentryHandlerAttachesAttrsAsContext(t *testing.T) {
 	hub, tr := newTestHub(t)
 	ctx := sentry.SetHubOnContext(context.Background(), hub)
 
@@ -75,11 +75,14 @@ func TestSentryHandlerAttachesAttrsAsExtra(t *testing.T) {
 	if len(tr.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(tr.events))
 	}
-	extra := tr.events[0].Extra
-	if extra["pkg"] != "cards" {
-		t.Errorf("expected pkg=cards in extra, got %v", extra["pkg"])
+	logCtx, ok := tr.events[0].Contexts["log"]
+	if !ok {
+		t.Fatalf("expected a %q context on the event, got %v", "log", tr.events[0].Contexts)
 	}
-	if extra["boardID"] != "b1" {
-		t.Errorf("expected boardID=b1 in extra, got %v", extra["boardID"])
+	if logCtx["pkg"] != "cards" {
+		t.Errorf("expected pkg=cards in log context, got %v", logCtx["pkg"])
+	}
+	if logCtx["boardID"] != "b1" {
+		t.Errorf("expected boardID=b1 in log context, got %v", logCtx["boardID"])
 	}
 }

--- a/core/server/logging/sentry_handler_test.go
+++ b/core/server/logging/sentry_handler_test.go
@@ -1,0 +1,85 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// captureTransport records events instead of sending them.
+type captureTransport struct {
+	events []*sentry.Event
+}
+
+func (t *captureTransport) Configure(sentry.ClientOptions)        {}
+func (t *captureTransport) SendEvent(e *sentry.Event)             { t.events = append(t.events, e) }
+func (t *captureTransport) Flush(time.Duration) bool              { return true }
+func (t *captureTransport) FlushWithContext(context.Context) bool { return true }
+func (t *captureTransport) Close()                                {}
+
+func newTestHub(t *testing.T) (*sentry.Hub, *captureTransport) {
+	t.Helper()
+	tr := &captureTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{Dsn: "", Transport: tr})
+	if err != nil {
+		t.Fatalf("sentry.NewClient: %v", err)
+	}
+	return sentry.NewHub(client, sentry.NewScope()), tr
+}
+
+func TestSentryHandlerCapturesAtOrAboveLevel(t *testing.T) {
+	hub, tr := newTestHub(t)
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	logger := slog.New(NewSentryHandler(slog.LevelWarn))
+	logger.WarnContext(ctx, "reconnect failed", "attempt", 3)
+
+	if len(tr.events) != 1 {
+		t.Fatalf("expected 1 captured event, got %d", len(tr.events))
+	}
+	if tr.events[0].Message != "reconnect failed" {
+		t.Errorf("unexpected message: %q", tr.events[0].Message)
+	}
+}
+
+func TestSentryHandlerIgnoresBelowLevel(t *testing.T) {
+	hub, tr := newTestHub(t)
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	logger := slog.New(NewSentryHandler(slog.LevelWarn))
+	logger.InfoContext(ctx, "just fyi")
+
+	if len(tr.events) != 0 {
+		t.Fatalf("expected no events, got %d", len(tr.events))
+	}
+}
+
+// A call site with no ctx (tickers, startup, background goroutines) must still
+// produce an event — the user id is enrichment, never a gate.
+func TestSentryHandlerCapturesWithoutAHubOnContext(t *testing.T) {
+	logger := slog.New(NewSentryHandler(slog.LevelWarn))
+	// Must not panic with no hub on the context.
+	logger.Warn("no ctx here")
+}
+
+func TestSentryHandlerAttachesAttrsAsExtra(t *testing.T) {
+	hub, tr := newTestHub(t)
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	logger := slog.New(NewSentryHandler(slog.LevelWarn)).With("pkg", "cards")
+	logger.ErrorContext(ctx, "flush failed", "boardID", "b1")
+
+	if len(tr.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(tr.events))
+	}
+	extra := tr.events[0].Extra
+	if extra["pkg"] != "cards" {
+		t.Errorf("expected pkg=cards in extra, got %v", extra["pkg"])
+	}
+	if extra["boardID"] != "b1" {
+		t.Errorf("expected boardID=b1 in extra, got %v", extra["boardID"])
+	}
+}

--- a/core/server/notify/notify.go
+++ b/core/server/notify/notify.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/pocketbase/pocketbase/core"
+	"tinycld.org/core/logging"
 	"tinycld.org/core/push"
 )
+
+var log = logging.ForPackage("notify")
 
 // NotifyParams describes a notification to send to a user.
 type NotifyParams struct {
@@ -33,7 +35,7 @@ func NotifyUser(app core.App, params NotifyParams) {
 	// Insert into notifications collection
 	collection, err := app.FindCollectionByNameOrId("notifications")
 	if err != nil {
-		log.Printf("[notify] failed to find notifications collection: %v", err)
+		log.Error("failed to find notifications collection", "err", err)
 		return
 	}
 
@@ -49,7 +51,7 @@ func NotifyUser(app core.App, params NotifyParams) {
 	record.Set("dismissed", false)
 
 	if err := app.Save(record); err != nil {
-		log.Printf("[notify] failed to save notification: %v", err)
+		log.Error("failed to save notification", "userID", params.UserID, "err", err)
 		return
 	}
 
@@ -153,7 +155,7 @@ func sendExpoPush(app core.App, userID string, params NotifyParams) {
 
 		body, err := json.Marshal(payload)
 		if err != nil {
-			log.Printf("[notify/expo] failed to marshal payload: %v", err)
+			log.Warn("failed to marshal expo payload", "token", token, "err", err)
 			continue
 		}
 
@@ -163,7 +165,7 @@ func sendExpoPush(app core.App, userID string, params NotifyParams) {
 			bytes.NewReader(body),
 		)
 		if err != nil {
-			log.Printf("[notify/expo] send failed for token %s: %v", token, err)
+			log.Info("expo send failed for token", "token", token, "err", err)
 			continue
 		}
 
@@ -177,9 +179,9 @@ func sendExpoPush(app core.App, userID string, params NotifyParams) {
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&result); err == nil {
 			if result.Data.Details.Error == "DeviceNotRegistered" {
-				log.Printf("[notify/expo] removing stale token %s", token)
+				log.Info("removing stale expo token", "token", token)
 				if err := app.Delete(record); err != nil {
-					log.Printf("[notify/expo] failed to delete stale token %s: %v", record.Id, err)
+					log.Warn("failed to delete stale expo token", "subscriptionID", record.Id, "err", err)
 				}
 			}
 		}

--- a/core/server/notify/notify.go
+++ b/core/server/notify/notify.go
@@ -181,7 +181,7 @@ func sendExpoPush(app core.App, userID string, params NotifyParams) {
 			if result.Data.Details.Error == "DeviceNotRegistered" {
 				log.Info("removing stale expo token", "token", token)
 				if err := app.Delete(record); err != nil {
-					log.Warn("failed to delete stale expo token", "subscriptionID", record.Id, "err", err)
+					log.Info("failed to delete stale expo token", "tokenID", record.Id, "err", err)
 				}
 			}
 		}

--- a/core/server/push/push.go
+++ b/core/server/push/push.go
@@ -123,7 +123,7 @@ func SendToUser(app core.App, userID string, payload Payload) {
 		if resp.StatusCode == http.StatusGone || resp.StatusCode == http.StatusNotFound {
 			log.Info("removing stale subscription", "subscriptionID", record.Id, "status", resp.StatusCode)
 			if err := app.Delete(record); err != nil {
-				log.Warn("failed to delete stale subscription", "subscriptionID", record.Id, "err", err)
+				log.Info("failed to delete stale subscription", "subscriptionID", record.Id, "err", err)
 			}
 		}
 	}

--- a/core/server/push/push.go
+++ b/core/server/push/push.go
@@ -2,12 +2,15 @@ package push
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("push")
 
 // systemSetting reads a value from the system_settings collection — the
 // system-wide config store (the same one coreserver.SystemConfig loads). push
@@ -49,7 +52,7 @@ func SendToUser(app core.App, userID string, payload Payload) {
 		map[string]any{"userId": userID},
 	)
 	if err != nil {
-		log.Printf("[push] failed to query subscriptions for user %s: %v", userID, err)
+		log.Warn("failed to query subscriptions", "userID", userID, "err", err)
 		return
 	}
 
@@ -59,7 +62,7 @@ func SendToUser(app core.App, userID string, payload Payload) {
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("[push] failed to marshal payload: %v", err)
+		log.Warn("failed to marshal payload", "err", err)
 		return
 	}
 
@@ -82,7 +85,7 @@ func SendToUser(app core.App, userID string, payload Payload) {
 		switch v := keysRaw.(type) {
 		case string:
 			if err := json.Unmarshal([]byte(v), &keys); err != nil {
-				log.Printf("[push] invalid keys JSON for subscription %s: %v", record.Id, err)
+				log.Warn("invalid keys JSON for subscription", "subscriptionID", record.Id, "err", err)
 				continue
 			}
 		case map[string]any:
@@ -93,7 +96,7 @@ func SendToUser(app core.App, userID string, payload Payload) {
 				keys.Auth = a
 			}
 		default:
-			log.Printf("[push] unexpected keys type for subscription %s", record.Id)
+			log.Warn("unexpected keys type for subscription", "subscriptionID", record.Id)
 			continue
 		}
 
@@ -112,15 +115,15 @@ func SendToUser(app core.App, userID string, payload Payload) {
 			TTL:             86400,
 		})
 		if err != nil {
-			log.Printf("[push] send failed for subscription %s: %v", record.Id, err)
+			log.Info("send failed for subscription", "subscriptionID", record.Id, "err", err)
 			continue
 		}
 		resp.Body.Close()
 
 		if resp.StatusCode == http.StatusGone || resp.StatusCode == http.StatusNotFound {
-			log.Printf("[push] removing stale subscription %s (status %d)", record.Id, resp.StatusCode)
+			log.Info("removing stale subscription", "subscriptionID", record.Id, "status", resp.StatusCode)
 			if err := app.Delete(record); err != nil {
-				log.Printf("[push] failed to delete stale subscription %s: %v", record.Id, err)
+				log.Warn("failed to delete stale subscription", "subscriptionID", record.Id, "err", err)
 			}
 		}
 	}

--- a/core/server/realtime/register.go
+++ b/core/server/realtime/register.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"log/slog"
 	"sync"
 	"time"
 
@@ -376,8 +375,8 @@ func runConnection(broker *Broker, opts Options, ident connIdentity, conn *webso
 	if opts, lookupErr := optionsFor(kind); lookupErr == nil && opts.OnConnect != nil {
 		payload, err := opts.OnConnect(roomID, client)
 		if err != nil {
-			slog.Warn(
-				"realtime: OnConnect failed; skipping MsgServerHello",
+			log.WarnContext(ctx,
+				"OnConnect failed; skipping MsgServerHello",
 				"kind", kind, "roomID", roomID, "err", err,
 			)
 		} else {

--- a/core/server/realtime/room.go
+++ b/core/server/realtime/room.go
@@ -3,9 +3,12 @@ package realtime
 import (
 	"bytes"
 	"fmt"
-	"log/slog"
 	"sync"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("realtime")
 
 // sendBufferSize is the number of frames buffered per client. A slow
 // reader that backs up past this many frames is dropped — that is, the
@@ -55,8 +58,8 @@ func newRoom(b *Broker, key roomKey, opts RoomKindOptions) *Room {
 			// behavior: clients can still join and fan out frames
 			// among themselves; only the server-side mirror (and
 			// therefore persistence) is disabled for this room.
-			slog.Error(
-				"realtime: DocRuntime.NewDoc failed; falling back to pure relay",
+			log.Error(
+				"DocRuntime.NewDoc failed; falling back to pure relay",
 				"kind", key.kind, "roomID", key.id, "err", err,
 			)
 		} else {
@@ -88,8 +91,8 @@ func newRoom(b *Broker, key roomKey, opts RoomKindOptions) *Room {
 					return nil
 				})
 				if replayErr != nil {
-					slog.Error(
-						"realtime: journal replay failed; room continues with partial state",
+					log.Error(
+						"journal replay failed; room continues with partial state",
 						"kind", key.kind, "roomID", key.id, "err", replayErr,
 					)
 				}
@@ -133,8 +136,8 @@ func (r *Room) remove(c *Client) {
 		}
 		if r.serverDoc != nil {
 			if err := r.serverDoc.Close(); err != nil {
-				slog.Warn(
-					"realtime: DocHandle.Close failed",
+				log.Warn(
+					"DocHandle.Close failed",
 					"kind", r.key.kind, "roomID", r.key.id, "err", err,
 				)
 			}
@@ -208,7 +211,7 @@ func (r *Room) route(from *Client, frame []byte) {
 		// (not a connection close) so a benign client with a stale flag
 		// isn't disconnected.
 		if r.opts.WritePredicate != nil && !r.opts.WritePredicate(from, r.key.id) {
-			slog.Warn("realtime: dropped MsgDocUpdate from read-only connection",
+			log.Warn("dropped MsgDocUpdate from read-only connection",
 				"kind", r.key.kind, "roomID", r.key.id, "authID", from.authID)
 			return
 		}
@@ -218,8 +221,8 @@ func (r *Room) route(from *Client, frame []byte) {
 			limit = DefaultMaxUpdateBytes
 		}
 		if len(payload) > limit {
-			slog.Warn(
-				"realtime: MsgDocUpdate exceeds cap; dropping",
+			log.Warn(
+				"MsgDocUpdate exceeds cap; dropping",
 				"kind", r.key.kind, "roomID", r.key.id,
 				"size", len(payload), "cap", limit,
 			)
@@ -234,8 +237,8 @@ func (r *Room) route(from *Client, frame []byte) {
 		// the journal, the server mirror, or any peer.
 		if r.opts.UpdateContentValidator != nil {
 			if err := r.opts.UpdateContentValidator(r.key.id, payload); err != nil {
-				slog.Warn(
-					"realtime: UpdateContentValidator rejected MsgDocUpdate; dropping",
+				log.Warn(
+					"UpdateContentValidator rejected MsgDocUpdate; dropping",
 					"kind", r.key.kind, "roomID", r.key.id, "err", err,
 				)
 				return
@@ -266,8 +269,8 @@ func (r *Room) route(from *Client, frame []byte) {
 			seq := r.nextSeq
 			r.mu.Unlock()
 			if err := r.opts.Journal.Append(r.key.kind, r.key.id, seq, payload); err != nil {
-				slog.Warn(
-					"realtime: journal append failed; dropping MsgDocUpdate",
+				log.Warn(
+					"journal append failed; dropping MsgDocUpdate",
 					"kind", r.key.kind, "roomID", r.key.id, "seq", seq, "err", err,
 				)
 				// Roll back the seq so the next attempt reuses it.
@@ -286,8 +289,8 @@ func (r *Room) route(from *Client, frame []byte) {
 		// relay mode for this kind and we just forward.
 		if r.serverDoc != nil {
 			if err := r.serverDoc.ApplyUpdate(payload); err != nil {
-				slog.Warn(
-					"realtime: ApplyUpdate rejected an inbound MsgDocUpdate; dropping frame",
+				log.Warn(
+					"ApplyUpdate rejected an inbound MsgDocUpdate; dropping frame",
 					"kind", r.key.kind, "roomID", r.key.id, "err", err,
 				)
 				return
@@ -327,8 +330,8 @@ func (r *Room) route(from *Client, frame []byte) {
 		if r.serverDoc != nil {
 			state, err := r.serverDoc.EncodeStateAsUpdate()
 			if err != nil {
-				slog.Warn(
-					"realtime: EncodeStateAsUpdate failed; falling back to peer bounce",
+				log.Warn(
+					"EncodeStateAsUpdate failed; falling back to peer bounce",
 					"kind", r.key.kind, "roomID", r.key.id, "err", err,
 				)
 			} else {
@@ -673,8 +676,8 @@ func (r *Room) PublishDocUpdate(payload []byte) error {
 				r.nextSeq--
 			}
 			r.mu.Unlock()
-			slog.Warn(
-				"realtime: PublishDocUpdate journal append failed; dropping",
+			log.Warn(
+				"PublishDocUpdate journal append failed; dropping",
 				"kind", r.key.kind, "roomID", r.key.id, "seq", seq, "err", err,
 			)
 			return fmt.Errorf("realtime: PublishDocUpdate journal append failed: %w", err)

--- a/core/server/yjsdoc/runtime.go
+++ b/core/server/yjsdoc/runtime.go
@@ -16,14 +16,16 @@ package yjsdoc
 
 import (
 	"fmt"
-	"log/slog"
 	"sync"
 	"time"
 
 	ycrdt "github.com/skyterra/y-crdt"
 
+	"tinycld.org/core/logging"
 	"tinycld.org/core/realtime"
 )
+
+var log = logging.ForPackage("yjsdoc")
 
 // Doc is a Yjs document. Aliased rather than wrapped so a consumer can pass it
 // to the bridge helpers in this package without importing y-crdt, while text/
@@ -163,7 +165,7 @@ func (r *Runtime) NewDoc(roomID string) (realtime.DocHandle, error) {
 
 	if hook != nil {
 		if err := hook(roomID, doc); err != nil {
-			slog.Warn("yjsdoc: bootstrap failed; room continues with an empty document",
+			log.Warn("bootstrap failed; room continues with an empty document",
 				"roomID", roomID, "err", err)
 		}
 	}

--- a/lib/use-server-address-gate.ts
+++ b/lib/use-server-address-gate.ts
@@ -1,3 +1,4 @@
+import { log } from '@tinycld/core/lib/logger'
 import {
     DEMO_SERVER,
     getResolvedAddress,
@@ -72,7 +73,7 @@ export function useServerAddressGate(pathname: string): GateState {
                 // diagnostic UI.
                 if (cancelled) return
                 const message = err instanceof Error ? err.message : String(err)
-                console.error('[layout-gate] failed to resolve providers:', err)
+                log.error('core.layout-gate.resolve-providers', err)
                 setState({ status: 'failed', error: message })
             }
         }

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -872,36 +872,27 @@ function exerciseCalendar(): void {
     )
 
     const json = cli(['--json', 'calendar', 'list'], OWNER_CTX)
-    const cals = parseJSON(json) as { id?: string; name?: string }[] | null
+    const cals = parseJSON(json) as { id?: string; name?: string; role?: string }[] | null
     assert(g, 'calendar list --json parses', Array.isArray(cals), firstLine(json.stderr))
 
-    // ROLE is the only warning a viewer gets before a write is refused, so it
-    // must actually be populated. Asserted against the TABLE, not --json: the
-    // role is joined in at render time and is deliberately absent from the JSON
-    // payload (see the note in the round-2 findings — the two formats disagree
-    // about which fields exist).
-    const table = cli(['calendar', 'list'], OWNER_CTX)
-    const roleColumn = table.stdout
-        .split('\n')
-        .slice(1)
-        .filter(l => l.trim())
-        .map(l => l.trim().split(/\s{2,}/)[1])
+    // ROLE decides whether a write will be accepted, so it must be readable
+    // from --json and not only from the table — otherwise a script has to
+    // parse columns to answer "which calendars may I write to", which is what
+    // this file used to do.
     assert(
         g,
-        'calendar list populates the ROLE column',
-        roleColumn.length > 0 && roleColumn.every(r => !!r && r !== '-'),
-        roleColumn.length ? `roles: ${roleColumn.join(', ')}` : 'no calendars seeded'
+        'calendar list --json carries the ROLE column',
+        !!cals?.length && cals.every(cl => !!cl.role),
+        cals?.length ? `roles: ${cals.map(cl => cl.role ?? '-').join(', ')}` : 'no calendars seeded'
     )
 
     // Write to a calendar the caller can actually write to. Read is membership
     // in ANY role, so the first row may well be one the user only views — the
     // seed's first calendar is exactly that — and picking it blindly turns a
     // correct refusal into a failure that looks like a broken `add`.
-    const writable = table.stdout
-        .split('\n')
-        .slice(1)
-        .map(l => l.trim().split(/\s{2,}/))
-        .filter(cols => cols.length >= 2 && (cols[1] === 'owner' || cols[1] === 'editor'))
+    const writable = (cals ?? [])
+        .filter(cl => cl.role === 'owner' || cl.role === 'editor')
+        .map(cl => [cl.name ?? cl.id ?? ''])
     const target = writable[0]?.[0]
     if (!target) {
         for (const name of [

--- a/tests/unit-setup.ts
+++ b/tests/unit-setup.ts
@@ -4,6 +4,12 @@
 // Add vi.mock() calls here for modules that cannot be handled by resolve.alias.
 import { vi } from 'vitest'
 
+// Metro injects __DEV__ at build time; vitest runs in Node, so declare it here.
+declare global {
+    const __DEV__: boolean
+}
+globalThis.__DEV__ = true
+
 // Mock the generated config to empty. This is REQUIRED to break an import
 // cycle: the real tinycld.config.ts imports each package's provider, some of
 // which (calc, text) eagerly import @tinycld/core/file-viewer components that

--- a/tests/unit-setup.ts
+++ b/tests/unit-setup.ts
@@ -4,13 +4,13 @@
 // Add vi.mock() calls here for modules that cannot be handled by resolve.alias.
 import { vi } from 'vitest'
 
-// Metro injects __DEV__ at build time; vitest runs in Node, so declare it here.
+// Metro injects __DEV__ at build time; vitest runs in Node, so seed it here.
+// react-native's globals.d.ts already declares the global as `const __DEV__`, so
+// this file must not redeclare it (that is a block-scoped collision) — it only
+// needs to install the value, which the cast through globalThis does.
 // Tests exercise the production default (__DEV__ = false) unless they opt into dev
 // behavior with a per-test vi.stubGlobal override (see logger.test.ts for examples).
-declare global {
-    const __DEV__: boolean
-}
-globalThis.__DEV__ = false
+;(globalThis as unknown as { __DEV__: boolean }).__DEV__ = false
 
 // Mock the generated config to empty. This is REQUIRED to break an import
 // cycle: the real tinycld.config.ts imports each package's provider, some of

--- a/tests/unit-setup.ts
+++ b/tests/unit-setup.ts
@@ -5,10 +5,12 @@
 import { vi } from 'vitest'
 
 // Metro injects __DEV__ at build time; vitest runs in Node, so declare it here.
+// Tests exercise the production default (__DEV__ = false) unless they opt into dev
+// behavior with a per-test vi.stubGlobal override (see logger.test.ts for examples).
 declare global {
     const __DEV__: boolean
 }
-globalThis.__DEV__ = true
+globalThis.__DEV__ = false
 
 // Mock the generated config to empty. This is REQUIRED to break an import
 // cycle: the real tinycld.config.ts imports each package's provider, some of


### PR DESCRIPTION
`auth login` printed this:

```
warning: OS keychain write failed (exit status 154); storing credentials in ~/.config/tinycld/credentials (mode 0600)
✓ Authenticated as user@tinycld.org
✓ Token saved to keychain
```

The two lines contradict each other, and the one a user is most likely to believe is the wrong one.

## The storage layer was already right

`systemStore` degrades per-write on purpose: a keychain can pass the read probe and still refuse writes (sandboxed process, locked login session — macOS `security` exits 154). By the time `Set` runs after a device login the server has already activated the grant, so failing the write would strand a live credential the user just approved. Falling back to a 0600 file is correct.

It just had no way to tell the caller where the write ended up. So the message was hardcoded.

## Fix

`Store` grows `Location(account)`, and the success line prints it:

```
✓ Token saved to /Users/you/.config/tinycld/credentials/localhost%3A7101.json
```

Three details worth calling out:

- **`fileStore.Location` names the file, not the directory.** A user told their credential is "in a file" still has to go find it.
- **The degraded flag is per-account, not a single bool on the store.** One context can fall back while another succeeds in the same process; a shared flag would mislabel the healthy one. There is a test for exactly this.
- **The healthy path still says "keychain".** Verified against a real `auth login` on a real macOS keychain, so reporting the truth on the degraded path did not trade one wrong message for another.

## Tests

Extended the existing degraded-write test to assert `Location` does not claim the keychain, added the healthy-keychain assertion to the stale-file test, and added a per-account test. All fail against a hardcoded `"keychain"` with the exact diagnosis.

## Also included

The smoke-test simplification that calendar#35 unblocked: the calendar checks now read `role` straight from `--json` instead of parsing table columns.

## Verification

- `go build ./... && go test ./... -count=1` across the CLI module — green
- Real `auth login` against a live server, healthy keychain — still reports "keychain", no stray warning

## Noticed, not fixed

The verification URL in that transcript reads `http://localhost:8090/...` while the server was on `7311`. It comes from `Settings().Meta.AppURL`, which a freshly seeded database leaves at PocketBase's default — a seed/config concern, separate from this change, and I did not want to widen the PR into it.