### PR TITLE
perf(ci): cache the Playwright browser between e2e runs

### DIFF
--- a/.github/actions/configure-test-env/action.yml
+++ b/.github/actions/configure-test-env/action.yml
@@ -1,7 +1,8 @@
 name: 'Configure tinycld test environment'
 description: >-
   Shared e2e prep every tinycld package's e2e job needs, in one place: install
-  the Playwright browser and pre-build the static web bundle (`expo export`
+  the Playwright browser (cached on its version) and pre-build the static web
+  bundle (`expo export`
   with external sourcemaps). The e2e webServer (scripts/e2e-serve.ts) then
   reuses that bundle via TINYCLD_E2E_SKIP_EXPORT instead of rebuilding it, so
   the (multi-minute) export happens exactly once per job as a visible,
@@ -17,11 +18,43 @@ runs:
     # (ws/tinycld/.github/actions/configure-test-env → ../../.. = ws/tinycld).
     # A composite action's steps do NOT inherit the calling job's
     # working-directory, so resolve it explicitly from $GITHUB_ACTION_PATH.
-    - name: Install Playwright browser (chromium)
+    # Cache key is the RESOLVED Playwright version, not a lockfile hash: the
+    # browser build is pinned to the Playwright release, so two lockfiles that
+    # resolve to the same version want the same cache entry — and a lockfile
+    # change that does not move Playwright must not evict it.
+    - name: Resolve Playwright version
+      id: pw
       shell: bash
       run: |
         cd "$GITHUB_ACTION_PATH/../../.."
-        pnpm exec playwright install --with-deps chromium
+        echo "version=$(pnpm exec playwright --version | tr -d '\n' | awk '{print $NF}')" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: pw-cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+    # Split deliberately. The browser BINARY is cacheable; the apt packages
+    # --with-deps installs are not (they land in system paths the cache does not
+    # cover), and on the Ubuntu runner image nearly all of them already report
+    # "already the newest version" — so that step is mostly apt confirming there
+    # is nothing to do. Running install-deps only on a cache miss would be
+    # wrong: the cache restores ~/.cache/ms-playwright but never the system
+    # libraries, so a hit still needs them present.
+    - name: Install Playwright system dependencies
+      shell: bash
+      run: |
+        cd "$GITHUB_ACTION_PATH/../../.."
+        pnpm exec playwright install-deps chromium
+
+    - name: Install Playwright browser (chromium)
+      if: steps.pw-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd "$GITHUB_ACTION_PATH/../../.."
+        pnpm exec playwright install chromium
 
     # Pre-build the static web bundle once. e2e-serve.ts runs with
     # TINYCLD_E2E_SKIP_EXPORT=1 (set on the E2E job step) and reuses this dist/.


### PR DESCRIPTION
Every e2e job runs `playwright install --with-deps chromium` from scratch. This caches the browser binary on its resolved Playwright version.

**Measured on a real run** (cards E2E, 16m46s total) rather than estimated:

| Phase | Time |
|---|---|
| `playwright install --with-deps chromium` | **32.5s** |
| — apt system deps | ~25s |
| — Chromium download | ~6s |
| Web bundle build | ~1m40s |
| The tests themselves | 13m07s |

So this is a modest win on the long jobs (~3%) but a real one on the short ones, where prep dominates: drive spends 74s prepping vs 128s testing. Across 8 repos it's ~4 min of wall-clock per full sweep.

**Two deliberate choices:**

- **Key is the resolved Playwright version, not a lockfile hash.** The browser build is pinned to the release, so a lockfile change that doesn't move Playwright shouldn't evict the entry, and two lockfiles resolving to the same version should share it.
- **`install-deps` is split out and runs unconditionally.** Gating it on a cache miss would be a real bug: the cache restores `~/.cache/ms-playwright` but never the system libraries, so a *hit* still needs them present. The 25s is mostly apt confirming the runner image already has them.

**Not doing `channel: 'chrome'`** (the other common suggestion): it swaps Playwright's pinned Chromium for whatever Chrome the runner ships, putting the E2E browser on Google's release cadence instead of our pinned version — and our shared `use` block would flip all eight packages at once. Saves ~6s; not worth the moving dependency.

The first run on this branch will be a cache MISS (populating it); the saving shows on the second.