### PR TITLE
fix(editor): make the editor render exactly as the markdown it replaces

### DIFF
--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -17,6 +17,36 @@ import type { SurfaceId } from '../../lib/editor/warm/warm-editor-store'
 import { captureException } from '../../lib/errors'
 import { isNoOpEdit, shouldCommitOnBlur } from './commit-policy'
 
+/** The coordinate fields a React Native press event carries. */
+export interface PressPoint {
+    pageX?: number
+    pageY?: number
+}
+
+/**
+ * The viewport point a press landed on, or undefined when there is none.
+ *
+ * `pageX/pageY` are viewport-relative on RN-Web — the same space
+ * `posAtCoords` reads — so they can be handed to the editor unchanged.
+ *
+ * Everything here is optional on purpose. A press does not always arrive with
+ * coordinates, or even with an event: an accessibility activation, a synthetic
+ * `onPress()` from a test, and a keyboard-triggered press all reach this with
+ * nothing to read. Each of those means "put the caret at the end", which is the
+ * behavior this whole path replaced for real pointer presses only.
+ *
+ * Exported because a surface whose swap is decided by a PARENT has to capture
+ * the point itself: the editor is not mounted when the press happens, so the
+ * press target below never sees it. Cards' comment list is the case.
+ */
+export function pressPoint(event?: {
+    nativeEvent?: PressPoint
+}): { x: number; y: number } | undefined {
+    const { pageX, pageY } = event?.nativeEvent ?? {}
+    if (typeof pageX !== 'number' || typeof pageY !== 'number') return undefined
+    return { x: pageX, y: pageY }
+}
+
 export interface LazyEditorSlots {
     EditorComponent: ComponentType
     commands: EditorCommands
@@ -53,8 +83,15 @@ export interface LazyEditorHandle {
      * a session that is already open reclaims the editor without resetting the
      * revert baseline, so a repeated press cannot turn half-typed text into the
      * thing Escape reverts to.
+     *
+     * `at` is the viewport point the user pressed. The read view and the
+     * editing surface occupy the same box, so that point is where the caret
+     * belongs — without it, clicking into the middle of a paragraph dropped the
+     * caret at the very end and the reader had to click a second time. Omitted
+     * by callers with no press to speak of (a Reply button, a shortcut), which
+     * still get the caret at the end.
      */
-    edit: () => void
+    edit: (at?: { x: number; y: number }) => void
     /** Commit through the ordinary path, guards and all. */
     submit: () => void
     /** Discard and end the session, as Escape does. */
@@ -145,6 +182,16 @@ export interface LazyEditorProps {
      */
     startOpen?: boolean
     /**
+     * Viewport point to put the caret at when a `startOpen` session opens.
+     *
+     * The press-target branch below captures this itself, but a surface whose
+     * swap is decided by a PARENT never renders that branch: it is mounted
+     * already editing, after the press it should honour. Cards' inline comment
+     * edit is the case — without this the caret went to the end of the comment
+     * however far up someone clicked.
+     */
+    openAt?: { x: number; y: number }
+    /**
      * Keep the session open after a commit, clearing the editor instead.
      *
      * A composer sends and stays — the next comment goes in the same box, and
@@ -226,6 +273,7 @@ export function useLazyEditor({
     onRelease,
     isDialogOpen: dialogOpenProp,
     startOpen = false,
+    openAt,
     stayOpenOnCommit = false,
     renderEditor,
     renderHeader,
@@ -262,6 +310,12 @@ export function useLazyEditor({
         initialContent: value,
         onFocus: () => {
             hasFocusedRef.current = true
+            // The editor has genuinely landed and taken the caret, so the swap
+            // is over and blur handling comes back on. Keyed on the real focus
+            // event rather than on the effect that requests focus: the request
+            // can be made against an instance tiptap is about to replace, and
+            // only the event says one actually holds it.
+            isSwappingRef.current = false
             editorOptions.onFocus?.()
         },
         onBlur: () => {
@@ -300,6 +354,9 @@ export function useLazyEditor({
         baselineRef.current = value
         hasFocusedRef.current = false
         settledRef.current = false
+        // Set BEFORE the acquire, which is what moves the DOM node and so what
+        // raises the blur this suppresses.
+        isSwappingRef.current = true
         lease.acquire()
         setIsEditing(true)
     }, [lease, value])
@@ -307,6 +364,7 @@ export function useLazyEditor({
     // Take the instance back without disturbing a session in progress. Focus
     // follows from the generation effect below, which fires on every acquire.
     const reclaim = useCallback(() => {
+        isSwappingRef.current = true
         lease.acquire()
     }, [lease])
 
@@ -328,7 +386,9 @@ export function useLazyEditor({
     // reclaiming on idle would rip it out of the surface the user just clicked.
     const acquire = lease.acquire
     useEffect(() => {
-        if (startOpen) acquire()
+        if (!startOpen) return
+        isSwappingRef.current = true
+        acquire()
     }, [startOpen, acquire])
 
     // The warm instance parks with autofocus off — focusing a parked editor
@@ -339,18 +399,97 @@ export function useLazyEditor({
     //
     // Keyed on the generation rather than isEditing so a handover refocuses the
     // incoming surface too.
-    const focusedGenerationRef = useRef<number | null>(null)
-    if (isEditing && lease.result != null) {
-        if (focusedGenerationRef.current !== lease.generation) {
-            focusedGenerationRef.current = lease.generation
-            // Deferred: the editor is reconfigured during this commit, and
-            // focusing before it has applied the new content moves the caret in
-            // the outgoing surface's document.
-            queueMicrotask(() => lease.result?.editor.focus('end'))
+    // Where the press that opened this session landed, consumed by the focus
+    // effect below. A ref rather than state because it must not cause a render:
+    // it is read once, when the caret is taken, and is meaningless after that.
+    //
+    // Seeded from `openAt` for a parent-owned surface, which is mounted after
+    // the press it should honour and so never runs the press target that would
+    // otherwise fill this in.
+    const pendingFocusPointRef = useRef<{ x: number; y: number } | null>(openAt ?? null)
+    const leaseResult = lease.result
+
+    // True from the moment a swap is requested until the editor has landed in
+    // this surface and been focused.
+    //
+    // Taking the shared editor MOVES its DOM node (@tiptap/react's EditorContent
+    // `append`s the live ProseMirror element into its new parent and parks it in
+    // a detached div on the way out), and removing a focused element from the
+    // document blurs it. That blur is MACHINERY, not the user leaving — but the
+    // handler below cannot tell the difference, and for a surface with no
+    // blur-commit it means `endSession`, which releases the editor and closes
+    // the session that was just opened. Clicking a description therefore swapped
+    // the editor in and immediately threw it away again, leaving no caret.
+    //
+    // Losing focus mid-move is fine; the focus effect re-takes it once the node
+    // has landed. This flag is what keeps the blur in between from being read as
+    // intent.
+    const isSwappingRef = useRef(false)
+    // In an EFFECT, and then again after the next frame.
+    //
+    // Two things defeat a single synchronous focus here:
+    //
+    //  - A microtask (what this used to be) runs BEFORE React commits, so the
+    //    ProseMirror node is not in the document yet and the call does nothing.
+    //  - Acquiring the shared editor MOVES its DOM node: the provider renders it
+    //    in the parked viewport while nobody holds it and the surface renders it
+    //    once someone does, so React unmounts one and mounts the other. Removing
+    //    a focused element blurs it, and that removal happens right after this
+    //    effect — the caret appeared and vanished in the same frame.
+    //
+    // Focus is therefore taken HERE, after the commit — which is what makes a
+    // click place the caret at all, and what gives `posAtCoords` a laid-out view
+    // to resolve the click point against.
+    //
+    // Keyed on the EDITOR HANDLE, not on the generation. One acquire produces
+    // several handles: tiptap tears its instance down and rebuilds it, and each
+    // rebuild is a NEW ProseMirror node — the one focused a moment ago is
+    // discarded, still holding the caret nobody can see. Keying on the
+    // generation meant focusing the first of those and skipping every later one
+    // (the guard read "already focused this generation"), so the caret reliably
+    // landed on a node that was about to be thrown away.
+    //
+    // Re-focusing per handle is safe because it is not per RENDER: the handle
+    // only changes when tiptap actually replaced the instance, and the identity
+    // check below stops a repeat for one we have already focused.
+    //
+    // The blur each rebuild raises is ignored while the swap is in flight — see
+    // isSwappingRef, which clears on the real focus event. Losing focus mid-swap
+    // does not matter; landing it on the node that survives does.
+    const focusedEditorRef = useRef<EditorHandle | null>(null)
+    useEffect(() => {
+        if (!isEditing || leaseResult == null) {
+            // Cleared whenever this surface does not HOLD an editor, not merely
+            // when its session closes.
+            //
+            // There is one editor app-wide, so re-acquiring hands back the very
+            // same object — and the identity check below would then read it as
+            // "already focused" and skip the caret. A surface whose session
+            // outlives its holding hits exactly that: a composer and an inline
+            // comment edit are parent-owned (`startOpen`), so releasing the
+            // editor leaves `isEditing` true, and every re-acquire after the
+            // first silently declined to focus. Descriptions were unaffected
+            // only because their session closes with the holding.
+            focusedEditorRef.current = null
+            if (!isEditing) {
+                pendingFocusPointRef.current = null
+                // No session, so nothing is in flight. Clearing here is what
+                // stops a swap that never completed (an acquire this surface
+                // lost to another) from leaving blur-handling disabled for good
+                // — which would silently stop committing an inline edit.
+                isSwappingRef.current = false
+            }
+            return
         }
-    } else if (!isEditing) {
-        focusedGenerationRef.current = null
-    }
+        const editor = leaseResult.editor
+        if (focusedEditorRef.current === editor) return
+        focusedEditorRef.current = editor
+        // Kept until the caret is placed, NOT cleared per attempt: the point
+        // describes the press that opened the session, and a rebuild an instant
+        // later still wants the caret where the user pressed.
+        const at = pendingFocusPointRef.current
+        editor.focus(at ?? 'end')
+    }, [isEditing, leaseResult])
 
     const readContent = useCallback(
         async (editor: EditorHandle): Promise<string> =>
@@ -515,11 +654,16 @@ export function useLazyEditor({
     // into a stale render's state. The object identity below therefore stays
     // fixed while its behavior stays current, which is what lets a caller put it
     // in a dependency array without re-running on every keystroke.
+    const setPendingFocusPoint = useCallback((at: { x: number; y: number } | null) => {
+        pendingFocusPointRef.current = at
+    }, [])
+
     const handleFnsRef = useRef({
         openSession,
         reclaim,
         submit,
         cancel,
+        setPendingFocusPoint,
         isEditing: false,
         isSessionOpen: false,
     })
@@ -528,6 +672,7 @@ export function useLazyEditor({
         reclaim,
         submit,
         cancel,
+        setPendingFocusPoint,
         // What a CALLER means by "is it editing": holding a usable editor. A
         // displaced surface whose session is still open has nothing to type
         // into, so it reads false.
@@ -540,8 +685,11 @@ export function useLazyEditor({
 
     const handle = useMemo<LazyEditorHandle>(
         () => ({
-            edit: () => {
+            edit: (at?: { x: number; y: number }) => {
                 const fns = handleFnsRef.current
+                // Recorded before either branch, because both end in an acquire
+                // and it is the acquire's focus that consumes this.
+                fns.setPendingFocusPoint(at ?? null)
                 // A session already open — INCLUDING one displaced by a steal,
                 // which is the case this exists for — only takes the instance
                 // back. Re-opening would snapshot the user's half-typed text as
@@ -559,6 +707,10 @@ export function useLazyEditor({
 
     submitRef.current = submit
     blurRef.current = () => {
+        // A blur raised by the node being re-attached is not the user leaving —
+        // see isSwappingRef. Acting on it would commit or end a session that has
+        // only just started.
+        if (isSwappingRef.current) return
         if (
             shouldCommitOnBlur({
                 commitOnBlur,
@@ -609,7 +761,12 @@ export function useLazyEditor({
                     // renders this branch too, and it must reclaim the instance
                     // rather than re-open — otherwise tapping back into a
                     // composer would make its half-typed draft the revert target.
-                    onPress={handle.edit}
+                    //
+                    // The press point rides along so the caret lands where the
+                    // reader pressed. `pageX/pageY` are viewport coordinates on
+                    // RN-Web, which is what posAtCoords wants; a native press
+                    // has them too and simply falls back to 'end' there.
+                    onPress={event => handle.edit(pressPoint(event))}
                     accessibilityRole="button"
                     accessibilityLabel={accessibilityLabel}
                 >

--- a/core/components/editor/__tests__/lazy-editor-slots.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-slots.test.tsx
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // A held lease. There is one editor app-wide, and a surface that does not hold
 // it renders its read view — so a test about the EDITING slots has to be the
 // holder, or there is nothing to render.
+const focusSpy = vi.fn()
+
 vi.mock('../../../lib/editor/warm', () => ({
     useWarmEditor: () => ({
         isWarm: true,
@@ -19,7 +21,7 @@ vi.mock('../../../lib/editor/warm', () => ({
                 getText: vi.fn(async () => 'x'),
                 getMarkdown: vi.fn(async () => 'typed'),
                 setContent: vi.fn(),
-                focus: vi.fn(),
+                focus: focusSpy,
                 clear: vi.fn(),
                 getSelection: vi.fn(async () => null),
             },
@@ -47,7 +49,7 @@ const { useLazyEditor } = await import('../LazyEditor')
  * is never bound to a DOM event and a click cannot reach it. The Probe hands its
  * press handler out here instead, which is what lets a test open a session.
  */
-let startEditing: (() => void) | null = null
+let startEditing: ((event?: unknown) => void) | null = null
 
 function Probe({ canEdit = true }: { canEdit?: boolean }) {
     const slots = useLazyEditor({
@@ -65,8 +67,9 @@ function Probe({ canEdit = true }: { canEdit?: boolean }) {
     // The read view's press target is the Pressable in the body slot; its
     // onPress is what the swap hangs off.
     startEditing =
-        (isValidElement<{ onPress?: () => void }>(slots.body) ? slots.body.props.onPress : null) ??
-        null
+        (isValidElement<{ onPress?: (event?: unknown) => void }>(slots.body)
+            ? slots.body.props.onPress
+            : null) ?? null
 
     return (
         <View>
@@ -104,5 +107,39 @@ describe('useLazyEditor slots', () => {
         const { queryByTestId, getByText } = render(<Probe canEdit={false} />)
         expect(queryByTestId('probe-press')).toBeNull()
         expect(getByText('read view')).toBeTruthy()
+    })
+
+    /**
+     * The read view and the editing surface occupy the same box, so the point
+     * someone pressed on the prose is where the caret belongs. Without this the
+     * caret landed at the very end of the document and a reader who clicked
+     * into the middle of a paragraph had to click again to get there.
+     */
+    it('puts the caret where the read view was pressed', async () => {
+        focusSpy.mockClear()
+        render(<Probe />)
+        act(() => startEditing?.({ nativeEvent: { pageX: 120, pageY: 240 } }))
+        // The focus is deferred to a microtask: the editor is reconfigured
+        // during the same commit, and focusing before it has applied the new
+        // content moves the caret in the OUTGOING surface's document.
+        await act(async () => {})
+        expect(focusSpy).toHaveBeenCalledWith({ x: 120, y: 240 })
+    })
+
+    /**
+     * A press does not always carry coordinates — an accessibility activation
+     * and a keyboard-triggered press both arrive without them, and RN calls
+     * onPress with no event at all in some paths. Each must still open a
+     * session, with the caret at the end.
+     */
+    it.each([
+        ['no event at all', undefined],
+        ['an event with no coordinates', { nativeEvent: {} }],
+    ])('falls back to the end of the document given %s', async (_label, event) => {
+        focusSpy.mockClear()
+        render(<Probe />)
+        act(() => startEditing?.(event))
+        await act(async () => {})
+        expect(focusSpy).toHaveBeenCalledWith('end')
     })
 })

--- a/core/components/help/MarkdownRenderer.tsx
+++ b/core/components/help/MarkdownRenderer.tsx
@@ -14,7 +14,7 @@ import {
 import Markdown, { type MarkedStyles, Renderer } from 'react-native-marked'
 import { openHelp } from '../../lib/help/open-help'
 import { parseHelpTopicId } from '../../lib/help/types'
-import { type MarkdownPurpose, markdownScale } from './markdown-purpose'
+import { type MarkdownPurpose, type MarkdownScale, markdownScale } from './markdown-purpose'
 
 interface Props {
     body: string
@@ -110,12 +110,53 @@ function handleLinkPress(href: string, onLinkPress?: LinkPressHandler) {
     Linking.openURL(href).catch(() => {})
 }
 
+/**
+ * A heading's line height: the SURFACE's own body ratio, applied to the
+ * heading's own size.
+ *
+ * That is what the editor does — it sets no per-heading line-height, so each
+ * heading takes the page's unitless ratio — and the ratio differs per surface:
+ * a description is 21/14 (1.5) but a comment is 21/15 (1.4). Hard-coding 1.5
+ * therefore matched descriptions by luck and made every rendered comment
+ * heading 2px taller than the editor's, so a comment with headings re-spaced
+ * itself when tapped.
+ */
+function headingLineHeight(scale: MarkdownScale, size: number): number {
+    return Math.round(size * (scale.bodyLineHeight / scale.bodySize))
+}
+
+/**
+ * Trailing space below the last block of rendered markdown.
+ *
+ * EXPORTED because a surface that swaps an editor in where this was must
+ * reserve the same amount, or everything below it shifts by the difference the
+ * moment someone taps. Cards' inline comment edit is the case, and it used to
+ * carry a hand-measured constant that silently went stale whenever this moved.
+ */
+export const MARKDOWN_TRAILING_SPACE = 8
+
+/**
+ * Width of a bullet/number marker box, mirroring @jsamr/react-native-li's own
+ * `maxNumOfCodepoints * fontSize * 0.6`.
+ *
+ * A disc marker is two codepoints (the glyph and its trailing space), which is
+ * what the library measures for an unordered list. Derived rather than measured
+ * at runtime because it feeds a style computed during render.
+ */
+function markerBoxWidth(fontSize: number): number {
+    return fontSize * 1.2
+}
+
 interface RendererOptions {
     translateKeys: boolean
     shortcutTables: boolean
     onLinkPress?: LinkPressHandler
     transformImageUri?: ImageUriTransform
     imageMaxHeight?: number
+    /** How far a whole list is indented — see HelpRenderer.list. */
+    listIndent: number
+    /** Body size, used to reserve the marker box inside that indent. */
+    bodySize: number
 }
 
 /**
@@ -166,9 +207,13 @@ class HelpRenderer extends Renderer {
     private readonly onLinkPress?: LinkPressHandler
     private readonly transformImageUri?: ImageUriTransform
     private readonly imageMaxHeight?: number
+    private readonly listIndent: number
+    private readonly bodySize: number
 
     constructor(options: RendererOptions) {
         super()
+        this.listIndent = options.listIndent
+        this.bodySize = options.bodySize
         this.translateKeys = options.translateKeys
         this.shortcutTables = options.shortcutTables
         this.onLinkPress = options.onLinkPress
@@ -185,6 +230,39 @@ class HelpRenderer extends Renderer {
     // box and applies the passed style only to the inner image — so a
     // maxHeight there letterboxes the pixels while the layout box stays
     // full-bleed. A capped surface therefore renders its own image.
+    /**
+     * A whole list, indented as one block.
+     *
+     * The indent goes on a WRAPPER rather than on the item, because none of the
+     * per-item style objects is just the row: `list` is the marker box, and `li`
+     * reaches the marker's text style as well as the row's content. Putting a
+     * margin on either separated the bullet from its words — the marker stayed
+     * at the margin while the text moved right — and knocked the marker off its
+     * own baseline. Wrapping moves marker and text together, which is what
+     * `padding-left` on `ul` does in the editor.
+     */
+    override list(
+        ordered: boolean,
+        li: ReactNode[],
+        listStyle?: ViewStyle,
+        textStyle?: TextStyle,
+        startIndex?: number
+    ): ReactNode {
+        // The marker box is part of the indent, not additional to it.
+        //
+        // In the editor `ul { padding-left }` reserves the space and the bullet
+        // is drawn INSIDE it, so the text starts at the indent. Here the marker
+        // is a sibling box laid out before the text, so wrapping at the full
+        // indent put the text a marker-width further right than the editor's.
+        // Reserving it keeps the TEXT on the same x in both.
+        const inset = Math.max(0, this.listIndent - markerBoxWidth(this.bodySize))
+        return (
+            <View key={this.getKey()} style={{ marginLeft: inset }}>
+                {super.list(ordered, li, listStyle, textStyle, startIndex)}
+            </View>
+        )
+    }
+
     override image(uri: string, alt?: string, style?: ImageStyle, title?: string): ReactNode {
         const resolved = this.transformImageUri ? this.transformImageUri(uri) : uri
         if (this.imageMaxHeight) {
@@ -337,7 +415,9 @@ const rendererCache = new Map<string, HelpRenderer>()
 function rendererFor(options: RendererOptions): HelpRenderer {
     // Per-consumer functions can't be stringified, so each gets an identity
     // tag: same function object → same cache slot.
-    const key = `${options.translateKeys}|${options.shortcutTables}|${functionTag(options.onLinkPress)}|${functionTag(options.transformImageUri)}|${options.imageMaxHeight ?? 'none'}`
+    // The indent is part of the key: it varies per PURPOSE, and a renderer
+    // cached without it would serve a comment the description's indent.
+    const key = `${options.translateKeys}|${options.shortcutTables}|${functionTag(options.onLinkPress)}|${functionTag(options.transformImageUri)}|${options.imageMaxHeight ?? 'none'}|${options.listIndent}|${options.bodySize}`
     const cached = rendererCache.get(key)
     if (cached) return cached
     const renderer = new HelpRenderer(options)
@@ -387,7 +467,32 @@ export function MarkdownRenderer({
     const styles = useMemo<MarkedStyles>(
         () => ({
             text: { color: foreground, fontSize: scale.bodySize, lineHeight: scale.bodyLineHeight },
-            paragraph: { marginVertical: scale.paragraphSpacing },
+            // A TOP margin only, never marginVertical.
+            //
+            // CSS collapses adjoining margins and React Native does not, so
+            // `marginVertical` puts the gap in twice between any two blocks —
+            // which is why a comment rendered with roughly double the rhythm of
+            // the editor that replaces it, and read as airy where the editor
+            // read as tight. The editor states the same thing once, as
+            // `.ProseMirror > * + * { margin-top }`, and the headings here
+            // already follow this rule (marginBottom: 0).
+            // paddingVertical: 0 is load-bearing. The library defaults a
+            // paragraph to `paddingVertical: 8` and our styles MERGE onto that
+            // rather than replace it, so every paragraph carried 16px of
+            // padding no other block had — the editor has none, so a rendered
+            // description read looser than the editor it swaps with even once
+            // the margins matched. Same trap as the h1/h2 border below.
+            // The gap BETWEEN blocks, stated once as a top margin (RN margins
+            // do not collapse). The leading one it also puts on the first block
+            // is cancelled by the consumer's wrapper — see MarkdownText.
+            //
+            // paddingVertical: 0 is load-bearing. The library defaults a
+            // paragraph to `paddingVertical: 8` and our styles MERGE onto that
+            // rather than replace it, so every paragraph carried 16px of
+            // padding no other block had — the editor has none, so a rendered
+            // description read looser than the editor it swaps with even once
+            // the margins matched. Same trap as the h1/h2 border below.
+            paragraph: { marginTop: scale.paragraphSpacing, paddingVertical: 0 },
             em: { fontStyle: 'italic' },
             strong: { fontWeight: '600' },
             link: { color: link, textDecorationLine: 'underline' },
@@ -399,6 +504,12 @@ export function MarkdownRenderer({
             h1: {
                 color: foreground,
                 fontSize: scale.h1.size,
+                // Stated, not inherited: the library defaults a heading to a
+                // much looser line than the editor's, which made every rendered
+                // heading taller than the one it swaps with. The editor sets no
+                // per-heading line-height, so a heading there takes the page's
+                // ratio — matched here against the heading's OWN size.
+                lineHeight: headingLineHeight(scale, scale.h1.size),
                 fontWeight: scale.h1.weight,
                 marginTop: scale.h1.marginTop,
                 marginBottom: scale.h1.marginBottom,
@@ -407,6 +518,12 @@ export function MarkdownRenderer({
             h2: {
                 color: foreground,
                 fontSize: scale.h2.size,
+                // Stated, not inherited: the library defaults a heading to a
+                // much looser line than the editor's, which made every rendered
+                // heading taller than the one it swaps with. The editor sets no
+                // per-heading line-height, so a heading there takes the page's
+                // ratio — matched here against the heading's OWN size.
+                lineHeight: headingLineHeight(scale, scale.h2.size),
                 fontWeight: scale.h2.weight,
                 marginTop: scale.h2.marginTop,
                 marginBottom: scale.h2.marginBottom,
@@ -415,6 +532,12 @@ export function MarkdownRenderer({
             h3: {
                 color: foreground,
                 fontSize: scale.h3.size,
+                // Stated, not inherited: the library defaults a heading to a
+                // much looser line than the editor's, which made every rendered
+                // heading taller than the one it swaps with. The editor sets no
+                // per-heading line-height, so a heading there takes the page's
+                // ratio — matched here against the heading's OWN size.
+                lineHeight: headingLineHeight(scale, scale.h3.size),
                 fontWeight: scale.h3.weight,
                 marginTop: scale.h3.marginTop,
                 marginBottom: scale.h3.marginBottom,
@@ -422,6 +545,12 @@ export function MarkdownRenderer({
             h4: {
                 color: foreground,
                 fontSize: scale.h4.size,
+                // Stated, not inherited: the library defaults a heading to a
+                // much looser line than the editor's, which made every rendered
+                // heading taller than the one it swaps with. The editor sets no
+                // per-heading line-height, so a heading there takes the page's
+                // ratio — matched here against the heading's OWN size.
+                lineHeight: headingLineHeight(scale, scale.h4.size),
                 fontWeight: scale.h4.weight,
                 marginTop: scale.h4.marginTop,
                 marginBottom: scale.h4.marginBottom,
@@ -433,6 +562,12 @@ export function MarkdownRenderer({
             h5: {
                 color: purpose === 'documentation' ? muted : foreground,
                 fontSize: scale.h5.size,
+                // Stated, not inherited: the library defaults a heading to a
+                // much looser line than the editor's, which made every rendered
+                // heading taller than the one it swaps with. The editor sets no
+                // per-heading line-height, so a heading there takes the page's
+                // ratio — matched here against the heading's OWN size.
+                lineHeight: headingLineHeight(scale, scale.h5.size),
                 fontWeight: scale.h5.weight,
                 marginTop: scale.h5.marginTop,
                 marginBottom: scale.h5.marginBottom,
@@ -440,6 +575,12 @@ export function MarkdownRenderer({
             h6: {
                 color: purpose === 'documentation' ? muted : foreground,
                 fontSize: scale.h6.size,
+                // Stated, not inherited: the library defaults a heading to a
+                // much looser line than the editor's, which made every rendered
+                // heading taller than the one it swaps with. The editor sets no
+                // per-heading line-height, so a heading there takes the page's
+                // ratio — matched here against the heading's OWN size.
+                lineHeight: headingLineHeight(scale, scale.h6.size),
                 fontWeight: scale.h6.weight,
                 marginTop: scale.h6.marginTop,
                 marginBottom: scale.h6.marginBottom,
@@ -470,7 +611,22 @@ export function MarkdownRenderer({
                 marginVertical: 8,
             },
             hr: { borderBottomColor: border, borderBottomWidth: 1, marginVertical: 12 },
-            list: { marginVertical: scale.listSpacing },
+            // NOT a list box. react-native-marked hands this straight to
+            // @jsamr/react-native-li as `markerBoxStyle`, which applies it to
+            // each BULLET GLYPH — so a margin here shifts the markers away from
+            // their own text rather than indenting the list. Everything the list
+            // needs therefore lives on `li` below, which IS the item row.
+            // Neither of these may carry GEOMETRY, and that is not obvious from
+            // the names. react-native-marked hands `list` to the marker box and
+            // `li` to three places at once — the item's text, the item's row,
+            // AND the marker's own text style — so a margin on either lands on
+            // the bullet as well as the row. That is what indented the text a
+            // second time (bullet at one x, words 38px further right) and
+            // dropped every marker 8px below its own line.
+            //
+            // Typography only here; the row's indent and rhythm are applied in
+            // HelpRenderer.listItem, which is the one place that IS just the row.
+            list: {},
             li: {
                 color: foreground,
                 fontSize: scale.bodySize,
@@ -492,6 +648,8 @@ export function MarkdownRenderer({
     const renderer = rendererFor({
         translateKeys: shouldTranslateKeys && !isMacLike(),
         shortcutTables: shortcutTableHeuristic,
+        listIndent: scale.listIndent,
+        bodySize: scale.bodySize,
         onLinkPress,
         transformImageUri,
         imageMaxHeight,
@@ -505,7 +663,7 @@ export function MarkdownRenderer({
             flatListProps={{
                 initialNumToRender: 8,
                 scrollEnabled: false,
-                contentContainerStyle: { paddingBottom: 8 },
+                contentContainerStyle: { paddingBottom: MARKDOWN_TRAILING_SPACE },
                 // Override the library's hardcoded #fff/#000 scheme background
                 // (its own style loses to flatListProps). An OPAQUE box here
                 // paints over anything a caller's negative margin pulls it

--- a/core/components/help/__tests__/markdown-purpose.test.ts
+++ b/core/components/help/__tests__/markdown-purpose.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { EDITOR_CONTENT_STYLES } from '../../../lib/editor/rich/editor-content-styles'
+import { editorScaleFor } from '../../../lib/editor/rich/editor-scale'
 import { markdownScale } from '../markdown-purpose'
 
 // The `description` scale exists to make the READ state of a card description
@@ -17,12 +18,20 @@ import { markdownScale } from '../markdown-purpose'
 const EDITOR_BASE_PX = 14
 
 /** Pull `font-size: <n>em` for a selector out of the editor stylesheet. */
+/**
+ * The `em` a heading falls back to when a surface states no scale of its own.
+ *
+ * Sizes are CSS variables now, because the surfaces genuinely differ: a comment
+ * caps its headings near body text while a description scales them like a
+ * document. The fallback in each `var()` is the description's value, which is
+ * what these tests pin.
+ */
 function editorEm(selector: string): number {
     const rule = new RegExp(`\\.ProseMirror ${selector}[^{]*\\{([^}]*)\\}`)
     const body = EDITOR_CONTENT_STYLES.match(rule)?.[1]
     if (!body) throw new Error(`no rule for ${selector} in the editor stylesheet`)
-    const size = body.match(/font-size:\s*([\d.]+)em/)?.[1]
-    if (!size) throw new Error(`no em font-size for ${selector}`)
+    const size = body.match(/font-size:\s*var\([^,]+,\s*([\d.]+)em\)/)?.[1]
+    if (!size) throw new Error(`no em fallback for ${selector}`)
     return Number.parseFloat(size)
 }
 
@@ -31,6 +40,32 @@ describe('the description scale matches the editor', () => {
 
     it('uses the editor page’s base font size for body text', () => {
         expect(scale.bodySize).toBe(EDITOR_BASE_PX)
+    })
+
+    // The editor previously stated no size of its own on web, so `.ProseMirror`
+    // inherited the app's 16px body while the read view rendered at 14 — every
+    // line and every `em`-sized heading grew the moment anyone tapped to edit.
+    // The declaration below is what closed that; the fallback in it is the
+    // description's base, so a surface that passes no scale still matches.
+    it('states a base font size rather than inheriting the page', () => {
+        const declared = EDITOR_CONTENT_STYLES.match(
+            /\.ProseMirror\s*\{[^}]*font-size:\s*var\(--editor-base-font-size,\s*(\d+)px\)/
+        )
+        expect(declared, 'the editor stylesheet states no base font size').not.toBeNull()
+        expect(Number(declared?.[1])).toBe(EDITOR_BASE_PX)
+    })
+
+    // A list's indent is `em` in the editor, so it tracks that surface's own
+    // base. The renderer indents nothing by default, so without porting this
+    // the rendered bullets hung at the margin while the editor's sat 1.5em in.
+    it('indents lists exactly as the editor does', () => {
+        const indent = EDITOR_CONTENT_STYLES.match(
+            /\.ProseMirror ul, \.ProseMirror ol\s*\{[^}]*padding-left:\s*([\d.]+)em/
+        )
+        expect(indent, 'the editor stylesheet states no list indent').not.toBeNull()
+        expect(scale.listIndent).toBe(
+            Math.round(EDITOR_BASE_PX * Number.parseFloat(indent?.[1] ?? '0'))
+        )
     })
 
     it.each([
@@ -47,7 +82,7 @@ describe('the description scale matches the editor', () => {
     // would reflow the prose the moment someone tapped to edit.
     it('spaces blocks on the editor’s single rhythm', () => {
         const emMatch = EDITOR_CONTENT_STYLES.match(
-            /\.ProseMirror > \* \+ \*\s*\{[^}]*margin-top:\s*([\d.]+)em/
+            /\.ProseMirror > \* \+ \*\s*\{[^}]*margin-top:\s*var\([^,]+,\s*([\d.]+)em\)/
         )
         expect(emMatch).not.toBeNull()
         const expected = Math.round(EDITOR_BASE_PX * Number.parseFloat(emMatch?.[1] ?? '0'))
@@ -68,6 +103,64 @@ describe('the description scale matches the editor', () => {
     it('draws no rule under a heading, because the editor draws none', () => {
         expect(scale.headingRule).toBe(false)
         expect(EDITOR_CONTENT_STYLES).not.toMatch(/\.ProseMirror h[12][^{]*\{[^}]*border-bottom/)
+    })
+})
+
+// The gap that let a comment edit at a description's proportions: the parity
+// suite only ever checked `description`, so nothing noticed that the editor
+// applied one scale to every surface. `editorScaleFor` is now the single source
+// both sides read, and these pin it per purpose.
+describe('the editor scale is the read scale, for every surface', () => {
+    it.each(['description', 'compact'] as const)('matches the %s read scale', purpose => {
+        const read = markdownScale(purpose)
+        const editor = editorScaleFor(purpose)
+
+        expect(editor.bodySize).toBe(read.bodySize)
+        expect(editor.bodyLineHeight).toBe(read.bodyLineHeight)
+        expect(editor.blockSpacing).toBe(read.paragraphSpacing)
+        expect(editor.h1).toBe(read.h1.size)
+        expect(editor.h2).toBe(read.h2.size)
+        expect(editor.h3).toBe(read.h3.size)
+        expect(editor.h4).toBe(read.h4.size)
+    })
+
+    // A comment is a message in a thread: its headings stay near body text and
+    // its rhythm is tight. A description is a document. If these ever converged
+    // the compact scale would have stopped meaning anything.
+    it('keeps a comment visibly tighter than a description', () => {
+        const comment = editorScaleFor('compact')
+        const description = editorScaleFor('description')
+        expect(comment.h1).toBeLessThan(description.h1)
+        expect(comment.blockSpacing).toBeLessThan(description.blockSpacing)
+    })
+})
+
+// RN margins do not collapse, so a bottom margin is ADDED to the next block's
+// top one. Every scale with an editor behind it must therefore state the gap
+// once, as a top margin — the editor says it once too, as `* + *`. Getting this
+// wrong is invisible in isolation and doubles the rhythm of the rendered view.
+describe('scales with an editor state their gaps once', () => {
+    it.each(['description', 'compact'] as const)('%s sets no bottom margins', purpose => {
+        const scale = markdownScale(purpose)
+        expect(scale.h1.marginBottom).toBe(0)
+        expect(scale.h2.marginBottom).toBe(0)
+        expect(scale.h3.marginBottom).toBe(0)
+        expect(scale.h4.marginBottom).toBe(0)
+        expect(scale.h5.marginBottom).toBe(0)
+        expect(scale.h6.marginBottom).toBe(0)
+    })
+})
+
+// The editor spaces every block with ONE rule — `* + * { margin-top }` — so a
+// heading gets exactly the same gap as a paragraph. A scale that gives headings
+// their own larger margin renders looser than the editor it swaps with, which
+// is what made a comment's headings sit twice as far from the text above them.
+describe('scales with an editor space every block alike', () => {
+    it.each(['description', 'compact'] as const)('%s spaces headings as blocks', purpose => {
+        const scale = markdownScale(purpose)
+        for (const key of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const) {
+            expect(scale[key].marginTop).toBe(scale.paragraphSpacing)
+        }
     })
 })
 

--- a/core/components/help/markdown-purpose.ts
+++ b/core/components/help/markdown-purpose.ts
@@ -31,6 +31,15 @@ export interface MarkdownScale {
     /** A rule under h1/h2 suits a long document and nothing shorter. */
     headingRule: boolean
     listSpacing: number
+    /**
+     * How far a list's text sits from the margin, in px.
+     *
+     * Ported from `.ProseMirror ul, .ProseMirror ol { padding-left: 1.5em }`.
+     * The renderer indents nothing by default, so a rendered bullet list hung
+     * at the margin while the editor's sat 1.5em in — and the markers landed on
+     * a different x the moment anyone tapped to edit.
+     */
+    listIndent: number
 }
 
 interface HeadingScale {
@@ -50,6 +59,12 @@ const EDITOR_BASE_PX = 14
 
 /** `.ProseMirror > * + * { margin-top: 0.6em }` — the editor's block rhythm. */
 const EDITOR_BLOCK_SPACING = Math.round(EDITOR_BASE_PX * 0.6)
+
+/**
+ * `.ProseMirror ul, .ProseMirror ol { padding-left: 1.5em }` — the editor's
+ * list indent, as a multiple of the surface's own base size.
+ */
+export const EDITOR_LIST_INDENT_EM = 1.5
 
 /**
  * Ported from `.ProseMirror h1/h2/h3` in editor-content-styles.ts.
@@ -93,6 +108,7 @@ const DESCRIPTION_SCALE: MarkdownScale = {
     // The editor draws no rule under a heading, so neither may this.
     headingRule: false,
     listSpacing: EDITOR_BLOCK_SPACING,
+    listIndent: Math.round(EDITOR_BASE_PX * EDITOR_LIST_INDENT_EM),
 }
 
 /**
@@ -113,6 +129,7 @@ const DOCUMENTATION_SCALE: MarkdownScale = {
     h6: { size: 13, weight: '600', marginTop: 8, marginBottom: 2 },
     headingRule: true,
     listSpacing: 6,
+    listIndent: Math.round(15 * EDITOR_LIST_INDENT_EM),
 }
 
 /**
@@ -122,19 +139,29 @@ const DOCUMENTATION_SCALE: MarkdownScale = {
  * someone reaching for emphasis, not declaring a document title, so the
  * loudest it gets is a little above body text. Spacing is tight for the same
  * reason: five short lines should read as five short lines, not fill a screen.
+ *
+ * Top margins only, as in DESCRIPTION_SCALE: RN margins do not collapse, and a
+ * bottom margin here would be ADDED to the next block's top one. The 2px bottom
+ * these headings used to carry is what made a rendered comment space nearly
+ * twice as far apart as the editor that replaces it.
  */
 const COMPACT_SCALE: MarkdownScale = {
     bodySize: 15,
     bodyLineHeight: 21,
     paragraphSpacing: 4,
-    h1: { size: 17, weight: '700', marginTop: 8, marginBottom: 2 },
-    h2: { size: 16, weight: '700', marginTop: 8, marginBottom: 2 },
-    h3: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
-    h4: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
-    h5: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
-    h6: { size: 15, weight: '600', marginTop: 6, marginBottom: 2 },
+    // marginTop is COMPACT_BLOCK_SPACING for every level, because the editor
+    // spaces all blocks with one `* + *` rule and a heading is not special to
+    // it. Giving headings a larger gap here made a rendered comment's headings
+    // sit twice as far from the text above them as the editor's did.
+    h1: { size: 17, weight: '700', marginTop: 4, marginBottom: 0 },
+    h2: { size: 16, weight: '700', marginTop: 4, marginBottom: 0 },
+    h3: { size: 15, weight: '600', marginTop: 4, marginBottom: 0 },
+    h4: { size: 15, weight: '600', marginTop: 4, marginBottom: 0 },
+    h5: { size: 15, weight: '600', marginTop: 4, marginBottom: 0 },
+    h6: { size: 15, weight: '600', marginTop: 4, marginBottom: 0 },
     headingRule: false,
     listSpacing: 4,
+    listIndent: Math.round(15 * EDITOR_LIST_INDENT_EM),
 }
 
 const SCALES: Record<MarkdownPurpose, MarkdownScale> = {

--- a/core/lib/editor/rich/editor-content-styles.ts
+++ b/core/lib/editor/rich/editor-content-styles.ts
@@ -41,19 +41,83 @@ export function scopeEditorStyles(css: string, scopeClass = EDITOR_SCOPE_CLASS):
     return css.replace(/(^|,)(\s*)\.ProseMirror\b/gm, `$1$2.${scopeClass} .ProseMirror`)
 }
 
+/**
+ * React Native Web's default `Text` font stack, as the read view resolves it.
+ *
+ * Kept beside the sheet that uses it rather than imported, because the sheet is
+ * a plain string shared with the native WebView page — which has no access to
+ * RN's runtime and must be handed the same list literally.
+ */
+const RN_WEB_FONT_STACK =
+    '-apple-system, "system-ui", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, ' +
+    '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
+
 export const EDITOR_CONTENT_STYLES = `
 .ProseMirror {
     padding: 0;
     caret-color: var(--editor-accent-color, currentColor);
+    /* The type scale the whole surface is built on.
+     *
+     * Every heading below is sized in \`em\`, so this ONE value decides how the
+     * editor reads — and the read view that swaps places with it derives its
+     * own sizes from the same number (components/help/markdown-purpose.ts).
+     * Stating it here is what keeps the two identical rather than merely
+     * similar: on web the editor previously set no size at all and inherited
+     * the app's 16px body, so tapping to edit grew every line and every
+     * heading, and the prose visibly reflowed under the caret.
+     *
+     * A variable rather than a literal because the surfaces differ: a card
+     * description is 14px, a comment 15px. The host sets it per surface and
+     * the fallback is the description's base. */
+    font-size: var(--editor-base-font-size, 14px);
+    line-height: var(--editor-base-line-height, 1.5);
+    /* The SAME stack React Native Web resolves its default Text to.
+     *
+     * Stated rather than inherited: on web this sheet lands in a page whose
+     * body font is Tailwind's "ui-sans-serif, system-ui, ...", so the editor
+     * rendered in a different face from the markdown it replaces. Same size,
+     * same line-height, different glyph widths — which shows up as the prose
+     * re-wrapping the instant someone taps to edit (a three-line comment
+     * became four), and reads as though the line spacing had changed. */
+    font-family: ${RN_WEB_FONT_STACK};
+    /* Ligatures back ON, matching the rendered markdown.
+     *
+     * Something in the page CSS (uniwind/Tailwind's preflight) disables them
+     * on the editing surface. Disabled ligatures set text measurably WIDER —
+     * the same 174 characters fitted 411px in the read view and only 398px
+     * here — so a comment that rendered in three lines re-wrapped to four the
+     * moment it was tapped, which reads as the line spacing having changed. */
+    font-variant-ligatures: normal;
+    font-feature-settings: normal;
 }
 .ProseMirror:focus {
     outline: none;
 }
-.ProseMirror > * + * {
-    margin-top: 0.6em;
-}
+/* The block rhythm. A variable because the surfaces differ: a description is a
+   document and spaces on the editor's own 0.6em, while a comment is a message
+   in a thread and spaces far more tightly. The read view derives the same
+   number from markdownScale(), which is what keeps the swap from reflowing. */
 .ProseMirror p {
-    margin: 0;
+    /* Reset the browser's default paragraph margins WITHOUT touching the top
+       one, which the block-rhythm rule below owns.
+    
+       A blanket "margin: 0" here always beat that rule: scoping prefixes both
+       selectors with the wrapper class, and this one carries an extra element
+       token, so it wins on specificity no matter which is declared first. The
+       result was that consecutive paragraphs got no gap at all in the editor
+       while the rendered markdown gave them one — a multi-paragraph comment
+       re-spaced itself the instant it was tapped. */
+    margin-right: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+}
+.ProseMirror > * + * {
+    margin-top: var(--editor-block-spacing, 0.6em);
+}
+/* The FIRST block has nothing above it to be spaced from. Stated separately
+   because the reset above no longer covers margin-top. */
+.ProseMirror > :first-child {
+    margin-top: 0;
 }
 /* Placeholder is a decoration on the first empty node, not real text — it must
    not be selectable or it lands in copied content. */
@@ -64,11 +128,42 @@ export const EDITOR_CONTENT_STYLES = `
     height: 0;
     pointer-events: none;
 }
-.ProseMirror h1 { font-size: 1.6em; font-weight: 700; }
-.ProseMirror h2 { font-size: 1.35em; font-weight: 700; }
-.ProseMirror h3 { font-size: 1.15em; font-weight: 600; }
+/* ProseMirror appends an empty paragraph after a document that ends in a
+   BLOCK node — a list, a table, a code block — so the caret has somewhere to go
+   to escape it. It is a caret affordance and nothing else: it is never typed,
+   never saved (the stored markdown has no trailing blank), and it is recreated
+   on load, so it cannot be removed from the document without taking that escape
+   route away.
+
+   Collapsing it is what keeps it from costing height. A comment ending in a
+   list opened 25px taller than the text it replaced — one line plus its gap —
+   which pushed every comment below it down on focus and back up on blur. The
+   node still exists and still accepts the caret; it simply reserves no space
+   until it does.
+
+   :focus-within so the escape route reappears the moment someone is actually in
+   the editor and might need it. */
+.ProseMirror > p:last-child:empty,
+.ProseMirror > p.is-empty:last-child:not(:first-child) {
+    height: 0;
+    margin-top: 0;
+    overflow: hidden;
+}
+.ProseMirror:focus-within > p:last-child:empty,
+.ProseMirror:focus-within > p.is-empty:last-child:not(:first-child) {
+    height: auto;
+    margin-top: var(--editor-block-spacing, 0.6em);
+    overflow: visible;
+}
+/* Heading sizes are variables for the same reason as the rhythm above. A
+   description SCALES them (a heading is a document heading); a comment CAPS
+   them near body size, because an "# H1" in a chat message is someone reaching
+   for emphasis, not declaring a title. The fallbacks are the description's. */
+.ProseMirror h1 { font-size: var(--editor-h1-size, 1.6em); font-weight: 700; }
+.ProseMirror h2 { font-size: var(--editor-h2-size, 1.35em); font-weight: 700; }
+.ProseMirror h3 { font-size: var(--editor-h3-size, 1.15em); font-weight: 600; }
 .ProseMirror h4, .ProseMirror h5, .ProseMirror h6 {
-    font-size: 1em;
+    font-size: var(--editor-h4-size, 1em);
     font-weight: 600;
 }
 .ProseMirror blockquote {
@@ -80,8 +175,12 @@ export const EDITOR_CONTENT_STYLES = `
     color: var(--editor-primary-color, #2563eb);
     text-decoration: underline;
 }
+/* Indent in \`em\`, not \`rem\`: a rem is the APP's root size, which has nothing
+   to do with this surface's type scale, so a 14px description and a 15px
+   comment both indented by the same 24px while their markers scaled with the
+   text. The read view derives its indent from the same multiple. */
 .ProseMirror ul, .ProseMirror ol {
-    padding-left: 1.5rem;
+    padding-left: 1.5em;
     margin: 0;
 }
 .ProseMirror ul { list-style: disc; }

--- a/core/lib/editor/rich/editor-scale.ts
+++ b/core/lib/editor/rich/editor-scale.ts
@@ -1,0 +1,55 @@
+import { type MarkdownPurpose, markdownScale } from '../../../components/help/markdown-purpose'
+import type { EditorTypeScale } from './options'
+
+/**
+ * The editor's type scale for a surface, derived from the SAME entry the read
+ * view renders at.
+ *
+ * The editor and the rendered markdown swap places on a tap, so every number
+ * they disagree on is prose that moves under the reader's caret at the moment
+ * they start editing. Deriving both from `markdownScale(purpose)` is what makes
+ * that impossible to get wrong — the alternative, restating the values in the
+ * stylesheet, is exactly how a comment ended up editing at a description's
+ * proportions: headings half again too large and blocks spaced twice as far
+ * apart as the comment they replaced.
+ *
+ * Returned in px rather than em because the caller writes them into CSS custom
+ * properties, and an em there would compound against the base this same object
+ * sets.
+ */
+export function editorScaleFor(purpose: MarkdownPurpose): EditorTypeScale {
+    const scale = markdownScale(purpose)
+    return {
+        bodySize: scale.bodySize,
+        bodyLineHeight: scale.bodyLineHeight,
+        // The renderer expresses the gap as a top margin on the following block
+        // (RN margins do not collapse); `.ProseMirror > * + *` is the same rule
+        // said in CSS, so the number carries over unchanged.
+        blockSpacing: scale.paragraphSpacing,
+        h1: scale.h1.size,
+        h2: scale.h2.size,
+        h3: scale.h3.size,
+        h4: scale.h4.size,
+    }
+}
+
+/**
+ * The scale as CSS custom properties for the web wrapper.
+ *
+ * Returns nothing when no scale was given, so the stylesheet's own fallbacks
+ * (the description's values) stay in force — writing `undefined` into a custom
+ * property breaks the cascade rather than falling back.
+ */
+export function editorScaleVars(scale?: EditorTypeScale): Record<string, string> {
+    if (!scale) return {}
+    return {
+        '--editor-base-font-size': `${scale.bodySize}px`,
+        // Unitless, so it inherits proportionally the way a line-height should.
+        '--editor-base-line-height': `${scale.bodyLineHeight / scale.bodySize}`,
+        '--editor-block-spacing': `${scale.blockSpacing}px`,
+        '--editor-h1-size': `${scale.h1}px`,
+        '--editor-h2-size': `${scale.h2}px`,
+        '--editor-h3-size': `${scale.h3}px`,
+        '--editor-h4-size': `${scale.h4}px`,
+    }
+}

--- a/core/lib/editor/rich/extensions.ts
+++ b/core/lib/editor/rich/extensions.ts
@@ -77,6 +77,21 @@ export function buildRichEditorExtensions(
             // Yjs owns history under collaboration; StarterKit's would undo
             // other people's edits.
             undoRedo: collab ? false : undefined,
+            // No phantom paragraph after a trailing list or table.
+            //
+            // TrailingNode INSERTS a real paragraph into the document whenever
+            // the last node is not one — `tr.insert(endPosition, type.create())`
+            // — so it is not a rendering artifact that could be styled away. It
+            // cost a full line plus its gap (25px) on every surface whose body
+            // ends in a list, which is height the rendered markdown does not
+            // have: opening such a comment for editing pushed everything below
+            // it down, and closing it pulled them back up.
+            //
+            // Its purpose is to leave the caret somewhere to go after a trailing
+            // block. Gapcursor, also in StarterKit and left enabled, already
+            // does that — it puts a real cursor position after the last node —
+            // so nothing is lost by not also materialising a paragraph.
+            trailingNode: false,
         }),
         TaskList,
         TaskItem.configure({ nested: true }),

--- a/core/lib/editor/rich/options.ts
+++ b/core/lib/editor/rich/options.ts
@@ -3,6 +3,23 @@ import type { TriggerConfig } from './triggers'
 
 export type { RichEditorCollabOptions }
 
+/**
+ * The type scale one editing surface renders at, in px.
+ *
+ * Built by `editorScaleFor()` from the same `markdownScale(purpose)` entry the
+ * read view uses, so the two cannot drift.
+ */
+export interface EditorTypeScale {
+    bodySize: number
+    bodyLineHeight: number
+    blockSpacing: number
+    h1: number
+    h2: number
+    h3: number
+    /** h4-h6 share one size in both the editor and the renderer. */
+    h4: number
+}
+
 /** How `initialContent` is interpreted and what `setContent` accepts. */
 export type EditorContentFormat = 'html' | 'markdown'
 
@@ -35,6 +52,21 @@ export interface UseRichEditorOptions {
     minHeight?: number
     /** Hard character ceiling; typing stops here rather than failing on save. */
     characterLimit?: number
+    /**
+     * The surface's type scale, in px.
+     *
+     * The editor and the read view swap places on a tap, so ANY difference
+     * between them reflows the prose under the caret at the moment someone
+     * starts editing. Both sides therefore derive from one source: pass
+     * `editorScaleFor(purpose)`, whose numbers come from the same
+     * `markdownScale(purpose)` the renderer uses.
+     *
+     * Headings and block spacing are included, not just the base, because the
+     * surfaces genuinely differ in more than size — a comment CAPS its headings
+     * near body text and spaces tightly, while a description scales them like a
+     * document. Omitted entirely, the sheet keeps the description's values.
+     */
+    scale?: EditorTypeScale
     /** ⌘/Ctrl+Enter handler. See SubmitShortcut for why this is not a DOM listener. */
     onSubmitShortcut?: () => void
     /**

--- a/core/lib/editor/rich/use-rich-editor.native.tsx
+++ b/core/lib/editor/rich/use-rich-editor.native.tsx
@@ -60,6 +60,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         autofocus,
         editable = true,
         characterLimit,
+        scale,
         minHeight,
         onSubmitShortcut,
         onEscape,
@@ -186,6 +187,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
             placeholder,
             editable,
             characterLimit,
+            scale,
             autofocus: autofocus ?? false,
             colors: {
                 bg: theme?.backgroundColor ?? bgColor,
@@ -241,6 +243,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         placeholder,
         editable,
         characterLimit,
+        scale,
         autofocus,
         theme?.backgroundColor,
         bgColor,

--- a/core/lib/editor/rich/use-rich-editor.web.tsx
+++ b/core/lib/editor/rich/use-rich-editor.web.tsx
@@ -10,6 +10,7 @@ import {
     EDITOR_SCOPE_CLASS,
     scopeEditorStyles,
 } from './editor-content-styles'
+import { editorScaleVars } from './editor-scale'
 import { buildRichEditorExtensions } from './extensions'
 import { extractImageFilesFromDrop, extractImageFilesFromPaste } from './extract-image-files'
 import { repairMarkdown } from './markdown-repair'
@@ -81,6 +82,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         onImageDrop,
         collab,
         triggers,
+        scale,
     } = options
 
     const placeholderColor = useThemeColor('field-placeholder')
@@ -184,10 +186,18 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     // identity of the configuration, never the caller's objects.
     const collabDoc = collab?.document ?? null
     const collabField = collab?.field ?? null
-    const collabAwareness = collab?.awareness ?? null
-    const collabUserId = collab?.user?.id ?? null
-    const collabUserName = collab?.user?.name ?? null
-    const collabUserColor = collab?.user?.color ?? null
+    // Read through a ref, and NOT in the deps below.
+    //
+    // Only the Yjs binding — the document and its field — genuinely needs a
+    // rebuild; the caret identity is read once when the extension is
+    // configured. Both of these arrive ASYNCHRONOUSLY though (awareness with
+    // the room, the user with the auth query), so depending on them destroyed
+    // and recreated the editor a beat after it mounted. That takes the
+    // ProseMirror node out of the document, which blurs it — the caret someone
+    // had just placed by clicking a description vanished a few hundred
+    // milliseconds later.
+    const collabIdentityRef = useRef({ awareness: collab?.awareness, user: collab?.user })
+    collabIdentityRef.current = { awareness: collab?.awareness, user: collab?.user }
 
     // Only WHETHER a submit handler exists belongs in the deps below — the ref
     // carries the value, and depending on the caller's inline closure would
@@ -209,30 +219,15 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                         ? {
                               document: collabDoc,
                               field: collabField,
-                              awareness: collabAwareness ?? undefined,
-                              user:
-                                  collabUserId && collabUserName && collabUserColor
-                                      ? {
-                                            id: collabUserId,
-                                            name: collabUserName,
-                                            color: collabUserColor,
-                                        }
-                                      : undefined,
+                              // The LIVE values at configure time, rather than
+                              // the ones captured when this memo last ran — see
+                              // the ref's note above for why they are not deps.
+                              awareness: collabIdentityRef.current.awareness,
+                              user: collabIdentityRef.current.user,
                           }
                         : undefined,
             }),
-        [
-            placeholder,
-            characterLimit,
-            stableTriggers,
-            hasSubmitShortcut,
-            collabDoc,
-            collabField,
-            collabAwareness,
-            collabUserId,
-            collabUserName,
-            collabUserColor,
-        ]
+        [placeholder, characterLimit, stableTriggers, hasSubmitShortcut, collabDoc, collabField]
     )
 
     const tiptapEditor = useEditor(
@@ -302,8 +297,22 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         // and caret would leak into the next one — the native page has always
         // done this by keying its mount on the same value (webview/source/
         // Editor.tsx, `key={init.generation}`).
-        [extensions, editable, generation]
+        //
+        // `editable` is deliberately NOT here. A dep change DESTROYS the editor,
+        // which takes its DOM node out of the document and blurs it — and this
+        // value resolves asynchronously (a card's write gate waits on the room's
+        // serverHello, which is null again after every disconnect). Rebuilding on
+        // it meant the editor was torn down a beat after someone clicked into it,
+        // losing the caret they had just placed. It is applied as a command
+        // below, which is what tiptap provides setEditable for.
+        [extensions, generation]
     )
+
+    // Applied rather than rebuilt — see the dep note above.
+    useEffect(() => {
+        if (!tiptapEditor || tiptapEditor.isDestroyed) return
+        if (tiptapEditor.isEditable !== editable) tiptapEditor.setEditable(editable)
+    }, [tiptapEditor, editable])
 
     const editor: EditorHandle = useMemo(() => {
         // tiptap nulls commandManager on destroy, and useEditor can briefly
@@ -337,10 +346,38 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                 if (!isLive() || warnIfCollab('setMarkdown')) return
                 tiptapEditor?.commands.setContent(markdown, { contentType: 'markdown' })
             },
-            focus: (position?: 'start' | 'end') => {
-                if (!isLive()) return
+            focus: (position?: 'start' | 'end' | { x: number; y: number }) => {
+                if (!isLive() || !tiptapEditor) return
+                if (position && typeof position === 'object') {
+                    // ProseMirror resolves a viewport point to a document
+                    // position itself, which is more accurate than anything
+                    // derived from the read view's text nodes — it knows the
+                    // editor's own layout, including nodes with no text.
+                    const at = tiptapEditor.view.posAtCoords({
+                        left: position.x,
+                        top: position.y,
+                    })?.pos
+                    // A press that lands outside any text (the padding below a
+                    // short description) resolves to nothing. Falling through
+                    // to 'end' puts the caret where a reader who clicked past
+                    // the prose would expect it.
+                    if (at != null) {
+                        // The DOM node first. Tiptap's `.focus()` chain command
+                        // schedules its own focus and does NOT reliably take DOM
+                        // focus when the view has just been mounted — the chain
+                        // reports success while `document.activeElement` stays
+                        // on <body>, which is the state that left a clicked
+                        // description showing an editor with no caret.
+                        tiptapEditor.view.dom.focus({ preventScroll: true })
+                        tiptapEditor.chain().focus().setTextSelection(at).run()
+                        return
+                    }
+                }
+                // Same reason as above: take DOM focus explicitly, then let the
+                // chain place the selection.
+                tiptapEditor.view.dom.focus({ preventScroll: true })
                 tiptapEditor
-                    ?.chain()
+                    .chain()
                     .focus(position === 'start' ? 'start' : 'end')
                     .run()
             },
@@ -430,13 +467,18 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                             // @ts-expect-error CSS custom properties for web
                             '--editor-placeholder-color': placeholderColor,
                             '--editor-primary-color': primaryColor,
+                            // The surface's type scale. Spread rather than set
+                            // one by one so an absent scale leaves the sheet's
+                            // own fallbacks in place — writing "undefined" into
+                            // a custom property breaks the cascade.
+                            ...editorScaleVars(scale),
                         }}
                     >
                         <EditorContent editor={tiptapEditor} />
                     </View>
                 )
             },
-        [tiptapEditor, placeholderColor, primaryColor, containerClassName]
+        [tiptapEditor, placeholderColor, primaryColor, containerClassName, scale]
     )
 
     return { editor, EditorComponent, commands, toolbarState, isReady: !!live }

--- a/core/lib/editor/rich/webview/source/Editor.tsx
+++ b/core/lib/editor/rich/webview/source/Editor.tsx
@@ -176,10 +176,10 @@ function EditorMounted({ init }: { init: RichEditorInitPayload }) {
     useEffect(() => {
         const style = document.createElement('style')
         style.id = 'tinycld-rich-editor-styles'
-        style.textContent = buildEditorCSS(init.colors)
+        style.textContent = buildEditorCSS(init.colors, init.scale)
         document.head.appendChild(style)
         return () => style.remove()
-    }, [init.colors])
+    }, [init.colors, init.scale])
 
     // Seed the credential store before the editor's first paint, so images
     // present in the initial document don't flash a broken frame while the

--- a/core/lib/editor/rich/webview/source/protocol.ts
+++ b/core/lib/editor/rich/webview/source/protocol.ts
@@ -9,7 +9,7 @@
  * This file names the types carried on the 'markdown' and 'app' namespaces and
  * types their payloads.
  */
-import type { EditorContentFormat } from '../../options'
+import type { EditorContentFormat, EditorTypeScale } from '../../options'
 import type { SerializableTriggerConfig, TriggerItem } from '../../triggers'
 
 /** host → WebView. Replaces the document. */
@@ -173,6 +173,13 @@ export interface RichEditorInitPayload {
     editable: boolean
     /** Hard ceiling; typing stops here rather than failing on save. */
     characterLimit?: number
+    /**
+     * The surface's type scale, in px. Must match what the host renders the
+     * read view at, or tapping to edit reflows the prose — both sides derive
+     * from `markdownScale(purpose)` via `editorScaleFor()`. Absent keeps the
+     * page's own description-shaped defaults.
+     */
+    scale?: EditorTypeScale
     /** Theme colors resolved on the native side, applied as CSS in-page. */
     colors: RichEditorColors
     autofocus: boolean

--- a/core/lib/editor/rich/webview/source/styles.ts
+++ b/core/lib/editor/rich/webview/source/styles.ts
@@ -1,4 +1,5 @@
 import { EDITOR_CONTENT_STYLES } from '../../editor-content-styles'
+import type { EditorTypeScale } from '../../options'
 import type { RichEditorColors } from './protocol'
 
 /**
@@ -16,13 +17,28 @@ import type { RichEditorColors } from './protocol'
  * native side reads them from the theme hook and the WebView has no access to
  * that), so they are mapped onto the custom properties the shared sheet reads.
  */
-export function buildEditorCSS(colors: RichEditorColors): string {
+export function buildEditorCSS(colors: RichEditorColors, scale?: EditorTypeScale): string {
     const accent = colors.accent ?? colors.primary
+    // The page's own defaults, kept as the fallback so a host that says nothing
+    // renders exactly as it always has (the description's proportions).
+    const baseFontSize = scale?.bodySize ?? 14
+    const baseLineHeight = scale ? scale.bodyLineHeight / scale.bodySize : 1.5
     return `
         :root {
             --editor-placeholder-color: ${colors.placeholder};
             --editor-primary-color: ${colors.primary};
             --editor-accent-color: ${accent};
+            /* The scale the shared sheet reads. Set here as well as on body so
+               the .ProseMirror rules resolve it. Headings and block spacing are
+               included because the surfaces genuinely differ in more than size:
+               a comment caps its headings and spaces tightly. */
+            --editor-base-font-size: ${baseFontSize}px;
+            --editor-base-line-height: ${baseLineHeight};
+            ${scale ? `--editor-block-spacing: ${scale.blockSpacing}px;` : ''}
+            ${scale ? `--editor-h1-size: ${scale.h1}px;` : ''}
+            ${scale ? `--editor-h2-size: ${scale.h2}px;` : ''}
+            ${scale ? `--editor-h3-size: ${scale.h3}px;` : ''}
+            ${scale ? `--editor-h4-size: ${scale.h4}px;` : ''}
         }
         * {
             -webkit-tap-highlight-color: transparent;
@@ -35,9 +51,12 @@ export function buildEditorCSS(colors: RichEditorColors): string {
             color: ${colors.fg};
         }
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-            font-size: 14px;
-            line-height: 1.5;
+            /* The shared sheet states the same stack on .ProseMirror — see
+               RN_WEB_FONT_STACK there. Repeated on body so chrome outside the
+               editing surface (the placeholder) matches too. */
+            font-family: -apple-system, "system-ui", 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            font-size: ${baseFontSize}px;
+            line-height: ${baseLineHeight};
             /* The host sizes the WebView; the page must never scroll itself. */
             overflow-wrap: break-word;
         }

--- a/core/lib/editor/types.ts
+++ b/core/lib/editor/types.ts
@@ -13,7 +13,20 @@ export interface EditorHandle {
     // where the shared document is the source of truth.
     setMarkdown?(markdown: string): void
     setContent(html: string): void
-    focus(position?: 'start' | 'end'): void
+    /**
+     * Put the caret in the editor.
+     *
+     * `'start'` / `'end'` are the document ends. A `{ x, y }` is a point in
+     * VIEWPORT coordinates — the place the user actually pressed — which the
+     * editor resolves to the nearest text position. That is what makes tapping
+     * into the middle of a paragraph land the caret there rather than at the
+     * end: the read view and the editing surface occupy the same box, so the
+     * point the reader pressed on the prose is the point the caret belongs at.
+     *
+     * A point that resolves to nothing (a press in the padding, an editor not
+     * yet laid out) falls back to `'end'`, which is the old behavior.
+     */
+    focus(position?: 'start' | 'end' | { x: number; y: number }): void
     clear(): void
     // Returns the editor's current selection range in ProseMirror
     // coordinate space, or null if there's no selection or the editor

--- a/core/lib/realtime/use-realtime-room.ts
+++ b/core/lib/realtime/use-realtime-room.ts
@@ -4,6 +4,7 @@ import { Awareness } from 'y-protocols/awareness'
 import * as Y from 'yjs'
 import { PB_SERVER_ADDR } from '../config'
 import { captureException } from '../errors'
+import { log } from '../logger'
 import { pb } from '../pocketbase'
 import { RealtimeClient } from './client'
 
@@ -53,6 +54,26 @@ export interface UseRealtimeRoomOptions {
     // the room kind's AuthorizeShare. When unset, the PB auth token is
     // used as before.
     shareSession?: string
+
+    // docEpochOf reads this room kind's document epoch out of the server
+    // hello, or returns null when the payload carries none.
+    //
+    // A server may DISCARD an idle document and rebuild it from storage —
+    // cards' janitor evicts a quiet board, and the next joiner's connect
+    // re-seeds the fragments from the cards table. The rebuilt document is a
+    // different incarnation: y-crdt mints a fresh clientID for it, so the
+    // inserts our surviving Y.Doc still holds are, to the CRDT, edits nobody
+    // has seen rather than the same text arriving twice.
+    //
+    // Merging across that boundary therefore CONVERGES on both copies. That is
+    // the CRDT working correctly — there is no merge that could recover the
+    // intent, because the two insert sets are genuinely independent — so the
+    // only correct move is to throw our state away and resync from scratch.
+    // Supplying this opts a room kind into that, and the doc is rebuilt
+    // whenever the epoch changes from the one we synced under.
+    //
+    // Rooms that leave it undefined keep the previous behavior exactly.
+    docEpochOf?: (serverHello: unknown) => number | null
 }
 
 export interface RealtimeRoomHandle {
@@ -98,10 +119,30 @@ export function useRealtimeRoom({
     onFirstJoinerBootstrap,
     isEmpty = defaultIsEmpty,
     shareSession,
+    docEpochOf,
 }: UseRealtimeRoomOptions): RealtimeRoomHandle | null {
     const [isReady, setIsReady] = useState(false)
     const [isConnected, setIsConnected] = useState(false)
     const [serverHello, setServerHello] = useState<unknown>(null)
+    // How many times the server's document has been REPLACED under us.
+    //
+    // The effect below keys on this rather than on the epoch value, because
+    // learning the epoch for the first time must not rebuild anything: a fresh
+    // doc has no stale state to discard, and tearing it down would drop the
+    // sync that is already in flight. Only a change from one known epoch to a
+    // different one is a discard, and each one bumps this by exactly 1.
+    const [docGeneration, setDocGeneration] = useState(0)
+    // The epoch the live doc was built against, held in a ref so the hello
+    // handler can compare without the connection effect depending on it.
+    // Written from the handler rather than through state for the same reason:
+    // the comparison must see the value the CURRENT doc was created under, not
+    // one a pending render has yet to commit.
+    const docEpochRef = useRef<number | null>(null)
+    // Read through a ref for the same reason the other callbacks are: the
+    // caller passes an inline closure, and depending on its identity would
+    // reopen the socket on every render.
+    const docEpochOfRef = useRef(docEpochOf)
+    docEpochOfRef.current = docEpochOf
     const [serverSlot, setServerSlot] = useState<unknown>(null)
     const handleRef = useRef<{ doc: Y.Doc; awareness: Awareness; client: RealtimeClient } | null>(
         null
@@ -145,6 +186,30 @@ export function useRealtimeRoom({
                     const text = new TextDecoder().decode(payload)
                     const parsed = text.length > 0 ? JSON.parse(text) : null
                     setServerHello(parsed)
+
+                    // The epoch check runs BEFORE the sync handshake can fold
+                    // remote state into this doc, because the hello frame
+                    // precedes the sync reply. That ordering is what makes
+                    // discarding cheap: we drop a doc that has not yet been
+                    // contaminated, rather than trying to unpick a merge.
+                    const epoch = docEpochOfRef.current?.(parsed) ?? null
+                    if (epoch != null) {
+                        const previous = docEpochRef.current
+                        docEpochRef.current = epoch
+                        // Learning the epoch for the first time is not a
+                        // discard — this doc has nothing stale in it yet.
+                        // Reconnecting to the SAME incarnation is not one
+                        // either, or every network blip would throw away
+                        // unsynced edits. Only a genuine replacement rebuilds.
+                        if (previous != null && previous !== epoch) {
+                            log.warn(
+                                'realtime.docEpoch',
+                                'server document was rebuilt; discarding local state',
+                                { roomKind, roomID, previous, epoch }
+                            )
+                            setDocGeneration(n => n + 1)
+                        }
+                    }
                 } catch (err) {
                     captureException('realtime.serverHello.parse', err, {
                         roomKind,
@@ -215,12 +280,21 @@ export function useRealtimeRoom({
             awareness.destroy()
             doc.destroy()
             handleRef.current = null
+            // The next doc is a NEW one, so it has no epoch until its own hello
+            // names one. Leaving the old value here would make that first hello
+            // read as a second replacement and rebuild again, forever.
+            docEpochRef.current = null
             setIsReady(false)
             setIsConnected(false)
             setServerHello(null)
             setServerSlot(null)
         }
-    }, [roomKind, roomID])
+        // `docGeneration` belongs here: it increments only when the server
+        // reports it replaced its document, and this effect's teardown/setup is
+        // exactly the discard — the old Y.Doc is destroyed and a fresh one
+        // resyncs from scratch. It never moves in an ordinary session, so the
+        // common path still opens one socket.
+    }, [roomKind, roomID, docGeneration])
 
     // Publish a clean leave whenever this screen stops being visible, and
     // republish on the way back.

--- a/core/server/yjsdoc/bridge.go
+++ b/core/server/yjsdoc/bridge.go
@@ -108,6 +108,18 @@ func SeedFragmentFromPMJSON(doc *Doc, fragment string, pmJSON []byte) error {
 		return fmt.Errorf("yjsdoc: GetXmlFragment did not return *YXmlFragment")
 	}
 
+	// Seeding APPENDS, so a fragment that already holds content would end up
+	// with the prose twice — and the doc comment above promises the fragment
+	// holds a faithful representation of pmJSON, not a concatenation.
+	//
+	// A populated fragment means this document has already been seeded or
+	// edited, so the stored text this call carries is not newer than what is
+	// here. Refusing is therefore the safe direction: the live content wins,
+	// and no caller has to remember whether its document is fresh.
+	if len(frag.ToArray()) > 0 {
+		return nil
+	}
+
 	for _, child := range root.Content {
 		if err := seedChildIntoFragment(frag, child); err != nil {
 			return err

--- a/core/server/yjsdoc/yjsdoc_test.go
+++ b/core/server/yjsdoc/yjsdoc_test.go
@@ -283,3 +283,36 @@ func TestJanitorSpareLiveRooms(t *testing.T) {
 		t.Error("janitor kept an idle document with no room")
 	}
 }
+
+// Seeding APPENDS into the fragment, so a second seed of an already-populated
+// one would leave the card's prose in the document twice. Cards hits this when
+// a board's document is rebuilt: the bootstrap hook re-seeds every card from
+// storage, and any fragment that already carries content must be left alone.
+func TestSeedingSkipsAPopulatedFragment(t *testing.T) {
+	doc := ycrdt.NewDoc("board", false, nil, nil, false)
+	InstallPatcher(doc)
+
+	if err := SeedFragmentFromPMJSON(doc, "card:aaa", pmDoc(t, "the live text")); err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	// A second seed carrying DIFFERENT text, so the assertion distinguishes
+	// "skipped" from "overwrote" rather than passing either way.
+	if err := SeedFragmentFromPMJSON(doc, "card:aaa", pmDoc(t, "stale storage")); err != nil {
+		t.Fatalf("second seed: %v", err)
+	}
+
+	got, err := PMJSONFromFragment(doc, "card:aaa")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed markdown.PMNode
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Content) != 1 {
+		t.Fatalf("fragment holds %d blocks, want 1 — the seed appended", len(parsed.Content))
+	}
+	if text := firstParagraphText(t, got); text != "the live text" {
+		t.Errorf("fragment = %q, want the live content to win", text)
+	}
+}

--- a/core/tests/unit/realtime-doc-epoch.test.tsx
+++ b/core/tests/unit/realtime-doc-epoch.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+import { act, render, waitFor } from '@testing-library/react'
+import { useRealtimeRoom } from '@tinycld/core/lib/realtime/use-realtime-room'
+import { setResolvedAddress } from '@tinycld/core/lib/server-address'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as Y from 'yjs'
+
+/**
+ * A server may DISCARD an idle collaborative document and rebuild it from
+ * storage — cards' janitor evicts a quiet board, and the next joiner re-seeds
+ * every card's description out of the cards table.
+ *
+ * The rebuilt document is a different incarnation, and y-crdt mints a fresh
+ * clientID for it. The inserts our surviving Y.Doc still holds are therefore
+ * NOT recognizable as the same text: they are independent operations nobody has
+ * seen. Merging converges — correctly, and on BOTH copies — which is what put a
+ * card's description on screen doubled, then tripled.
+ *
+ * `docEpochOf` is how a room opts into discarding local state instead. These
+ * tests pin the two halves of that: an unchanged epoch must NOT disturb a live
+ * session, and a changed one must rebuild the doc.
+ */
+
+const CLIENT_ID_LEN = 16
+const FRAME_OVERHEAD = CLIENT_ID_LEN + 1
+const MSG_ASSIGN_ID = 0x05
+const MSG_SERVER_HELLO = 0x06
+
+class FakeSocket {
+    static OPEN = 1
+    readyState = 1
+    sent: Uint8Array[] = []
+    closed = false
+    onopen: (() => void) | null = null
+    onmessage: ((evt: { data: ArrayBuffer }) => void) | null = null
+    onclose: (() => void) | null = null
+    onerror: (() => void) | null = null
+    binaryType = 'arraybuffer'
+
+    send(frame: Uint8Array) {
+        this.sent.push(new Uint8Array(frame))
+    }
+    close() {
+        this.closed = true
+    }
+    deliver(msgType: number, payload: Uint8Array, senderID?: Uint8Array) {
+        const frame = new Uint8Array(FRAME_OVERHEAD + payload.length)
+        if (senderID) frame.set(senderID, 0)
+        frame[CLIENT_ID_LEN] = msgType
+        frame.set(payload, FRAME_OVERHEAD)
+        this.onmessage?.({ data: frame.buffer as ArrayBuffer })
+    }
+    /** The server's per-connection handshake payload, as JSON bytes. */
+    deliverHello(payload: unknown) {
+        this.deliver(MSG_SERVER_HELLO, new TextEncoder().encode(JSON.stringify(payload)))
+    }
+}
+
+let sockets: FakeSocket[] = []
+
+afterEach(() => setResolvedAddress(null))
+
+beforeEach(() => {
+    // buildRealtimeURL reads the deployment address, which the app resolves
+    // through its layout gate rather than a constant.
+    setResolvedAddress('https://test.tinycld.org')
+    sockets = []
+    const WebSocketStub = function WebSocketStub() {
+        const socket = new FakeSocket()
+        sockets.push(socket)
+        return socket
+    } as unknown as typeof WebSocket
+    ;(WebSocketStub as { OPEN: number }).OPEN = FakeSocket.OPEN
+    vi.stubGlobal('WebSocket', WebSocketStub)
+})
+
+interface Captured {
+    doc: Y.Doc | null
+}
+
+function Harness({ captured }: { captured: Captured }) {
+    const room = useRealtimeRoom({
+        roomKind: 'cards-board',
+        roomID: 'board-1',
+        initialAwareness: null,
+        docEpochOf: hello =>
+            typeof (hello as { docEpoch?: unknown })?.docEpoch === 'number'
+                ? (hello as { docEpoch: number }).docEpoch
+                : null,
+    })
+    captured.doc = room?.doc ?? null
+    return null
+}
+
+/** Bring a socket up far enough that the hook will accept a hello. */
+function open(socket: FakeSocket) {
+    socket.onopen?.()
+    socket.deliver(MSG_ASSIGN_ID, new Uint8Array(0), new Uint8Array(CLIENT_ID_LEN).fill(7))
+}
+
+describe('useRealtimeRoom — document epoch', () => {
+    it('keeps the same document while the epoch is unchanged', async () => {
+        const captured: Captured = { doc: null }
+        render(<Harness captured={captured} />)
+        await waitFor(() => expect(captured.doc).not.toBeNull())
+
+        const first = captured.doc
+        act(() => {
+            open(sockets[0])
+            sockets[0].deliverHello({ readOnly: false, docEpoch: 42 })
+        })
+        // A reconnect to the SAME incarnation: the local state is still valid,
+        // and tearing the doc down here would throw away unsynced edits on
+        // every ordinary network blip.
+        act(() => {
+            sockets[0].deliverHello({ readOnly: false, docEpoch: 42 })
+        })
+
+        await waitFor(() => expect(captured.doc).toBe(first))
+        expect(sockets).toHaveLength(1)
+    })
+
+    it('rebuilds the document when the server reports a new epoch', async () => {
+        const captured: Captured = { doc: null }
+        render(<Harness captured={captured} />)
+        await waitFor(() => expect(captured.doc).not.toBeNull())
+
+        act(() => {
+            open(sockets[0])
+            sockets[0].deliverHello({ readOnly: false, docEpoch: 1 })
+        })
+        const first = captured.doc
+        // Something only the local doc knows, so the assertion below proves the
+        // state was DISCARDED rather than merely that the object changed.
+        act(() => {
+            first?.getText('probe').insert(0, 'stale')
+        })
+
+        // The board was evicted and rebuilt while we were away. Everything our
+        // doc holds predates that incarnation and must not reach it.
+        act(() => {
+            sockets[0].deliverHello({ readOnly: false, docEpoch: 2 })
+        })
+
+        await waitFor(() => expect(captured.doc).not.toBe(first))
+        expect(captured.doc?.getText('probe').toString()).toBe('')
+        // The discard is a reconnect: the old socket is torn down and a fresh
+        // one resyncs from the server.
+        expect(sockets.length).toBeGreaterThan(1)
+    })
+
+    it('leaves a room that reports no epoch alone', async () => {
+        const captured: Captured = { doc: null }
+        render(<Harness captured={captured} />)
+        await waitFor(() => expect(captured.doc).not.toBeNull())
+
+        const first = captured.doc
+        act(() => {
+            open(sockets[0])
+            // A room kind whose hello carries no epoch at all — text and calc
+            // today. Nothing about their behavior may change.
+            sockets[0].deliverHello({ readOnly: false })
+        })
+
+        await waitFor(() => expect(captured.doc).toBe(first))
+        expect(sockets).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
Tapping a description or comment changed how it looked, where the caret went, and sometimes what it said. This fixes the underlying causes in core; the cards half is in tinycld/cards#(companion PR).

## Duplicated descriptions

A card description came back doubled, then tripled. Not an editor bug: the janitor evicts an idle board document and the next joiner re-seeds it from storage, so a surviving client Y.Doc holds the same prose under a clientID that incarnation never saw. Merging converges — correctly — on **both** copies.

The server already sent `docEpoch` for exactly this and documents the contract; nothing read it. Clients now discard local state when the epoch changes. It has to be the client's call: to the server those inserts are indistinguishable from someone typing.

## No caret on tap

Focus ran in a microtask, before React commits, so the call did nothing. Then the effect keyed on the lease generation while one acquire produces several editor instances — so the caret landed on a node about to be discarded. Each rebuild also raised a blur that ended the session that had just opened.

`focus()` now takes a viewport point, so clicking mid-paragraph puts the caret there rather than at the end.

## Layout parity

Six ways the two renderings disagreed, including the editor stating no font-size or font-family (inheriting 16px and Tailwind's stack against the read view's 14px and RN Web's), one hard-coded heading scale for every surface, and `.ProseMirror p { margin: 0 }` outranking the block-rhythm rule so paragraphs got no gap at all.

`editorScaleFor(purpose)` now derives both sides from one `markdownScale(purpose)` entry.

## Verification

- core 191 files / 1448 tests, tsc clean, biome clean
- 37 cards e2e, 3 mail compose e2e, mail 18/141 and text 105/927 green (shared editor)
- Each fix confirmed to **fail on revert** — the parity tolerance was 2px, exactly the size of one real defect, so the suite had been green on the bug it was added to catch

Web only; the same extension list drives the native WebView but I have not run a simulator.