### PR TITLE
fix(rules): make the rule builder usable on native and easier to get right

### DIFF
--- a/core/components/rules/ActionsCard.tsx
+++ b/core/components/rules/ActionsCard.tsx
@@ -18,6 +18,7 @@ import { ArrowDown, ArrowUp, Braces, Plus, Trash2 } from 'lucide-react-native'
 import { newRecordId } from 'pbtsdb/core'
 import { Fragment } from 'react'
 import { Pressable, Text, View } from 'react-native'
+import { RuleCard } from './RuleCard'
 import { ValueInput } from './ValueInput'
 
 export interface ActionsCardProps {
@@ -280,9 +281,7 @@ export function ActionsCard({ draft, catalog, onChange }: ActionsCardProps) {
     }
 
     return (
-        <View className="rounded-xl border p-4 bg-surface-secondary border-border gap-3">
-            <Text className="text-sm font-semibold text-foreground">THEN</Text>
-
+        <RuleCard title="THEN" isDisabled={!trigger} disabledHint="Choose a trigger first">
             {draft.actions.map((draftAction, index) => (
                 <ActionEntry
                     // Keyed on the builder-local uid (condition-helpers.ts's
@@ -306,6 +305,6 @@ export function ActionsCard({ draft, catalog, onChange }: ActionsCardProps) {
             ))}
 
             <AddActionMenu catalog={catalog} trigger={trigger} onSelect={handleSelectAction} />
-        </View>
+        </RuleCard>
     )
 }

--- a/core/components/rules/ActionsCard.tsx
+++ b/core/components/rules/ActionsCard.tsx
@@ -9,10 +9,12 @@ import {
     appendPlaceholder,
     compatibleActions,
     moveAction,
+    orderGroupsByUserPreference,
 } from '@tinycld/core/lib/automation/condition-helpers'
 import type { RuleDraft } from '@tinycld/core/lib/automation/draft'
 import { parseRefSafe } from '@tinycld/core/lib/automation/helpers'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useSortedPackages } from '@tinycld/core/lib/use-sorted-packages'
 import { Menu } from '@tinycld/core/ui/menu'
 import { ArrowDown, ArrowUp, Braces, Plus, Trash2 } from 'lucide-react-native'
 import { newRecordId } from 'pbtsdb/core'
