### PR TITLE
Release review: automation blockers, rules UI, and CLI hardening

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -116,6 +116,11 @@ func newAuthLoginCmd(d *deps) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if config.IsInsecureOrigin(origin) {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: %s is plain http — your access token will cross the network in cleartext\n",
+					origin)
+			}
 			flow := &deviceflow.Flow{
 				Origin:   origin,
 				ClientID: client.DefaultClientID,
@@ -151,18 +156,30 @@ func newAuthLoginCmd(d *deps) *cobra.Command {
 				return fmt.Errorf("saving credentials: %w", err)
 			}
 
-			var user userinfoResponse
-			c := client.New(origin, store, d.httpClient)
-			if err := c.GetJSON(cmd.Context(), "/oauth/userinfo", &user); err != nil {
-				return fmt.Errorf("fetching identity: %w", err)
-			}
-
+			// Write the context BEFORE the userinfo fetch. The credential is
+			// already stored, so a failure past this point must still leave
+			// something that names it — otherwise the token sits in the
+			// keychain with no context referencing it, invisible to `context
+			// list` and unreachable by `auth logout`. The email is filled in
+			// below once known.
 			cfg, err := d.loadConfig()
 			if err != nil {
 				return err
 			}
-			cfg.Contexts[host] = config.Context{Origin: origin, User: user.Email}
+			cfg.Contexts[host] = config.Context{Origin: origin}
 			cfg.Current = host
+			if err := cfg.Save(d.configDir); err != nil {
+				return err
+			}
+
+			var user userinfoResponse
+			c := client.New(origin, store, d.httpClient)
+			if err := c.GetJSON(cmd.Context(), "/oauth/userinfo", &user); err != nil {
+				return fmt.Errorf("fetching identity (you are logged in to %s; `tinycld auth logout` to undo): %w",
+					host, err)
+			}
+
+			cfg.Contexts[host] = config.Context{Origin: origin, User: user.Email}
 			if err := cfg.Save(d.configDir); err != nil {
 				return err
 			}

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -207,3 +207,57 @@ func TestAuthLogoutSurvivesRevokeFailure(t *testing.T) {
 		t.Fatal("credential should be cleared even when revocation fails")
 	}
 }
+
+// The credential is stored before the identity is known, so a userinfo failure
+// past that point must still leave a context naming it. Otherwise the token
+// sits in the keychain with nothing referencing it: invisible to `context
+// list` and unreachable by `auth logout`.
+func TestAuthLoginLeavesNoOrphanedCredential(t *testing.T) {
+	counts := &struct{ tokenPolls int }{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /oauth/device", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"device_code": "dev-code", "user_code": "WDJB-MJHT",
+			"verification_uri":          "http://x/p/oauth/authorize",
+			"verification_uri_complete": "http://x/p/oauth/authorize?user_code=WDJB-MJHT",
+			"expires_in":                900, "interval": 5,
+		})
+	})
+	mux.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+		counts.tokenPolls++
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-1", "token_type": "Bearer",
+			"expires_in": 3600, "refresh_token": "refresh-1", "scope": "profile",
+		})
+	})
+	// The grant is live, but identity cannot be read (a transient 500, a
+	// revoked scope, a proxy hiccup).
+	mux.HandleFunc("GET /oauth/userinfo", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	d, store := loginDeps(t, srv)
+	host := hostOf(srv)
+
+	if _, _, err := runCLI(t, d, "auth", "login", host); err == nil {
+		t.Fatal("a failed userinfo must surface as an error")
+	}
+
+	// The token was saved, so a context must name it.
+	if _, err := store.Get(host); err != nil {
+		t.Fatalf("the credential should still be stored: %v", err)
+	}
+	cfg, err := config.Load(d.configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, ok := cfg.Contexts[host]
+	if !ok {
+		t.Fatal("a stored credential with no context is orphaned — unreachable by logout")
+	}
+	if ctx.Origin != "http://"+host {
+		t.Errorf("context origin = %q", ctx.Origin)
+	}
+}

--- a/cli/client/download.go
+++ b/cli/client/download.go
@@ -7,7 +7,27 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// LocalFileName reduces a server-supplied name to a single path segment safe to
+// join onto a local directory. Remote names are data, never paths: an item or
+// attachment named "../../.ssh/authorized_keys" must land in the directory the
+// user chose, not wherever its name points.
+//
+// filepath.Base collapses any traversal and strips separators; the fallbacks
+// cover names that are entirely separators or dots ("..", "/", ""), where Base
+// still yields something unusable as a filename.
+func LocalFileName(name string) string {
+	// Treat both separators as such regardless of host OS: a name authored on
+	// one platform must not become a path component on the other.
+	name = strings.ReplaceAll(name, "\\", "/")
+	base := filepath.Base(filepath.FromSlash(name))
+	if base == "." || base == ".." || base == string(filepath.Separator) {
+		return "download"
+	}
+	return base
+}
 
 // DownloadToFile streams an authenticated GET of path (origin-relative) into
 // dest, writing through a temp file in dest's directory and renaming into
@@ -50,6 +70,15 @@ func writeStream(src io.Reader, total int64, dest string, progress ProgressFunc)
 	dir := filepath.Dir(dest)
 	tmp, err := os.CreateTemp(dir, ".tinycld-download-*")
 	if err != nil {
+		return err
+	}
+	// os.CreateTemp always makes 0600 files. That is right for a credential but
+	// wrong for a download: this is ordinary user data (a spreadsheet, an
+	// attachment), and landing it 0600 regardless of umask means a file the
+	// user cannot share with their own group — unlike curl, scp, or a browser.
+	// 0666 &^ umask is the conventional "new data file" mode.
+	if err := tmp.Chmod(dataFileMode()); err != nil {
+		tmp.Close()
 		return err
 	}
 	defer func() {

--- a/cli/client/download_test.go
+++ b/cli/client/download_test.go
@@ -6,11 +6,36 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+// TestLocalFileName pins the sanitizer every download path relies on to keep a
+// server-supplied name from steering a write out of the user's chosen directory.
+func TestLocalFileName(t *testing.T) {
+	cases := map[string]string{
+		"report.pdf":                 "report.pdf",
+		"../../escaped.txt":          "escaped.txt",
+		"/etc/passwd":                "passwd",
+		"..":                         "download",
+		".":                          "download",
+		"/":                          "download",
+		"":                           "download",
+		"a/b/c.txt":                  "c.txt",
+		`..\..\windows\evil.txt`:     "evil.txt",
+		"trailing/":                  "trailing",
+		"weird name (1).tar.gz":      "weird name (1).tar.gz",
+		"....//....//still-escaping": "still-escaping",
+	}
+	for in, want := range cases {
+		if got := LocalFileName(in); got != want {
+			t.Errorf("LocalFileName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
 
 func TestDownloadToFile(t *testing.T) {
 	content := strings.Repeat("x", 4096)
@@ -125,5 +150,39 @@ func TestStreamingOutlivesClientTimeout(t *testing.T) {
 	got, _ := os.ReadFile(dest)
 	if string(got) != strings.Repeat("chunk", 6) {
 		t.Fatalf("content = %q", got)
+	}
+}
+
+// A download is ordinary user data, not a credential. os.CreateTemp hardcodes
+// 0600, so downloads used to land owner-only regardless of umask — a file the
+// user could not share with their own group, unlike curl or scp.
+func TestDownloadRespectsUmask(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no umask on Windows")
+	}
+	// dataFileMode samples the umask once per process, so this asserts against
+	// whatever it actually sampled rather than re-setting it here — the point
+	// is that the mode is umask-derived data, not the hardcoded 0600.
+	want := dataFileMode().Perm()
+	if want == 0o600 {
+		t.Skip("umask makes the expected mode indistinguishable from the old hardcoded 0600")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("payload"))
+	}))
+	t.Cleanup(srv.Close)
+
+	dest := filepath.Join(t.TempDir(), "report.csv")
+	if err := DownloadPublic(t.Context(), srv.Client(), srv.URL, dest, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Errorf("downloaded file mode = %04o, want %04o (0666 minus the umask)", got, want)
 	}
 }

--- a/cli/client/filemode_unix.go
+++ b/cli/client/filemode_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package client
+
+import (
+	"io/fs"
+	"sync"
+	"syscall"
+)
+
+// dataFileMode is the mode a newly downloaded FILE should get: the
+// conventional 0666 reduced by the process umask, the same result an ordinary
+// `open(..., 0666)` produces in curl or scp.
+//
+// os.CreateTemp hardcodes 0600, which is right for a credential and wrong for
+// user data — a downloaded spreadsheet the user cannot share with their own
+// group is a surprise no other tool produces.
+//
+// Umask can only be READ by setting it, so this samples once and restores
+// immediately. Done under a sync.Once at first use rather than in an init:
+// the swap is momentarily visible to other goroutines, so it must happen as
+// few times as possible.
+var (
+	umaskOnce  sync.Once
+	cachedMode fs.FileMode
+)
+
+func dataFileMode() fs.FileMode {
+	umaskOnce.Do(func() {
+		mask := syscall.Umask(0)
+		syscall.Umask(mask)
+		cachedMode = fs.FileMode(0o666 &^ mask)
+	})
+	return cachedMode
+}

--- a/cli/client/filemode_windows.go
+++ b/cli/client/filemode_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package client
+
+import "io/fs"
+
+// dataFileMode: Windows has no umask, and Go maps the mode bits onto the
+// read-only attribute alone. 0666 is the plain "writable data file" answer.
+func dataFileMode() fs.FileMode { return 0o666 }

--- a/cli/client/records.go
+++ b/cli/client/records.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -112,15 +113,30 @@ func recordsPath(collection string) string {
 	return "/api/collections/" + url.PathEscape(collection) + "/records"
 }
 
+var filterPlaceholder = regexp.MustCompile(`\{:(\w+)\}`)
+
 // Filter substitutes each {:name} placeholder in expr with the quoted value,
 // using the same quoting as PocketBase's own pb.filter helper (and the web
 // client's inline quote()): strings get `\` and `"` escaped and are wrapped
 // in double quotes; numbers and bools render bare.
+//
+// One pass over the expression, not one ReplaceAll per param: a substituted
+// VALUE containing "{:something}" must never itself be treated as a
+// placeholder. With map iteration that was both order-dependent (so the same
+// inputs could produce different filters run to run) and a way for
+// user-supplied text to reach the filter as syntax.
+//
+// An unknown placeholder is left verbatim — the server rejects it, which is a
+// better failure than silently querying with a hole in the expression.
 func Filter(expr string, params map[string]any) string {
-	for name, v := range params {
-		expr = strings.ReplaceAll(expr, "{:"+name+"}", filterValue(v))
-	}
-	return expr
+	return filterPlaceholder.ReplaceAllStringFunc(expr, func(match string) string {
+		name := match[2 : len(match)-1]
+		v, ok := params[name]
+		if !ok {
+			return match
+		}
+		return filterValue(v)
+	})
 }
 
 func filterValue(v any) string {

--- a/cli/client/records_test.go
+++ b/cli/client/records_test.go
@@ -197,3 +197,39 @@ func TestUserIDMemoizesUserinfo(t *testing.T) {
 		t.Fatalf("userinfo calls = %d, want 1 (memoized)", calls)
 	}
 }
+
+// A substituted VALUE must never be rescanned for placeholders. The old
+// per-param ReplaceAll loop did exactly that, so a filename or search term
+// containing "{:something}" could reach the filter as syntax — and which params
+// won depended on Go's randomized map iteration order.
+func TestFilterDoesNotRescanSubstitutedValues(t *testing.T) {
+	// The value of :name itself looks like the :secret placeholder.
+	got := Filter(`name = {:name} && owner = {:secret}`, map[string]any{
+		"name":   `{:secret}`,
+		"secret": "rec_private",
+	})
+	want := `name = "{:secret}" && owner = "rec_private"`
+	if got != want {
+		t.Errorf("Filter() = %q, want %q", got, want)
+	}
+
+	// Stable across runs regardless of map iteration order.
+	for range 50 {
+		if again := Filter(`name = {:name} && owner = {:secret}`, map[string]any{
+			"name":   `{:secret}`,
+			"secret": "rec_private",
+		}); again != want {
+			t.Fatalf("Filter() is order-dependent: got %q, want %q", again, want)
+		}
+	}
+}
+
+// An unknown placeholder stays verbatim so the server rejects the filter,
+// rather than being dropped and silently widening the query.
+func TestFilterLeavesUnknownPlaceholders(t *testing.T) {
+	got := Filter(`a = {:known} && b = {:missing}`, map[string]any{"known": 1})
+	want := `a = 1 && b = {:missing}`
+	if got != want {
+		t.Errorf("Filter() = %q, want %q", got, want)
+	}
+}

--- a/cli/context.go
+++ b/cli/context.go
@@ -105,6 +105,11 @@ func newContextAddCmd(d *deps) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if config.IsInsecureOrigin(origin) {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: %s is plain http — your access token will cross the network in cleartext\n",
+					origin)
+			}
 			cfg.Contexts[name] = config.Context{Origin: origin}
 			if cfg.Current == "" {
 				cfg.Current = name

--- a/cli/context_test.go
+++ b/cli/context_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -136,6 +137,29 @@ func TestQuietSuppressesInfo(t *testing.T) {
 	}
 	if stdout != "" {
 		t.Fatalf("quiet stdout = %q", stdout)
+	}
+}
+
+// --output csv used to fall through to the human-readable line, so a scripted
+// caller asking for CSV got prose no parser accepts.
+func TestVersionCSV(t *testing.T) {
+	d, _ := testDeps(t)
+	stdout, _, err := runCLI(t, d, "version", "--output", "csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	records, err := csv.NewReader(strings.NewReader(stdout)).ReadAll()
+	if err != nil {
+		t.Fatalf("version --output csv did not emit parseable CSV: %v\n%s", err, stdout)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected a header and one row, got %d records:\n%s", len(records), stdout)
+	}
+	if records[0][0] != "VERSION" {
+		t.Errorf("header = %v", records[0])
+	}
+	if records[1][0] != "dev" {
+		t.Errorf("row = %v", records[1])
 	}
 }
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -162,3 +162,20 @@ func isLoopback(host string) bool {
 	}
 	return false
 }
+
+// IsInsecureOrigin reports whether origin sends credentials in cleartext: plain
+// http to a host that is not loopback.
+//
+// NormalizeOrigin only picks the scheme for a BARE host (loopback → http, else
+// https); an explicit "http://mail.example.com" is honored verbatim, which is
+// the case worth warning about. Every request carries a bearer token, so this
+// is a credential on the wire, not merely unencrypted content. It stays a
+// warning rather than an error: an internal deployment behind a VPN, or a
+// staging box on a private network, is a legitimate reason to accept it.
+func IsInsecureOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme != "http" {
+		return false
+	}
+	return !isLoopback(u.Hostname()) && !isLoopback(u.Host)
+}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -142,3 +142,32 @@ func TestDirEnvOverride(t *testing.T) {
 		t.Fatalf("Dir() = %q", got)
 	}
 }
