### PR TITLE
Bump the drax fork past the dragHandle touchAction crash

### DIFF
--- a/core/package-versions.json
+++ b/core/package-versions.json
@@ -27,5 +27,5 @@
     "@tanstack/react-db": "0.3.5",
     "@tanstack/query-db-collection": "1.2.10",
     "@tanstack/react-query": "5.101.0",
-    "react-native-drax": "github:nathanstitt/react-native-drax#b863d89a70c73454d7f3495bf79e382586495fa4"
+    "react-native-drax": "github:nathanstitt/react-native-drax#bc83061aceb7eae462cecc4756b3a4c81dcd1d30"
 }


### PR DESCRIPTION
Opening a card whose checklist already had items blanked the peek on web — `TypeError: Cannot read properties of undefined (reading 'userSelect')` tripped the error boundary, so the panel never rendered. Reproducible without a test harness: open a card → add a checklist item → close → reopen.

## Cause

A `dragHandle` DraxView does **not** wrap itself in a `GestureDetector`. It hands the gesture to a descendant `DraxHandle`, so the gesture is **created by an ancestor** and **attached by a child**. RNGH's config effect belongs to the creator, so the web `touchAction` reached the handler before anything had attached a view to it — and `GestureHandlerWebDelegate` assigns `gestureHandler` only in `init()`, so `updateDOM()` dereferenced undefined.

`BoardColumn` is the control case: it uses `SortableItem` **without** `dragHandle`, so create and attach happen in the same component. It has never hit this.

## Fix ([fork commit](https://github.com/nathanstitt/react-native-drax/commit/bc83061aceb7eae462cecc4756b3a4c81dcd1d30))

`DraxHandle` — the component that owns the attach — now passes `touchAction` as a `GestureDetector` prop. Not a reordering trick: RNGH's web detector applies DOM props **only to handlers already in `attachedHandlers`**, so attach-then-config is structural rather than raced. Non-handle DraxViews are unchanged.

## Blast radius

Core's `SortableList` is the only route to the `dragHandle` path, so this also covers **settings → Rules** and **settings → Packages**. Those are worse than the checklist case: a non-editable row renders `SortableDragHandle disabled`, which emits no `DraxHandle` at all — so the delegate was never initialized rather than merely late. That means a non-admin viewing org rules (`canEdit={isAdmin}`) was permanently exposed.

## Ruled out

- **RNGH 3.2.1 / 3.3.0-nightly** — the crash path is byte-identical to 3.0.1 in all three; upgrading does not fix it.
- **`fixed`/`draggable`** — `useDragGesture` is a hook, called unconditionally, and `touchAction` is computed independently of `enabled`. A non-draggable row is equally exposed.

The underlying RNGH gap (`updateDOM` lacks the `isInitialized` guard its sibling `onEnabledChange` has) is real and unreported upstream. Worth filing, but this change means we no longer depend on it.

## Verification

Against the **installed tarball** from the new pin, with RNGH unpatched:

- cards `card-editing` 13/13 (was 12/13) — `:395` now passes, and drops 9.0s → 3.5s since it no longer burns the locator timeout
- cards `board-dnd` 8/8, including `reorders checklist items by their drag handle` — the changed path, exercising a real drag
- tinycld `tinycld-pkg check` — 1515 tests pass