### PR TITLE
refactor(core/server): adopt the logging facility across core's own call sites

### DIFF
--- a/core/server/automation/catalog.go
+++ b/core/server/automation/catalog.go
@@ -337,7 +337,7 @@ type catalogRow struct {
 func (e *Engine) syncCatalog() {
 	col, err := e.app.FindCollectionByNameOrId("automation_catalog")
 	if err != nil {
-		e.app.Logger().Error("automation: automation_catalog collection missing", "err", err)
+		log.Error("automation_catalog collection missing", "err", err)
 		return
 	}
 	res := e.buildCatalog(e.app)
@@ -352,7 +352,7 @@ func (e *Engine) syncCatalog() {
 
 	existing, err := e.app.FindRecordsByFilter("automation_catalog", "", "", 0, 0)
 	if err != nil {
-		e.app.Logger().Error("automation: load catalog rows", "err", err)
+		log.Error("load catalog rows failed", "err", err)
 		return
 	}
 	byRef := map[string]*core.Record{}
@@ -363,7 +363,7 @@ func (e *Engine) syncCatalog() {
 	for ref, row := range desired {
 		defJSON, err := json.Marshal(row.Def)
 		if err != nil {
-			e.app.Logger().Error("automation: marshal catalog definition", "ref", ref, "err", err)
+			log.Error("marshal catalog definition failed", "ref", ref, "err", err)
 			continue
 		}
 		rec, ok := byRef[ref]
@@ -377,7 +377,7 @@ func (e *Engine) syncCatalog() {
 		rec.Set("definition", json.RawMessage(defJSON))
 		rec.Set("available", row.Available)
 		if err := e.app.Save(rec); err != nil {
-			e.app.Logger().Error("automation: save catalog row", "ref", ref, "err", err)
+			log.Error("save catalog row failed", "ref", ref, "err", err)
 		}
 	}
 
@@ -386,7 +386,7 @@ func (e *Engine) syncCatalog() {
 			continue
 		}
 		if err := e.app.Delete(rec); err != nil {
-			e.app.Logger().Error("automation: delete stale catalog row", "ref", ref, "err", err)
+			log.Error("delete stale catalog row failed", "ref", ref, "err", err)
 		}
 	}
 }

--- a/core/server/automation/engine.go
+++ b/core/server/automation/engine.go
@@ -53,7 +53,7 @@ func NewEngine(app core.App, defs *Defs) *Engine {
 // an SMTP delivery.
 func (e *Engine) Start() {
 	if e.started {
-		e.app.Logger().Warn("automation: Start called more than once, ignoring")
+		log.Warn("Start called more than once, ignoring")
 		return
 	}
 	e.started = true
@@ -73,7 +73,7 @@ func (e *Engine) Start() {
 		select {
 		case <-e.done:
 		case <-time.After(shutdownDrainWait):
-			e.app.Logger().Warn("automation: worker did not drain before terminate; abandoning in-flight dispatch")
+			log.Warn("worker did not drain before terminate; abandoning in-flight dispatch")
 		}
 		return te.Next()
 	})
@@ -149,7 +149,9 @@ func (e *Engine) reloadScheduleFor(rule *core.Record) {
 		e.enqueue(event{TriggerRef: "core:schedule", Trigger: trigger, Record: nil, RuleID: ruleID})
 	})
 	if err != nil {
-		e.app.Logger().Warn("automation: invalid schedule", "rule", rule.Id, "cron", cfg.Cron, "err", err)
+		// Info, not warn: the cron expression is user input on the rule, and the
+		// failure is already surfaced to that user through the rule_runs row below.
+		log.Info("invalid schedule", "ruleID", rule.Id, "cron", cfg.Cron, "err", err)
 		WriteRun(e.app, rule, nil, TriggerDef{}, RunOutcome{Err: "invalid schedule: " + cfg.Cron})
 	}
 }
@@ -163,7 +165,10 @@ func (e *Engine) recordHookHandler(col, op string) func(*core.RecordEvent) error
 			source = w.RuleID
 		}
 		if depth > maxChainDepth {
-			e.app.Logger().Warn("automation: chain depth exceeded", "collection", col, "record", ev.Record.Id, "sourceRule", source)
+			// Info, not warn: rules that trigger each other are a user
+			// misconfiguration, recorded to rule_runs for that user, and a loop
+			// would hit this on every write in the cycle.
+			log.Info("chain depth exceeded", "collection", col, "recordID", ev.Record.Id, "sourceRuleID", source)
 			if source != "" {
 				if rule, err := e.app.FindRecordById("rules", source); err == nil {
 					// nil record, not ev.Record: an empty TriggerDef has no
@@ -196,7 +201,7 @@ func (e *Engine) enqueue(ev event) {
 	default:
 		// A dropped dispatch is recoverable (the data is in the DB); a blocked
 		// write path is not. Log loudly and move on.
-		e.app.Logger().Error("automation: dispatch queue full, dropping event", "trigger", ev.TriggerRef)
+		log.Error("dispatch queue full, dropping event", "trigger", ev.TriggerRef)
 	}
 }
 

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -5,8 +5,11 @@ import (
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 
+	"tinycld.org/core/logging"
 	"tinycld.org/core/notify"
 )
+
+var log = logging.ForPackage("automation")
 
 type Options struct {
 	DefsPath string
@@ -18,11 +21,11 @@ type Options struct {
 func Register(app *pocketbase.PocketBase, opts Options) {
 	defs, err := LoadDefs(opts.DefsPath)
 	if err != nil {
-		app.Logger().Error("automation: defs unreadable, engine disabled", "err", err)
+		log.Error("defs unreadable, engine disabled", "err", err)
 		return
 	}
 	if len(defs.Packages) == 0 {
-		app.Logger().Info("automation: no definitions, engine inert")
+		log.Info("no definitions, engine inert")
 		return
 	}
 

--- a/core/server/automation/runs.go
+++ b/core/server/automation/runs.go
@@ -59,7 +59,9 @@ func triggerSummary(record *core.Record, trigger TriggerDef) map[string]any {
 func WriteRun(app core.App, rule *core.Record, record *core.Record, trigger TriggerDef, outcome RunOutcome) {
 	col, err := app.FindCollectionByNameOrId("rule_runs")
 	if err != nil {
-		app.Logger().Error("automation: rule_runs collection missing", "err", err)
+		// Warn, not error: WriteRun is called for every rule evaluation, so a
+		// missing collection would otherwise page on every record write.
+		log.Warn("rule_runs collection missing", "err", err)
 		return
 	}
 	run := core.NewRecord(col)
@@ -74,7 +76,7 @@ func WriteRun(app core.App, rule *core.Record, record *core.Record, trigger Trig
 	run.Set("error", outcome.Err)
 	run.Set("duration_ms", outcome.Duration.Milliseconds())
 	if err := app.Save(run); err != nil {
-		app.Logger().Error("automation: write rule_run", "rule", rule.Id, "err", err)
+		log.Warn("write rule_run failed", "ruleID", rule.Id, "err", err)
 		return
 	}
 	pruneRuns(app, rule.Id)
@@ -91,7 +93,9 @@ func pruneRuns(app core.App, ruleID string) {
 		}
 		for _, r := range extra {
 			if err := app.Delete(r); err != nil {
-				app.Logger().Error("automation: prune rule_run", "err", err)
+				// Warn, not error: losing a retention pass costs disk, not correctness,
+				// and it runs after every rule evaluation.
+				log.Warn("prune rule_run failed", "ruleID", ruleID, "err", err)
 				return
 			}
 		}
@@ -129,7 +133,7 @@ func recordRunResult(app core.App, rule *core.Record, fullyFailed bool) {
 	rule.Set("enabled", false)
 	markEngineWrite(rule.Id, rule.Id, 0)
 	if err := app.Save(rule); err != nil {
-		app.Logger().Error("automation: auto-disable", "rule", rule.Id, "err", err)
+		log.Error("auto-disable failed", "ruleID", rule.Id, "err", err)
 		return
 	}
 	go func() {

--- a/core/server/automation/schedule.go
+++ b/core/server/automation/schedule.go
@@ -31,7 +31,7 @@ func (e *Engine) syncSchedules() {
 		"rules", "trigger = 'core:schedule' && enabled = true", "", 0, 0,
 	)
 	if err != nil {
-		e.app.Logger().Error("automation: load schedule rules", "err", err)
+		log.Error("load schedule rules failed", "err", err)
 		return
 	}
 	for _, r := range rules {

--- a/core/server/caldav/backend.go
+++ b/core/server/caldav/backend.go
@@ -149,8 +149,19 @@ func (b *Backend) authorize(user *core.Record, record *core.Record, kind ruleKin
 
 	ok, err := b.app.CanAccessRecord(record, info, ruleFor(record.Collection(), kind))
 	if err != nil {
-		log.Warn("access rule evaluation failed",
-			"slug", b.src.Slug, "recordID", record.Id, "err", err)
+		// ruleList runs once per record inside ListCalendars/ListCalendarObjects'
+		// listing loops, so a single broken ListRule would otherwise emit one
+		// Sentry event per record on every PROPFIND — and DAV clients poll on a
+		// timer, turning one admin typo into sustained paging. The other kinds
+		// (view/create/update/delete) are each at most one per request, so they
+		// stay at warn.
+		if kind == ruleList {
+			log.Info("access rule evaluation failed",
+				"slug", b.src.Slug, "recordID", record.Id, "err", err)
+		} else {
+			log.Warn("access rule evaluation failed",
+				"slug", b.src.Slug, "recordID", record.Id, "err", err)
+		}
 		return errNotFound
 	}
 	if !ok {

--- a/core/server/caldav/backend.go
+++ b/core/server/caldav/backend.go
@@ -15,8 +15,11 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 
 	"tinycld.org/core/davcond"
+	"tinycld.org/core/logging"
 	"tinycld.org/core/pkgaccess"
 )
+
+var log = logging.ForPackage("caldav")
 
 // requirePkgWrite refuses the write when the caller's org_pkg_access level
 // for this source's package is not full. CalDAV bypasses the REST layer
@@ -124,8 +127,8 @@ func (b *Backend) canCreate(txApp core.App, user *core.Record, record *core.Reco
 	ok, err := txApp.CanAccessRecord(record, info, ruleFor(record.Collection(), ruleCreate))
 	if err != nil {
 		// An unevaluable rule must not fail open.
-		b.app.Logger().Warn("caldav: create rule evaluation failed",
-			"slug", b.src.Slug, "id", record.Id, "error", err)
+		log.Warn("create rule evaluation failed",
+			"slug", b.src.Slug, "recordID", record.Id, "err", err)
 		return false, nil
 	}
 	return ok, nil
@@ -146,8 +149,8 @@ func (b *Backend) authorize(user *core.Record, record *core.Record, kind ruleKin
 
 	ok, err := b.app.CanAccessRecord(record, info, ruleFor(record.Collection(), kind))
 	if err != nil {
-		b.app.Logger().Warn("caldav: access rule evaluation failed",
-			"slug", b.src.Slug, "id", record.Id, "error", err)
+		log.Warn("access rule evaluation failed",
+			"slug", b.src.Slug, "recordID", record.Id, "err", err)
 		return errNotFound
 	}
 	if !ok {
@@ -262,8 +265,8 @@ func (b *Backend) ListCalendarObjects(ctx context.Context, path string, _ *calda
 	for _, record := range authorized {
 		obj, err := b.toCalendarObject(record, calID)
 		if err != nil {
-			b.app.Logger().Debug("caldav: skipping unencodable event",
-				"slug", b.src.Slug, "id", record.Id, "error", err)
+			log.DebugContext(ctx, "skipping unencodable event",
+				"slug", b.src.Slug, "recordID", record.Id, "err", err)
 			continue
 		}
 		objects = append(objects, *obj)
@@ -538,8 +541,8 @@ func (b *Backend) backfillUID(record *core.Record) {
 	}
 	record.Set(b.src.Event.UID, "urn:uuid:"+uuid.NewString())
 	if err := b.app.Save(record); err != nil {
-		b.app.Logger().Warn("caldav: failed to backfill event UID",
-			"slug", b.src.Slug, "id", record.Id, "error", err)
+		log.Warn("failed to backfill event UID",
+			"slug", b.src.Slug, "recordID", record.Id, "err", err)
 	}
 }
 

--- a/core/server/caldav/hooks.go
+++ b/core/server/caldav/hooks.go
@@ -172,7 +172,7 @@ func (b *Backend) hookFilterList(userID, calendarID string, records []*core.Reco
 		// A handler that returned something other than a list is a bug in the
 		// hook, not a reason to leak the unfiltered listing — but neither is it
 		// a reason to fail the request. Keep the Go answer and say so.
-		b.app.Logger().Warn("caldav: filterList handler returned a non-list; ignoring",
+		log.Warn("filterList handler returned a non-list; ignoring",
 			"slug", b.src.Slug, "type", fmt.Sprintf("%T", v))
 		return records, nil
 	}

--- a/core/server/carddav/backend.go
+++ b/core/server/carddav/backend.go
@@ -18,8 +18,11 @@ import (
 
 	"tinycld.org/core/davauth"
 	"tinycld.org/core/davcond"
+	"tinycld.org/core/logging"
 	"tinycld.org/core/pkgaccess"
 )
+
+var log = logging.ForPackage("carddav")
 
 // requirePkgWrite refuses the write when the caller's org_pkg_access level
 // for this source's package is not full. CardDAV bypasses the REST layer
@@ -281,8 +284,8 @@ func (b *Backend) saveAuthorized(user *core.Record, record *core.Record, kind ru
 		}, rule)
 		if err != nil {
 			// An unevaluable rule must not fail open.
-			b.app.Logger().Warn("carddav: rule evaluation failed",
-				"id", record.Id, "error", err)
+			log.Warn("rule evaluation failed",
+				"recordID", record.Id, "err", err)
 			return errDenied
 		}
 		if !ok {

--- a/core/server/coreserver/app_updates.go
+++ b/core/server/coreserver/app_updates.go
@@ -181,8 +181,8 @@ func currentBuildBundles(app core.App) (string, []any) {
 		// writes a JSON array), but if it does we'd otherwise silently serve 204
 		// to every mobile client forever. Log it so the cause is visible rather
 		// than presenting as "updates mysteriously never arrive".
-		app.Logger().Error("app-update: failed to decode current build bundles",
-			"build_id", rec.GetString("build_id"), "err", err)
+		srvLog.Error("app-update: failed to decode current build bundles",
+			"buildID", rec.GetString("build_id"), "err", err)
 		return rec.GetString("build_id"), nil
 	}
 	return rec.GetString("build_id"), bundles
@@ -198,7 +198,7 @@ func loadBadBundles(app core.App) (ids map[string]bool, hashes map[string]bool) 
 	hashes = map[string]bool{}
 	recs, err := app.FindRecordsByFilter("pkg_bad_bundle", "1=1", "", 0, 0)
 	if err != nil {
-		app.Logger().Error("app-update: failed to load bad bundles", "err", err)
+		srvLog.Error("app-update: failed to load bad bundles", "err", err)
 		return ids, hashes
 	}
 	for _, r := range recs {
@@ -310,7 +310,7 @@ func registerAppUpdateEndpoints(app core.App, src appUpdateSources) {
 			// `docker logs` (and lets the install e2e assert on the decision). Kept at
 			// Info so it's visible without enabling debug-level logging.
 			buildID, bundles := src.bundles(app)
-			app.Logger().Info("app-update: request",
+			srvLog.InfoContext(re.Request.Context(), "app-update: request",
 				"method", re.Request.Method,
 				"path", re.Request.URL.RequestURI(),
 				"remoteAddr", re.Request.RemoteAddr,
@@ -326,25 +326,25 @@ func registerAppUpdateEndpoints(app core.App, src appUpdateSources) {
 			)
 
 			if platform == "" || runtime == "" {
-				app.Logger().Info("app-update: response 400 (missing platform/runtimeVersion)",
+				srvLog.InfoContext(re.Request.Context(), "app-update: response 400 (missing platform/runtimeVersion)",
 					"q.platform", platform, "q.runtimeVersion", runtime)
 				return re.BadRequestError("platform and runtimeVersion are required", nil)
 			}
 			if buildID == "" {
-				app.Logger().Info("app-update: response 204 (no current build / no bundles)")
+				srvLog.InfoContext(re.Request.Context(), "app-update: response 204 (no current build / no bundles)")
 				return re.NoContent(204)
 			}
 			badIDs, badHashes := loadBadBundles(app)
 			m, status := resolveManifest(bundles, platform, runtime, currentID, currentHash, badIDs, badHashes)
 			if status != manifestNew {
-				app.Logger().Info("app-update: response 204 (no new bundle)",
+				srvLog.InfoContext(re.Request.Context(), "app-update: response 204 (no new bundle)",
 					"status", manifestStatusName(status),
 					"q.platform", platform, "q.runtimeVersion", runtime,
 					"q.currentId", currentID, "q.currentHash", currentHash)
 				return re.NoContent(204)
 			}
 			fillManifestURLs(&m, buildID, platform)
-			app.Logger().Info("app-update: response 200 (update available)",
+			srvLog.InfoContext(re.Request.Context(), "app-update: response 200 (update available)",
 				"manifest.id", m.ID,
 				"manifest.runtimeVersion", m.RuntimeVersion,
 				"manifest.bundleHash", m.BundleHash,
@@ -367,13 +367,13 @@ func registerAppUpdateEndpoints(app core.App, src appUpdateSources) {
 			}
 			count, err := recordBadBundle(app, body)
 			if err != nil {
-				app.Logger().Error("app-update: failed to record bad bundle",
-					"bundle_id", body.ID, "platform", body.Platform, "err", err)
+				srvLog.ErrorContext(re.Request.Context(), "app-update: failed to record bad bundle",
+					"bundleID", body.ID, "platform", body.Platform, "err", err)
 				return re.InternalServerError("failed to record report", err)
 			}
-			app.Logger().Warn("app-update: bundle reported bad",
-				"bundle_id", body.ID, "platform", body.Platform,
-				"reports", count, "error", body.Error)
+			srvLog.WarnContext(re.Request.Context(), "app-update: bundle reported bad",
+				"bundleID", body.ID, "platform", body.Platform,
+				"reports", count, "err", body.Error)
 			return re.JSON(http.StatusOK, map[string]any{"ok": true, "reports": count})
 		})
 
@@ -395,6 +395,12 @@ func registerAppUpdateEndpoints(app core.App, src appUpdateSources) {
 			if body.ID == "" {
 				return re.BadRequestError("id is required", nil)
 			}
+			// Deliberately NOT migrated to srvLog. The OTA e2e harness
+			// (scripts/ota-e2e/boot-beacon-poller.ts) polls _logs with an exact
+			// filter message='app-boot: rendered' and reads data.q.bundleId, so
+			// this record's shape is release-verification infrastructure. The
+			// fan-out would very likely preserve it, but "very likely" is not a
+			// basis for risking a silent break in release verification.
 			app.Logger().Info("app-boot: rendered",
 				"q.bundleId", body.ID,
 				"q.platform", body.Platform,

--- a/core/server/coreserver/app_updates_tenant.go
+++ b/core/server/coreserver/app_updates_tenant.go
@@ -72,7 +72,7 @@ func (a *artifactBundles) source(app core.App) (string, []any) {
 			// Not fatal: mobile stays on its embedded bundle. Log it, because
 			// the alternative presentation is "updates mysteriously never
 			// arrive" with nothing in the logs to explain why.
-			app.Logger().Error("app-update: failed to load artifact recipe",
+			srvLog.Error("app-update: failed to load artifact recipe",
 				"artifactDir", a.artifactDir, "err", err)
 			return
 		}
@@ -84,13 +84,13 @@ func (a *artifactBundles) source(app core.App) (string, []any) {
 		}
 		raw, err := json.Marshal(recipe.Bundles)
 		if err != nil {
-			app.Logger().Error("app-update: failed to encode artifact bundles",
+			srvLog.Error("app-update: failed to encode artifact bundles",
 				"artifactDir", a.artifactDir, "err", err)
 			return
 		}
 		var decoded []any
 		if err := json.Unmarshal(raw, &decoded); err != nil {
-			app.Logger().Error("app-update: failed to decode artifact bundles",
+			srvLog.Error("app-update: failed to decode artifact bundles",
 				"artifactDir", a.artifactDir, "err", err)
 			return
 		}

--- a/core/server/coreserver/demo_reset.go
+++ b/core/server/coreserver/demo_reset.go
@@ -70,11 +70,11 @@ func RegisterDemoReset(app *pocketbase.PocketBase) {
 		resetURLMu.Lock()
 		resetURL = url
 		resetURLMu.Unlock()
-		app.Logger().Info("demo reset target captured", "url", url)
+		srvLog.Info("demo reset target captured", "url", url)
 		return e.Next()
 	})
 
-	app.Logger().Info("demo reset cron registered", "schedule", schedule)
+	srvLog.Info("demo reset cron registered", "schedule", schedule)
 }
 
 func deriveResetURL(e *core.ServeEvent) string {
@@ -103,7 +103,7 @@ func demoResetEnabled() bool {
 
 func runDemoReset(app *pocketbase.PocketBase) {
 	if !resetMu.TryLock() {
-		app.Logger().Warn("demo reset skipped: previous run still in flight")
+		srvLog.Warn("demo reset skipped: previous run still in flight")
 		return
 	}
 	defer resetMu.Unlock()
@@ -116,7 +116,7 @@ func runDemoReset(app *pocketbase.PocketBase) {
 	url := resetURL
 	resetURLMu.RUnlock()
 	if url == "" {
-		app.Logger().Error("demo reset skipped: server not yet serving (resetURL empty)")
+		srvLog.Error("demo reset skipped: server not yet serving (resetURL empty)")
 		return
 	}
 
@@ -128,13 +128,13 @@ func runDemoReset(app *pocketbase.PocketBase) {
 	// (which bind 80/443 instead of 127.0.0.1:7090).
 	cmd.Env = os.Environ()
 
-	app.Logger().Info("demo reset starting", "dir", scriptDir)
+	srvLog.Info("demo reset starting", "dir", scriptDir)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		app.Logger().Error("demo reset failed", "err", err, "output", string(out))
+		srvLog.Error("demo reset failed", "err", err, "output", string(out))
 		return
 	}
-	app.Logger().Info("demo reset succeeded", "output", string(out))
+	srvLog.Info("demo reset succeeded", "output", string(out))
 }
 
 // resolveAppDir returns the directory that contains scripts/, package.json,

--- a/core/server/coreserver/invite_lifecycle.go
+++ b/core/server/coreserver/invite_lifecycle.go
@@ -95,7 +95,7 @@ func send(app core.App, toName, toEmail, subject, htmlBody, textBody string) {
 		Text:    textBody,
 	}
 	if err := mailer.DefaultSender().Send(context.Background(), msg); err != nil {
-		app.Logger().Error("invite lifecycle: failed to send email",
-			"to", toEmail, "subject", subject, "error", err)
+		srvLog.Error("invite lifecycle: failed to send email",
+			"to", toEmail, "subject", subject, "err", err)
 	}
 }

--- a/core/server/coreserver/password_reset_mailer.go
+++ b/core/server/coreserver/password_reset_mailer.go
@@ -34,7 +34,7 @@ func registerPasswordResetMailerCore(app core.App) {
 		if token == "" {
 			// Without a token we can't build a working link; let PB send its
 			// default email rather than a broken one.
-			app.Logger().Warn("password reset: missing token in mailer event; deferring to PB")
+			srvLog.Warn("password reset: missing token in mailer event; deferring to PB")
 			return e.Next()
 		}
 

--- a/core/server/coreserver/pkg_hosted.go
+++ b/core/server/coreserver/pkg_hosted.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -686,7 +685,13 @@ func copyFileOver(src, dst string) error {
 	return out.Close()
 }
 
-// jobLogfStandalone logs outside a job context (request-scoped paths).
+// jobLogfStandalone logs outside a job context (request-scoped paths). Its
+// only caller is the drop-report best-effort fallback narration — a
+// progress-narration path, not a failure path — so a fixed Info level is
+// correct here. Unlike jobLogf's job-bound sibling, this has no per-call
+// severity (a variadic Printf passthrough): if a future caller embeds a
+// "WARNING:" marker in its format string expecting it to page, it will not —
+// that marker would need a real level parameter to reach warn+.
 func jobLogfStandalone(format string, args ...any) {
-	log.Printf(format, args...)
+	srvLog.Info(fmt.Sprintf(format, args...))
 }

--- a/core/server/coreserver/pkg_seed.go
+++ b/core/server/coreserver/pkg_seed.go
@@ -140,7 +140,7 @@ func SyncBundledPackages(app core.App) {
 		if !bundledSlugs[slug] {
 			record.Set("status", "disabled")
 			if err := app.Save(record); err != nil {
-				srvLog.Warn("failed to disable removed bundled package", "slug", slug, "err", err)
+				srvLog.Error("failed to disable removed bundled package", "slug", slug, "err", err)
 			}
 		}
 	}

--- a/core/server/coreserver/pkg_version_change.go
+++ b/core/server/coreserver/pkg_version_change.go
@@ -3,7 +3,6 @@ package coreserver
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -143,7 +142,9 @@ func handleDropReport(app *pocketbase.PocketBase, re *core.RequestEvent) error {
 		if targetFiles, err := targetMigrationFiles(app, body.Slug, body.TargetVersion); err == nil {
 			files = subtractStrings(files, targetFiles)
 		} else {
-			log.Printf("pkg_version_change: drop-report target fetch failed (%v); reporting full set", err)
+			// Best-effort fallback already in play (reports the conservative
+			// full set); nothing pages on this.
+			srvLog.Info("drop-report target fetch failed, reporting full set", "err", err)
 		}
 	}
 

--- a/core/server/coreserver/sentry.go
+++ b/core/server/coreserver/sentry.go
@@ -44,6 +44,12 @@ func initSentryFromConfig(cfg *SystemConfig) {
 		TracesSampleRate: 0.2,
 		AttachStacktrace: true,
 	}); err != nil {
+		// Deliberately stdlib log, not srvLog: this reports that Sentry
+		// itself failed to initialize, and srvLog's warn+ path publishes to
+		// Sentry. Routing this failure through that path is circular — if
+		// Sentry is broken, the report that Sentry is broken can never
+		// arrive. Mirrors the console.* exemption in the client's sentry.ts
+		// for the same reason.
 		log.Printf("Sentry initialization failed: %v", err)
 	}
 }

--- a/core/server/coreserver/system_config.go
+++ b/core/server/coreserver/system_config.go
@@ -1,7 +1,6 @@
 package coreserver
 
 import (
-	"log"
 	"strings"
 	"sync"
 
@@ -94,7 +93,7 @@ func (c *SystemConfig) load(app core.App) {
 	if err != nil {
 		// The collection may not exist yet on a brand-new DB whose migrations
 		// haven't run; treat as empty rather than failing the boot.
-		log.Printf("system_config: load skipped: %v", err)
+		srvLog.Info("system config load skipped", "err", err)
 		return
 	}
 	next := make(map[string]string, len(recs))

--- a/core/server/fts/register.go
+++ b/core/server/fts/register.go
@@ -55,8 +55,8 @@ func registerSearchRoute(app *pocketbase.PocketBase, e *core.ServeEvent, cfg Con
 
 		results, total, err := Search(app, cfg, re.Auth.Id, opts)
 		if err != nil {
-			app.Logger().Warn("fts: search query failed",
-				"slug", cfg.Slug, "error", err)
+			log.WarnContext(re.Request.Context(), "search query failed",
+				"pkgSlug", cfg.Slug, "err", err)
 			return re.JSON(http.StatusOK, empty)
 		}
 

--- a/core/server/fts/sanitize.go
+++ b/core/server/fts/sanitize.go
@@ -46,10 +46,11 @@ func SanitizeQuery(input string) string {
 // SanitizeQueryWithExclusions builds an FTS5 MATCH expression requiring every
 // include term and rejecting every exclude term.
 //
-// Both sides arrive as already-split plain terms from the client's parseQuery —
-// no operator syntax ever reaches this function, so quoteTerms stays the only
-// trust boundary. An exclude-only query returns "" rather than a bare NOT,
-// which FTS5 rejects: there is no result set to subtract from.
+// Both sides may be raw, unsplit query-string values (the /api/{slug}/search
+// route passes q.Get("q")/q.Get("not") straight through) — quoteTerms is the
+// only trust boundary and must treat the input as hostile. An exclude-only
+// query returns "" rather than a bare NOT, which FTS5 rejects: there is no
+// result set to subtract from.
 func SanitizeQueryWithExclusions(include, exclude string) string {
 	base := SanitizeQuery(include)
 	if base == "" {

--- a/core/server/fts/sync.go
+++ b/core/server/fts/sync.go
@@ -5,7 +5,11 @@ import (
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("fts")
 
 // RegisterSync binds the FTS index-sync record hooks for one collection. On
 // every create/update it does an idempotent delete-then-insert; on delete it
@@ -35,8 +39,8 @@ func syncRecord(app *pocketbase.PocketBase, cfg Config, record *core.Record, rem
 	// Always delete first — makes create/update idempotent and handles delete.
 	if _, err := db.NewQuery("DELETE FROM " + cfg.Table + " WHERE record_id = {:id}").
 		Bind(map[string]any{"id": record.Id}).Execute(); err != nil {
-		app.Logger().Warn("fts: delete from index failed",
-			"table", cfg.Table, "id", record.Id, "error", err)
+		log.Warn("delete from index failed",
+			"table", cfg.Table, "recordID", record.Id, "err", err)
 	}
 
 	if remove {
@@ -62,7 +66,7 @@ func syncRecord(app *pocketbase.PocketBase, cfg Config, record *core.Record, rem
 	q := "INSERT INTO " + cfg.Table +
 		" (" + strings.Join(cols, ", ") + ") VALUES (" + strings.Join(placeholders, ", ") + ")"
 	if _, err := db.NewQuery(q).Bind(params).Execute(); err != nil {
-		app.Logger().Warn("fts: index insert failed",
-			"table", cfg.Table, "id", record.Id, "error", err)
+		log.Warn("index insert failed",
+			"table", cfg.Table, "recordID", record.Id, "err", err)
 	}
 }

--- a/core/server/mailproto/imap.go
+++ b/core/server/mailproto/imap.go
@@ -2,6 +2,7 @@ package mailproto
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -10,7 +11,11 @@ import (
 	"github.com/emersion/go-imap/v2/imapserver"
 	"github.com/pocketbase/pocketbase/core"
 	"golang.org/x/crypto/acme/autocert"
+
+	"tinycld.org/core/logging"
 )
+
+var mailLog = logging.ForPackage("mailproto")
 
 // NewIMAPSession builds the per-connection IMAP session. The session speaks the
 // feature's own schema, so the feature package supplies it; mailproto only owns
@@ -38,6 +43,21 @@ func listenWith(listen ListenFunc, addr string) (net.Listener, error) {
 		return listen(addr)
 	}
 	return net.Listen("tcp", addr)
+}
+
+// logServeExit reports why a protocol server's Serve loop returned.
+//
+// net.ErrClosed is the NORMAL shutdown path, not a fault: every shutdown func
+// here closes the listener before the server, so Accept fails with a closed
+// socket while the server still considers itself running and hands the error
+// back. Logging that at error level would page on every deploy and restart —
+// so the expected exit is info and only an unexpected one escalates.
+func logServeExit(label, addr string, err error) {
+	if err == nil || errors.Is(err, net.ErrClosed) {
+		mailLog.Info("server stopped accepting", "server", label, "addr", addr)
+		return
+	}
+	mailLog.Error("server error", "server", label, "addr", addr, "err", err)
 }
 
 // IMAPOptions configures StartIMAP beyond the app/cert wiring.
@@ -80,7 +100,7 @@ var IMAPCaps = imap.CapSet{
 // and an optional implicit TLS listener on :1993.
 func StartIMAP(app core.App, certManager *autocert.Manager, opts IMAPOptions) (func(), error) {
 	if os.Getenv("IMAP_ENABLED") == "false" {
-		app.Logger().Info("IMAP server disabled via IMAP_ENABLED=false")
+		mailLog.Info("IMAP server disabled via IMAP_ENABLED=false")
 		return func() {}, nil
 	}
 
@@ -135,15 +155,13 @@ func startIMAPExternalTLS(app core.App, opts IMAPOptions) (func(), error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %w", imapsAddr, err)
 	}
-	app.Logger().Info("IMAP server listening (external TLS termination)", "addr", imapsAddr)
+	mailLog.Info("IMAP server listening (external TLS termination)", "addr", imapsAddr)
 	go func() {
-		if err := server.Serve(ln); err != nil {
-			app.Logger().Error("IMAP server error", "addr", imapsAddr, "error", err)
-		}
+		logServeExit("IMAP", imapsAddr, server.Serve(ln))
 	}()
 
 	return func() {
-		app.Logger().Info("Shutting down IMAP server")
+		mailLog.Info("Shutting down IMAP server")
 		ln.Close()
 		server.Close()
 	}, nil
@@ -162,15 +180,13 @@ func startIMAPTLSOnly(app core.App, tlsConfig *tls.Config, opts IMAPOptions) (fu
 		return nil, fmt.Errorf("failed to listen on %s: %w", imapsAddr, err)
 	}
 	tlsLn := tls.NewListener(rawLn, tlsConfig)
-	app.Logger().Info("IMAPS server listening (implicit TLS, no plain listener)", "addr", imapsAddr)
+	mailLog.Info("IMAPS server listening (implicit TLS, no plain listener)", "addr", imapsAddr)
 	go func() {
-		if err := server.Serve(tlsLn); err != nil {
-			app.Logger().Error("IMAPS server error", "addr", imapsAddr, "error", err)
-		}
+		logServeExit("IMAPS", imapsAddr, server.Serve(tlsLn))
 	}()
 
 	return func() {
-		app.Logger().Info("Shutting down IMAP server")
+		mailLog.Info("Shutting down IMAP server")
 		tlsLn.Close()
 		server.Close()
 	}, nil
@@ -189,11 +205,9 @@ func startIMAPDev(app core.App, tlsConfig *tls.Config, opts IMAPOptions) (func()
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
-	app.Logger().Info("IMAP server listening", "addr", addr, "starttls", tlsConfig != nil)
+	mailLog.Info("IMAP server listening", "addr", addr, "starttls", tlsConfig != nil)
 	go func() {
-		if err := server.Serve(plainLn); err != nil {
-			app.Logger().Error("IMAP server error", "addr", addr, "error", err)
-		}
+		logServeExit("IMAP", addr, server.Serve(plainLn))
 	}()
 
 	var tlsLn net.Listener
@@ -214,24 +228,25 @@ func startIMAPDev(app core.App, tlsConfig *tls.Config, opts IMAPOptions) (func()
 			//
 			// Production never reaches this branch: it returns earlier via
 			// startIMAPTLSOnly, or refuses to boot without a TLS source.
-			app.Logger().Warn(
+			// Info, not warn: this branch is dev-only (production returns via
+			// startIMAPTLSOnly or refuses to boot), and the usual cause is another
+			// local server already holding the optional port.
+			mailLog.Info(
 				"IMAPS listener unavailable; continuing with plain IMAP only",
 				"addr", imapsAddr,
-				"error", err,
+				"err", err,
 			)
 		} else {
 			tlsLn = tls.NewListener(rawLn, tlsConfig)
-			app.Logger().Info("IMAPS server listening (implicit TLS)", "addr", imapsAddr)
+			mailLog.Info("IMAPS server listening (implicit TLS)", "addr", imapsAddr)
 			go func() {
-				if err := server.Serve(tlsLn); err != nil {
-					app.Logger().Error("IMAPS server error", "addr", imapsAddr, "error", err)
-				}
+				logServeExit("IMAPS", imapsAddr, server.Serve(tlsLn))
 			}()
 		}
 	}
 
 	return func() {
-		app.Logger().Info("Shutting down IMAP server")
+		mailLog.Info("Shutting down IMAP server")
 		plainLn.Close()
 		if tlsLn != nil {
 			tlsLn.Close()

--- a/core/server/mailproto/smtp.go
+++ b/core/server/mailproto/smtp.go
@@ -66,12 +66,12 @@ type SMTPOptions struct {
 // a silent fallthrough when production has no TLS.
 func StartSMTP(app core.App, certManager *autocert.Manager, opts SMTPOptions) (func(), error) {
 	if opts.EnabledEnv != "" && os.Getenv(opts.EnabledEnv) == "false" {
-		app.Logger().Info(opts.Label + " server disabled via " + opts.EnabledEnv + "=false")
+		mailLog.Info("server disabled by env", "server", opts.Label, "env", opts.EnabledEnv)
 		return func() {}, nil
 	}
 
 	if opts.ExternalTLS {
-		return startSMTPExternalTLS(app, opts)
+		return startSMTPExternalTLS(opts)
 	}
 
 	tlsConfig, err := ResolveTLSConfig(
@@ -82,7 +82,7 @@ func StartSMTP(app core.App, certManager *autocert.Manager, opts SMTPOptions) (f
 	}
 
 	if !app.IsDev() && tlsConfig != nil {
-		return startSMTPTLSOnly(app, tlsConfig, opts)
+		return startSMTPTLSOnly(tlsConfig, opts)
 	}
 
 	if !app.IsDev() && opts.ProductionTLSError != "" {
@@ -118,7 +118,7 @@ func newSMTPServerInstance(tlsConfig *tls.Config, insecureAuth bool, opts SMTPOp
 
 // startSMTPExternalTLS serves plaintext SMTP on the injected listener with the
 // TLS-terminated posture ExternalTLS documents: auth allowed, no STARTTLS.
-func startSMTPExternalTLS(app core.App, opts SMTPOptions) (func(), error) {
+func startSMTPExternalTLS(opts SMTPOptions) (func(), error) {
 	if opts.Listen == nil {
 		return nil, fmt.Errorf("%s ExternalTLS requires an injected listener (SMTPOptions.Listen)", opts.Label)
 	}
@@ -138,21 +138,19 @@ func startSMTPExternalTLS(app core.App, opts SMTPOptions) (func(), error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
-	app.Logger().Info(opts.Label+" server listening (external TLS termination)", "addr", addr)
+	mailLog.Info("server listening (external TLS termination)", "server", opts.Label, "addr", addr)
 	go func() {
-		if err := server.Serve(ln); err != nil {
-			app.Logger().Error(opts.Label+" server error", "addr", addr, "error", err)
-		}
+		logServeExit(opts.Label, addr, server.Serve(ln))
 	}()
 
 	return func() {
-		app.Logger().Info("Shutting down " + opts.Label + " server")
+		mailLog.Info("shutting down server", "server", opts.Label)
 		ln.Close()
 		server.Close()
 	}, nil
 }
 
-func startSMTPTLSOnly(app core.App, tlsConfig *tls.Config, opts SMTPOptions) (func(), error) {
+func startSMTPTLSOnly(tlsConfig *tls.Config, opts SMTPOptions) (func(), error) {
 	addr := os.Getenv(opts.TLSAddrEnv)
 	if addr == "" {
 		addr = opts.DefaultTLSAddr
@@ -166,15 +164,13 @@ func startSMTPTLSOnly(app core.App, tlsConfig *tls.Config, opts SMTPOptions) (fu
 		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
 	tlsLn := tls.NewListener(rawLn, tlsConfig)
-	app.Logger().Info(opts.Label+" server listening (implicit TLS, no plain listener)", "addr", addr)
+	mailLog.Info("server listening (implicit TLS, no plain listener)", "server", opts.Label, "addr", addr)
 	go func() {
-		if err := server.Serve(tlsLn); err != nil {
-			app.Logger().Error(opts.Label+" server error", "addr", addr, "error", err)
-		}
+		logServeExit(opts.Label, addr, server.Serve(tlsLn))
 	}()
 
 	return func() {
-		app.Logger().Info("Shutting down " + opts.Label + " server")
+		mailLog.Info("shutting down server", "server", opts.Label)
 		tlsLn.Close()
 		server.Close()
 	}, nil
@@ -197,11 +193,9 @@ func startSMTPDev(app core.App, tlsConfig *tls.Config, opts SMTPOptions) (func()
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
-	app.Logger().Info(opts.Label+" server listening", "addr", addr, "starttls", tlsConfig != nil)
+	mailLog.Info("server listening", "server", opts.Label, "addr", addr, "starttls", tlsConfig != nil)
 	go func() {
-		if err := server.Serve(plainLn); err != nil {
-			app.Logger().Error(opts.Label+" server error", "addr", addr, "error", err)
-		}
+		logServeExit(opts.Label, addr, server.Serve(plainLn))
 	}()
 
 	var tlsLn net.Listener
@@ -216,24 +210,25 @@ func startSMTPDev(app core.App, tlsConfig *tls.Config, opts SMTPOptions) (func()
 			// plain listener above is the one that matters. Closing it because
 			// an optional TLS port is already held by another local server
 			// turns a taken port into a total outage of the protocol.
-			app.Logger().Warn(
-				opts.Label+" implicit-TLS listener unavailable; continuing with plain only",
+			// Info, not warn: dev-only branch (see startSMTPTLSOnly for the
+			// production path), usually another local server on the optional port.
+			mailLog.Info(
+				"implicit-TLS listener unavailable; continuing with plain only",
+				"server", opts.Label,
 				"addr", tlsAddr,
-				"error", err,
+				"err", err,
 			)
 		} else {
 			tlsLn = tls.NewListener(rawLn, tlsConfig)
-			app.Logger().Info(opts.Label+" server listening (implicit TLS)", "addr", tlsAddr)
+			mailLog.Info("server listening (implicit TLS)", "server", opts.Label, "addr", tlsAddr)
 			go func() {
-				if err := server.Serve(tlsLn); err != nil {
-					app.Logger().Error(opts.Label+" server error", "addr", tlsAddr, "error", err)
-				}
+				logServeExit(opts.Label, tlsAddr, server.Serve(tlsLn))
 			}()
 		}
 	}
 
 	return func() {
-		app.Logger().Info("Shutting down " + opts.Label + " server")
+		mailLog.Info("shutting down server", "server", opts.Label)
 		plainLn.Close()
 		if tlsLn != nil {
 			tlsLn.Close()

--- a/core/server/markdown/types.go
+++ b/core/server/markdown/types.go
@@ -38,9 +38,9 @@ const (
 	// TypeScript md-to-pm in text/ flattens header cells to tableCell; that
 	// flattening is NOT copied here, because a doc seeded with plain cells
 	// loses its header row the first time it round-trips.
-	NodeTableHeader    = "tableHeader"
-	NodeImage = "image"
-	NodeText  = "text"
+	NodeTableHeader = "tableHeader"
+	NodeImage       = "image"
+	NodeText        = "text"
 	// NodeMention is an @mention. It is an ATOM carrying only a user id — the
 	// name a reader sees is resolved at render time from the board roster, so
 	// the node has no children and no text of its own. That is why it needs an

--- a/core/server/notify/comment_mentions.go
+++ b/core/server/notify/comment_mentions.go
@@ -56,11 +56,16 @@ func handleCommentMention(app core.App, mention *core.Record) {
 	commentCollection := mention.GetString("comment_collection")
 	packageSlug, ok := allowedCommentCollections[commentCollection]
 	if !ok {
-		// Unknown comment_collection — silently drop. The allowlist
-		// is the security boundary; logging at warn level so an
-		// attacker probing the surface is visible without flooding
-		// the log on legitimate (but unknown-to-this-build) packages.
-		log.Warn("comment mention: unknown comment_collection",
+		// Unknown comment_collection — silently drop. The allowlist is the
+		// security boundary and it has already failed closed here, so there is
+		// nothing for an operator to act on.
+		//
+		// Info, not warn, precisely BECAUSE this is the probe surface:
+		// comment_collection is free text any authenticated commenter can set,
+		// so paging on it would hand every account holder a remote pager DoS.
+		// The record is kept for forensics — info still reaches stderr and
+		// _logs, which is where you go looking for a probe.
+		log.Info("comment mention: unknown comment_collection",
 			"collection", commentCollection)
 		return
 	}

--- a/core/server/notify/comment_mentions.go
+++ b/core/server/notify/comment_mentions.go
@@ -60,7 +60,7 @@ func handleCommentMention(app core.App, mention *core.Record) {
 		// is the security boundary; logging at warn level so an
 		// attacker probing the surface is visible without flooding
 		// the log on legitimate (but unknown-to-this-build) packages.
-		app.Logger().Warn("comment_mention: unknown comment_collection",
+		log.Warn("comment mention: unknown comment_collection",
 			"collection", commentCollection)
 		return
 	}
@@ -80,10 +80,12 @@ func handleCommentMention(app core.App, mention *core.Record) {
 	// skip here too if the comment author equals the mentioned user.
 	comment, err := app.FindRecordById(commentCollection, mention.GetString("comment_record"))
 	if err != nil {
-		app.Logger().Warn("comment_mention: comment record not found",
+		// Info, not warn: the comment being gone by the time this async
+		// handler runs is a normal delete race, not an operator problem.
+		log.Info("comment mention: comment record not found",
 			"collection", commentCollection,
-			"record", mention.GetString("comment_record"),
-			"error", err)
+			"recordID", mention.GetString("comment_record"),
+			"err", err)
 		return
 	}
 	if comment.GetString("author") == mentionedUserID {

--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -443,8 +443,10 @@ func enforceGrant(re *core.RequestEvent) error {
 	}
 
 	if err := TouchGrant(re.App, grant); err != nil {
-		// Non-fatal: last_used_at is cosmetic.
-		re.App.Logger().Warn("oauth: touch grant", "error", err)
+		// Debug, not warn: last_used_at is cosmetic and this runs on every
+		// OAuth-authenticated request, so a warn here would page continuously
+		// over a field nothing depends on.
+		log.DebugContext(re.Request.Context(), "touch grant failed", "grantID", grant.Id, "err", err)
 	}
 
 	// Publish the grant's scopes for handlers that must narrow their OWN

--- a/core/server/oauth/revoke.go
+++ b/core/server/oauth/revoke.go
@@ -4,7 +4,11 @@ import (
 	"net/http"
 
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("oauth")
 
 // handleRevoke implements RFC 7009 token revocation.
 //
@@ -25,7 +29,7 @@ func handleRevoke(app core.App, re *core.RequestEvent) error {
 	if jti := grantIDFromToken(token); jti != "" {
 		if grant, err := FindGrantByJTI(app, jti); err == nil {
 			if err := RevokeGrant(app, grant.Id); err != nil {
-				re.App.Logger().Warn("oauth: revoke by jti", "error", err)
+				log.WarnContext(re.Request.Context(), "revoke by jti failed", "grantID", grant.Id, "err", err)
 			}
 		}
 		return re.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -37,7 +41,7 @@ func handleRevoke(app core.App, re *core.RequestEvent) error {
 	)
 	if err == nil && grant != nil {
 		if err := RevokeGrant(app, grant.Id); err != nil {
-			re.App.Logger().Warn("oauth: revoke by refresh token", "error", err)
+			log.WarnContext(re.Request.Context(), "revoke by refresh token failed", "grantID", grant.Id, "err", err)
 		}
 	}
 	return re.JSON(http.StatusOK, map[string]string{"status": "ok"})

--- a/core/server/offboard/offboard.go
+++ b/core/server/offboard/offboard.go
@@ -9,7 +9,11 @@ import (
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("offboard")
 
 // Mode chooses what happens to the offboarded user's owned content.
 type Mode string
@@ -232,7 +236,7 @@ func writeOffboardAudit(app core.App, leaverUserID, actorUserID string, mode Mod
 		"user_anonymized":    result.UserAnonymized,
 	})
 	if err := app.Save(r); err != nil {
-		app.Logger().Warn("offboard: audit write failed", "user", leaverUserID, "error", err)
+		log.Warn("audit write failed", "userID", leaverUserID, "err", err)
 	}
 }
 

--- a/core/server/offboard/offboard.go
+++ b/core/server/offboard/offboard.go
@@ -236,7 +236,7 @@ func writeOffboardAudit(app core.App, leaverUserID, actorUserID string, mode Mod
 		"user_anonymized":    result.UserAnonymized,
 	})
 	if err := app.Save(r); err != nil {
-		log.Warn("audit write failed", "userID", leaverUserID, "err", err)
+		log.Error("audit write failed", "userID", leaverUserID, "err", err)
 	}
 }
 

--- a/core/server/pkgaccess/pkgaccess.go
+++ b/core/server/pkgaccess/pkgaccess.go
@@ -29,7 +29,11 @@ import (
 
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("pkgaccess")
 
 const (
 	LevelFull     = "full"
@@ -140,8 +144,8 @@ func ownerSlug(app core.App, collection string) string {
 	pkgs, err := app.FindRecordsByFilter("pkg_registry",
 		"status = 'installed' || status = 'bundled'", "", 0, 0)
 	if err != nil {
-		app.Logger().Warn("pkgaccess: cannot read pkg_registry; skipping package-access check",
-			"collection", collection, "error", err)
+		log.Warn("cannot read pkg_registry; skipping package-access check",
+			"collection", collection, "err", err)
 		return ""
 	}
 

--- a/core/server/pkgbuild/exec.go
+++ b/core/server/pkgbuild/exec.go
@@ -3,12 +3,17 @@ package pkgbuild
 import (
 	"bufio"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"tinycld.org/core/logging"
 )
+
+// log is pkgbuild's package-wide structured logger. No file in this package
+// imports stdlib "log" any longer, so the short identifier is free to use.
+var log = logging.ForPackage("pkgbuild")
 
 // CmdRunner runs a command in dir and returns its combined output. It is the
 // sandbox seam for buffered steps: coreserver binds it to RunCmd (in-process
@@ -24,12 +29,6 @@ type StreamingRunner func(onLine func(line string), dir, name string, args ...st
 // cross-compiles). Signature matches RunCmdEnv.
 type CmdEnvRunner func(dir string, extraEnv []string, name string, args ...string) (string, error)
 
-// LogPrefix tags every command echo in the process log. The default keeps the
-// single-tenant server's historical "[pkg_install]" prefix so operator `docker
-// logs` greps keep working; the multi-org builder sets its own at startup
-// (write-once, before jobs run — it is not synchronized).
-var LogPrefix = "[pkg_install]"
-
 // RunCmd runs a command, capturing its combined output to return to the
 // caller (which surfaces it via its ProgressSink / install log) AND echoing
 // the command line and its output to the process log so `docker logs` shows
@@ -44,7 +43,7 @@ func RunCmd(dir string, name string, args ...string) (string, error) {
 // NOT logged (only the command + args are), so a value like a Sentry auth token
 // never lands in the build log — unlike threading it through args.
 func RunCmdEnv(dir string, extraEnv []string, name string, args ...string) (string, error) {
-	log.Printf("%s $ (cd %s && %s %s)", LogPrefix, dir, name, strings.Join(args, " "))
+	log.Debug("$ command", "dir", dir, "cmd", name, "args", strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	if len(extraEnv) > 0 {
@@ -52,10 +51,13 @@ func RunCmdEnv(dir string, extraEnv []string, name string, args ...string) (stri
 	}
 	out, err := cmd.CombinedOutput()
 	if s := strings.TrimRight(string(out), "\n"); s != "" {
-		log.Printf("%s output of %s:\n%s", LogPrefix, name, s)
+		log.Debug("command output", "cmd", name, "output", s)
 	}
 	if err != nil {
-		log.Printf("%s %s FAILED: %v", LogPrefix, name, err)
+		// The caller's own step-level handling (e.g. coreserver's timeStep)
+		// is what decides whether this failure escalates; logging it warn+
+		// here would double-page the same error.
+		log.Info("command failed", "cmd", name, "err", err)
 	}
 	return string(out), err
 }
@@ -67,21 +69,22 @@ func RunCmdEnv(dir string, extraEnv []string, name string, args ...string) (stri
 // every version listing into a decode error whenever npm had anything to
 // warn about (the hosted e2e's router cwd sat under a workspace .npmrc).
 func RunCmdStdout(dir string, name string, args ...string) (string, error) {
-	log.Printf("%s $ (cd %s && %s %s)", LogPrefix, dir, name, strings.Join(args, " "))
+	log.Debug("$ command", "dir", dir, "cmd", name, "args", strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if s := strings.TrimRight(string(out), "\n"); s != "" {
-		log.Printf("%s output of %s:\n%s", LogPrefix, name, s)
+		log.Debug("command output", "cmd", name, "output", s)
 	}
 	if s := strings.TrimSpace(stderr.String()); s != "" {
-		log.Printf("%s stderr of %s:\n%s", LogPrefix, name, s)
+		log.Debug("command stderr", "cmd", name, "stderr", s)
 	}
 	if err != nil {
-		log.Printf("%s %s FAILED: %v", LogPrefix, name, err)
-		// The caller surfaces the error; stderr carries npm's actual reason.
+		// The caller surfaces the error (stderr carries npm's actual reason);
+		// its own step-level handling decides whether this escalates.
+		log.Info("command failed", "cmd", name, "err", err)
 		return string(out), ErrFromCmd(name, stderr.String(), err)
 	}
 	return string(out), nil
@@ -93,7 +96,7 @@ func RunCmdStdout(dir string, name string, args ...string) (string, error) {
 // sit frozen for minutes. It still buffers + returns the full output and error
 // so the buffered-RunCmd contract is preserved.
 func RunCmdStreaming(onLine func(line string), dir, name string, args ...string) (string, error) {
-	log.Printf("%s $ (cd %s && %s %s)", LogPrefix, dir, name, strings.Join(args, " "))
+	log.Debug("$ command", "dir", dir, "cmd", name, "args", strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 
@@ -128,10 +131,12 @@ func RunCmdStreaming(onLine func(line string), dir, name string, args ...string)
 
 	out := buf.String()
 	if s := strings.TrimRight(out, "\n"); s != "" {
-		log.Printf("%s output of %s:\n%s", LogPrefix, name, s)
+		log.Debug("command output", "cmd", name, "output", s)
 	}
 	if err != nil {
-		log.Printf("%s %s FAILED: %v", LogPrefix, name, err)
+		// See RunCmdEnv: the caller's step-level handling is the escalation
+		// point, so this stays below warn to avoid double-paging.
+		log.Info("command failed", "cmd", name, "err", err)
 	}
 	return out, err
 }

--- a/core/server/search/aggregate.go
+++ b/core/server/search/aggregate.go
@@ -6,7 +6,11 @@ import (
 	"time"
 
 	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/logging"
 )
+
+var log = logging.ForPackage("search")
 
 // sourceTimeout bounds one package's search. The whole request is only as slow
 // as its slowest source, so a package wedged on a lock or a pathological query
@@ -119,7 +123,7 @@ func Aggregate(ctx context.Context, app core.App, userID string, q Query, source
 		if o.err != nil {
 			// A failure must never read as an empty result set — that swallow
 			// is what let a renamed column present as a silent zero before.
-			app.Logger().Warn("search: source failed", "package", o.slug, "error", o.err)
+			log.WarnContext(ctx, "source failed", "pkgSlug", o.slug, "err", o.err)
 			resp.Partial = append(resp.Partial, o.slug)
 			continue
 		}

--- a/core/server/tenantmain/tenantmain.go
+++ b/core/server/tenantmain/tenantmain.go
@@ -36,7 +36,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -52,11 +51,16 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 
 	"tinycld.org/core/coreserver"
+	"tinycld.org/core/logging"
 	"tinycld.org/core/mailproto"
 	"tinycld.org/core/orgcookie"
 	"tinycld.org/core/quota"
 	"tinycld.org/core/tenantcfg"
 )
+
+// log is tenantmain's package-wide structured logger. No file in this
+// package imports stdlib "log" any longer, so the short identifier is free.
+var log = logging.ForPackage("tenantmain")
 
 // Options composes a tenant on top of the transport.
 type Options struct {
@@ -342,7 +346,10 @@ func run(cfg runConfig) error {
 			_ = listener.Close()
 		}
 		if err := app.ResetBootstrapState(); err != nil {
-			log.Printf("tenant: reset bootstrap state: %v", err)
+			// Leaves bootstrap state stale for the next boot to sort out —
+			// same class of "deferred to next boot" condition tenant_pkg_state
+			// pages on, so this pages too.
+			log.WarnContext(ctx, "reset bootstrap state failed", "err", err)
 		}
 		// os.Exit skips deferred functions, so flush Sentry here too.
 		sentry.Flush(2 * time.Second)

--- a/core/server/webdav/file.go
+++ b/core/server/webdav/file.go
@@ -189,8 +189,8 @@ func (f *davFile) persistWrite() error {
 			// Archiving the outgoing blob is best-effort: losing a version
 			// snapshot must not fail the write the user actually asked for.
 			if err := hooks.BeforeOverwrite(fs.app, f.user.Id, f.existing); err != nil {
-				fs.app.Logger().Warn("webdav: BeforeOverwrite failed",
-					"slug", fs.src.Slug, "id", f.existing.Id, "error", err)
+				davLog.Warn("BeforeOverwrite failed",
+					"slug", fs.src.Slug, "recordID", f.existing.Id, "err", err)
 			}
 		}
 

--- a/core/server/webdav/filesystem.go
+++ b/core/server/webdav/filesystem.go
@@ -163,8 +163,20 @@ func (fs *FileSystem) authorize(user *core.Record, record *core.Record, kind rul
 	ok, err := fs.app.CanAccessRecord(record, info, ruleFor(record.Collection(), kind))
 	if err != nil {
 		// An unevaluable rule must not fail open.
-		davLog.Warn("access rule evaluation failed",
-			"slug", fs.src.Slug, "recordID", record.Id, "err", err)
+		//
+		// ruleList runs once per record inside a directory listing loop
+		// (filesystem.go's listing path), so a single broken ListRule would
+		// otherwise emit one Sentry event per record on every PROPFIND — and
+		// DAV clients poll on a timer, turning one admin typo into sustained
+		// paging. The other kinds (view/create/update/delete) are each at
+		// most one per request, so they stay at warn.
+		if kind == ruleList {
+			davLog.Info("access rule evaluation failed",
+				"slug", fs.src.Slug, "recordID", record.Id, "err", err)
+		} else {
+			davLog.Warn("access rule evaluation failed",
+				"slug", fs.src.Slug, "recordID", record.Id, "err", err)
+		}
 		return os.ErrPermission
 	}
 	if !ok {

--- a/core/server/webdav/filesystem.go
+++ b/core/server/webdav/filesystem.go
@@ -8,7 +8,11 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 	"golang.org/x/net/webdav"
+
+	"tinycld.org/core/logging"
 )
+
+var davLog = logging.ForPackage("webdav")
 
 type contextKey string
 
@@ -159,8 +163,8 @@ func (fs *FileSystem) authorize(user *core.Record, record *core.Record, kind rul
 	ok, err := fs.app.CanAccessRecord(record, info, ruleFor(record.Collection(), kind))
 	if err != nil {
 		// An unevaluable rule must not fail open.
-		fs.app.Logger().Warn("webdav: access rule evaluation failed",
-			"slug", fs.src.Slug, "id", record.Id, "error", err)
+		davLog.Warn("access rule evaluation failed",
+			"slug", fs.src.Slug, "recordID", record.Id, "err", err)
 		return os.ErrPermission
 	}
 	if !ok {
@@ -250,8 +254,8 @@ func (fs *FileSystem) saveAuthorizedCreate(user *core.Record, record *core.Recor
 		ok, err := txApp.CanAccessRecord(record, info, ruleFor(record.Collection(), ruleCreate))
 		if err != nil {
 			// An unevaluable rule must not fail open.
-			fs.app.Logger().Warn("webdav: create rule evaluation failed",
-				"slug", fs.src.Slug, "id", record.Id, "error", err)
+			davLog.Warn("create rule evaluation failed",
+				"slug", fs.src.Slug, "recordID", record.Id, "err", err)
 			return denied
 		}
 		if !ok {

--- a/core/server/webdav/hooks.go
+++ b/core/server/webdav/hooks.go
@@ -193,7 +193,7 @@ func (fs *FileSystem) hookFilterList(ctx context.Context, userID string, infos [
 		// A handler that returned something other than a list is a bug in the
 		// hook, not a reason to leak the unfiltered listing — but neither is it
 		// a reason to fail the request. Keep the Go answer and say so.
-		fs.app.Logger().Warn("webdav: filterList handler returned a non-list; ignoring",
+		davLog.WarnContext(ctx, "filterList handler returned a non-list; ignoring",
 			"slug", fs.src.Slug, "type", fmt.Sprintf("%T", v))
 		return infos, nil
 	}

--- a/core/server/webdav/register.go
+++ b/core/server/webdav/register.go
@@ -42,7 +42,7 @@ func Register(app *pocketbase.PocketBase, sources []Source, host HostBindings) (
 			fs.SetTSHooks(RegisterTSHooks(host, src))
 		}
 		filesystems = append(filesystems, fs)
-		handlers = append(handlers, newDAVHandler(app, fs))
+		handlers = append(handlers, newDAVHandler(fs))
 	}
 
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
@@ -116,7 +116,7 @@ func HandlerFor(app core.App, sources []Source, host HostBindings) (http.Handler
 		}
 		filesystems = append(filesystems, fs)
 
-		handler := newDAVHandler(app, fs)
+		handler := newDAVHandler(fs)
 		serve := func(w http.ResponseWriter, r *http.Request) {
 			// See Register: refuse before spending bcrypt on an attacker.
 			if davauth.TooManyFailures(app, r) {
@@ -151,17 +151,17 @@ func HandlerFor(app core.App, sources []Source, host HostBindings) (http.Handler
 //
 // NewMemLS is load-bearing: an in-memory lock system is what advertises DAV
 // class 2, and macOS Finder mounts a class-1-only share read-only.
-func newDAVHandler(app core.App, fs *FileSystem) *webdav.Handler {
+func newDAVHandler(fs *FileSystem) *webdav.Handler {
 	return &webdav.Handler{
 		FileSystem: fs,
 		LockSystem: webdav.NewMemLS(),
 		Logger: func(r *http.Request, err error) {
 			if err != nil {
-				app.Logger().Debug("WebDAV",
+				davLog.DebugContext(r.Context(), "request failed",
 					"slug", fs.src.Slug,
 					"method", r.Method,
 					"path", r.URL.Path,
-					"error", err)
+					"err", err)
 			}
 		},
 	}


### PR DESCRIPTION
Follow-up to #208. That PR built the logging facility and installed it at bootstrap; this one makes core's own server code actually use it, so the convention the docs describe is one the code follows.

~199 call sites across 19 packages move onto `logging.ForPackage("<pkg>")`. Before this, only 12 sites in core reached Sentry — the rest logged to stderr or the `_logs` table only.

| Was | Sites | Reached |
|---|---|---|
| stdlib `log.*` | 104 | stderr only |
| `app.Logger()` | 95 | `_logs` table only |
| bare `slog.*` | 12 | the fan-out, minus the `pkg` attribute |

Manual `"[pkg_install] "`-style prefixes give way to the `pkg` attribute, `Printf` formats become structured attrs, and `*Context` variants are used wherever a `ctx` was already in scope — never added just to log.

### Two bugs found while migrating

**All six SMTP/IMAP servers would have paged on every deploy.** Their `Serve` goroutines logged at `Error` on exit, but go-smtp returns `net.ErrClosed` on clean shutdown, and our shutdown closes the listener first. Invisible before — those calls never reached Sentry — and a pager on every restart afterwards. Now behind `logServeExit`, which escalates only unexpected exits.

**A remote pager DoS in comment mentions.** `comment_collection` is free text any authenticated commenter can set, and an unknown value logged at `warn`. Any account holder could page the on-call at will. Now `info`, with the forensic attr retained.

### Deliberate exceptions

- `coreserver/sentry.go` stays stdlib — it reports that Sentry itself failed to initialize, so routing it through Sentry is circular.
- `coreserver/server.go`'s `log.Fatalf` stays — it terminates the process.
- `coreserver/app_updates.go`'s `app-boot: rendered` beacon stays on `app.Logger()` — the OTA e2e harness polls `_logs` for it with an exact message filter. Conversion looked safe but wasn't demonstrable, and this is release-verification infrastructure.
- Everything under `cmd/` stays stdlib — standalone CLI binaries with no PocketBase app.

### Worth knowing before deploy

This takes core from **12 to ~94 Sentry-eligible sites**. Every `warn`/`error` was audited individually for whether it should page someone, and review caught three cross-cutting issues that per-file review structurally couldn't: two level-drift pairs (the same failure logged at different levels in different places), plus a DAV listing path where one malformed admin `ListRule` would have emitted a Sentry event *per record per PROPFIND*, with clients polling on a timer. All fixed.

Still worth watching Sentry volume for a day after this deploys.

Tests: `go build`, `go vet`, `gofmt -l` clean; `go test ./... -count=1` green across all 35 packages.