+
+// A plain-http origin to a non-loopback host sends the bearer token in
+// cleartext. NormalizeOrigin only picks a scheme for a BARE host, so an
+// explicit http:// URL reaches the config verbatim — that is what this flags.
+func TestIsInsecureOrigin(t *testing.T) {
+	insecure := []string{
+		"http://mail.example.com",
+		"http://mail.example.com:8080",
+		"http://192.168.1.10:7110",
+	}
+	for _, o := range insecure {
+		if !IsInsecureOrigin(o) {
+			t.Errorf("IsInsecureOrigin(%q) = false, want true", o)
+		}
+	}
+
+	secure := []string{
+		"https://mail.example.com",
+		"http://localhost:7110",
+		"http://127.0.0.1:7110",
+		"http://[::1]:7110",
+		"https://localhost",
+	}
+	for _, o := range secure {
+		if IsInsecureOrigin(o) {
+			t.Errorf("IsInsecureOrigin(%q) = true, want false", o)
+		}
+	}
+}

--- a/cli/internal/keychain/keychain.go
+++ b/cli/internal/keychain/keychain.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/zalando/go-keyring"
 )
@@ -95,7 +96,17 @@ func (s *systemStore) Set(account, value string) error {
 	if err == nil {
 		// A keychain write supersedes any stale file copy from a degraded
 		// earlier session; drop it so Get cannot resurrect old credentials.
-		s.file.Delete(account)
+		//
+		// Reported, not swallowed: Get consults the file store when the
+		// keychain misses, so a file that outlives its replacement can hand
+		// back a SUPERSEDED credential — a silently stale token is exactly the
+		// failure a user cannot diagnose. The Set itself still succeeded, so
+		// this warns rather than erroring.
+		if derr := s.file.Delete(account); derr != nil {
+			fmt.Fprintf(s.warn,
+				"warning: saved to the keychain, but the older copy at %s could not be removed (%v); delete it by hand\n",
+				s.file.Location(account), derr)
+		}
 		s.setDegraded(account, false)
 		return nil
 	}
@@ -144,8 +155,35 @@ func (s *systemStore) Delete(account string) error {
 type fileStore struct{ dir string }
 
 func (f fileStore) path(account string) string {
-	// Context names carry ':' (host:port), which Windows filenames reject.
-	return filepath.Join(f.dir, url.PathEscape(account)+".json")
+	return filepath.Join(f.dir, escapeAccount(account)+".json")
+}
+
+// escapeAccount turns an account name into a filename that is legal on every
+// platform we ship to.
+//
+// url.PathEscape alone is not enough: it deliberately leaves ':' (and a few
+// other Windows-reserved characters) unescaped because they are legal in a URL
+// path. Windows rejects them in filenames, so `localhost:7110.json` cannot be
+// created at all — the fallback store silently fails to persist a credential
+// the user has already authenticated for.
+//
+// PathEscape still runs first, since it handles the separators that would let
+// an account name escape the store directory; this pass then covers what it
+// leaves behind.
+func escapeAccount(account string) string {
+	escaped := url.PathEscape(account)
+	var b strings.Builder
+	b.Grow(len(escaped))
+	for _, r := range escaped {
+		// The Windows-reserved set that survives PathEscape. '%' is already the
+		// escape character, so these encode unambiguously.
+		if strings.ContainsRune(`:*?"<>|`, r) {
+			fmt.Fprintf(&b, "%%%02X", r)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // Location names the actual file, not just the directory: a user told their

--- a/cli/internal/keychain/keychain_test.go
+++ b/cli/internal/keychain/keychain_test.go
@@ -3,6 +3,7 @@ package keychain
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -72,6 +73,57 @@ func TestFileStoreEscapesAccountNames(t *testing.T) {
 	}
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 files inside the store dir, got %d", len(entries))
+	}
+}
+
+// The fallback store must produce filenames Windows can actually create.
+// url.PathEscape leaves ':' alone (it is legal in a URL path), so the default
+// context name `localhost:7110` produced a filename Windows rejects outright —
+// stranding a credential the user had already authenticated for. The assertion
+// is on the NAME, so it holds when the suite runs on Linux or macOS too.
+func TestFileStorePathIsLegalOnWindows(t *testing.T) {
+	fs := fileStore{dir: t.TempDir()}
+	for _, account := range []string{
+		"localhost:7110",
+		"example.com:443",
+		`weird*name?with"reserved<chars>|here`,
+		"weird/../name",
+	} {
+		name := filepath.Base(fs.path(account))
+		if strings.ContainsAny(name, `<>:"/\|?*`) {
+			t.Errorf("path(%q) = %q contains a character Windows rejects", account, name)
+		}
+		// Still inside the store dir.
+		if dir := filepath.Dir(fs.path(account)); dir != fs.dir {
+			t.Errorf("path(%q) escaped the store dir: %q", account, dir)
+		}
+	}
+}
+
+// Distinct accounts must never collide on one file, or two contexts would
+// share (and overwrite) a single credential.
+func TestFileStoreEscapingIsUnambiguous(t *testing.T) {
+	fs := fileStore{dir: t.TempDir()}
+	accounts := []string{"localhost:7110", "localhost%3A7110", "localhost7110"}
+	seen := map[string]string{}
+	for _, a := range accounts {
+		p := fs.path(a)
+		if prev, dup := seen[p]; dup {
+			t.Fatalf("accounts %q and %q both map to %q", prev, a, p)
+		}
+		seen[p] = a
+	}
+	// And each round-trips to its own value.
+	for i, a := range accounts {
+		if err := fs.Set(a, fmt.Sprintf("v%d", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i, a := range accounts {
+		v, err := fs.Get(a)
+		if err != nil || v != fmt.Sprintf("v%d", i) {
+			t.Errorf("get %q = %q, %v", a, v, err)
+		}
 	}
 }
 

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -37,7 +37,15 @@ type Options struct {
 	Format  Format
 	Quiet   bool
 	NoColor bool
-	TTY     bool
+	// TTY reports whether STDOUT is a terminal — the right question for
+	// colour and progress rendering, which write there.
+	TTY bool
+	// Interactive reports whether STDIN is a terminal, which is the question a
+	// PROMPT has to ask: it reads from stdin, so `tinycld ... | less` (stdout
+	// piped, stdin still the keyboard) can prompt perfectly well. Deciding that
+	// from TTY refused to prompt whenever output was piped, and would equally
+	// have hung on a prompt whose input came from a pipe.
+	Interactive bool
 }
 
 var headerStyle = lipgloss.NewStyle().Bold(true).Faint(true)
@@ -106,9 +114,10 @@ func FromCommand(cmd *cobra.Command) (Options, bool, error) {
 	yes, _ := cmd.Flags().GetBool("yes")
 	tty := term.IsTerminal(int(os.Stdout.Fd()))
 	return Options{
-		Format:  format,
-		Quiet:   quiet,
-		NoColor: noColor || !tty,
-		TTY:     tty,
+		Format:      format,
+		Quiet:       quiet,
+		NoColor:     noColor || !tty,
+		TTY:         tty,
+		Interactive: term.IsTerminal(int(os.Stdin.Fd())),
 	}, yes, nil
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -23,6 +23,9 @@ type deps struct {
 	stderr     io.Writer
 	httpClient *http.Client
 	isTTY      bool
+	// isInteractive tracks STDIN separately from isTTY (stdout): a prompt reads
+	// stdin, so piping output must not disable prompting.
+	isInteractive bool
 
 	openStore func(configDir string, warn io.Writer) keychain.Store
 	// sleep is nil in production (real time.Sleep); tests inject a no-op so
@@ -44,12 +47,13 @@ type deps struct {
 
 func defaultDeps() *deps {
 	return &deps{
-		configDir:  config.Dir(),
-		stdout:     os.Stdout,
-		stderr:     os.Stderr,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		isTTY:      term.IsTerminal(int(os.Stdout.Fd())),
-		openStore:  keychain.Open,
+		configDir:     config.Dir(),
+		stdout:        os.Stdout,
+		stderr:        os.Stderr,
+		httpClient:    &http.Client{Timeout: 30 * time.Second},
+		isTTY:         term.IsTerminal(int(os.Stdout.Fd())),
+		isInteractive: term.IsTerminal(int(os.Stdin.Fd())),
+		openStore:     keychain.Open,
 	}
 }
 
@@ -106,10 +110,11 @@ func newRootCmd(d *deps) *cobra.Command {
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		noColor, _ := cmd.Flags().GetBool("no-color")
 		d.out = output.Options{
-			Format:  format,
-			Quiet:   quiet,
-			NoColor: noColor || !d.isTTY,
-			TTY:     d.isTTY,
+			Format:      format,
+			Quiet:       quiet,
+			NoColor:     noColor || !d.isTTY,
+			TTY:         d.isTTY,
+			Interactive: d.isInteractive,
 		}
 		return nil
 	}

--- a/cli/search.go
+++ b/cli/search.go
@@ -66,7 +66,23 @@ func newSearchCmd(d *deps) *cobra.Command {
 			// The same grammar the palette uses, so a query copied from the app
 			// behaves identically here (see parse_query.go).
 			parsed := parseQuery(args[0], slugs)
-			parsed.Exclude = append(parsed.Exclude, parseQuery(not, slugs).Include...)
+			// --not is a list of terms to exclude, so only its plain terms are
+			// meaningful. Anything else it parses into — a `pkg:` chip, or a
+			// nested `-term` (excluding an exclusion) — has no sensible reading
+			// here, and silently dropping it made `--not "pkg:mail"` look like
+			// it worked. Refuse instead of guessing.
+			negated := parseQuery(not, slugs)
+			if len(negated.Chips) > 0 {
+				return fmt.Errorf(
+					"--not takes terms to exclude, not a package filter; use --pkg %s",
+					strings.Join(negated.Chips, ","))
+			}
+			if len(negated.Exclude) > 0 {
+				return fmt.Errorf(
+					"--not %q contains a nested negation (%s); list the terms to exclude plainly",
+					not, strings.Join(negated.Exclude, ", "))
+			}
+			parsed.Exclude = append(parsed.Exclude, negated.Include...)
 
 			// An exclude-only query has no meaning: FTS5 cannot subtract from
 			// nothing, and the server would return an empty set with no

--- a/cli/search_test.go
+++ b/cli/search_test.go
@@ -374,3 +374,26 @@ func TestSearchRejectsUnknownPackage(t *testing.T) {
 		t.Error("should not have reached the server")
 	}
 }
+
+// --not is a list of terms to exclude. Anything else it parses into — a `pkg:`
+// chip, a nested `-term` — has no meaning there, and was silently dropped:
+// `--not "pkg:mail"` looked like it worked and filtered nothing.
+func TestSearchNotRejectsNonTerms(t *testing.T) {
+	srv := newSearchServer(t)
+	d := searchDeps(t, srv)
+
+	for _, tc := range []struct{ name, not, wantMsg string }{
+		{"a package chip", "mail:", "--pkg"},
+		{"a nested negation", "-spam", "nested negation"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := runCLI(t, d, "search", "invoice", "--not", tc.not)
+			if err == nil {
+				t.Fatalf("--not %q must be refused, not silently dropped", tc.not)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error should mention %q, got %q", tc.wantMsg, err)
+			}
+		})
+	}
+}

--- a/cli/ui/ui.go
+++ b/cli/ui/ui.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"tinycld.org/cli/output"
@@ -17,7 +18,7 @@ import (
 // WaitEnter pauses until the user presses Enter. Skipped (returning
 // immediately) under --yes or when stdin is not a terminal.
 func WaitEnter(o output.Options, yes bool, stdin io.Reader, stdout io.Writer, msg string) {
-	if yes || !o.TTY {
+	if yes || !o.Interactive {
 		return
 	}
 	fmt.Fprint(stdout, msg)
@@ -31,7 +32,7 @@ func Confirm(o output.Options, yes bool, stdin io.Reader, stdout io.Writer, msg 
 	if yes {
 		return true, nil
 	}
-	if !o.TTY {
+	if !o.Interactive {
 		return false, errors.New("refusing to prompt without a terminal — pass --yes to proceed")
 	}
 	fmt.Fprintf(stdout, "%s [y/N] ", msg)
@@ -41,4 +42,30 @@ func Confirm(o output.Options, yes bool, stdin io.Reader, stdout io.Writer, msg 
 	}
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	return answer == "y" || answer == "yes", nil
+}
+
+// ConfirmOverwrite asks before a download clobbers an existing local file.
+//
+// One helper rather than the check open-coded per command: `drive get`,
+// `drive export`, `mail download` and the contacts/calendar `--out` writers all
+// stream onto a caller-named path, and a silent overwrite of the wrong file is
+// not recoverable from the CLI.
+//
+// Returns nil when the path is free, when the user agrees, or under --yes.
+// A refusal (or a non-TTY run without --yes) comes back as an error the caller
+// can return unchanged — the download simply does not happen.
+func ConfirmOverwrite(o output.Options, yes bool, stdin io.Reader, stdout io.Writer, path string) error {
+	if _, err := os.Stat(path); err != nil {
+		// Not there (or unreadable — the write itself will report that
+		// properly): nothing to overwrite, so nothing to ask about.
+		return nil
+	}
+	ok, err := Confirm(o, yes, stdin, stdout, fmt.Sprintf("%s already exists. Overwrite?", path))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%s: not overwritten", path)
+	}
+	return nil
 }

--- a/cli/version.go
+++ b/cli/version.go
@@ -26,8 +26,15 @@ func newVersionCmd(d *deps) *cobra.Command {
 				Arch    string `json:"arch"`
 			}
 			v := info{Version: version, Go: runtime.Version(), OS: runtime.GOOS, Arch: runtime.GOARCH}
-			if d.out.Format == output.JSON {
-				return d.out.Write(cmd.OutOrStdout(), nil, nil, v)
+			// Only the human format is hand-written. --output csv used to fall
+			// through to it, so a caller asking for CSV got a prose line that
+			// no parser accepts; routing both machine formats through Write
+			// keeps them in step with every other command.
+			if d.out.Format != output.Table {
+				return d.out.Write(cmd.OutOrStdout(),
+					[]string{"VERSION", "GO", "OS", "ARCH"},
+					[][]string{{v.Version, v.Go, v.OS, v.Arch}},
+					v)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "tinycld %s (%s %s/%s)\n", v.Version, v.Go, v.OS, v.Arch)
 			return nil

--- a/core/components/rules/ActionsCard.tsx
+++ b/core/components/rules/ActionsCard.tsx
@@ -11,7 +11,7 @@ import {
     moveAction,
 } from '@tinycld/core/lib/automation/condition-helpers'
 import type { RuleDraft } from '@tinycld/core/lib/automation/draft'
-import { parseRef } from '@tinycld/core/lib/automation/helpers'
+import { parseRefSafe } from '@tinycld/core/lib/automation/helpers'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { Menu } from '@tinycld/core/ui/menu'
 import { ArrowDown, ArrowUp, Braces, Plus, Trash2 } from 'lucide-react-native'
@@ -153,7 +153,7 @@ function ActionParamRow({
     param: CatalogParam
     trigger: CatalogTrigger | undefined
     value: string | number | boolean | undefined
-    onChange: (v: string | number | boolean) => void
+    onChange: (v: string | number | boolean | undefined) => void
 }) {
     const isTemplateText = param.template && param.field.type === 'text'
     const textValue = typeof value === 'string' ? value : ''
@@ -195,10 +195,19 @@ function ActionEntry({
 }) {
     const mutedColor = useThemeColor('muted-foreground')
     const action = catalog.actions.find(a => a.ref === draftAction.ref)
-    const { pkg, id } = parseRef(draftAction.ref)
+    const { pkg, id } = parseRefSafe(draftAction.ref)
 
-    const handleParamChange = (key: string, value: string | number | boolean) => {
-        onChangeParams({ ...draftAction.params, [key]: value })
+    // undefined = the input has no usable value right now (a numeric field
+    // mid-edit). Drop the key rather than storing undefined, so the saved
+    // params carry only values the action can actually use.
+    const handleParamChange = (key: string, value: string | number | boolean | undefined) => {
+        const params = { ...draftAction.params }
+        if (value === undefined) {
+            delete params[key]
+        } else {
+            params[key] = value
+        }
+        onChangeParams(params)
     }
 
     return (

--- a/core/components/rules/ConditionGroupBox.tsx
+++ b/core/components/rules/ConditionGroupBox.tsx
@@ -16,13 +16,24 @@ import { MatchPillPair } from './MatchPillPair'
 export interface ConditionGroupBoxProps {
     draft: RuleDraft
     fields: CatalogField[]
+    // The group to RENDER, passed rather than re-derived from groupIndex: the
+    // parent keys these on the builder-local uid, so a re-derive by index reads
+    // a different group than the one React reconciled this element to whenever
+    // groups are added or removed above it.
+    group: RuleDraft['conditions']['groups'][number]
+    // The group's position, which is how the mutation helpers address it.
     groupIndex: number
     onChange: (patch: Partial<RuleDraft>) => void
 }
 
-export function ConditionGroupBox({ draft, fields, groupIndex, onChange }: ConditionGroupBoxProps) {
+export function ConditionGroupBox({
+    draft,
+    fields,
+    group,
+    groupIndex,
+    onChange,
+}: ConditionGroupBoxProps) {
     const mutedColor = useThemeColor('muted-foreground')
-    const group = draft.conditions.groups[groupIndex]
 
     return (
         <View className="rounded-lg border p-3 gap-2.5 border-border">

--- a/core/components/rules/ConditionsCard.tsx
+++ b/core/components/rules/ConditionsCard.tsx
@@ -44,6 +44,7 @@ export function ConditionsCard({ draft, catalog, onChange }: ConditionsCardProps
                     key={group.uid}
                     draft={draft}
                     fields={trigger?.fields ?? []}
+                    group={group}
                     groupIndex={groupIndex}
                     onChange={onChange}
                 />

--- a/core/components/rules/DryRunPanel.tsx
+++ b/core/components/rules/DryRunPanel.tsx
@@ -1,4 +1,4 @@
-import type { CatalogResponse, DryRunResponse } from '@tinycld/core/lib/automation/api'
+import type { CatalogResponse, DryRunMatch, DryRunResult } from '@tinycld/core/lib/automation/api'
 import type { RuleDraft } from '@tinycld/core/lib/automation/draft'
 import { conditionsAstSchema } from '@tinycld/core/lib/automation/schemas'
 import { useRuleMutations } from '@tinycld/core/lib/automation/use-rule-mutations'
@@ -15,7 +15,7 @@ export interface DryRunPanelProps {
 
 const MAX_MATCH_ROWS = 10
 
-function matchSummaryText(match: DryRunResponse['matches'][number], fieldKeys: string[]): string {
+function matchSummaryText(match: DryRunMatch, fieldKeys: string[]): string {
     const parts = fieldKeys
         .map(key => match.summary[key])
         .filter(v => v !== undefined && v !== null)
@@ -23,17 +23,11 @@ function matchSummaryText(match: DryRunResponse['matches'][number], fieldKeys: s
     return parts.length > 0 ? parts.join(' · ') : match.id
 }
 
-function MatchRow({
-    match,
-    fieldKeys,
-}: {
-    match: DryRunResponse['matches'][number]
-    fieldKeys: string[]
-}) {
+function MatchRow({ match, fieldKeys }: { match: DryRunMatch; fieldKeys: string[] }) {
     return <Text className="text-sm text-foreground">{matchSummaryText(match, fieldKeys)}</Text>
 }
 
-function ResultSummary({ result, fieldKeys }: { result: DryRunResponse; fieldKeys: string[] }) {
+function ResultSummary({ result, fieldKeys }: { result: DryRunResult; fieldKeys: string[] }) {
     return (
         <View className="gap-1.5">
             <Text className="text-sm text-foreground">
@@ -79,12 +73,18 @@ export function DryRunPanel({ draft, catalog, isVisible }: DryRunPanelProps) {
     const trigger = catalog.triggers.find(t => t.ref === draft.trigger)
     if (!trigger || trigger.synthetic) return null
 
-    // Keying on trigger + a stringified snapshot of conditions remounts the
-    // content below whenever either changes — the simplest way to drop a
-    // stale dry-run result/error without an effect: useMutation's data/error
-    // live in that mount's local state, so a fresh key means a fresh
-    // (empty) mutation state, same as if the user had never pressed Test.
-    const conditionsKey = JSON.stringify(draft.conditions)
+    // Keying on trigger + a digest of the conditions remounts the content
+    // below whenever either changes — the simplest way to drop a stale dry-run
+    // result/error without an effect: useMutation's data/error live in that
+    // mount's local state, so a fresh key means a fresh (empty) mutation
+    // state, same as if the user had never pressed Test.
+    //
+    // The digest deliberately excludes the builder-local `uid`s that
+    // JSON.stringify(draft.conditions) would carry: those are fresh React keys
+    // regenerated as groups and rows are added, so including them remounted the
+    // panel — discarding an in-flight request and its result — on edits that
+    // did not change what would be matched at all.
+    const conditionsKey = conditionsDigest(draft.conditions)
 
     return (
         <DryRunPanelContent
@@ -93,6 +93,19 @@ export function DryRunPanel({ draft, catalog, isVisible }: DryRunPanelProps) {
             trigger={trigger}
         />
     )
+}
+
+// conditionsDigest reduces an AST to what a dry run actually depends on: the
+// match modes and each condition's field/op/value, in order. Two ASTs that
+// would query identically produce the same digest.
+function conditionsDigest(conditions: RuleDraft['conditions']): string {
+    return JSON.stringify([
+        conditions.match,
+        conditions.groups.map(group => [
+            group.match,
+            group.conditions.map(c => [c.field, c.op, c.value ?? null]),
+        ]),
+    ])
 }
 
 function DryRunPanelContent({

--- a/core/components/rules/RulesPanel.tsx
+++ b/core/components/rules/RulesPanel.tsx
@@ -107,6 +107,11 @@ function sortByOrder(rules: Rules[]): Rules[] {
 // order 0) can't cause display/execution divergence — max is taken over the
 // FULL rule set, not the pkgFilter-narrowed `rules` list, so a mail-scoped
 // "New rule" still lands after every org/personal rule regardless of package.
+//
+// This is only the draft's initial value, shown while the builder is open. The
+// AUTHORITATIVE order is recomputed against the live collection at insert time
+// (see useRuleMutations), because this one is captured when the builder opens
+// and goes stale if rules change in another tab meanwhile.
 function nextOrderFor(allRules: Rules[]): number {
     if (allRules.length === 0) return 0
     return Math.max(...allRules.map(r => r.order)) + 1

--- a/core/components/rules/TriggerCard.tsx
+++ b/core/components/rules/TriggerCard.tsx
@@ -1,7 +1,7 @@
 import { MenuActionItem } from '@tinycld/core/components/DropdownMenu'
 import type { CatalogResponse, CatalogTrigger } from '@tinycld/core/lib/automation/api'
 import type { RuleDraft } from '@tinycld/core/lib/automation/draft'
-import { parseRef } from '@tinycld/core/lib/automation/helpers'
+import { parseRefSafe } from '@tinycld/core/lib/automation/helpers'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { Menu } from '@tinycld/core/ui/menu'
 import { PlainInput } from '@tinycld/core/ui/PlainInput'
@@ -94,7 +94,7 @@ function LockedTriggerLabel({
     catalog: CatalogResponse
 }) {
     const trigger = catalog.triggers.find(t => t.ref === triggerRef)
-    const { pkg } = parseRef(triggerRef)
+    const { pkg } = parseRefSafe(triggerRef)
     return (
         <Text className="text-sm text-foreground">
             {trigger?.label ?? triggerRef}
@@ -182,6 +182,11 @@ export function TriggerCard({ draft, catalog, onChange, isLocked, presetPkg }: T
     const triggers = triggersForPreset(catalog, presetPkg)
 
     const handleSelectTrigger = (trigger: CatalogTrigger) => {
+        // Re-picking the trigger already selected is a no-op, not a reset:
+        // the menu shows the current choice, so clicking it is the natural way
+        // to close the menu — and it used to silently discard every condition
+        // and action the user had built.
+        if (trigger.ref === draft.trigger) return
         // Switching triggers invalidates conditions (built against the old
         // trigger's field set) and actions (may target the old trigger's
         // collection) — both reset rather than silently carrying over.

--- a/core/components/rules/ValueInput.tsx
+++ b/core/components/rules/ValueInput.tsx
@@ -4,6 +4,7 @@ import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { Menu } from '@tinycld/core/ui/menu'
 import { PlainInput } from '@tinycld/core/ui/PlainInput'
 import { ChevronDown } from 'lucide-react-native'
+import { useState } from 'react'
 import { Pressable, Text } from 'react-native'
 import { RelationRecordPicker } from './RelationRecordPicker'
 
@@ -11,7 +12,10 @@ export interface ValueInputProps {
     field: CatalogField
     op: string
     value: unknown
-    onChange: (v: string | number | boolean) => void
+    // `undefined` means "no usable value right now" — a numeric field mid-edit
+    // ("" or "-") reports it rather than storing a non-numeric string that
+    // would make the condition fail closed forever.
+    onChange: (v: string | number | boolean | undefined) => void
 }
 
 // `within_last_days` is a numeric "N days ago" value regardless of the
@@ -46,21 +50,31 @@ function NumberValueInput({
     onChange: ValueInputProps['onChange']
 }) {
     const placeholderColor = useThemeColor('field-placeholder')
+    // While typing, "" and "-" are legitimate intermediate states that are not
+    // numbers. They stay local: propagating them would store a non-numeric
+    // value in the condition, and the engine's numeric operators fail closed on
+    // anything toFloat can't read — so the rule would silently never match
+    // again, even after the user typed a real number elsewhere.
+    const [draft, setDraft] = useState<string | null>(null)
 
     const handleChangeText = (text: string) => {
         if (text === '' || text === '-') {
-            onChange(text)
+            setDraft(text)
+            onChange(undefined)
             return
         }
         const digitsOnly = text.replace(/[^0-9-]/g, '')
         if (digitsOnly !== text) return
         const numValue = Number.parseInt(digitsOnly, 10)
-        if (!Number.isNaN(numValue)) onChange(numValue)
+        if (Number.isFinite(numValue)) {
+            setDraft(null)
+            onChange(numValue)
+        }
     }
 
     return (
         <PlainInput
-            value={value === '' || value === '-' ? value : String(value ?? '')}
+            value={draft ?? (typeof value === 'number' ? String(value) : '')}
             onChangeText={handleChangeText}
             keyboardType="numeric"
             placeholderTextColor={placeholderColor}

--- a/core/lib/automation/__tests__/draft.test.ts
+++ b/core/lib/automation/__tests__/draft.test.ts
@@ -18,6 +18,8 @@ const catalog: CatalogResponse = {
             fields: [
                 { key: 'subject', label: 'Subject', type: 'text' },
                 { key: 'has_attachments', label: 'Has attachments', type: 'boolean' },
+                { key: 'size', label: 'Size', type: 'number' },
+                { key: 'due', label: 'Due', type: 'date' },
                 {
                     key: 'status',
                     label: 'Status',
@@ -415,6 +417,76 @@ describe('validateDraft', () => {
         })
         const errors = validateDraft(draft, catalog)
         expect(errors.some(e => /not-a-field/.test(e))).toBe(true)
+    })
+
+    // A numeric operator whose value isn't a number fails closed in the engine
+    // (toFloat can't read it), so the rule would silently never match. The
+    // motivating case is a half-typed "" or "-" left in the value input.
+    function numericDraft(value: unknown) {
+        return validDraft({
+            conditions: {
+                match: 'all',
+                groups: [
+                    {
+                        match: 'all',
+                        conditions: [
+                            { field: 'size', op: 'gt', value: value as string | number | boolean },
+                        ],
+                    },
+                ],
+            },
+        })
+    }
+
+    it.each([
+        ['an empty string', ''],
+        ['a lone minus sign', '-'],
+        ['undefined', undefined],
+        ['a non-numeric string', 'abc'],
+        ['NaN', Number.NaN],
+        ['Infinity', Number.POSITIVE_INFINITY],
+    ])('rejects a numeric condition whose value is %s', (_label, value) => {
+        const errors = validateDraft(numericDraft(value), catalog)
+        expect(errors.some(e => /needs a number/i.test(e))).toBe(true)
+    })
+
+    it.each([
+        ['a number', 5],
+        ['zero', 0],
+        ['a negative number', -3],
+        ['a numeric string from an older build', '42'],
+    ])('accepts a numeric condition whose value is %s', (_label, value) => {
+        expect(validateDraft(numericDraft(value), catalog)).toEqual([])
+    })
+
+    it('applies the numeric check to within_last_days on a date field', () => {
+        const draft = validDraft({
+            conditions: {
+                match: 'all',
+                groups: [
+                    {
+                        match: 'all',
+                        conditions: [{ field: 'due', op: 'within_last_days', value: '' }],
+                    },
+                ],
+            },
+        })
+        expect(validateDraft(draft, catalog).some(e => /needs a number/i.test(e))).toBe(true)
+    })
+
+    it('leaves value-less operators alone', () => {
+        const draft = validDraft({
+            conditions: {
+                match: 'all',
+                groups: [
+                    {
+                        match: 'all',
+                        conditions: [{ field: 'folder', op: 'is_empty' }],
+                    },
+                ],
+            },
+        })
+        expect(validateDraft(draft, catalog)).toEqual([])
     })
 
     it('rejects an operator illegal for the field type', () => {

--- a/core/lib/automation/api.ts
+++ b/core/lib/automation/api.ts
@@ -54,12 +54,25 @@ export interface DryRunRequest {
     conditions: ConditionsAst
 }
 
+export interface DryRunMatch {
+    id: string
+    summary: Record<string, unknown>
+}
+
+// `matches` is nullable on the wire: Go marshals an empty slice as `null`
+// unless it was explicitly initialized, and an older server on the other side
+// of an upgrade still does. Typed honestly so the compiler forces the guard —
+// consumers should read the normalized result from dryRun() rather than
+// touching this shape directly.
 export interface DryRunResponse {
     total: number
-    matches: Array<{
-        id: string
-        summary: Record<string, unknown>
-    }>
+    matches: DryRunMatch[] | null
+}
+
+// DryRunResult is what callers actually get: matches is guaranteed present.
+export interface DryRunResult {
+    total: number
+    matches: DryRunMatch[]
 }
 
 export interface RunResponse {

--- a/core/lib/automation/draft.ts
+++ b/core/lib/automation/draft.ts
@@ -8,6 +8,7 @@ import type { ActionItem } from './condition-helpers'
 import { ensureActionUids, ensureUids } from './condition-helpers'
 import { OPERATORS_BY_TYPE } from './helpers'
 import { conditionsAstSchema, ruleActionsSchema } from './schemas'
+import type { ConditionOp } from './types'
 
 export interface RuleDraft {
     id?: string
@@ -169,9 +170,27 @@ function validateConditionsAgainstTrigger(
                     `Operator '${condition.op}' is not valid for field '${field.label}' (${field.type})`
                 )
             }
+            if (NUMERIC_OPS.has(condition.op as ConditionOp) && !isFiniteValue(condition.value)) {
+                // The engine's numeric operators fail closed on a value they
+                // can't read as a number, so saving one is saving a rule that
+                // silently never matches. Caught here rather than at the input.
+                errors.push(`Condition on '${field.label}' needs a number`)
+            }
         }
     }
     return errors
+}
+
+// The operators evalCondition reads with toFloat: eq/neq/gt/lt over a number
+// field, plus within_last_days, whose value is a day count on a date field.
+const NUMERIC_OPS: ReadonlySet<ConditionOp> = new Set(['eq', 'neq', 'gt', 'lt', 'within_last_days'])
+
+function isFiniteValue(value: unknown): boolean {
+    if (typeof value === 'number') return Number.isFinite(value)
+    // A stored string is tolerated only if it actually reads as a number: rules
+    // written by an older build (or by hand) may carry "5" rather than 5.
+    if (typeof value === 'string' && value.trim() !== '') return Number.isFinite(Number(value))
+    return false
 }
 
 function validateTrigger(draft: RuleDraft, catalog: CatalogResponse): string[] {

--- a/core/lib/automation/helpers.ts
+++ b/core/lib/automation/helpers.ts
@@ -29,3 +29,19 @@ export function parseRef(ref: string): { pkg: string; id: string } {
     }
     return { pkg: ref.slice(0, idx), id: ref.slice(idx + 1) }
 }
+
+/**
+ * parseRef for RENDER paths, where throwing is the wrong failure.
+ *
+ * A rule's stored ref comes from the database — an older build, a hand-edited
+ * row, or a package removed since it was written. Throwing during render blanks
+ * the whole builder, so the user cannot even open the offending rule to fix or
+ * delete it. Falling back to the raw ref shows something identifiable instead.
+ */
+export function parseRefSafe(ref: string): { pkg: string; id: string } {
+    try {
+        return parseRef(ref)
+    } catch {
+        return { pkg: '', id: ref }
+    }
+}

--- a/core/lib/automation/use-rule-mutations.ts
+++ b/core/lib/automation/use-rule-mutations.ts
@@ -2,9 +2,17 @@ import { useAuth } from '@tinycld/core/lib/auth'
 import { mutation, useMutation } from '@tinycld/core/lib/mutations'
 import { pb, useStore } from '@tinycld/core/lib/pocketbase'
 import { newRecordId } from 'pbtsdb/core'
-import type { DryRunRequest, DryRunResponse, RunResponse } from './api'
+import type { DryRunRequest, DryRunResponse, DryRunResult, RunResponse } from './api'
 import type { RuleDraft } from './draft'
 import { draftToRecord } from './draft'
+
+// A new rule sorts after every existing one. Ties (several rules sharing an
+// order) make the displayed sequence and the execution sequence disagree, so
+// this is read at insert time from the live collection.
+function nextOrderFor(rules: { order: number }[]): number {
+    if (rules.length === 0) return 0
+    return Math.max(...rules.map(r => r.order)) + 1
+}
 
 // `useCurrentUserId`/`useOrgLiveQuery` doesn't export a bare user-id hook —
 // the established idiom (see useLabelMutations) is `useAuth().user.id`.
@@ -19,7 +27,16 @@ export function useRuleMutations() {
             if (draft.id) {
                 yield rulesCollection.update(draft.id, r => Object.assign(r, fields))
             } else {
-                yield rulesCollection.insert({ id: newRecordId(), owner: userId, ...fields })
+                // Order is computed HERE, not captured when the builder opened:
+                // two tabs (or a builder left open while rules changed) would
+                // otherwise both seed the same stale "max + 1" and land on the
+                // same order, where ties make display and execution diverge.
+                yield rulesCollection.insert({
+                    id: newRecordId(),
+                    owner: userId,
+                    ...fields,
+                    order: nextOrderFor(rulesCollection.toArray),
+                })
             }
         }),
     })
@@ -50,9 +67,16 @@ export function useRuleMutations() {
         mutationFn: async (id: string): Promise<RunResponse> =>
             await pb.send(`/api/automation/rules/${id}/run`, { method: 'POST' }),
     })
+    // Normalized here so no consumer has to: `matches` is nullable on the wire
+    // (Go marshals an uninitialized slice as null), and the panel maps over it.
     const dryRun = useMutation({
-        mutationFn: async (body: DryRunRequest): Promise<DryRunResponse> =>
-            await pb.send('/api/automation/dry-run', { method: 'POST', body }),
+        mutationFn: async (body: DryRunRequest): Promise<DryRunResult> => {
+            const res: DryRunResponse = await pb.send('/api/automation/dry-run', {
+                method: 'POST',
+                body,
+            })
+            return { total: res.total, matches: res.matches ?? [] }
+        },
     })
 
     return { save, remove, setEnabled, reorder, runNow, dryRun }

--- a/core/server/automation/actions.go
+++ b/core/server/automation/actions.go
@@ -32,6 +32,35 @@ func takeEngineWrite(recordID string) (engineWrite, bool) {
 	return v.(engineWrite), true
 }
 
+// MarkEngineWrite stamps provenance on a write a native action handler performs
+// itself, then runs it. Record-ops get this for free inside ExecuteAction;
+// a native handler holds its own app and calls Save directly, so without this
+// its output looks like an ordinary user write to the record hook — a handler
+// that writes to a collection its own trigger watches re-fires that trigger
+// with depth 0 forever, never reaching maxChainDepth.
+//
+// Call it around the Save/Delete, passing the ActionRequest so the rule id and
+// depth come from the firing that invoked the handler:
+//
+//	return automation.MarkEngineWrite(req, record.Id, func() error {
+//	    return app.Save(record)
+//	})
+//
+// The record id must be known before the write (native handlers set an explicit
+// id on create). The stamp is removed again if the write fails, so a failed
+// attempt doesn't suppress the next genuine user edit of that record.
+func MarkEngineWrite(req ActionRequest, recordID string, write func() error) error {
+	if req.Rule == nil || recordID == "" {
+		return write()
+	}
+	markEngineWrite(recordID, req.Rule.Id, req.Depth)
+	if err := write(); err != nil {
+		takeEngineWrite(recordID)
+		return err
+	}
+	return nil
+}
+
 func substituteParams(defs ActionDef, raw map[string]any, record *core.Record, trigger TriggerDef, relationKeys map[string]bool) map[string]string {
 	out := map[string]string{}
 	for _, p := range defs.Params {
@@ -142,6 +171,51 @@ func authorizeRelationParams(app core.App, ref string, action ActionDef, req Act
 	return nil
 }
 
+// authorizeTriggerRecordWrite gates a record-op that mutates or deletes the
+// trigger record itself. It is the write-side mirror of the relation-param
+// floor in authorizeRelationParams, and exists for the same reason: the op
+// runs as superuser, so nothing below it consults the collection's own rules.
+//
+// checkPersonalAccess is not a substitute — it asks whether the owner may
+// write to the PACKAGE, never whether they may write THIS record. A trigger
+// fires for a whole audience (an org rule, a shared mailbox, a team board), so
+// without this a rule owner who can merely see a record could move or delete
+// it through automation while the same edit through the UI is refused.
+//
+// The floor is the collection's own updateRule/deleteRule evaluated as the
+// owner, so it travels in migrations and holds in every deployment. A nil rule
+// means superuser-only in PocketBase, so it is refused rather than waved
+// through. Packages needing a stricter check register a TriggerRecordAuthorizer.
+func authorizeTriggerRecordWrite(app core.App, ref string, op string, record *core.Record, req ActionRequest) error {
+	owner, err := app.FindRecordById("users", req.OwnerID)
+	if err != nil {
+		return fmt.Errorf("trigger-record %s: rule owner lookup: %w", op, err)
+	}
+
+	collectionRule := record.Collection().UpdateRule
+	if op == "delete" {
+		collectionRule = record.Collection().DeleteRule
+	}
+	if collectionRule == nil {
+		return fmt.Errorf(
+			"trigger-record %s: %s is superuser-only (no %s rule) — refusing to act as the rule owner",
+			op, record.Collection().Name, op,
+		)
+	}
+	info := &core.RequestInfo{Auth: owner}
+	if ok, err := app.CanAccessRecord(record, info, collectionRule); err != nil || !ok {
+		return fmt.Errorf("trigger-record %s: rule owner may not %s %s record %q",
+			op, op, record.Collection().Name, record.Id)
+	}
+
+	if authorize, registered := triggerRecordAuthorizer(ref); registered {
+		if err := authorize(app, req, record); err != nil {
+			return fmt.Errorf("trigger-record %s: %w", op, err)
+		}
+	}
+	return nil
+}
+
 func resolveSetValue(sv SetValue, params map[string]string, record *core.Record, ownerID string) (any, error) {
 	switch {
 	case sv.Param != "":
@@ -199,7 +273,7 @@ func ExecuteAction(app core.App, defs *Defs, ref string, rawParams map[string]an
 		}
 	}
 	params := substituteParams(action, rawParams, record, trigger, relationKeys)
-	req := ActionRequest{Rule: rule, OwnerID: ownerID, Params: params, Record: record}
+	req := ActionRequest{Rule: rule, OwnerID: ownerID, Params: params, Record: record, Depth: depth}
 
 	// Both kinds pass the relation-id gates: a record-op's superuser Save
 	// bypasses collection rules just as thoroughly as a native handler's
@@ -255,6 +329,9 @@ func ExecuteAction(app core.App, defs *Defs, ref string, rawParams map[string]an
 		}
 		if record.Collection().Name != action.Collection {
 			return fmt.Errorf("record-op %q: trigger record is %q, action declares %q", ref, record.Collection().Name, action.Collection)
+		}
+		if err := authorizeTriggerRecordWrite(app, ref, action.Op.Type, record, req); err != nil {
+			return err
 		}
 		if action.Op.Type == "delete" {
 			marked := defsHaveTrigger(defs, action.Collection, "delete")

--- a/core/server/automation/actions_test.go
+++ b/core/server/automation/actions_test.go
@@ -13,6 +13,21 @@ import (
 	"tinycld.org/core/rlstest"
 )
 
+// allowAuthedWrites gives a fixture collection the update/delete rules a real
+// feature collection always declares in its migration. The trigger-record
+// authorization floor evaluates them as the rule owner, and treats a nil rule
+// (PB's superuser-only) as a refusal — so a fixture with no rules at all would
+// test a configuration no deployment ships.
+func allowAuthedWrites(t *testing.T, app core.App, col *core.Collection) {
+	t.Helper()
+	authed := "@request.auth.id != ''"
+	col.UpdateRule = &authed
+	col.DeleteRule = &authed
+	if err := app.Save(col); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // actionApp builds: users (fixture), label_assignments-like target collection,
 // a source collection, one user, one source record, and a personal rule record
 // shape (plain base collection standing in for `rules` — executor only reads
@@ -33,6 +48,7 @@ func actionApp(t *testing.T) (*tests.TestApp, *core.Record, *core.Record, *Defs)
 	if err := app.Save(src); err != nil {
 		t.Fatal(err)
 	}
+	allowAuthedWrites(t, app, src)
 	tgt := core.NewBaseCollection("thing_labels")
 	tgt.Fields.Add(&core.TextField{Name: "label"})
 	tgt.Fields.Add(&core.TextField{Name: "record_id"})
@@ -131,6 +147,96 @@ func TestRecordOpUpdateTriggerRecord(t *testing.T) {
 	if !ok || w.Depth != 1 || w.RuleID != rule.Id {
 		t.Fatalf("provenance: %+v %v", w, ok)
 	}
+}
+
+// TestTriggerRecordWriteAuthorization is the B3 regression. A record-op on the
+// trigger record runs as superuser, so before the fix a rule owner who could
+// merely SEE a record could mutate or delete it through automation even where
+// the collection's own rules refuse that same edit — the cards case being a
+// viewer moving a card. The floor is the collection's update/delete rule
+// evaluated as the rule owner.
+func TestTriggerRecordWriteAuthorization(t *testing.T) {
+	t.Run("owner who fails the update rule is refused", func(t *testing.T) {
+		app, rec, rule, defs := actionApp(t)
+
+		// Stand in for "viewer, not editor": a rule only the record's own
+		// creator satisfies, which this rule's owner is not.
+		col, _ := app.FindCollectionByNameOrId("things")
+		onlySomeoneElse := "@request.auth.id = 'nonexistent_user_id'"
+		col.UpdateRule = &onlySomeoneElse
+		if err := app.Save(col); err != nil {
+			t.Fatal(err)
+		}
+		rec, _ = app.FindRecordById("things", rec.Id)
+
+		err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0)
+		if err == nil {
+			t.Fatal("a rule owner who fails the collection's update rule must not move the trigger record")
+		}
+		fresh, _ := app.FindRecordById("things", rec.Id)
+		if fresh.GetString("status") == "filed" {
+			t.Fatal("the refused update must not have been written")
+		}
+		if _, ok := takeEngineWrite(rec.Id); ok {
+			t.Fatal("a refused write must not strand a provenance sentinel")
+		}
+	})
+
+	t.Run("superuser-only collection is refused", func(t *testing.T) {
+		app, rec, rule, defs := actionApp(t)
+
+		// nil rule = superuser-only in PocketBase. Acting as the rule owner
+		// here would be a straight privilege escalation, so it fails closed.
+		col, _ := app.FindCollectionByNameOrId("things")
+		col.UpdateRule = nil
+		if err := app.Save(col); err != nil {
+			t.Fatal(err)
+		}
+		rec, _ = app.FindRecordById("things", rec.Id)
+
+		if err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0); err == nil {
+			t.Fatal("a superuser-only collection must refuse a trigger-record write")
+		}
+	})
+
+	t.Run("registered authorizer can refuse what the floor allows", func(t *testing.T) {
+		app, rec, rule, defs := actionApp(t)
+		RegisterTriggerRecordAuthorizer("things:set-status",
+			func(_ core.App, _ ActionRequest, r *core.Record) error {
+				return fmt.Errorf("package says no for %s", r.Id)
+			})
+
+		err := ExecuteAction(app, defs, "things:set-status", map[string]any{"status": "filed"}, rule, openTrigger, rec, 0)
+		if err == nil {
+			t.Fatal("a registered trigger-record authorizer must be able to refuse")
+		}
+		if !strings.Contains(err.Error(), "package says no") {
+			t.Fatalf("the authorizer's reason must surface: %v", err)
+		}
+	})
+
+	t.Run("delete is gated by the delete rule", func(t *testing.T) {
+		app, rec, rule, defs := actionApp(t)
+		defs.Packages[1].Actions = append(defs.Packages[1].Actions, ActionDef{
+			ID: "drop", Kind: "record-op", Collection: "things",
+			Op: RecordOp{Type: "delete", Target: "trigger-record"},
+		})
+
+		col, _ := app.FindCollectionByNameOrId("things")
+		onlySomeoneElse := "@request.auth.id = 'nonexistent_user_id'"
+		col.DeleteRule = &onlySomeoneElse
+		if err := app.Save(col); err != nil {
+			t.Fatal(err)
+		}
+		rec, _ = app.FindRecordById("things", rec.Id)
+
+		if err := ExecuteAction(app, defs, "things:drop", nil, rule, openTrigger, rec, 0); err == nil {
+			t.Fatal("a rule owner who fails the delete rule must not delete the trigger record")
+		}
+		if _, err := app.FindRecordById("things", rec.Id); err != nil {
+			t.Fatal("the record must still exist after a refused delete")
+		}
+	})
 }
 
 // TestFailedSaveLeavesNoSentinel proves the mark-before-write ordering
@@ -235,6 +341,7 @@ func pkgaccessApp(t *testing.T) (*tests.TestApp, *core.Record, *core.Record, *co
 	if err := app.Save(src); err != nil {
 		t.Fatal(err)
 	}
+	allowAuthedWrites(t, app, src)
 
 	registry, err := app.FindCollectionByNameOrId("pkg_registry")
 	if err != nil {
@@ -406,6 +513,7 @@ func relationGateApp(t *testing.T) (app *tests.TestApp, u1, u2, rule, crate, box
 	if err := app.Save(crates); err != nil {
 		t.Fatal(err)
 	}
+	allowAuthedWrites(t, app, crates)
 	rulesCol := core.NewBaseCollection("fake_rules")
 	rulesCol.Fields.Add(&core.TextField{Name: "scope"})
 	rulesCol.Fields.Add(&core.TextField{Name: "owner"})

--- a/core/server/automation/endpoints.go
+++ b/core/server/automation/endpoints.go
@@ -74,7 +74,10 @@ func (e *Engine) ownerFilterFor(trigger TriggerDef) (string, bool) {
 }
 
 func (e *Engine) dryRun(caller *core.Record, triggerRef string, ast ConditionsAST) (dryRunResult, error) {
-	var out dryRunResult
+	// Non-nil so zero matches marshals to [] rather than null: the client maps
+	// over this array, and a null crashes the dry-run panel on the very common
+	// "conditions match nothing yet" case.
+	out := dryRunResult{Matches: []dryRunMatch{}}
 	trigger, _, ok := e.defs.Trigger(triggerRef)
 	if !ok || trigger.Synthetic != "" {
 		return out, fmt.Errorf("unknown or synthetic trigger %q", triggerRef)

--- a/core/server/automation/endpoints_test.go
+++ b/core/server/automation/endpoints_test.go
@@ -2,8 +2,10 @@
 package automation
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/pocketbase/pocketbase/core"
 
@@ -76,6 +78,49 @@ func TestDryRunScoping(t *testing.T) {
 	}
 }
 
+// TestDryRunZeroMatchesMarshalsToEmptyArray pins the wire shape, not just the
+// Go value: the client maps over `matches`, so a nil slice serializing to
+// `null` crashes the dry-run panel on the ordinary "nothing matches yet" case.
+func TestDryRunZeroMatchesMarshalsToEmptyArray(t *testing.T) {
+	app, eng, u := engineApp(t)
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	r := core.NewRecord(col)
+	r.Set("title", "routine")
+	r.Set("user", u.Id)
+	if err := app.Save(r); err != nil {
+		t.Fatal(err)
+	}
+	ast := ConditionsAST{Match: "all", Groups: []ConditionGroup{{
+		Match:      "any",
+		Conditions: []Condition{{Field: "title", Op: "contains", Value: "matches-nothing"}},
+	}}}
+
+	res, err := eng.dryRun(u, "tickets:ticket-created", ast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Matches) != 0 {
+		t.Fatalf("expected no matches, got %d", len(res.Matches))
+	}
+	b, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"matches":[]`) {
+		t.Fatalf("zero matches must marshal to [], got %s", b)
+	}
+
+	// An error return must not emit `null` either — the client parses the body
+	// on the failure path too.
+	bad, err := eng.dryRun(u, "tickets:no-such-trigger", ast)
+	if err == nil {
+		t.Fatal("unknown trigger must error")
+	}
+	if b, _ := json.Marshal(bad); !strings.Contains(string(b), `"matches":[]`) {
+		t.Fatalf("error result must still marshal matches as [], got %s", b)
+	}
+}
+
 // TestDryRunUnscopedRequiresAdmin covers the "collection has no resolvable
 // owner field" branch: ownerFilterFor returns ok=false for "broadcasts" (no
 // user/owner/author relation), so dry-run can't scope results to the caller.
@@ -116,18 +161,20 @@ func TestDryRunUnscopedRequiresAdmin(t *testing.T) {
 // TestCoreNotifyHandler exercises the real core:notify handler as Register
 // installs it — not a test-local stub (actions_test.go's
 // TestNativeDispatchAndMissingHandler registers its own) — and asserts it
-// goes through the notifyUser seam rather than calling notify.NotifyUser
-// directly, so a test can observe it without racing real push I/O.
+// goes through the deliverNotification seam rather than calling
+// notify.DeliverToUser directly, so a test can observe it without racing real
+// push I/O.
 func TestCoreNotifyHandler(t *testing.T) {
 	t.Cleanup(ResetRegistriesForTest)
 	registerCoreNativeActions()
 
 	captured := make(chan notify.NotifyParams, 1)
-	original := notifyUser
-	notifyUser = func(app core.App, params notify.NotifyParams) {
+	original := deliverNotification
+	deliverNotification = func(app core.App, params notify.NotifyParams) error {
 		captured <- params
+		return nil
 	}
-	t.Cleanup(func() { notifyUser = original })
+	t.Cleanup(func() { deliverNotification = original })
 
 	app, rule := runsApp(t)
 	defs := &Defs{Packages: []PackageDefs{{
@@ -147,6 +194,9 @@ func TestCoreNotifyHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Synchronous: the handler has returned, so the notification is already
+	// delivered. It used to run on a detached goroutine, which is why the
+	// action recorded "ok" before delivery had even been attempted.
 	select {
 	case params := <-captured:
 		if params.Type != "automation" || params.Package != "core" {
@@ -158,7 +208,39 @@ func TestCoreNotifyHandler(t *testing.T) {
 		if params.UserID != rule.GetString("owner") {
 			t.Fatalf("UserID must be the rule owner: got %q want %q", params.UserID, rule.GetString("owner"))
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for the async core:notify handler")
+	default:
+		t.Fatal("core:notify must deliver before returning, so its run result reflects the outcome")
+	}
+}
+
+// A failed delivery must surface as a failed action, not a cheerful "ok".
+// Before the handler ran synchronously, a notification that never landed left
+// run history looking healthy — and auto-disable could never see it failing.
+func TestCoreNotifyReportsDeliveryFailure(t *testing.T) {
+	t.Cleanup(ResetRegistriesForTest)
+	registerCoreNativeActions()
+
+	original := deliverNotification
+	deliverNotification = func(core.App, notify.NotifyParams) error {
+		return fmt.Errorf("notifications collection unavailable")
+	}
+	t.Cleanup(func() { deliverNotification = original })
+
+	app, rule := runsApp(t)
+	defs := &Defs{Packages: []PackageDefs{{
+		Slug: "core",
+		Actions: []ActionDef{{
+			ID: "notify", Kind: "native",
+			Params: []ParamDef{{Key: "title"}},
+		}},
+	}}}
+
+	err := ExecuteAction(app, defs, "core:notify",
+		map[string]any{"title": "x"}, rule, TriggerDef{}, nil, 0)
+	if err == nil {
+		t.Fatal("a failed notification must fail the action")
+	}
+	if !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("the reason must reach run history: %v", err)
 	}
 }

--- a/core/server/automation/engine.go
+++ b/core/server/automation/engine.go
@@ -4,6 +4,8 @@ package automation
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"runtime/debug"
 	"sort"
 	"time"
 
@@ -215,9 +217,24 @@ func (e *Engine) worker(ctx context.Context) {
 			if !appIsLive(e.app) {
 				return
 			}
-			e.dispatch(ev)
+			e.dispatchSafely(ev)
 		}
 	}
+}
+
+// dispatchSafely contains a panic to the one event that caused it. The worker
+// is the only consumer of the queue, so an unwinding panic here would take the
+// process down and leave every later trigger unserved — a single malformed rule
+// must not become a crash loop.
+func (e *Engine) dispatchSafely(ev event) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("dispatch panicked, dropping event",
+				"trigger", ev.TriggerRef, "rule", ev.RuleID, "panic", r,
+				"stack", string(debug.Stack()))
+		}
+	}()
+	e.dispatch(ev)
 }
 
 // DispatchForTest runs one event synchronously.
@@ -283,13 +300,22 @@ func (e *Engine) dispatch(ev event) {
 		ownerSet[id] = true
 	}
 
+	// An org rule's stop halts everything downstream; a personal rule's stop
+	// halts only that owner's later rules. A shared-audience trigger (a team
+	// mailbox, a board everyone watches) dispatches one event to every member's
+	// personal rules, so a global stop would let whoever happens to sort first
+	// silently switch off everybody else's automation.
 	stopped := false
+	stoppedOwners := map[string]bool{}
 	for _, rule := range rules {
 		if stopped {
 			break
 		}
 		if rule.Id == ev.SourceRule {
 			continue // a rule never re-fires on its own write
+		}
+		if stoppedOwners[rule.GetString("owner")] {
+			continue
 		}
 		// No record → no owner to resolve (ResolveOwners returns nil); the
 		// rule firing IS the owner's context (e.g. a scheduled rule), so the
@@ -332,7 +358,10 @@ func (e *Engine) dispatch(ev event) {
 			if rule.GetString("scope") == "org" {
 				stopped = true // org stop halts everything downstream
 			} else {
-				stopped = true // personal stop halts later personal rules — org already ran (org-first ordering)
+				// Personal stop: only this owner's later rules. Org rules have
+				// already run (org-first ordering), so nothing of theirs is
+				// skipped by stopping here.
+				stoppedOwners[rule.GetString("owner")] = true
 			}
 		}
 	}
@@ -353,6 +382,17 @@ func (timeoutErr) Error() string { return "action timed out" }
 func (e *Engine) runActionWithTimeout(a storedAction, rule *core.Record, ev event) error {
 	done := make(chan error, 1)
 	go func() {
+		// A handler panic must surface as a failed action on this rule's run,
+		// not as a dead process: this goroutine is separate from the worker's,
+		// so the worker's recover cannot see it.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("action panicked",
+					"action", a.Ref, "rule", rule.Id, "panic", r,
+					"stack", string(debug.Stack()))
+				done <- fmt.Errorf("action %s panicked: %v", a.Ref, r)
+			}
+		}()
 		done <- ExecuteAction(e.app, e.defs, a.Ref, a.Params, rule, ev.Trigger, ev.Record, ev.Depth)
 	}()
 	select {

--- a/core/server/automation/engine_test.go
+++ b/core/server/automation/engine_test.go
@@ -2,6 +2,7 @@
 package automation
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +54,7 @@ func engineApp(t *testing.T) (core.App, *Engine, *core.Record) {
 	if err := app.Save(col); err != nil {
 		t.Fatal(err)
 	}
+	allowAuthedWrites(t, app, col)
 
 	// broadcasts: no user/owner/author relation at all — exercises the
 	// unscoped dry-run path (TestDryRunUnscopedRequiresAdmin), which
@@ -86,6 +88,10 @@ func engineApp(t *testing.T) (core.App, *Engine, *core.Record) {
 				"title": {Literal: "clone"},
 				"user":  {Context: "owner"},
 			}},
+		}, {
+			// boom's handler panics, so a test can assert the engine records a
+			// failed run rather than taking the process down with it.
+			ID: "boom", Label: "boom", Kind: "native",
 		}},
 	}}}
 	eng := NewEngine(app, defs)
@@ -270,6 +276,101 @@ func TestStopProcessingAndOrdering(t *testing.T) {
 	}
 }
 
+// TestPersonalStopIsScopedToItsOwner is the N5 regression. A shared-audience
+// trigger (a team mailbox, a board everyone watches) dispatches ONE event to
+// every member's personal rules. A personal stop_processing must therefore halt
+// only its own owner's later rules — before the fix it set a global flag, so
+// whoever sorted first silently switched off everybody else's automation.
+func TestPersonalStopIsScopedToItsOwner(t *testing.T) {
+	app, _, u := engineApp(t)
+
+	users, _ := app.FindCollectionByNameOrId("users")
+	other := core.NewRecord(users)
+	other.Set("email", "other@example.com")
+	other.Set("username", "otheruser")
+	other.Set("name", "Other")
+	other.Set("role", "member")
+	other.SetPassword("0123456789")
+	if err := app.Save(other); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both users are in the audience for every ticket — the shared-mailbox
+	// shape, where one record legitimately belongs to several people.
+	RegisterOwnerResolver("tickets:ticket-created", func(core.App, *core.Record) []string {
+		return []string{u.Id, other.Id}
+	})
+
+	// u's rule stops processing; it sorts first, so before the fix it halted
+	// the loop outright and other's rule never ran.
+	stopper := makeRule(t, app, u.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "from-u"}}}, 0, true)
+	uLater := makeRule(t, app, u.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "u-later"}}}, 1, false)
+	otherRule := makeRule(t, app, other.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "from-other"}}}, 2, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "shared")
+	rec.Set("user", u.Id)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForRuns(t, app, stopper.Id, 1)
+	waitForRuns(t, app, otherRule.Id, 1)
+
+	// u's own later rule is still skipped — that is what stop_processing means.
+	time.Sleep(200 * time.Millisecond)
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0,
+		map[string]any{"id": uLater.Id})
+	if len(runs) != 0 {
+		t.Fatalf("a personal stop must still skip its OWN owner's later rules, got %d runs", len(runs))
+	}
+}
+
+// An org rule's stop is deliberately global: it speaks for the deployment, not
+// for one person, so it halts every owner's personal rules downstream.
+func TestOrgStopHaltsEveryOwner(t *testing.T) {
+	app, _, u := engineApp(t)
+
+	users, _ := app.FindCollectionByNameOrId("users")
+	other := core.NewRecord(users)
+	other.Set("email", "other2@example.com")
+	other.Set("username", "otheruser2")
+	other.Set("name", "Other Two")
+	other.Set("role", "member")
+	other.SetPassword("0123456789")
+	if err := app.Save(other); err != nil {
+		t.Fatal(err)
+	}
+	RegisterOwnerResolver("tickets:ticket-created", func(core.App, *core.Record) []string {
+		return []string{u.Id, other.Id}
+	})
+
+	orgStop := makeRule(t, app, u.Id, "org", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "org"}}}, 0, true)
+	personal := makeRule(t, app, other.Id, "personal", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "personal"}}}, 1, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "t")
+	rec.Set("user", u.Id)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForRuns(t, app, orgStop.Id, 1)
+	time.Sleep(200 * time.Millisecond)
+	runs, _ := app.FindRecordsByFilter("rule_runs", "rule = {:id}", "", 0, 0,
+		map[string]any{"id": personal.Id})
+	if len(runs) != 0 {
+		t.Fatalf("an org stop must halt other owners' rules too, got %d runs", len(runs))
+	}
+}
+
 func TestStartIsIdempotent(t *testing.T) {
 	app, eng, _ := engineApp(t)
 
@@ -364,6 +465,129 @@ func TestChainDepthExceededRunRow(t *testing.T) {
 	if len(summary) != 0 {
 		t.Fatalf("chain-depth-exceeded row must have an empty trigger_summary, got %+v", summary)
 	}
+}
+
+// TestNativeWriteProvenanceStopsChain is the B2 regression: a native handler
+// that creates a record in the collection its own trigger watches must stamp
+// provenance via MarkEngineWrite so the chain terminates at maxChainDepth.
+// Without the stamp every generation looks like a fresh user write (depth 0)
+// and the handler recurses until the process dies.
+func TestNativeWriteProvenanceStopsChain(t *testing.T) {
+	app, _, u := engineApp(t)
+	col, _ := app.FindCollectionByNameOrId("tickets")
+
+	var created int
+	RegisterAction("tickets:boom", func(app core.App, req ActionRequest) error {
+		created++
+		if created > 50 {
+			return nil // safety valve: without the fix this never terminates
+		}
+		made := core.NewRecord(col)
+		made.Set("id", core.GenerateDefaultRandomId())
+		made.Set("title", "native clone")
+		made.Set("user", u.Id)
+		return MarkEngineWrite(req, made.Id, func() error { return app.Save(made) })
+	})
+	makeRule(t, app, u.Id, "org", nil,
+		[]any{map[string]any{"ref": "tickets:boom"}}, 0, false)
+
+	seed := core.NewRecord(col)
+	seed.Set("title", "seed")
+	seed.Set("user", u.Id)
+	if err := app.Save(seed); err != nil {
+		t.Fatal(err)
+	}
+
+	// The chain must go quiet on its own. Poll until the handler stops being
+	// invoked, then assert it stopped because of the depth cap rather than the
+	// safety valve.
+	stable, last := 0, -1
+	for range 100 {
+		if created == last {
+			if stable++; stable >= 5 {
+				break
+			}
+		} else {
+			stable, last = 0, created
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if created == 0 {
+		t.Fatal("the native action never ran")
+	}
+	if created > maxChainDepth+1 {
+		t.Fatalf("native writes must stop at the depth cap, handler ran %d times", created)
+	}
+}
+
+// TestActionPanicRecordsFailedRun proves a panicking native handler becomes a
+// failed action result instead of a dead process. The handler runs on its own
+// goroutine, so only its own recover can contain it.
+func TestActionPanicRecordsFailedRun(t *testing.T) {
+	app, _, u := engineApp(t)
+	RegisterAction("tickets:boom", func(core.App, ActionRequest) error {
+		panic("handler exploded")
+	})
+	rule := makeRule(t, app, u.Id, "org", nil,
+		[]any{map[string]any{"ref": "tickets:boom"}}, 0, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "t")
+	rec.Set("user", u.Id)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	runs := waitForRuns(t, app, rule.Id, 1)
+	if !runs[0].GetBool("matched") {
+		t.Fatal("the rule matched, so the run row must say so")
+	}
+	var results []ActionResult
+	if err := json.Unmarshal([]byte(runs[0].GetString("results")), &results); err != nil {
+		t.Fatalf("decode results: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != "error" {
+		t.Fatalf("panicking action must record an error result, got %+v", results)
+	}
+	if !strings.Contains(results[0].Message, "panicked") {
+		t.Fatalf("result message should name the panic, got %q", results[0].Message)
+	}
+}
+
+// TestDispatchPanicDoesNotKillWorker proves the worker survives a panic raised
+// in dispatch itself (outside the action goroutine) and keeps serving later
+// events. Before the recover, one such panic unwound the only queue consumer
+// and every subsequent trigger went unserved.
+func TestDispatchPanicDoesNotKillWorker(t *testing.T) {
+	app, eng, u := engineApp(t)
+
+	// An owner resolver runs inside dispatch, on the worker's goroutine.
+	panicOnce := true
+	RegisterOwnerResolver("tickets:ticket-created", func(core.App, *core.Record) []string {
+		if panicOnce {
+			panicOnce = false
+			panic("resolver exploded")
+		}
+		return []string{u.Id}
+	})
+
+	trigger, _, _ := eng.defs.Trigger("tickets:ticket-created")
+	rule := makeRule(t, app, u.Id, "org", nil,
+		[]any{map[string]any{"ref": "tickets:set-status", "params": map[string]any{"status": "after-panic"}}}, 0, false)
+
+	col, _ := app.FindCollectionByNameOrId("tickets")
+	rec := core.NewRecord(col)
+	rec.Set("title", "t")
+	rec.Set("user", u.Id)
+	if err := app.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	// The Save above enqueued the panicking dispatch. If the worker died, this
+	// second event is never served and waitForRuns times out.
+	eng.enqueue(event{TriggerRef: "tickets:ticket-created", Trigger: trigger, Record: rec})
+	waitForRuns(t, app, rule.Id, 1)
 }
 
 // TestManualRunOfDisabledRuleStillExecutes proves the manual-run endpoint's

--- a/core/server/automation/eval.go
+++ b/core/server/automation/eval.go
@@ -180,12 +180,12 @@ func evalCondition(c Condition, record *core.Record) bool {
 	return false
 }
 
-func evalGroup(g ConditionGroup, record *core.Record, exposed map[string]bool, gate bool) bool {
+func evalGroup(g ConditionGroup, record *core.Record, exposed map[string]bool) bool {
 	if len(g.Conditions) == 0 {
 		return true
 	}
 	for _, c := range g.Conditions {
-		hit := (!gate || exposed[c.Field]) && evalCondition(c, record)
+		hit := exposed[c.Field] && evalCondition(c, record)
 		if g.Match == "any" && hit {
 			return true
 		}
@@ -205,21 +205,21 @@ func evalGroup(g ConditionGroup, record *core.Record, exposed map[string]bool, g
 // caller probe curated-away/hidden columns via match/no-match (e.g.
 // starts_with as a binary-search oracle over a hidden field's value).
 //
-// record == nil (scheduled trigger): unchanged from pre-fix behavior — there
-// is no record whose fields could leak, so the exposure gate doesn't apply;
-// an empty AST still matches, a non-empty AST falls through to evalCondition
-// exactly as before this fix.
+// record == nil (scheduled and manual "run now" dispatch): there is no record
+// to test, so a non-empty AST cannot be satisfied and evaluates to a non-match.
+// Every evalCondition branch reads the record, so this guard is what keeps
+// those paths from dereferencing nil — a rule saved with conditions still
+// reaches here on both. An empty AST matches, as it does everywhere else.
 func EvaluateConditions(ast ConditionsAST, record *core.Record, trigger TriggerDef) bool {
 	if len(ast.Groups) == 0 {
 		return true
 	}
-	gate := record != nil
-	var exposed map[string]bool
-	if gate {
-		exposed = exposedFields(record, trigger)
+	if record == nil {
+		return false
 	}
+	exposed := exposedFields(record, trigger)
 	for _, g := range ast.Groups {
-		hit := evalGroup(g, record, exposed, gate)
+		hit := evalGroup(g, record, exposed)
 		if ast.Match == "any" && hit {
 			return true
 		}

--- a/core/server/automation/eval_test.go
+++ b/core/server/automation/eval_test.go
@@ -150,6 +150,41 @@ func TestConditionsFailClosedOnNonExposedFields(t *testing.T) {
 	}
 }
 
+// TestConditionsWithoutRecordFailClosed covers the scheduled and manual
+// "run now" dispatch paths, which both fire with Record == nil. A rule saved
+// with conditions still reaches EvaluateConditions on those paths, so every
+// operator must fail closed instead of dereferencing the nil record.
+func TestConditionsWithoutRecordFailClosed(t *testing.T) {
+	if !EvaluateConditions(ConditionsAST{}, nil, openEvalTrigger) {
+		t.Fatal("empty AST must still match without a record")
+	}
+
+	// One case per branch of evalCondition's operator switch: each of these
+	// reads the record, so a missing nil guard panics rather than not-matching.
+	for _, c := range []Condition{
+		cond("subject", "contains", "invoice"),
+		cond("subject", "not_contains", "invoice"),
+		cond("subject", "equals", "invoice"),
+		cond("subject", "starts_with", "invoice"),
+		cond("size", "eq", 1500),
+		cond("size", "neq", 1500),
+		cond("size", "gt", 1),
+		cond("size", "lt", 9999),
+		cond("flagged", "is_true", nil),
+		cond("flagged", "is_false", nil),
+		cond("happened", "before", "2030-01-01"),
+		cond("happened", "after", "2000-01-01"),
+		cond("happened", "within_last_days", 7),
+		cond("tags", "is", "a"),
+		cond("tags", "is_not", "a"),
+		cond("subject", "is_empty", nil),
+	} {
+		if EvaluateConditions(one(c), nil, openEvalTrigger) {
+			t.Fatalf("op %q must fail closed without a record, got a match", c.Op)
+		}
+	}
+}
+
 func TestWatchChanged(t *testing.T) {
 	app, r := evalRecord(t)
 	r.Set("subject", "Changed subject")

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -2,6 +2,7 @@
 package automation
 
 import (
+	"fmt"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 
@@ -60,29 +61,30 @@ func registerCoreNativeActions() {
 		return nil
 	})
 
-	// core:notify is fire-and-forget: the handler returns nil immediately and
-	// the actual push happens on a detached goroutine. The engine records this
-	// action's ActionResult as "ok" the instant the handler returns, before
-	// notifyUser has run (or even before its liveness check) — a delivery
-	// failure inside the goroutine is invisible to rule_runs.results.
+	// Runs SYNCHRONOUSLY so the action's run result reflects what happened.
+	// It used to hand the work to a detached goroutine and return nil at once,
+	// which recorded "ok" before delivery had even been attempted — a rule
+	// whose notification never landed looked healthy in run history, and
+	// auto-disable could never see it failing.
+	//
+	// The write itself is cheap (one row); DeliverToUser keeps the PUSH
+	// dispatch best-effort internally, so an unreachable device still is not a
+	// rule failure. The engine's per-action timeout bounds this either way.
+	//
+	// deliverNotification is runs.go's package-level seam — tests intercept it
+	// to assert on the notification without racing real push I/O against app
+	// teardown (same rationale as the auto-disable notification's seam).
 	RegisterAction("core:notify", func(a core.App, req ActionRequest) error {
-		go func() {
-			if !appIsLive(a) {
-				return
-			}
-			// notifyUser is runs.go's package-level seam over notify.NotifyUser —
-			// tests intercept it to assert on the notification without racing the
-			// real push I/O against app teardown (same rationale as the
-			// auto-disable notification's use of the seam).
-			notifyUser(a, notify.NotifyParams{
-				UserID:  req.OwnerID,
-				Type:    "automation",
-				Package: "core",
-				Title:   req.Params["title"],
-				Body:    req.Params["body"],
-				URL:     req.Params["url"],
-			})
-		}()
-		return nil
+		if !appIsLive(a) {
+			return fmt.Errorf("core:notify: server is shutting down")
+		}
+		return deliverNotification(a, notify.NotifyParams{
+			UserID:  req.OwnerID,
+			Type:    "automation",
+			Package: "core",
+			Title:   req.Params["title"],
+			Body:    req.Params["body"],
+			URL:     req.Params["url"],
+		})
 	})
 }

--- a/core/server/automation/registry.go
+++ b/core/server/automation/registry.go
@@ -29,11 +29,22 @@ type ActionRequest struct {
 	OwnerID string
 	Params  map[string]string
 	Record  *core.Record
+	// Depth is how many engine writes deep this firing already is. A handler
+	// that writes to a trigger-bound collection must pass the request to
+	// MarkEngineWrite so its output carries this provenance forward and the
+	// chain terminates at maxChainDepth.
+	Depth int
 }
 
 // ActionHandler is the function shape RegisterAction installs. See
 // ActionRequest's doc for the access-control implication: nothing upstream of
 // the handler enforces pkgaccess for native actions.
+//
+// A handler that writes to a collection any installed trigger watches MUST
+// perform that write through MarkEngineWrite. The engine cannot stamp
+// provenance for you here — it hands the handler an app and never sees the
+// Save — so an unstamped write reads as a user edit and re-fires the trigger
+// that invoked the handler, with no depth to terminate on.
 type ActionHandler func(app core.App, req ActionRequest) error
 
 // OwnerResolver maps a trigger record to the user ids the event belongs to,
@@ -58,6 +69,16 @@ type TriggerFilter func(app core.App, record *core.Record) bool
 // to allow; a returned error fails the action and lands in run history.
 type RelationAuthorizer func(app core.App, req ActionRequest, recordID string) error
 
+// TriggerRecordAuthorizer answers the may-this-rule-write-THIS-record question
+// for a record-op whose target is the trigger record. Unlike a relation param,
+// this one is optional: the engine's floor (the rule owner passes the
+// collection's own update/delete rule) is meaningful on its own here, because
+// the record was chosen by the trigger rather than supplied by the rule author.
+// Register one when a collection's rules are looser than its write semantics —
+// e.g. a board a member may view and a card they may not move. Return nil to
+// allow; an error fails the action and lands in run history.
+type TriggerRecordAuthorizer func(app core.App, req ActionRequest, record *core.Record) error
+
 var (
 	registryMu     sync.RWMutex
 	actionHandlers = map[string]ActionHandler{}
@@ -65,6 +86,8 @@ var (
 	triggerFilters = map[string]TriggerFilter{}
 	// actionRef -> paramKey -> authorizer
 	relationAuthorizers = map[string]map[string]RelationAuthorizer{}
+	// actionRef -> authorizer
+	triggerRecordAuthorizers = map[string]TriggerRecordAuthorizer{}
 )
 
 // RegisterAction installs the Go handler for a native action ref. Packages
@@ -114,6 +137,22 @@ func hasRelationAuthorizer(actionRef, paramKey string) bool {
 	return ok
 }
 
+// RegisterTriggerRecordAuthorizer installs the package's write-level check for
+// a record-op that targets the trigger record. Optional — see
+// TriggerRecordAuthorizer for when the engine's floor alone is not enough.
+func RegisterTriggerRecordAuthorizer(actionRef string, a TriggerRecordAuthorizer) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	triggerRecordAuthorizers[actionRef] = a
+}
+
+func triggerRecordAuthorizer(actionRef string) (TriggerRecordAuthorizer, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	a, ok := triggerRecordAuthorizers[actionRef]
+	return a, ok
+}
+
 // RegisterOwnerResolver overrides owner auto-detection for one trigger ref.
 func RegisterOwnerResolver(triggerRef string, r OwnerResolver) {
 	registryMu.Lock()
@@ -149,6 +188,7 @@ func ResetRegistriesForTest() {
 	ownerResolvers = map[string]OwnerResolver{}
 	triggerFilters = map[string]TriggerFilter{}
 	relationAuthorizers = map[string]map[string]RelationAuthorizer{}
+	triggerRecordAuthorizers = map[string]TriggerRecordAuthorizer{}
 }
 
 var autoOwnerFields = []string{"user", "owner", "author"}

--- a/core/server/automation/runs.go
+++ b/core/server/automation/runs.go
@@ -20,6 +20,10 @@ const (
 // notification without racing the real push I/O against app teardown.
 var notifyUser = notify.NotifyUser
 
+// deliverNotification is the reporting variant, for core:notify — an action
+// whose run result must reflect whether the notification actually landed.
+var deliverNotification = notify.DeliverToUser
+
 // appIsLive reports whether app still has a usable DB connection pool. The
 // auto-disable notification fires from a background goroutine that can
 // outlive the request/test that triggered it; checking this before touching

--- a/core/server/notify/notify.go
+++ b/core/server/notify/notify.go
@@ -26,17 +26,30 @@ type NotifyParams struct {
 
 // NotifyUser persists a notification record and dispatches push notifications
 // to all registered devices for the user.
+// NotifyUser delivers a notification, logging and swallowing any failure.
+// Callers that need to REPORT the outcome (an automation action recording a
+// run result, say) should use DeliverToUser instead.
 func NotifyUser(app core.App, params NotifyParams) {
+	_ = DeliverToUser(app, params)
+}
+
+// DeliverToUser is NotifyUser with the outcome returned rather than swallowed.
+//
+// "Delivered" means the notifications row was written — that is the durable
+// part a user can still see later. The push dispatches below are genuinely
+// best-effort (an unreachable device is not a rule failure), so they stay
+// non-fatal. A muted type is a success: the user asked not to be told.
+func DeliverToUser(app core.App, params NotifyParams) error {
 	// Check user preferences — skip if this notification type is muted
 	if isNotificationMuted(app, params.UserID, params.Type) {
-		return
+		return nil
 	}
 
 	// Insert into notifications collection
 	collection, err := app.FindCollectionByNameOrId("notifications")
 	if err != nil {
 		log.Error("failed to find notifications collection", "err", err)
-		return
+		return fmt.Errorf("notifications collection unavailable: %w", err)
 	}
 
 	record := core.NewRecord(collection)
@@ -52,7 +65,7 @@ func NotifyUser(app core.App, params NotifyParams) {
 
 	if err := app.Save(record); err != nil {
 		log.Error("failed to save notification", "userID", params.UserID, "err", err)
-		return
+		return fmt.Errorf("saving notification: %w", err)
 	}
 
 	// Dispatch web push
@@ -65,6 +78,7 @@ func NotifyUser(app core.App, params NotifyParams) {
 
 	// Dispatch Expo push
 	sendExpoPush(app, params.UserID, params)
+	return nil
 }
 
 // isNotificationMuted checks user_preferences for a muted notification type.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -182,8 +182,12 @@ Native-action caveats:
   unavailable and the UI greys it out ("needs <pkg>") —
   declared-but-unregistered is a supported state, not an error.
 - **Handlers self-enforce access** — see **Record-level authorization**
-  below for what the engine gates for you (relation params) and what stays
-  your job (everything else).
+  below for what the engine gates for you (relation params, trigger-record
+  writes) and what stays your job (everything else).
+- **A write to a trigger-bound collection must go through
+  `MarkEngineWrite`** or your handler's own output re-fires the trigger that
+  invoked it, with no depth to terminate on. See **Record-level
+  authorization** below.
 - Returning an error records the action as failed in `rule_runs` and
   continues to the rule's later actions (mail-filter semantics).
 
@@ -195,8 +199,12 @@ PocketBase collection rules therefore do NOT protect anything on this path —
 whatever check a write needs has to happen in engine or package Go. The
 division of labor:
 
-**The engine gates relation params — and only relation params.** A relation
-param's value is a caller-supplied record id (the rule JSON is
+**The engine gates two things: relation params, and writes to the trigger
+record.** Everything else is the handler's job.
+
+### Relation params
+
+A relation param's value is a caller-supplied record id (the rule JSON is
 client-authored; the picker is a convenience, not a boundary). Before an
 action of either kind runs, every non-empty relation param passes two
 fail-closed layers:
@@ -226,6 +234,60 @@ fail-closed layers:
    core's `apply-label` authorizer returns nil with a comment saying why
    (labels are org-wide by design). The point is that the decision is
    written down where review can see it.
+
+### Trigger-record writes
+
+A record-op with `target: 'trigger-record'` mutates or deletes the record the
+trigger fired on. The record wasn't chosen by the rule author, but the write is
+still a superuser one, so the engine applies its own floor: **the rule owner
+must pass the collection's `updateRule` (or `deleteRule`) for that record.** A
+nil rule means superuser-only in PocketBase and is refused rather than waved
+through.
+
+This is what stops a rule owner who can merely *see* a record from moving or
+deleting it through automation when the same edit through the UI is refused —
+a trigger fires for a whole audience (an org rule, a shared mailbox, a team
+board), so "the owner may write this package" is not the same question.
+`checkPersonalAccess` does not cover it: that is a package-level `pkgaccess`
+floor, never a per-record one.
+
+Register a `TriggerRecordAuthorizer` when the collection's own rules are looser
+than its write semantics — it runs after the floor:
+
+```go
+automation.RegisterTriggerRecordAuthorizer("cards:move-card",
+    func(app core.App, req automation.ActionRequest, record *core.Record) error {
+        return cardMovableBy(app, req.OwnerID, record)
+    })
+```
+
+Unlike a relation param's authorizer this one is optional: the floor is
+meaningful on its own here, because the record came from the trigger rather
+than from client-authored rule JSON.
+
+### Native handlers that write trigger-bound collections
+
+A record-op's writes are stamped with provenance automatically, which is how a
+rule's own output stops re-firing the rule that produced it (`maxChainDepth`).
+The engine cannot do that for a native handler — it hands you an `app` and
+never sees your `Save` — so an unstamped write reads as an ordinary user edit
+and re-fires the trigger with depth 0, forever.
+
+**If your handler writes to a collection any installed trigger watches, perform
+that write through `MarkEngineWrite`:**
+
+```go
+record.Set("id", core.GenerateDefaultRandomId()) // the sentinel is keyed by id
+return automation.MarkEngineWrite(req, record.Id, func() error {
+    return app.Save(record)
+})
+```
+
+It stamps `req`'s rule id and depth, runs the write, and removes the stamp
+again if the write fails (so a failed attempt can't suppress the next genuine
+user edit of that record). `calendar/server/automation.go`'s
+`actionCreateEvent` is the reference: `calendar:event-added` watches
+`calendar_events`, the very collection it creates into.
 
 **Everything else stays the handler's job.** The floor+authorizer pair
 covers ids the *engine* hands you; records your handler looks up itself,


### PR DESCRIPTION
Fixes the `tinycld` items from the pre-release review (`PLAN-release-review-fixes.md`).

**Blockers**
- `EvaluateConditions` dereferenced a nil record. Scheduled and manual "run now" both dispatch with no record, so any such rule saved with conditions crashed the process — a real SIGSEGV, and the doc comment claiming the path was safe was wrong.
- A panic in dispatch unwound the worker (the queue's only consumer), taking the process down; a handler panic did the same from its own goroutine. Both contained now.
- Record-ops targeting the trigger record ran as superuser with no per-record check, so an owner who could merely *see* a record could move or delete it through automation. The floor is the collection's own update/deleteRule evaluated as the owner.
- `MarkEngineWrite` is exported so a native handler writing to a trigger-bound collection stamps provenance — otherwise it re-fires its own trigger forever.

**Also**
- `stop_processing` on a personal rule halted *every* owner's rules on a shared-audience trigger.
- `core:notify` recorded "ok" before delivery was attempted, so a failing rule looked healthy and auto-disable never saw it.
- Dry-run returned `null` for zero matches, crashing the client panel on the ordinary "nothing matches yet" case.
- Rules UI: a half-typed number silently disabled a condition forever; re-picking the current trigger discarded all work; `parseRef` threw during render for a malformed stored ref, blanking the builder.
- CLI: filter placeholder injection, prompts gated on stdout instead of stdin, `auth login` orphaning a live credential, an invalid-on-Windows keychain filename, downloads ignoring umask, `search --not` silently dropping input, `version --output csv` emitting non-CSV.

Every fix has a regression test; where practical I verified the test fails without the fix.

`pnpm run lint` and `pnpm run pkg:check` are green (2040 files linted, 1433 tests).