@@ -77,7 +79,10 @@ function AddActionMenu({
 }) {
     const mutedColor = useThemeColor('muted-foreground')
     const options = trigger ? compatibleActions(catalog, trigger) : []
-    const groups = groupActionsByPackage(options)
+    // Ordered like the trigger menu (and the sidebar): the user's own app
+    // order, with core's package-neutral actions leading.
+    const orderedSlugs = useSortedPackages().map(p => p.slug)
+    const groups = orderGroupsByUserPreference(groupActionsByPackage(options), orderedSlugs)
     const ambiguous = ambiguousLabels(options)
 
     return (
@@ -91,7 +96,7 @@ function AddActionMenu({
             <Menu.Portal>
                 <Menu.Overlay />
                 <Menu.Content presentation="popover" placement="bottom" align="start">
-                    {[...groups.entries()].map(([pkg, actions]) => (
+                    {groups.map(([pkg, actions]) => (
                         <Fragment key={pkg}>
                             <Menu.Label>{pkg}</Menu.Label>
                             {actions.map(action => (

--- a/core/components/rules/ConditionRow.tsx
+++ b/core/components/rules/ConditionRow.tsx
@@ -20,7 +20,9 @@ export interface ConditionRowProps {
     condition: ConditionRowCondition
     fields: CatalogField[]
     onChange: (patch: Partial<ConditionRowCondition>) => void
-    onRemove: () => void
+    /** Omitted by the ready-to-fill first row, which isn't in the draft yet and
+     * so has nothing to remove — a trash icon there would be dead. */
+    onRemove?: () => void
 }
 
 function FieldMenu({
@@ -103,7 +105,6 @@ function OperatorMenu({
 }
 
 export function ConditionRow({ condition, fields, onChange, onRemove }: ConditionRowProps) {
-    const mutedColor = useThemeColor('muted-foreground')
     const selectedField = fields.find(f => f.key === condition.field)
     const showValue = condition.op && !NO_VALUE_OPS.has(condition.op as ConditionOp)
 
@@ -137,9 +138,17 @@ export function ConditionRow({ condition, fields, onChange, onRemove }: Conditio
                     onChange={v => onChange({ value: v })}
                 />
             ) : null}
-            <Pressable onPress={onRemove} className="p-1.5" hitSlop={8}>
-                <Trash2 size={14} color={mutedColor} />
-            </Pressable>
+            <RemoveButton onRemove={onRemove} />
         </View>
+    )
+}
+
+function RemoveButton({ onRemove }: { onRemove: (() => void) | undefined }) {
+    const mutedColor = useThemeColor('muted-foreground')
+    if (!onRemove) return null
+    return (
+        <Pressable onPress={onRemove} className="p-1.5" hitSlop={8}>
+            <Trash2 size={14} color={mutedColor} />
+        </Pressable>
     )
 }

--- a/core/components/rules/ConditionsCard.tsx
+++ b/core/components/rules/ConditionsCard.tsx
@@ -1,11 +1,18 @@
-import type { CatalogResponse } from '@tinycld/core/lib/automation/api'
-import { addGroup, setTopMatch } from '@tinycld/core/lib/automation/condition-helpers'
+import type { CatalogField, CatalogResponse } from '@tinycld/core/lib/automation/api'
+import type { Condition } from '@tinycld/core/lib/automation/condition-helpers'
+import {
+    addGroup,
+    seedFirstCondition,
+    setTopMatch,
+} from '@tinycld/core/lib/automation/condition-helpers'
 import type { RuleDraft } from '@tinycld/core/lib/automation/draft'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { Plus } from 'lucide-react-native'
 import { Pressable, Text, View } from 'react-native'
 import { ConditionGroupBox } from './ConditionGroupBox'
+import { ConditionRow } from './ConditionRow'
 import { MatchPillPair } from './MatchPillPair'
+import { RuleCard } from './RuleCard'
 
 export interface ConditionsCardProps {
     draft: RuleDraft
@@ -13,28 +20,76 @@ export interface ConditionsCardProps {
     onChange: (patch: Partial<RuleDraft>) => void
 }
 
+const NO_TRIGGER_HINT = 'Choose a trigger first'
+// Distinct from NO_TRIGGER_HINT on purpose: "choose a trigger" is something the
+// user can act on, whereas a schedule/manual rule has no record behind it and
+// so can never have conditions. One string for both would be wrong in one case.
+const SYNTHETIC_HINT = 'This trigger has no fields to filter on'
+
+/**
+ * The ready-to-fill first condition, shown when the draft has no groups yet.
+ *
+ * Rendered, NOT seeded into the draft. Reaching a first condition used to take
+ * two clicks through "add OR group" — a control that means nothing when there
+ * is nothing to OR with — and seeding a blank row into the draft instead would
+ * break saving outright: the zod schemas require a non-empty field and at least
+ * one condition per group, so a blank row throws in draftToRecord. Keeping it
+ * render-only means an untouched builder still saves a rule with no conditions.
+ */
+function SyntheticFirstGroup({
+    isVisible,
+    fields,
+    onSeed,
+}: {
+    isVisible: boolean
+    fields: CatalogField[]
+    onSeed: (patch: Partial<Condition>) => void
+}) {
+    if (!isVisible) return null
+    return (
+        <View className="rounded-lg border p-3 gap-2.5 border-border">
+            <ConditionRow
+                condition={{ field: '', op: '', value: undefined }}
+                fields={fields}
+                onChange={onSeed}
+            />
+        </View>
+    )
+}
+
 export function ConditionsCard({ draft, catalog, onChange }: ConditionsCardProps) {
     const mutedColor = useThemeColor('muted-foreground')
     const trigger = catalog.triggers.find(t => t.ref === draft.trigger)
-    const isVisible = Boolean(trigger && !trigger.synthetic)
+    const isSynthetic = Boolean(trigger?.synthetic)
+    const isDisabled = !trigger || isSynthetic
+    const hasGroups = draft.conditions.groups.length > 0
 
-    if (!isVisible) return null
+    const handleSeed = (patch: Partial<Condition>) =>
+        onChange({ conditions: seedFirstCondition(draft.conditions, patch) })
+
+    const matchPills = (
+        <View className="flex-row items-center gap-2">
+            <Text className="text-xs text-muted-foreground">Match</Text>
+            <MatchPillPair
+                match={draft.conditions.match}
+                onSelect={match => onChange({ conditions: setTopMatch(draft.conditions, match) })}
+            />
+            <Text className="text-xs text-muted-foreground">groups</Text>
+        </View>
+    )
 
     return (
-        <View className="rounded-xl border p-4 bg-surface-secondary border-border gap-3">
-            <View className="flex-row items-center justify-between">
-                <Text className="text-sm font-semibold text-foreground">IF</Text>
-                <View className="flex-row items-center gap-2">
-                    <Text className="text-xs text-muted-foreground">Match</Text>
-                    <MatchPillPair
-                        match={draft.conditions.match}
-                        onSelect={match =>
-                            onChange({ conditions: setTopMatch(draft.conditions, match) })
-                        }
-                    />
-                    <Text className="text-xs text-muted-foreground">groups</Text>
-                </View>
-            </View>
+        <RuleCard
+            title="IF"
+            isDisabled={isDisabled}
+            disabledHint={trigger ? SYNTHETIC_HINT : NO_TRIGGER_HINT}
+            trailing={matchPills}
+        >
+            <SyntheticFirstGroup
+                isVisible={!isDisabled && !hasGroups}
+                fields={trigger?.fields ?? []}
+                onSeed={handleSeed}
+            />
 
             {draft.conditions.groups.map((group, groupIndex) => (
                 <ConditionGroupBox
@@ -50,13 +105,16 @@ export function ConditionsCard({ draft, catalog, onChange }: ConditionsCardProps
                 />
             ))}
 
+            {/* Secondary to the "add condition" link inside each group: adding a
+                whole OR group is the rarer, more advanced move, and leading with
+                it is what made the first condition hard to find. */}
             <Pressable
                 onPress={() => onChange({ conditions: addGroup(draft.conditions) })}
-                className="self-start flex-row items-center gap-1 py-1"
+                className="self-start flex-row items-center gap-1 py-1 opacity-70"
             >
-                <Plus size={13} color={mutedColor} />
-                <Text className="text-xs text-muted-foreground">add OR group</Text>
+                <Plus size={12} color={mutedColor} />
+                <Text className="text-[11px] text-muted-foreground">add OR group</Text>
             </Pressable>
-        </View>
+        </RuleCard>
     )
 }

--- a/core/components/rules/ConditionsCard.tsx
+++ b/core/components/rules/ConditionsCard.tsx
@@ -1,6 +1,7 @@
 import type { CatalogField, CatalogResponse } from '@tinycld/core/lib/automation/api'
 import type { Condition } from '@tinycld/core/lib/automation/condition-helpers'
 import {
+    addCondition,
     addGroup,
     seedFirstCondition,
     setTopMatch,
@@ -67,6 +68,18 @@ export function ConditionsCard({ draft, catalog, onChange }: ConditionsCardProps
     const handleSeed = (patch: Partial<Condition>) =>
         onChange({ conditions: seedFirstCondition(draft.conditions, patch) })
 
+    // Adding the FIRST group has to carry a condition row with it. The offered
+    // row above is render-only and disappears the moment a real group exists,
+    // so appending an empty group would make the row the user was looking at
+    // vanish and be replaced by a group with nothing in it — the work they were
+    // about to do, silently discarded. Later groups start empty as before.
+    const handleAddGroup = () =>
+        onChange({
+            conditions: hasGroups
+                ? addGroup(draft.conditions)
+                : addCondition(addGroup(draft.conditions), 0),
+        })
+
     const matchPills = (
         <View className="flex-row items-center gap-2">
             <Text className="text-xs text-muted-foreground">Match</Text>
@@ -109,7 +122,7 @@ export function ConditionsCard({ draft, catalog, onChange }: ConditionsCardProps
                 whole OR group is the rarer, more advanced move, and leading with
                 it is what made the first condition hard to find. */}
             <Pressable
-                onPress={() => onChange({ conditions: addGroup(draft.conditions) })}
+                onPress={handleAddGroup}
                 className="self-start flex-row items-center gap-1 py-1 opacity-70"
             >
                 <Plus size={12} color={mutedColor} />

--- a/core/components/rules/RuleBuilder.tsx
+++ b/core/components/rules/RuleBuilder.tsx
@@ -68,7 +68,8 @@ function BuilderContent({
     presetPkg,
     nextOrder = 0,
     sessionKey,
-}: Omit<RuleBuilderProps, 'isOpen'> & { sessionKey: number }) {
+    isMobile,
+}: Omit<RuleBuilderProps, 'isOpen'> & { sessionKey: number; isMobile: boolean }) {
     const { record, isReady: recordReady } = useEditingRecord(ruleId)
     const { catalog, isReady: catalogReady } = useAutomationCatalog()
     const { save } = useRuleMutations()
@@ -108,6 +109,7 @@ function BuilderContent({
             catalog={catalog}
             isLocked={Boolean(ruleId)}
             isSaving={save.isPending}
+            isMobile={isMobile}
             onSave={draft => save.mutate(draft, { onSuccess: onClose })}
         />
     )
@@ -142,7 +144,26 @@ interface RuleBuilderFormProps {
     catalog: NonNullable<ReturnType<typeof useAutomationCatalog>['catalog']>
     isLocked: boolean
     isSaving: boolean
+    isMobile: boolean
     onSave: (draft: RuleDraft) => void
+}
+
+// The scroll region's sizing differs by shell, because the two shells bound
+// their content differently.
+//
+// Modal: ModalContent is `overflow-hidden` with no height of its own, so the
+// form caps it (max-h-[85vh] below) and the middle band takes whatever is left
+// via flex — `min-h-0` is required, since RN's `min-height: auto` default
+// otherwise refuses to shrink a flex child below its content and the cap is
+// ignored, clipping the footer off-screen.
+//
+// BottomDrawer: the sheet measures its own height from its content (onLayout)
+// and caps at 85% of the screen. A `flex-1` child inside an intrinsically-sized
+// parent has no definite height to flex against and can collapse to zero, so
+// the drawer path keeps an explicit cap instead. 70vh sits under the sheet's
+// own 85% so the header and footer stay inside the sheet.
+function scrollRegionClass(isMobile: boolean): string {
+    return isMobile ? 'max-h-[70vh]' : 'flex-1 min-h-0'
 }
 
 function RuleBuilderForm({
@@ -152,6 +173,7 @@ function RuleBuilderForm({
     catalog,
     isLocked,
     isSaving,
+    isMobile,
     onSave,
 }: RuleBuilderFormProps) {
     const { draft, patch, errors, validate } = useRuleDraft(initial)
@@ -162,10 +184,10 @@ function RuleBuilderForm({
     }
 
     return (
-        <View className="gap-4">
+        <View className={isMobile ? 'gap-4' : 'gap-4 flex-1 min-h-0'}>
             <BuilderHeader isLocked={isLocked} onClose={onClose} />
 
-            <ScrollView className="max-h-[70vh]">
+            <ScrollView className={scrollRegionClass(isMobile)}>
                 <View className="gap-4 pb-2">
                     <PlainInput
                         value={draft.name}
@@ -226,11 +248,19 @@ function BuilderErrors({ errors }: { errors: string[] | null }) {
             <Text className="text-sm font-semibold text-danger mb-2">
                 Please fix the following errors:
             </Text>
-            {errors.map(error => (
-                <Text key={error} className="text-xs text-danger mb-1">
-                    {error}
-                </Text>
-            ))}
+            {/* Capped and scrollable: validateDraft emits one error per invalid
+                condition AND per missing action param, so a badly-filled rule can
+                produce a list tall enough to squeeze the scroll region above it to
+                nothing. max-h is intrinsic-until-cap, so the common one- or
+                two-error case still renders at natural height. The heading stays
+                outside so it is never scrolled out of view. */}
+            <ScrollView className="max-h-[20vh]">
+                {errors.map(error => (
+                    <Text key={error} className="text-xs text-danger mb-1">
+                        {error}
+                    </Text>
+                ))}
+            </ScrollView>
         </View>
     )
 }
@@ -314,6 +344,7 @@ export function RuleBuilder({
                         presetPkg={presetPkg}
                         nextOrder={nextOrder}
                         sessionKey={session.current.count}
+                        isMobile
                     />
                 </View>
             </BottomDrawer>
@@ -323,7 +354,13 @@ export function RuleBuilder({
     return (
         <Modal isOpen={isOpen} onClose={onClose} size="lg">
             <ModalBackdrop />
-            <ModalContent>
+            {/* ModalContent is `overflow-hidden` with no height of its own, so
+                without this cap the form's header + scroll region + errors +
+                footer can exceed the viewport and the excess is CLIPPED — and
+                because modalStyle centers the content, what gets clipped is the
+                footer, stranding Save and Cancel off-screen. 85vh matches
+                BottomDrawer's own 85% cap. */}
+            <ModalContent className="max-h-[85vh]">
                 <BuilderContent
                     onClose={onClose}
                     scope={scope}
@@ -331,6 +368,7 @@ export function RuleBuilder({
                     presetPkg={presetPkg}
                     nextOrder={nextOrder}
                     sessionKey={session.current.count}
+                    isMobile={false}
                 />
             </ModalContent>
         </Modal>

--- a/core/components/rules/RuleBuilder.tsx
+++ b/core/components/rules/RuleBuilder.tsx
@@ -16,7 +16,7 @@ import { PlainInput } from '@tinycld/core/ui/PlainInput'
 import { Switch } from '@tinycld/core/ui/switch'
 import { X } from 'lucide-react-native'
 import { useEffect, useRef } from 'react'
-import { ActivityIndicator, ScrollView, Text, View } from 'react-native'
+import { ActivityIndicator, ScrollView, Text, type TextInput, View } from 'react-native'
 import { ActionsCard } from './ActionsCard'
 import { ConditionsCard } from './ConditionsCard'
 import { DryRunPanel } from './DryRunPanel'
@@ -177,6 +177,26 @@ function RuleBuilderForm({
     onSave,
 }: RuleBuilderFormProps) {
     const { draft, patch, errors, validate } = useRuleDraft(initial)
+    const nameRef = useRef<TextInput>(null)
+
+    // Naming the rule is the first thing every new rule needs, so start there
+    // rather than making the user click in.
+    //
+    // Only for a NEW rule on the modal: opening an existing rule is usually to
+    // change a condition or an action, so grabbing focus (and on touch, raising
+    // the keyboard over the sheet whose height is measured from its content)
+    // would fight what the user came to do.
+    const shouldFocusName = !isLocked && !isMobile
+
+    // `autoFocus` alone is not enough — GlueStack's overlay installs a focus
+    // trap after mount and ModalContent enters with a ZoomIn animation, which
+    // between them clobber it. Focus on the next frame instead, once the trap
+    // has settled and the content has painted (same fix as PromptDialog).
+    useEffect(() => {
+        if (!shouldFocusName) return
+        const raf = requestAnimationFrame(() => nameRef.current?.focus())
+        return () => cancelAnimationFrame(raf)
+    }, [shouldFocusName])
 
     const handleSave = () => {
         if (!validate(catalog)) return
@@ -190,9 +210,12 @@ function RuleBuilderForm({
             <ScrollView className={scrollRegionClass(isMobile)}>
                 <View className="gap-4 pb-2">
                     <PlainInput
+                        ref={nameRef}
                         value={draft.name}
                         onChangeText={name => patch({ name })}
                         placeholder="Rule name"
+                        autoFocus={shouldFocusName}
+                        accessibilityLabel="Rule name"
                         className="text-base font-semibold px-3 py-2 border rounded-lg text-foreground bg-background border-border"
                     />
 

--- a/core/components/rules/RuleCard.tsx
+++ b/core/components/rules/RuleCard.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react'
+import { Text, View } from 'react-native'
+
+export interface RuleCardProps {
+    /** The step name shown top-left: WHEN / IF / THEN. */
+    title: string
+    /** Dims the card and makes its whole subtree non-interactive. */
+    isDisabled?: boolean
+    /** Why the card is unusable. Rendered only while disabled. */
+    disabledHint?: string
+    /** Rendered on the title row's right — ConditionsCard's match pills. */
+    trailing?: ReactNode
+    children: ReactNode
+}
+
+function CardHint({ isVisible, text }: { isVisible: boolean; text: string | undefined }) {
+    if (!isVisible || !text) return null
+    return <Text className="text-xs text-muted-foreground">{text}</Text>
+}
+
+/**
+ * The shared shell for the builder's step cards.
+ *
+ * A disabled card stays MOUNTED and keeps its place in the WHEN → IF → THEN
+ * sequence rather than disappearing. Unmounting an unusable step made the cards
+ * below it jump up the moment a trigger was picked, and it hid the shape of a
+ * rule from someone building their first one; a dimmed card carrying its own
+ * reason explains itself instead.
+ *
+ * Disabling is enforced two ways, and both are needed:
+ *
+ *   • `pointerEvents="none"` stops touch and mouse.
+ *   • the accessibility props take the subtree out of the focus order — on web
+ *     `pointerEvents: none` does NOT stop Tab reaching a Pressable, so without
+ *     these a keyboard user could still open a menu inside a disabled card
+ *     (THEN's add-action menu, which lists nothing until a trigger exists).
+ */
+export function RuleCard({
+    title,
+    isDisabled = false,
+    disabledHint,
+    trailing,
+    children,
+}: RuleCardProps) {
+    return (
+        <View
+            className={`rounded-xl border p-4 bg-surface-secondary border-border gap-3 ${
+                isDisabled ? 'opacity-40' : ''
+            }`}
+            pointerEvents={isDisabled ? 'none' : 'auto'}
+            accessibilityElementsHidden={isDisabled}
+            importantForAccessibility={isDisabled ? 'no-hide-descendants' : 'auto'}
+        >
+            <View className="flex-row items-center justify-between">
+                <Text className="text-sm font-semibold text-foreground">{title}</Text>
+                {trailing}
+            </View>
+            <CardHint isVisible={isDisabled} text={disabledHint} />
+            {children}
+        </View>
+    )
+}

--- a/core/components/rules/RunHistory.tsx
+++ b/core/components/rules/RunHistory.tsx
@@ -54,7 +54,7 @@ export function RunHistory({ ruleId, onClose }: RunHistoryProps) {
         return (
             <BottomDrawer isOpen={isOpen} onClose={onClose}>
                 <View className="px-4 pb-4">
-                    <RunHistoryContent ruleId={ruleId} onClose={onClose} />
+                    <RunHistoryContent ruleId={ruleId} onClose={onClose} isMobile />
                 </View>
             </BottomDrawer>
         )
@@ -63,21 +63,28 @@ export function RunHistory({ ruleId, onClose }: RunHistoryProps) {
     return (
         <Modal isOpen={isOpen} onClose={onClose}>
             <ModalBackdrop />
-            <ModalContent>
-                <RunHistoryContent ruleId={ruleId} onClose={onClose} />
+            {/* Caps the shell so the run list scrolls inside it rather than
+                overflowing ModalContent's `overflow-hidden` and being clipped.
+                Same rationale as RuleBuilder — see the note there. */}
+            <ModalContent className="max-h-[85vh]">
+                <RunHistoryContent ruleId={ruleId} onClose={onClose} isMobile={false} />
             </ModalContent>
         </Modal>
     )
 }
 
-function RunHistoryContent({ ruleId, onClose }: RunHistoryProps) {
+function RunHistoryContent({ ruleId, onClose, isMobile }: RunHistoryProps & { isMobile: boolean }) {
     const { data: rawRuns, isReady } = useRuleRuns(ruleId)
     const runs = sortRunsDesc(rawRuns)
 
     return (
-        <View className="gap-3">
+        <View className={isMobile ? 'gap-3' : 'gap-3 flex-1 min-h-0'}>
             <RunHistoryHeader onClose={onClose} />
-            <ScrollView className="max-h-[70vh]">
+            {/* Sizing splits by shell for the same reason as RuleBuilder's
+                scrollRegionClass: the modal caps the shell and lets this flex,
+                while the drawer measures its own height from content and would
+                collapse a flex-1 child to nothing. */}
+            <ScrollView className={isMobile ? 'max-h-[70vh]' : 'flex-1 min-h-0'}>
                 <RunHistoryBody isReady={isReady} runs={runs} />
             </ScrollView>
         </View>

--- a/core/components/rules/TriggerCard.tsx
+++ b/core/components/rules/TriggerCard.tsx
@@ -1,8 +1,10 @@
 import { MenuActionItem } from '@tinycld/core/components/DropdownMenu'
 import type { CatalogResponse, CatalogTrigger } from '@tinycld/core/lib/automation/api'
+import { orderGroupsByUserPreference } from '@tinycld/core/lib/automation/condition-helpers'
 import type { RuleDraft } from '@tinycld/core/lib/automation/draft'
 import { parseRefSafe } from '@tinycld/core/lib/automation/helpers'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
+import { useSortedPackages } from '@tinycld/core/lib/use-sorted-packages'
 import { Menu } from '@tinycld/core/ui/menu'
 import { PlainInput } from '@tinycld/core/ui/PlainInput'
 import { ChevronDown } from 'lucide-react-native'
@@ -52,7 +54,13 @@ function TriggerMenu({
 }) {
     const mutedColor = useThemeColor('muted-foreground')
     const selected = catalog.triggers.find(t => t.ref === selectedRef)
-    const groups = groupTriggersByPackage(catalog.triggers)
+    // Same order the user dragged their apps into, so the menu reads like the
+    // sidebar. core's package-neutral triggers always lead.
+    const orderedSlugs = useSortedPackages().map(p => p.slug)
+    const groups = orderGroupsByUserPreference(
+        groupTriggersByPackage(catalog.triggers),
+        orderedSlugs
+    )
 
     return (
         <Menu>
@@ -67,7 +75,7 @@ function TriggerMenu({
             <Menu.Portal>
                 <Menu.Overlay />
                 <Menu.Content presentation="popover" placement="bottom" align="start">
-                    {[...groups.entries()].map(([pkg, triggers]) => (
+                    {groups.map(([pkg, triggers]) => (
                         <Fragment key={pkg}>
                             <Menu.Label>{pkg}</Menu.Label>
                             {triggers.map(trigger => (

--- a/core/components/rules/TriggerCard.tsx
+++ b/core/components/rules/TriggerCard.tsx
@@ -8,6 +8,7 @@ import { PlainInput } from '@tinycld/core/ui/PlainInput'
 import { ChevronDown } from 'lucide-react-native'
 import { Fragment } from 'react'
 import { Pressable, Text, View } from 'react-native'
+import { RuleCard } from './RuleCard'
 
 export interface TriggerCardProps {
     draft: RuleDraft
@@ -190,6 +191,11 @@ export function TriggerCard({ draft, catalog, onChange, isLocked, presetPkg }: T
         // Switching triggers invalidates conditions (built against the old
         // trigger's field set) and actions (may target the old trigger's
         // collection) — both reset rather than silently carrying over.
+        //
+        // Resetting to zero groups is also what re-arms ConditionsCard's ready
+        // first row against the NEW trigger's fields (see its SyntheticFirstGroup).
+        // The literal deliberately skips ensureUids, which is safe only because
+        // the array is empty — anything seeded here would need uids to key on.
         onChange({
             trigger: trigger.ref,
             conditions: { match: 'all', groups: [] },
@@ -198,8 +204,7 @@ export function TriggerCard({ draft, catalog, onChange, isLocked, presetPkg }: T
     }
 
     return (
-        <View className="rounded-xl border p-4 bg-surface-secondary border-border gap-3">
-            <Text className="text-sm font-semibold text-foreground">WHEN</Text>
+        <RuleCard title="WHEN">
             {isLocked ? (
                 <LockedTriggerLabel catalog={catalog} triggerRef={draft.trigger} />
             ) : (
@@ -210,6 +215,6 @@ export function TriggerCard({ draft, catalog, onChange, isLocked, presetPkg }: T
                 />
             )}
             {isSchedule ? <ScheduleRow draft={draft} onChange={onChange} /> : null}
-        </View>
+        </RuleCard>
     )
 }

--- a/core/components/workspace/MoreDrawer.tsx
+++ b/core/components/workspace/MoreDrawer.tsx
@@ -84,9 +84,13 @@ export function MoreDrawer() {
                     </Text>
                 </Pressable>
 
+                {/* The settings HUB, not the personal page. MobileTabBar has no
+                    settings entry, so this row is the ONLY way into settings on a
+                    phone — pointing it at a single section left Rules, Members and
+                    every other page unreachable there. */}
                 <Pressable
                     className="flex-row items-center gap-3.5 px-4 py-3.5 rounded-lg"
-                    onPress={() => handleNav(() => router.push(orgHref('settings/personal')))}
+                    onPress={() => handleNav(() => router.push(orgHref('settings')))}
                 >
                     <Settings size={20} color={textColor} />
                     <Text className="text-base font-medium" style={{ color: textColor }}>

--- a/core/components/workspace/UserMenu.tsx
+++ b/core/components/workspace/UserMenu.tsx
@@ -42,10 +42,15 @@ export function UserMenu() {
 
                     <Separator />
 
+                    {/* The settings HUB, not the personal page: a generic
+                        "Settings" label must reach every section. Rules, Members
+                        and the rest are only listed on the hub, and on a tablet
+                        (>=768dp, see the note below) this menu is the sole
+                        Settings affordance — MoreDrawer never mounts. */}
                     <MenuActionItem
                         label="Settings"
                         icon={Settings}
-                        onPress={() => router.push(orgHref('settings/personal'))}
+                        onPress={() => router.push(orgHref('settings'))}
                     />
 
                     <OrganizationsSection orgs={orgs} />

--- a/core/lib/automation/condition-helpers.ts
+++ b/core/lib/automation/condition-helpers.ts
@@ -258,6 +258,38 @@ export function moveAction<T>(list: T[], from: number, to: number): T[] {
     return next
 }
 
+/**
+ * Orders the builder's package groups to match the order the user dragged their
+ * apps into (Settings → Personal → Navigation), so the trigger and action menus
+ * read the same way as the sidebar and tab bar rather than alphabetically.
+ *
+ * Two kinds of slug are deliberately NOT in `orderedSlugs`:
+ *
+ *   • `core`, which has no manifest and so never appears in the nav order at
+ *     all. Its synthetic triggers (run manually / on a schedule) are the
+ *     package-neutral starting points every rule can use, so they lead.
+ *   • packages with no nav entry (settings-only contributors), which the nav
+ *     order filters out. They still contribute automation, so they follow the
+ *     ordered ones alphabetically instead of being dropped.
+ */
+export function orderGroupsByUserPreference<T>(
+    groups: Map<string, T>,
+    orderedSlugs: string[]
+): [string, T][] {
+    const rank = new Map(orderedSlugs.map((slug, i) => [slug, i]))
+    const weight = (pkg: string) => {
+        if (pkg === 'core') return -1
+        return rank.get(pkg) ?? Number.MAX_SAFE_INTEGER
+    }
+    return [...groups.entries()].sort(([a], [b]) => {
+        const delta = weight(a) - weight(b)
+        // Equal weight means both are unranked; alphabetical keeps them stable
+        // rather than leaving it to Map insertion order, which varies with the
+        // catalog's own row order.
+        return delta !== 0 ? delta : a.localeCompare(b)
+    })
+}
+
 /** Appends a `{{key}}` template placeholder to a param's current text value. */
 export function appendPlaceholder(value: string, key: string): string {
     return `${value}{{${key}}}`

--- a/core/lib/automation/condition-helpers.ts
+++ b/core/lib/automation/condition-helpers.ts
@@ -114,6 +114,38 @@ export function addGroup(ast: ConditionsAst): ConditionsAst {
     }
 }
 
+/**
+ * The AST that the first edit to an empty condition set produces: one group
+ * holding one condition carrying the user's field pick.
+ *
+ * ConditionsCard renders a ready-to-fill first row against `groups: []` WITHOUT
+ * putting it in the draft, and calls this only once the user actually picks a
+ * field. Keeping the blank row out of the draft is what lets an untouched
+ * builder still save a rule with no conditions (which matches everything) — and
+ * it is load-bearing, not just tidy: `conditionSchema.field` is `min(1)` and
+ * `conditionGroupSchema.conditions` is `min(1)`, so a blank condition or an
+ * empty group reaching `conditionsAstSchema.parse` in draftToRecord THROWS on
+ * save.
+ *
+ * A patch that names no field is ignored for the same reason. That is currently
+ * unreachable — ConditionRow's operator menu lists nothing until a field is
+ * chosen — but the invariant lives in a different component, so this guards it
+ * here rather than trusting a sibling's render logic to hold forever.
+ */
+export function seedFirstCondition(ast: ConditionsAst, patch: Partial<Condition>): ConditionsAst {
+    if (!patch.field) return ast
+    return {
+        ...ast,
+        groups: [
+            {
+                ...EMPTY_GROUP,
+                uid: newRecordId(),
+                conditions: [{ ...EMPTY_CONDITION, ...patch, uid: newRecordId() }],
+            },
+        ],
+    }
+}
+
 /** Removes the group at `groupIndex`. */
 export function removeGroup(ast: ConditionsAst, groupIndex: number): ConditionsAst {
     return { ...ast, groups: ast.groups.filter((_, i) => i !== groupIndex) }

--- a/core/tests/unit/automation-group-order.test.ts
+++ b/core/tests/unit/automation-group-order.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { orderGroupsByUserPreference } from '../../lib/automation/condition-helpers'
+
+// The trigger and action menus group by package. They used to come out
+// alphabetically by slug (a stability hack in use-automation-catalog), which
+// matched nothing else in the app. Now they follow the order the user dragged
+// their apps into in Settings → Personal → Navigation, so the menus read like
+// the sidebar and tab bar.
+
+function groupsOf(...slugs: string[]) {
+    return new Map(slugs.map(slug => [slug, [`${slug}-item`]]))
+}
+
+function orderedSlugsOf(result: [string, string[]][]) {
+    return result.map(([slug]) => slug)
+}
+
+describe('orderGroupsByUserPreference', () => {
+    it('follows the user order rather than the alphabet', () => {
+        const result = orderGroupsByUserPreference(groupsOf('calendar', 'mail', 'drive'), [
+            'mail',
+            'drive',
+            'calendar',
+        ])
+        expect(orderedSlugsOf(result)).toEqual(['mail', 'drive', 'calendar'])
+    })
+
+    it('puts core first, ahead of everything the user ordered', () => {
+        // core owns the synthetic run-manually / on-a-schedule triggers — the
+        // package-neutral starting points every rule can use — and it has no
+        // manifest, so it never appears in the nav order to be placed by hand.
+        const result = orderGroupsByUserPreference(groupsOf('mail', 'core', 'drive'), [
+            'mail',
+            'drive',
+        ])
+        expect(orderedSlugsOf(result)[0]).toBe('core')
+    })
+
+    it('keeps core first even when the user order happens to name it', () => {
+        const result = orderGroupsByUserPreference(groupsOf('mail', 'core'), ['mail', 'core'])
+        expect(orderedSlugsOf(result)).toEqual(['core', 'mail'])
+    })
+
+    it('appends packages missing from the nav order instead of dropping them', () => {
+        // Settings-only contributors have no nav entry, so useSortedPackages
+        // filters them out — but they can still contribute automation, and a
+        // menu that silently omitted their triggers would be worse than one
+        // that lists them last.
+        const result = orderGroupsByUserPreference(groupsOf('takeout', 'mail'), ['mail'])
+        expect(orderedSlugsOf(result)).toEqual(['mail', 'takeout'])
+    })
+
+    it('sorts unranked packages alphabetically so the menu is stable', () => {
+        // Map insertion order follows the catalog's row order, which is not a
+        // guarantee worth depending on for what the user sees.
+        const result = orderGroupsByUserPreference(groupsOf('zeta', 'alpha', 'mid'), [])
+        expect(orderedSlugsOf(result)).toEqual(['alpha', 'mid', 'zeta'])
+    })
+
+    it('falls back to alphabetical-after-core when no preference is set', () => {
+        const result = orderGroupsByUserPreference(groupsOf('mail', 'core', 'calendar'), [])
+        expect(orderedSlugsOf(result)).toEqual(['core', 'calendar', 'mail'])
+    })
+
+    it('leaves the grouped items untouched', () => {
+        const result = orderGroupsByUserPreference(groupsOf('mail'), ['mail'])
+        expect(result).toEqual([['mail', ['mail-item']]])
+    })
+
+    it('handles an empty catalog', () => {
+        expect(orderGroupsByUserPreference(new Map(), ['mail'])).toEqual([])
+    })
+})

--- a/core/tests/unit/condition-helpers-seed.test.ts
+++ b/core/tests/unit/condition-helpers-seed.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { ConditionsAst } from '../../lib/automation/condition-helpers'
+import { seedFirstCondition } from '../../lib/automation/condition-helpers'
+import { conditionsAstSchema } from '../../lib/automation/schemas'
+
+const EMPTY: ConditionsAst = { match: 'all', groups: [] }
+
+describe('seedFirstCondition', () => {
+    it('promotes the rendered first row into one group holding one condition', () => {
+        const ast = seedFirstCondition(EMPTY, {
+            field: 'subject',
+            op: 'contains',
+            value: undefined,
+        })
+        expect(ast.groups).toHaveLength(1)
+        expect(ast.groups[0].conditions).toHaveLength(1)
+        expect(ast.groups[0].conditions[0]).toMatchObject({ field: 'subject', op: 'contains' })
+    })
+
+    it('assigns uids so the new rows have stable React keys', () => {
+        // Without these, deleting a row while a sibling's Menu is open would
+        // reconcile that Menu onto the wrong row (Menu owns isOpen internally).
+        const ast = seedFirstCondition(EMPTY, { field: 'subject', op: 'contains' })
+        expect(ast.groups[0].uid).toBeTruthy()
+        expect(ast.groups[0].conditions[0].uid).toBeTruthy()
+    })
+
+    it('ignores a patch that names no field', () => {
+        // Currently unreachable — ConditionRow's operator menu lists nothing
+        // until a field is picked — but that invariant lives in a different
+        // component. Seeding `field: ''` would produce a draft that throws in
+        // draftToRecord, so the guard belongs here rather than in a sibling.
+        expect(seedFirstCondition(EMPTY, { op: 'contains' })).toEqual(EMPTY)
+    })
+
+    it('replaces rather than appends, so the rendered row cannot double up', () => {
+        // SyntheticFirstGroup only renders while groups is empty, so this is
+        // defensive: a second call must not leave two groups behind.
+        const once = seedFirstCondition(EMPTY, { field: 'subject', op: 'contains' })
+        const twice = seedFirstCondition(once, { field: 'folder', op: 'is' })
+        expect(twice.groups).toHaveLength(1)
+    })
+
+    it('preserves the top-level match mode', () => {
+        const ast = seedFirstCondition(
+            { match: 'any', groups: [] },
+            { field: 'subject', op: 'contains' }
+        )
+        expect(ast.match).toBe('any')
+    })
+
+    it('produces an AST the persistence schema accepts once a value is set', () => {
+        const ast = seedFirstCondition(EMPTY, {
+            field: 'subject',
+            op: 'contains',
+            value: 'invoice',
+        })
+        const parsed = conditionsAstSchema.parse(ast)
+        // uid is builder-local and must never reach the server.
+        expect(parsed.groups[0]).not.toHaveProperty('uid')
+        expect(parsed.groups[0].conditions[0]).not.toHaveProperty('uid')
+    })
+})

--- a/core/tests/unit/condition-helpers-seed.test.ts
+++ b/core/tests/unit/condition-helpers-seed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { ConditionsAst } from '../../lib/automation/condition-helpers'
-import { seedFirstCondition } from '../../lib/automation/condition-helpers'
+import { addCondition, addGroup, seedFirstCondition } from '../../lib/automation/condition-helpers'
 import { conditionsAstSchema } from '../../lib/automation/schemas'
 
 const EMPTY: ConditionsAst = { match: 'all', groups: [] }
@@ -47,6 +47,16 @@ describe('seedFirstCondition', () => {
             { field: 'subject', op: 'contains' }
         )
         expect(ast.match).toBe('any')
+    })
+
+    // ConditionsCard's handleAddGroup composes these two for the FIRST group.
+    // The offered row is render-only and unmounts as soon as a real group
+    // exists, so appending an EMPTY first group would make the row the user was
+    // looking at disappear and leave a group with nothing in it behind.
+    it('composes with addGroup so a first group is never empty', () => {
+        const ast = addCondition(addGroup(EMPTY), 0)
+        expect(ast.groups).toHaveLength(1)
+        expect(ast.groups[0].conditions).toHaveLength(1)
     })
 
     it('produces an AST the persistence schema accepts once a value is set', () => {

--- a/core/tests/unit/rule-card-disabled.test.tsx
+++ b/core/tests/unit/rule-card-disabled.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { RuleCard } from '../../components/rules/RuleCard'
+
+// A disabled step card must be genuinely inert, not merely faint. Dimming alone
+// left THEN's add-action menu clickable before a trigger was chosen, and it
+// opened listing nothing — the dead end this card exists to close.
+//
+// Two mechanisms, asserted separately because they fail independently:
+// pointerEvents stops touch/mouse, while the accessibility props take the
+// subtree out of the focus order (on web, pointerEvents: none does NOT stop Tab
+// reaching a Pressable inside).
+
+afterEach(cleanup)
+
+function card(props: Partial<React.ComponentProps<typeof RuleCard>> = {}) {
+    return render(
+        <RuleCard title="THEN" {...props}>
+            <span data-testid="body">body</span>
+        </RuleCard>
+    )
+}
+
+describe('RuleCard when enabled', () => {
+    it('renders its title and children and stays interactive', () => {
+        const { container, getByTestId } = card()
+        expect(container.textContent).toContain('THEN')
+        expect(getByTestId('body')).toBeTruthy()
+        expect(container.firstElementChild?.getAttribute('pointerEvents')).toBe('auto')
+    })
+
+    it('shows no hint even when one is supplied', () => {
+        // The hint explains a disabled state; showing it on a usable card would
+        // tell the user to fix something that isn't broken.
+        const { container } = card({ disabledHint: 'Choose a trigger first' })
+        expect(container.textContent).not.toContain('Choose a trigger first')
+    })
+})
+
+describe('RuleCard when disabled', () => {
+    it('blocks pointer input over the whole card', () => {
+        const { container } = card({ isDisabled: true })
+        expect(container.firstElementChild?.getAttribute('pointerEvents')).toBe('none')
+    })
+
+    it('takes its subtree out of the focus order', () => {
+        const { container } = card({ isDisabled: true })
+        const root = container.firstElementChild
+        expect(root?.getAttribute('importantForAccessibility')).toBe('no-hide-descendants')
+        expect(root?.hasAttribute('accessibilityElementsHidden')).toBe(true)
+    })
+
+    it('dims without unmounting, so the cards below it do not jump', () => {
+        // Unmounting an unusable step was the original behavior; it moved
+        // everything underneath the moment a trigger was picked.
+        const { container, getByTestId } = card({ isDisabled: true })
+        expect(container.firstElementChild?.getAttribute('class')).toContain('opacity-40')
+        expect(getByTestId('body')).toBeTruthy()
+        expect(container.textContent).toContain('THEN')
+    })
+
+    it('states why it is unusable', () => {
+        const { container } = card({ isDisabled: true, disabledHint: 'Choose a trigger first' })
+        expect(container.textContent).toContain('Choose a trigger first')
+    })
+})

--- a/core/tests/unit/rule-draft-validation.test.ts
+++ b/core/tests/unit/rule-draft-validation.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import type { CatalogResponse } from '../../lib/automation/api'
+import { draftToRecord, emptyDraft, validateDraft } from '../../lib/automation/draft'
+
+// The IF card renders a ready-to-fill first condition row WITHOUT putting it in
+// the draft (ConditionsCard's SyntheticFirstGroup). These pin the two halves of
+// why that has to stay render-only:
+//
+//   • validateDraft must not error on a rule the user never added conditions to
+//     — a seeded blank row would report "Condition field '' is not available".
+//   • draftToRecord must not throw — conditionSchema.field is min(1) and
+//     conditionGroupSchema.conditions is min(1), so a blank condition or an
+//     empty group makes conditionsAstSchema.parse throw ON SAVE, turning a UX
+//     nicety into a crash.
+//
+// Nothing else covers draft.ts, so a future "just seed it in emptyDraft, it's
+// simpler" refactor would otherwise land silently.
+
+const CATALOG: CatalogResponse = {
+    triggers: [
+        {
+            ref: 'mail:message-received',
+            pkg: 'mail',
+            id: 'message-received',
+            label: 'A message arrives',
+            collection: 'mail_messages',
+            fields: [
+                { key: 'subject', label: 'Subject', type: 'text' },
+                { key: 'size', label: 'Size', type: 'number' },
+            ],
+        },
+        {
+            ref: 'core:manual',
+            pkg: 'core',
+            id: 'manual',
+            label: 'Run manually',
+            synthetic: 'manual',
+            fields: [],
+        },
+    ],
+    actions: [
+        {
+            ref: 'core:notify',
+            pkg: 'core',
+            id: 'notify',
+            label: 'Send me a notification',
+            kind: 'native',
+            available: true,
+            params: [{ key: 'title', label: 'Title', template: true, field: { type: 'text' } }],
+        },
+    ],
+} as unknown as CatalogResponse
+
+function savableDraft() {
+    return {
+        ...emptyDraft('personal'),
+        name: 'My rule',
+        trigger: 'mail:message-received',
+        actions: [{ uid: 'a1', ref: 'core:notify', params: { title: 'hi' } }],
+    }
+}
+
+describe('validateDraft with no conditions', () => {
+    it('accepts a rule whose condition row was never filled in', () => {
+        // The exact state the builder is in when a user picks a trigger, adds an
+        // action, and saves without touching the offered condition row.
+        expect(validateDraft(savableDraft(), CATALOG)).toEqual([])
+    })
+
+    it('still requires a name, a trigger and an action', () => {
+        const errors = validateDraft(emptyDraft('personal'), CATALOG)
+        expect(errors).toContain('Name is required')
+        expect(errors).toContain('Trigger is required')
+        expect(errors).toContain('At least one action is required')
+    })
+})
+
+describe('validateDraft with a partly-filled condition', () => {
+    it('rejects a numeric condition with no value', () => {
+        // Field chosen but value left blank is INCOMPLETE, not blank: the user
+        // showed intent by picking a field, and the engine's numeric operators
+        // fail closed on an unreadable value, so saving it would save a rule
+        // that silently never matches.
+        const draft = savableDraft()
+        draft.conditions = {
+            match: 'all',
+            groups: [{ uid: 'g1', match: 'all', conditions: [{ field: 'size', op: 'gt' }] }],
+        }
+        expect(validateDraft(draft, CATALOG)).toContain("Condition on 'Size' needs a number")
+    })
+
+    it('rejects a condition naming a field the trigger does not expose', () => {
+        const draft = savableDraft()
+        draft.conditions = {
+            match: 'all',
+            groups: [
+                {
+                    uid: 'g1',
+                    match: 'all',
+                    conditions: [{ field: 'nope', op: 'contains', value: 'x' }],
+                },
+            ],
+        }
+        expect(validateDraft(draft, CATALOG)).toContain(
+            "Condition field 'nope' is not available on trigger 'A message arrives'"
+        )
+    })
+})
+
+describe('validateDraft on a synthetic trigger', () => {
+    it('rejects conditions on a trigger with no record behind it', () => {
+        // The IF card renders disabled for schedule/manual rather than hiding,
+        // and this is the rule that disabling is enforcing.
+        const draft = { ...savableDraft(), trigger: 'core:manual' }
+        draft.conditions = {
+            match: 'all',
+            groups: [
+                {
+                    uid: 'g1',
+                    match: 'all',
+                    conditions: [{ field: 'subject', op: 'contains', value: 'x' }],
+                },
+            ],
+        }
+        expect(validateDraft(draft, CATALOG)).toContain(
+            "Trigger 'Run manually' has no fields — it cannot have conditions"
+        )
+    })
+})
+
+describe('draftToRecord', () => {
+    it('serializes an untouched condition set without throwing', () => {
+        const record = draftToRecord(savableDraft())
+        expect(record.conditions).toEqual({ match: 'all', groups: [] })
+    })
+
+    it('throws on a blank condition — which is why none is ever seeded', () => {
+        // Documents the failure mode the render-only approach avoids. If this
+        // ever stops throwing, the schemas were loosened and the constraint
+        // driving SyntheticFirstGroup's design no longer holds.
+        const draft = savableDraft()
+        draft.conditions = {
+            match: 'all',
+            groups: [{ uid: 'g1', match: 'all', conditions: [{ field: '', op: '' }] }],
+        }
+        expect(() => draftToRecord(draft)).toThrow()
+    })
+
+    it('throws on an empty group — likewise', () => {
+        const draft = savableDraft()
+        draft.conditions = {
+            match: 'all',
+            groups: [{ uid: 'g1', match: 'all', conditions: [] }],
+        }
+        expect(() => draftToRecord(draft)).toThrow()
+    })
+
+    it('strips the builder-local uid from persisted conditions', () => {
+        const draft = savableDraft()
+        draft.conditions = {
+            match: 'all',
+            groups: [
+                {
+                    uid: 'g1',
+                    match: 'all',
+                    conditions: [{ uid: 'c1', field: 'subject', op: 'contains', value: 'invoice' }],
+                },
+            ],
+        }
+        const record = draftToRecord(draft)
+        expect(record.conditions).toEqual({
+            match: 'all',
+            groups: [
+                {
+                    match: 'all',
+                    conditions: [{ field: 'subject', op: 'contains', value: 'invoice' }],
+                },
+            ],
+        })
+    })
+})

--- a/tests/e2e/change-password.spec.ts
+++ b/tests/e2e/change-password.spec.ts
@@ -26,9 +26,14 @@ test.describe('change password', () => {
     })
 
     // Open Settings → Personal via the user menu (SPA nav, not page.goto).
+    // The menu's generic "Settings" lands on the settings HUB — a section list —
+    // so this clicks through to Personal from there. It used to jump straight to
+    // the personal page, which is exactly what left Rules (and every other
+    // section) unreachable wherever that menu is the only Settings affordance.
     async function openPersonalSettings(page: Page) {
         await page.getByLabel('User menu').click()
         await page.getByText('Settings', { exact: true }).click()
+        await page.getByText('Personal', { exact: true }).first().click()
         // Gate on the control the callers use, not the URL: the route changes
         // as soon as the router accepts the push, while the screen is still
         // mounting, so a URL wait can return before 'Change password' exists.

--- a/tests/e2e/rules.spec.ts
+++ b/tests/e2e/rules.spec.ts
@@ -178,6 +178,103 @@ test.describe('Rules', () => {
         })
     })
 
+    // The builder's Save/Cancel used to be CLIPPED off-screen: ModalContent is
+    // `overflow-hidden` with no height of its own, so header + scroll region +
+    // error list + footer could exceed the viewport and the excess simply
+    // vanished — and because the modal is centered, what vanished was the
+    // footer. toBeVisible() is NOT enough to catch this (a clipped element
+    // still reports visible); toBeInViewport is the assertion that fails on the
+    // old layout.
+    test('the footer stays reachable when the error list is long', async ({ page }) => {
+        await login(page)
+        // Short viewport so the modal has to cope with real overflow rather
+        // than merely fitting by luck on a tall CI screen.
+        await page.setViewportSize({ width: 1280, height: 600 })
+        await navigateToRulesSettings(page)
+
+        await page.getByText('New rule', { exact: true }).first().click()
+        await expect(page.getByText('New rule', { exact: true }).last()).toBeVisible()
+
+        await page.getByText('Save', { exact: true }).click()
+        await expect(
+            page.getByText('Please fix the following errors:', { exact: true })
+        ).toBeVisible()
+
+        await expect(page.getByText('Save', { exact: true })).toBeInViewport()
+        await expect(page.getByText('Cancel', { exact: true })).toBeInViewport()
+        // Still clickable, not just painted inside the viewport.
+        await page.getByText('Cancel', { exact: true }).click()
+        await expect(page.getByPlaceholder('Rule name')).not.toBeVisible()
+    })
+
+    test('IF and THEN render disabled until a trigger is chosen', async ({ page }) => {
+        await login(page)
+        await navigateToRulesSettings(page)
+
+        await page.getByText('New rule', { exact: true }).first().click()
+        await expect(page.getByText('New rule', { exact: true }).last()).toBeVisible()
+
+        // Both steps stay mounted so the shape of a rule is visible from the
+        // start and nothing jumps when the trigger lands.
+        await expect(page.getByText('IF', { exact: true })).toBeVisible()
+        await expect(page.getByText('THEN', { exact: true })).toBeVisible()
+        await expect(page.getByText('Choose a trigger first').first()).toBeVisible()
+
+        // "add action" is inert, not merely faint. pointerEvents:none sets no
+        // DOM `disabled`, so assert the click itself cannot land — a trial
+        // click fails actionability instead of opening an empty menu.
+        await expect(
+            page.getByText('add action', { exact: true }).click({ trial: true, timeout: 2000 })
+        ).rejects.toThrow()
+
+        // Picking a synthetic trigger keeps IF mounted but explains that it can
+        // never apply, rather than silently vanishing.
+        await selectFromMenu(
+            page,
+            page.getByText('Select a trigger…', { exact: true }),
+            'Run manually'
+        )
+        await expect(page.getByText('This trigger has no fields to filter on')).toBeVisible()
+        await expect(page.getByText('Choose a trigger first')).not.toBeVisible()
+    })
+
+    // "A user joins" is core-owned, so this holds in a lean shell with no
+    // feature packages installed — unlike mail/drive triggers.
+    test('a record trigger offers a ready condition row that need not be filled', async ({
+        page,
+    }) => {
+        await login(page)
+        await navigateToRulesSettings(page)
+
+        const ruleName = `E2E ready-condition rule ${Date.now()}`
+
+        await page.getByText('New rule', { exact: true }).first().click()
+        await expect(page.getByText('New rule', { exact: true }).last()).toBeVisible()
+        await page.getByPlaceholder('Rule name').fill(ruleName)
+
+        await selectFromMenu(
+            page,
+            page.getByText('Select a trigger…', { exact: true }),
+            'A user joins'
+        )
+
+        // The row is there immediately — reaching a first condition used to
+        // require clicking "add OR group" first, which means nothing when there
+        // is nothing to OR with.
+        await expect(page.getByText('Field…', { exact: true })).toBeVisible()
+        await expect(page.getByText('add OR group', { exact: true })).toBeVisible()
+
+        // Saving WITHOUT touching that row must work: the offered row is
+        // rendered, never seeded into the draft, so the rule saves with no
+        // conditions (matching everything) instead of failing validation.
+        await page.getByText('add action', { exact: true }).click()
+        await page.getByText('Send me a notification', { exact: true }).click()
+        await page.getByText('Title').locator('..').getByRole('textbox').first().fill('Welcome')
+        await page.getByText('Save', { exact: true }).click()
+
+        await expect(page.getByText(ruleName, { exact: true })).toBeVisible()
+    })
+
     test('the rules help topic is searchable and renders', async ({ page }) => {
         await login(page)
 

--- a/tests/e2e/rules.spec.ts
+++ b/tests/e2e/rules.spec.ts
@@ -178,6 +178,39 @@ test.describe('Rules', () => {
         })
     })
 
+    // The trigger menu groups by package. It used to come out alphabetically by
+    // slug — a stability hack in use-automation-catalog that matched nothing
+    // else in the app — and now follows the user's own app order, with core's
+    // package-neutral triggers leading.
+    test('the trigger menu groups packages in the sidebar order, core first', async ({ page }) => {
+        await login(page)
+        await navigateToRulesSettings(page)
+
+        await page.getByText('New rule', { exact: true }).first().click()
+        await page.getByText('Select a trigger…', { exact: true }).click()
+        // Gate on a known option so the assertions read a painted menu.
+        await expect(page.getByTestId('trigger-option-core:manual')).toBeVisible()
+
+        // Menu.Label renders the bare package slug (uppercased in CSS only).
+        const groupOrder = await page.evaluate(() => {
+            const slugs = ['core', 'mail', 'drive', 'calendar', 'contacts', 'cards', 'calc', 'text']
+            const seen: string[] = []
+            const walk = (node: Element) => {
+                const text = (node.textContent ?? '').trim().toLowerCase()
+                if (node.children.length === 0 && slugs.includes(text)) seen.push(text)
+                for (const child of Array.from(node.children)) walk(child)
+            }
+            walk(document.body)
+            return seen
+        })
+
+        expect(groupOrder.length).toBeGreaterThan(1)
+        expect(groupOrder[0]).toBe('core')
+        // Not the old alphabetical order — that would have put calc/calendar
+        // ahead of core and is exactly what this replaced.
+        expect(groupOrder).not.toEqual([...groupOrder].sort())
+    })
+
     // Naming is the first thing a new rule needs, and `autoFocus` alone does
     // not survive GlueStack's focus trap plus ModalContent's enter animation —
     // so this asserts the field is really focused, not merely that the prop is

--- a/tests/e2e/rules.spec.ts
+++ b/tests/e2e/rules.spec.ts
@@ -178,6 +178,50 @@ test.describe('Rules', () => {
         })
     })
 
+    // Naming is the first thing a new rule needs, and `autoFocus` alone does
+    // not survive GlueStack's focus trap plus ModalContent's enter animation —
+    // so this asserts the field is really focused, not merely that the prop is
+    // set. Typing without clicking is the behavior users feel.
+    test('the name field is focused when a new rule opens', async ({ page }) => {
+        await login(page)
+        await navigateToRulesSettings(page)
+
+        await page.getByText('New rule', { exact: true }).first().click()
+        await expect(page.getByText('New rule', { exact: true }).last()).toBeVisible()
+
+        const nameInput = page.getByPlaceholder('Rule name')
+        await expect(nameInput).toBeFocused()
+        await page.keyboard.type('typed without clicking')
+        await expect(nameInput).toHaveValue('typed without clicking')
+    })
+
+    test('editing an existing rule does not steal focus', async ({ page }) => {
+        await login(page)
+        await navigateToRulesSettings(page)
+
+        const ruleName = `E2E focus rule ${Date.now()}`
+
+        await page.getByText('New rule', { exact: true }).first().click()
+        await page.getByPlaceholder('Rule name').fill(ruleName)
+        await selectFromMenu(
+            page,
+            page.getByText('Select a trigger…', { exact: true }),
+            'Run manually'
+        )
+        await page.getByText('add action', { exact: true }).click()
+        await page.getByText('Send me a notification', { exact: true }).click()
+        await page.getByText('Title').locator('..').getByRole('textbox').first().fill('t')
+        await page.getByText('Save', { exact: true }).click()
+        await expect(page.getByText(ruleName, { exact: true })).toBeVisible()
+
+        // Reopening is usually to change a condition or action, so grabbing the
+        // name field would fight what the user came in to do.
+        await openOverflowMenu(page, ruleName)
+        await page.getByText('Edit', { exact: true }).click()
+        await expect(page.getByText('Edit rule', { exact: true })).toBeVisible()
+        await expect(page.getByPlaceholder('Rule name')).not.toBeFocused()
+    })
+
     // The builder's Save/Cancel used to be CLIPPED off-screen: ModalContent is
     // `overflow-hidden` with no height of its own, so header + scroll region +
     // error list + footer could exceed the viewport and the excess simply


### PR DESCRIPTION
Five fixes to the rule builder, found by using the shipped feature.

### Settings couldn't reach Rules on a phone

The user menu and the mobile More drawer both pushed `settings/personal`, while only the desktop rail pushed the hub that lists Rules, Members and the rest. `MobileTabBar` has no settings entry, so on a phone the More drawer is the *only* way in — and every section but Personal was unreachable.

### The builder modal clipped its own footer

`ModalContent` is `overflow-hidden` with no height of its own, so header + scroll region + error list + footer could exceed the viewport. Because the modal is centered, what got clipped was Save and Cancel.

The shell now caps at `85vh` with the scroll region as the only flexible band. The drawer path keeps an explicit cap instead — a `flex-1` child inside the intrinsically-sized sheet can collapse to zero. `RunHistory` had the same shape and gets the same treatment.

This is also why multiple THEN actions looked broken: they worked, but the list was below the fold.

### IF and THEN gave no signal that they needed a trigger

IF unmounted entirely, so everything below it jumped once a trigger landed. THEN's add-action menu stayed clickable and opened listing nothing.

Both now render dimmed and inert via a shared `RuleCard`, carrying the reason they can't be used. Disabling sets `pointerEvents` **and** hides the subtree from assistive tech — on web `pointerEvents` alone doesn't stop Tab reaching a `Pressable` inside.

### The first condition took two non-obvious clicks

Reaching a first condition meant clicking "add OR group" then "add condition" — and "OR group" means nothing when there's nothing to OR with. The IF card now offers a ready field/operator/value row as soon as a record trigger is chosen.

The row is **rendered, never seeded into the draft**. `conditionSchema.field` is `min(1)` and `conditionGroupSchema.conditions` is `min(1)`, so a blank row in the draft would make `draftToRecord` throw on save. Keeping it render-only means an untouched builder still saves a rule with no conditions, which matches everything.

### Menus ordered alphabetically by slug

The trigger and action menus grouped by package in catalog ref order — alphabetical, a stability hack rather than a designed order. They now follow the order the user dragged their apps into, via the same `useSortedPackages` the rail and tab bar use. `core` always leads: it owns the package-neutral manual/schedule triggers and has no manifest, so it never appears in the nav order to be placed by hand.

Also: the name field now takes focus when a **new** rule opens (not when editing, and not on the sheet, where it would raise the keyboard over content-measured height).

## Testing

- 1463 unit tests / 194 files, including 4 new suites covering the draft-validation invariants, the seed helper, the disabled card, and group ordering.
- 51 app-shell e2e. New guards use `toBeInViewport()` for the footer — `toBeVisible()` does not catch clipping, which is why this shipped.
- Verified the focus and footer tests fail without their fixes.
- Menu order confirmed in a real browser, not just in unit tests.

`change-password.spec.ts`'s helper encoded the old one-hop settings route and now clicks through the hub.

## Note for reviewers

Companion PRs in `mail` and `drive` drop the obsolete two-step condition setup from their rule specs. **Merge this one first** — those PRs only pass against the new builder behavior.

One pre-existing defect surfaced but deliberately not fixed here: the builder lets you save a `core:notify` rule with an empty title, which then fails at runtime with `title: cannot be blank`. The param model has no `required` concept, so fixing it properly spans the manifest contract, generator, Go catalog and every package's declarations. Out of scope for a UX pass.