### PR TITLE
ci: cap every job at 30 minutes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,9 @@ jobs:
   build:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
+    # Without an explicit cap a hung job rides GitHub's 6-hour default,
+    # blocking the PR and burning a runner the whole time.
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -201,6 +204,9 @@ jobs:
     name: Merge multi-arch manifest
     needs: build
     runs-on: ubuntu-latest
+    # Without an explicit cap a hung job rides GitHub's 6-hour default,
+    # blocking the PR and burning a runner the whole time.
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Jobs without an explicit `timeout-minutes` inherit GitHub's **6-hour default**, so a hung step rides for 360 minutes — blocking the PR and holding a runner the whole time. Two e2e jobs did exactly that today, wedged ~90 minutes on an infrastructure step before being restarted manually.

This caps **every job at 30 minutes**. The slowest real work is well inside that (e2e peaks around 17 minutes, docker builds 10–13), so it only ever fires on a hang.

Pre-existing stricter caps are left alone (drive's 20-minute check, the 10-minute smoke test).

### This cannot live in the shared action

Worth recording, since it was the first thing we looked at: `timeout-minutes` is a property of the **job**, and a composite action has no way to bound its caller. `configure-test-env` runs *inside* a job that has already started its clock. So the cap has to be set per workflow — hence the identical change across every repo.