### PR TITLE
perf(ci): drop playwright install-deps, verify libraries instead

### DIFF
--- a/.github/actions/configure-test-env/action.yml
+++ b/.github/actions/configure-test-env/action.yml
@@ -21,7 +21,9 @@ runs:
     # Cache key is the RESOLVED Playwright version, not a lockfile hash: the
     # browser build is pinned to the Playwright release, so two lockfiles that
     # resolve to the same version want the same cache entry — and a lockfile
-    # change that does not move Playwright must not evict it.
+    # change that does not move Playwright must not evict it. The cache covers
+    # ~/.cache/ms-playwright only; see the library check below for the system
+    # side, which no cache restores.
     - name: Resolve Playwright version
       id: pw
       shell: bash
@@ -36,25 +38,49 @@ runs:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
 
-    # Split deliberately. The browser BINARY is cacheable; the apt packages
-    # --with-deps installs are not (they land in system paths the cache does not
-    # cover), and on the Ubuntu runner image nearly all of them already report
-    # "already the newest version" — so that step is mostly apt confirming there
-    # is nothing to do. Running install-deps only on a cache miss would be
-    # wrong: the cache restores ~/.cache/ms-playwright but never the system
-    # libraries, so a hit still needs them present.
-    - name: Install Playwright system dependencies
-      shell: bash
-      run: |
-        cd "$GITHUB_ACTION_PATH/../../.."
-        pnpm exec playwright install-deps chromium
-
     - name: Install Playwright browser (chromium)
       if: steps.pw-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd "$GITHUB_ACTION_PATH/../../.."
         pnpm exec playwright install chromium
+
+    # `playwright install-deps` is deliberately NOT run. On the ubuntu-latest
+    # image every library Chromium links against is already present — the
+    # 2026-08-18 logs show all 20 reporting "already the newest version", and
+    # the only 9 packages it actually installed were FONTS (21.1 MB): CJK,
+    # Thai, Cyrillic and legacy X11 bitmap faces. Nothing here renders those:
+    # no spec does pixel comparison (no toHaveScreenshot/toMatchSnapshot
+    # anywhere in the ecosystem) and no e2e assertion contains non-Latin text.
+    # Emoji already work — fonts-noto-color-emoji ships in the image.
+    #
+    # The cost was 10-80s per job depending on which apt mirror the runner drew
+    # (7s to 1m21s for the same 21.1 MB across five runs on one day), across
+    # eight repos' e2e jobs.
+    #
+    # This check is the safety net for that decision. A MISSING LIBRARY IS
+    # OTHERWISE SILENT: Chromium fails to start (or renders tofu) and, with no
+    # screenshot assertions to catch it, the suite can still go green. ldd names
+    # the missing object and fails the job here instead — so if the runner image
+    # ever drops something, this step says which library, not "some test broke".
+    #
+    # Fonts are NOT covered by this check; they are not linked objects. If a
+    # visual-regression test is ever added, restore install-deps rather than
+    # extending this.
+    - name: Verify Chromium's shared libraries are present
+      shell: bash
+      run: |
+        cd "$GITHUB_ACTION_PATH/../../.."
+        binary="$(pnpm exec node -e 'const {chromium}=require("playwright-core");console.log(chromium.executablePath())')"
+        echo "Checking $binary"
+        missing="$(ldd "$binary" | grep 'not found' || true)"
+        if [ -n "$missing" ]; then
+          echo "::error::Chromium is missing shared libraries the runner image no longer provides:"
+          echo "$missing"
+          echo "Restore 'pnpm exec playwright install-deps chromium' in this action."
+          exit 1
+        fi
+        echo "All shared libraries resolved."
 
     # Pre-build the static web bundle once. e2e-serve.ts runs with
     # TINYCLD_E2E_SKIP_EXPORT=1 (set on the E2E job step) and reuses this dist/.


### PR DESCRIPTION
Stacked on #213 (based on that branch, so the diff here is only this change).

## install-deps installs nothing Chromium links against

From the 2026-08-18 E2E logs on `ubuntu-latest`, all 20 libraries report `already the newest version` — `libnss3`, `libgbm1`, `libdrm2`, `libxkbcommon0`, `xvfb`, the lot. The only 9 packages it actually installs are **fonts** (21.1 MB, 79.5 MB on disk):

```
fonts-freefont-ttf  fonts-ipafont-gothic  fonts-tlwg-loma-otf
fonts-unifont       fonts-wqy-zenhei      xfonts-cyrillic
xfonts-encodings    xfonts-scalable       xfonts-utils
```

CJK, Thai, Cyrillic and legacy X11 bitmap faces.

## Nothing here renders them

- **No pixel comparison anywhere** — zero `toHaveScreenshot` / `toMatchSnapshot` across every repo.
- **No non-Latin text in any e2e assertion.** (The one CJK string in the codebase, `東` in the truncation test, is a *Go CLI* test — no browser.)
- **Emoji already work**: `fonts-noto-color-emoji` ships in the image and is untouched.

## The cost is mostly mirror variance

Same 21.1 MB fetch, five runs, one day:

| Run | Fetch |
|---|---|
| cards | 7s |
| drive | 10s |
| mail | 31s |
| calc | 41s |
| tinycld | **1m21s** |

A 12× spread on identical bytes — so this is 10–80s of unpredictable latency per job, across eight repos, buying fonts nothing renders.

## The ldd check is the point of this PR

**I did not simply delete the step.** The failure mode it guards against is silent: a missing library means Chromium fails to start or draws tofu, and with no screenshot assertions the suite can still go green — the worst shape of regression.

So `ldd` runs against the resolved Chromium binary and fails the job *here*, naming the missing object, if the runner image ever drops something. A future breakage reports "libfoo.so not found" at a step called "Verify Chromium's shared libraries are present", rather than surfacing as an unrelated broken test.

Verified the resolution and quoting locally (the path contains spaces on macOS, so it is quoted throughout).

**Limitation, stated plainly:** the check covers *linked objects only*. Fonts are not linked, so it would not catch a font regression. If a visual-regression test is ever added, restore `install-deps` rather than extending this check.