### PR TITLE
Scope the demo reset to the demo user's own data

### DIFF
--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -48,13 +48,36 @@ export interface PackageEventSource {
     order: number
     load: () => Promise<unknown>
 }
+export interface SeedUser {
+    id: string
+    username: string
+    email: string
+    name: string
+}
+
 export interface SeedContext {
     // Single-org: package seeds own data by the user id directly (the former
     // org/userOrg junction is gone; the `role` enum lives on the user record).
     // `username` is what mail derives mailbox addresses from — the server
     // provisions from username, never the email local-part, so seeds must too
     // or seeded users get a different address than the server would create.
-    user: { id: string; username: string; email: string; name: string }
+    user: SeedUser
+
+    // The seeded collaborator, for fixtures that need a second person: a
+    // teammate-owned board, a shared calendar, a share recipient.
+    //
+    // Seeds MUST resolve "the other person" to this user rather than querying
+    // `users` for `id != user.id`. That query returns real accounts, and a seed
+    // that writes rows owned by them (a mailbox, a membership, a share) creates
+    // data no user-scoped reset can ever reclaim — the nightly demo reset wipes
+    // the demo user, and the litter attributed to everyone else accumulates
+    // forever. Scoping every seeded row to {user, companion} is what makes the
+    // reset's blast radius equal to what the seed actually created.
+    //
+    // Optional: a deployment seeded without a collaborator (or a package seeded
+    // standalone) still works — seeds fall back to skipping the multi-user
+    // fixtures rather than reaching for a stranger.
+    companion?: SeedUser
 }
 
 // pbtsdb's collection factory, typed over the broadest schema. Each package's

--- a/scripts/reset-demo.ts
+++ b/scripts/reset-demo.ts
@@ -2,14 +2,23 @@
 /**
  * Demo Reset Script
  *
- * Wipes all data owned by the singleton demo user and re-seeds it. Designed
- * to run nightly (see coreserver/demo_reset.go) so the demo workspace is
- * always pristine for the next unauthenticated visitor that hits
+ * Wipes the data owned by the demo user and its companion, then re-seeds both.
+ * Designed to run nightly (see coreserver/demo_reset.go) so the demo workspace
+ * is always pristine for the next unauthenticated visitor that hits
  * /api/demo/start.
  *
- * The demo *user* (`demo@tinycld.org`, is_demo=true) is preserved across
- * resets — only the records they own are wiped, then every linked package's
- * seed() re-creates them.
+ * The demo *users* (`demo@tinycld.org` and `demo-teammate@tinycld.org`, both
+ * is_demo=true) are preserved across resets — only the records they own are
+ * wiped, then every linked package's seed() re-creates them.
+ *
+ * TWO users, not one: the demo shows off shared boards, shared calendars and
+ * shared files, which need a second person to point at. The seeds used to
+ * resolve that person by querying `users` for `id != demo`, so on a deployment
+ * with real accounts they wrote mailboxes, memberships and shares owned by
+ * strangers — rows a demo-scoped reset could never reclaim, accumulating on
+ * every nightly run. Seeding a dedicated companion makes the demo data set
+ * exactly two users wide, so this script's blast radius equals what the seeds
+ * actually created. See SeedContext.companion in core/lib/packages/config-types.ts.
  *
  * Single-org: there is no `orgs` row to delete and no cascade to ride. Data
  * is reached through each collection's ownership FK, which now points at
@@ -27,7 +36,7 @@
 
 import { loadEnv } from '@tinycld/core/lib/load-env'
 import type PocketBase from 'pocketbase'
-import { authSuperuser, seedForUser } from './seed-db'
+import { authSuperuser, DEMO_COMPANION_DEFAULTS, seedForUser } from './seed-db'
 
 function log(...args: unknown[]) {
     process.stdout.write(`[reset-demo] ${args.join(' ')}\n`)
@@ -47,6 +56,13 @@ const DEMO_USER_EMAIL = process.env.REVIEW_DEMO_EMAIL || 'demo@tinycld.org'
 const DEMO_USER_USERNAME = 'demo'
 const DEMO_USER_NAME = 'Demo Tour'
 
+// The companion that owns the other half of the shared fixtures. Imported from
+// seed-db (which creates it) rather than re-declared here, so the identity this
+// script wipes cannot drift from the one that gets seeded — a mismatch would
+// silently orphan the companion's data forever.
+const DEMO_COMPANION_USERNAME = DEMO_COMPANION_DEFAULTS.username
+const DEMO_COMPANION_NAME = DEMO_COMPANION_DEFAULTS.name
+
 // Collections holding demo-owned data, paired with the FK naming the owner.
 // Order matters: children before parents, so a cascade or a required-relation
 // guard never blocks a delete.
@@ -57,18 +73,34 @@ const DEMO_USER_NAME = 'Demo Tour'
 // removal of the `orgs` collection into a silent no-op that reported success
 // while wiping nothing, nightly. Any other failure must be loud.
 const OWNED_COLLECTIONS: Array<{ collection: string; ownerField: string }> = [
+    // label_assignments is polymorphic: `record_id` is a plain text id with no
+    // FK, so NOTHING cascades into it. Mail creates one per labeled thread
+    // (mail/seed.ts), and before this entry existed they survived every reset
+    // and accumulated nightly, forever. Must run first — once the thread state
+    // it points at is gone, the row is unreachable garbage.
+    { collection: 'label_assignments', ownerField: 'user' },
     // Comments and mentions reference drive_items + users; clear them first.
     { collection: 'comment_mentions', ownerField: 'mentioned_user' },
     { collection: 'text_comments', ownerField: 'author' },
     { collection: 'calc_comments', ownerField: 'author' },
     { collection: 'drive_share_links', ownerField: 'created_by' },
     { collection: 'drive_item_versions', ownerField: 'created_by' },
-    { collection: 'drive_shares', ownerField: 'user' },
+    // created_by, NOT user: the seed sets `user` to the share RECIPIENT and
+    // `created_by` to the sharer (drive/seed.ts). Keying on `user` missed every
+    // share the demo user granted — they were reclaimed only when the recipient
+    // happened to be wiped too.
+    { collection: 'drive_shares', ownerField: 'created_by' },
+    { collection: 'drive_item_state', ownerField: 'user' },
     { collection: 'drive_items', ownerField: 'created_by' },
     { collection: 'contacts', ownerField: 'owner' },
+    // Only labels with an owner. Mail seeds its labels with NO `user` — they are
+    // deliberately shared, visible to everyone (mail/seed.ts) — so this filter
+    // skips them and the shared set survives the reset. That is the intended
+    // outcome; the seed find-or-creates them by name, so a surviving row is
+    // reused rather than duplicated. Contacts' labels DO set `user` and are
+    // reclaimed here.
     { collection: 'labels', ownerField: 'user' },
     { collection: 'calendar_events', ownerField: 'created_by' },
-    { collection: 'calendar_calendars', ownerField: 'created_by' },
     { collection: 'notifications', ownerField: 'user' },
 ]
 
@@ -80,6 +112,26 @@ const OWNED_COLLECTIONS: Array<{ collection: string; ownerField: string }> = [
 // ownerField entry cannot express this (mail_messages has no user column at
 // all, and mail_mailboxes has no user column either).
 const MAIL_MEMBERSHIP = { junction: 'mail_mailbox_members', mailboxes: 'mail_mailboxes' }
+
+// Cards and calendar hang off a root record that has no usable owner FK, so a
+// flat OWNED_COLLECTIONS entry cannot express them — and until now neither
+// package was wiped by this script AT ALL. Their demo data survived every reset.
+//
+// - calendar_calendars has NO owner column whatsoever; ownership lives only in
+//   the calendar_members junction. (This script used to list it with
+//   ownerField: 'created_by', a field that does not exist — a silent no-op.)
+// - cards_projects HAS created_by, but the seed deliberately points it at the
+//   teammate for the "Team retrospective" board, so filtering on created_by
+//   alone leaves a whole board behind.
+//
+// Both roots cascade cleanly: deleting the project/calendar row removes every
+// list, card, checklist item, comment, attachment, share link, member and event
+// beneath it (verified against each package's create migration). So resolving
+// the root ids through membership and deleting those is sufficient and complete.
+const MEMBERSHIP_ROOTS: Array<{ junction: string; rootField: string; roots: string }> = [
+    { junction: 'cards_project_members', rootField: 'project', roots: 'cards_projects' },
+    { junction: 'calendar_members', rootField: 'calendar', roots: 'calendar_calendars' },
+]
 
 function parseArgs() {
     const args = process.argv.slice(2)
@@ -139,9 +191,12 @@ async function hasCollection(pb: PocketBase, name: string): Promise<boolean> {
     }
 }
 
-async function findDemoUser(pb: PocketBase): Promise<{ id: string } | null> {
+async function findUserByUsername(
+    pb: PocketBase,
+    username: string
+): Promise<{ id: string } | null> {
     try {
-        return await pb.collection('users').getFirstListItem(`username = "${DEMO_USER_USERNAME}"`)
+        return await pb.collection('users').getFirstListItem(`username = "${username}"`)
     } catch (err) {
         if (isNotFound(err)) return null
         throw err
@@ -176,9 +231,81 @@ async function wipeOwnedData(pb: PocketBase, userId: string): Promise<number> {
         }
     }
 
+    deleted += await wipeMembershipRoots(pb, userId)
     deleted += await wipeMailboxes(pb, userId)
-    deleted += await wipeOrphanedRealtimeJournal(pb)
     return deleted
+}
+
+// wipeMembershipRoots deletes the cards boards and calendars the user belongs
+// to, letting each package's cascade clear everything beneath. See
+// MEMBERSHIP_ROOTS for why these can't be expressed as a flat owner filter.
+//
+// Membership (not created_by) is the key deliberately: it catches the
+// teammate-owned board and the calendars the user is only an editor/viewer of,
+// which an ownership filter misses. That is safe HERE — and only here —
+// because the demo workspace's users are seed-created and every board or
+// calendar they belong to is seed data by construction. This script must never
+// be pointed at a deployment with real accounts.
+async function wipeMembershipRoots(pb: PocketBase, userId: string): Promise<number> {
+    let deleted = 0
+    for (const { junction, rootField, roots } of MEMBERSHIP_ROOTS) {
+        if (!(await hasCollection(pb, junction))) continue
+        if (!(await hasCollection(pb, roots))) continue
+
+        const memberships = await pb
+            .collection(junction)
+            .getFullList({ filter: `user = "${userId}"`, fields: `id,${rootField}` })
+        const rootIds = [...new Set(memberships.map(m => m[rootField] as string).filter(Boolean))]
+        if (rootIds.length === 0) continue
+
+        log(`Wiping ${rootIds.length} ${roots} record(s) (contents cascade)`)
+        for (const id of rootIds) {
+            try {
+                await pb.collection(roots).delete(id)
+                deleted++
+            } catch (err) {
+                if (!isNotFound(err)) throw err
+            }
+        }
+    }
+    return deleted
+}
+
+// restorePersonalCalendar re-creates the calendar that calendar's lifecycle
+// hook provisions on user-create (calendar/server/lifecycle.go).
+//
+// That hook fires ONLY on create. The demo users are preserved across resets by
+// design, so the hook never re-fires — and wipeMembershipRoots deletes the
+// personal calendar along with the seeded ones, since the user owns it. Without
+// this the demo user ends up with no default calendar, and every subsequent
+// reset leaves them worse off.
+//
+// Mirrors the hook's shape exactly: calendar + owner membership, name from the
+// user's display name. Idempotent — an existing owned calendar is left alone.
+async function restorePersonalCalendar(
+    pb: PocketBase,
+    userId: string,
+    userName: string
+): Promise<void> {
+    if (!(await hasCollection(pb, 'calendar_calendars'))) return
+    if (!(await hasCollection(pb, 'calendar_members'))) return
+
+    const owned = await pb
+        .collection('calendar_members')
+        .getFullList({ filter: `user = "${userId}" && role = "owner"`, fields: 'id' })
+    if (owned.length > 0) return
+
+    const calendar = await pb.collection('calendar_calendars').create({
+        name: userName,
+        description: '',
+        color: 'blue',
+    })
+    await pb.collection('calendar_members').create({
+        calendar: calendar.id,
+        user: userId,
+        role: 'owner',
+    })
+    log(`Restored personal calendar for ${userId}`)
 }
 
 // wipeMailboxes clears the demo user's mail by deleting the mailboxes they
@@ -241,7 +368,6 @@ async function wipeOrphanedRealtimeJournal(pb: PocketBase): Promise<number> {
             if (!isNotFound(err)) throw err
         }
     }
-    if (deleted > 0) log(`Wiping ${deleted} orphaned realtime_doc_updates record(s)`)
     return deleted
 }
 
@@ -249,13 +375,34 @@ async function main() {
     const config = parseArgs()
     const pb = await authSuperuser(config)
 
-    const demoUser = await findDemoUser(pb)
-    if (demoUser) {
-        const deleted = await wipeOwnedData(pb, demoUser.id)
-        log(`Wiped ${deleted} record(s) owned by demo user ${demoUser.id}`)
-    } else {
-        log('No existing demo user found — nothing to wipe, will create fresh')
+    // Wipe the companion BEFORE the demo user. Shared fixtures (boards,
+    // calendars, mailboxes) are reachable from either member, and clearing the
+    // companion first means the demo user's pass finds a smaller, already
+    // partly-cascaded set rather than re-walking the same roots.
+    for (const username of [DEMO_COMPANION_USERNAME, DEMO_USER_USERNAME]) {
+        const target = await findUserByUsername(pb, username)
+        if (!target) {
+            log(`No existing "${username}" user found — nothing to wipe`)
+            continue
+        }
+        const deleted = await wipeOwnedData(pb, target.id)
+        log(`Wiped ${deleted} record(s) owned by "${username}" (${target.id})`)
+        // Before the seeds run: calendar's seed guard counts events, not
+        // calendars, so it will happily seed into a user with no calendar at
+        // all — leaving them without the default one the lifecycle hook would
+        // have given a freshly-created account.
+        await restorePersonalCalendar(
+            pb,
+            target.id,
+            username === DEMO_USER_USERNAME ? DEMO_USER_NAME : DEMO_COMPANION_NAME
+        )
     }
+
+    // After BOTH users' drive_items are gone, so every room deleted in either
+    // pass reads as orphaned. Running it inside wipeOwnedData would leave the
+    // companion's journal rows behind whenever their items outlived the pass.
+    const journalRows = await wipeOrphanedRealtimeJournal(pb)
+    if (journalRows > 0) log(`Wiped ${journalRows} orphaned realtime_doc_updates record(s)`)
 
     // seedForUser handles the find-or-create dance for the user and runs every
     // linked package's seed() against the demo workspace.

--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -30,6 +30,7 @@
 
 import { deriveUsername } from '@tinycld/core/lib/derive-username'
 import { loadEnv } from '@tinycld/core/lib/load-env'
+import type { SeedContext, SeedUser } from '@tinycld/core/lib/packages/config-types'
 import { deriveSeeds } from '@tinycld/core/lib/packages/derive-seeds'
 import PocketBase from 'pocketbase'
 import { tinycldSeeds } from '../tinycld.seeds'
@@ -121,6 +122,23 @@ const COLLABORATOR_DEFAULTS = {
     email: process.env.TEST_COLLABORATOR_LOGIN || 'collaborator@tinycld.org',
     username: process.env.TEST_COLLABORATOR_USERNAME || 'collaborator',
     name: 'Collaborator Tester',
+}
+
+// Demo mode's equivalent of the collaborator. The demo tour shows off shared
+// boards, shared calendars and shared files, all of which need a second person
+// to point at. Before this existed the seeds resolved that person by querying
+// `users` for `id != demo`, which meant they wrote mailboxes, memberships and
+// shares owned by whoever else happened to exist — rows the nightly reset
+// (scoped to the demo user) could never reclaim.
+//
+// Seeding a dedicated companion instead makes the demo's data set exactly two
+// users wide, so reset-demo.ts can wipe both and return the workspace to a
+// known state. is_demo is set so the account is recognizably part of the demo
+// singleton and never mistaken for a real signup.
+export const DEMO_COMPANION_DEFAULTS = {
+    email: 'demo-teammate@tinycld.org',
+    username: 'demo-teammate',
+    name: 'Sam Rivera',
 }
 
 // These mirror the singleton constants in
@@ -264,8 +282,9 @@ function isNotFoundError(err: unknown): boolean {
 
 /**
  * Find-or-create the target user (single-org: the `role` enum lives on the user
- * record; the orgs/user_org collections are gone), then run all linked package
- * seeds against it.
+ * record; the orgs/user_org collections are gone) plus the companion that owns
+ * the other half of the shared fixtures, then run all linked package seeds
+ * against both.
  *
  * Exported so reset-demo.ts can re-seed without shelling out.
  */
@@ -356,13 +375,20 @@ export async function seedForUser(pb: PocketBase, config: SeedConfig): Promise<S
         user = await pb.collection('users').update(user.id, { role: 'owner' })
     }
 
-    const seedContext = {
+    // Created here rather than in main() so BOTH entry points get a companion —
+    // reset-demo.ts calls seedForUser directly, and a demo re-seeded without one
+    // would fall back to resolving teammates from real accounts, reintroducing
+    // exactly the unreclaimable rows this refactor removes.
+    const companion = await ensureCompanionUser(pb, config, companionPassword(config))
+
+    const seedContext: SeedContext = {
         user: {
             id: user.id,
             username: config.userUsername,
             email: config.userEmail,
             name: config.userName,
         },
+        companion,
     }
     const orderedSeeds = deriveSeeds(tinycldSeeds)
     log(`Running ${orderedSeeds.length} package seed(s)...`)
@@ -433,14 +459,19 @@ async function ensureAdminAppUser(pb: PocketBase, config: SeedConfig): Promise<v
 }
 
 /**
- * The collaborator's password, resolved the same way the fixture user's is.
+ * The companion's password, resolved the same way the fixture user's is.
  *
  * TEST_COLLABORATOR_PW wins so CI can set it; otherwise the collaborator shares
  * the fixture user's password. Falling back to the SAME literal the e2e helper
  * hardcodes is what makes a clean checkout work at all — playwright.config.ts
  * never loads .env, so seed and helper can only meet at a shared constant.
+ *
+ * The demo companion is never signed into (it exists only to own the other half
+ * of the shared fixtures), so it gets a fresh random password each reset rather
+ * than a predictable literal on a public deployment.
  */
-function collaboratorPassword(config: SeedConfig): string {
+function companionPassword(config: SeedConfig): string {
+    if (config.isDemo) return generatePassword()
     return (
         process.env.TEST_COLLABORATOR_PW ||
         (config.userPasswordExplicit ? config.userPassword : TEST_USER_DEFAULT_PASSWORD)
@@ -448,55 +479,69 @@ function collaboratorPassword(config: SeedConfig): string {
 }
 
 /**
- * Find-or-create the seeded collaborator (see COLLABORATOR_DEFAULTS).
+ * Find-or-create the seeded companion — the collaborator in test mode, the demo
+ * teammate in demo mode (see COLLABORATOR_DEFAULTS / DEMO_COMPANION_DEFAULTS).
  *
- * Runs BEFORE seedForUser so package seeds that look for a "teammate" (cards'
- * seed resolves its `teammate` rows from the other users in the deployment)
- * find a real one, rather than collapsing those rows onto the seeded owner.
+ * Runs BEFORE seedForUser and its record is passed through as
+ * SeedContext.companion, so package seeds that need a second person (cards'
+ * teammate-owned board, calendar's shared calendars, drive's share targets)
+ * resolve to THIS user rather than querying for any other account. That is what
+ * bounds the seeded data to two users and makes the demo reset able to reclaim
+ * all of it.
  *
  * Idempotent in the same shape as ensureAdminAppUser: an existing row keeps its
  * id but has its password reset to the known fixture value, because a
  * re-seeded DB must be signable-into with the credential the e2e helper
  * hardcodes — a row left with an unknown password would fail every
  * signInAsCollaborator() with no clue why.
+ *
+ * role is 'member', deliberately NOT 'owner': a second owner would silently
+ * weaken every last-owner and role-gate assertion that relies on the fixture
+ * owner being the only one.
  */
-async function ensureCollaboratorUser(pb: PocketBase, password: string): Promise<void> {
+async function ensureCompanionUser(
+    pb: PocketBase,
+    config: SeedConfig,
+    password: string
+): Promise<SeedUser> {
+    const defaults = config.isDemo ? DEMO_COMPANION_DEFAULTS : COLLABORATOR_DEFAULTS
+    const fields = {
+        email: defaults.email,
+        name: defaults.name,
+        password,
+        passwordConfirm: password,
+        role: 'member',
+        // The demo companion carries is_demo so it is recognizable as part of
+        // the demo singleton rather than a real signup, and so reset-demo.ts can
+        // find it the same way it finds the demo user.
+        ...(config.isDemo ? { is_demo: true } : {}),
+    }
+
     let existing: { id: string } | null = null
     try {
         existing = await pb
             .collection('users')
-            .getFirstListItem(`username = "${COLLABORATOR_DEFAULTS.username}"`)
+            .getFirstListItem(`username = "${defaults.username}"`)
     } catch (err) {
         if (!isNotFoundError(err)) throw err
     }
 
     if (existing) {
-        log('Found existing collaborator user:', COLLABORATOR_DEFAULTS.username)
-        await pb.collection('users').update(existing.id, {
-            email: COLLABORATOR_DEFAULTS.email,
-            name: COLLABORATOR_DEFAULTS.name,
-            password,
-            passwordConfirm: password,
-            role: 'member',
-        })
-        return
+        log('Found existing companion user:', defaults.username)
+        await pb.collection('users').update(existing.id, fields)
+        return { id: existing.id, ...defaults }
     }
 
-    log('Creating collaborator user:', COLLABORATOR_DEFAULTS.username)
-    await pb.collection('users').create({
-        username: COLLABORATOR_DEFAULTS.username,
-        email: COLLABORATOR_DEFAULTS.email,
-        password,
-        passwordConfirm: password,
-        name: COLLABORATOR_DEFAULTS.name,
-        // The share dialog searches people by email; a collaborator whose email
+    log('Creating companion user:', defaults.username)
+    const created = await pb.collection('users').create({
+        username: defaults.username,
+        ...fields,
+        // The share dialog searches people by email; a companion whose email
         // is hidden cannot be found and added through the real UI.
         emailVisibility: true,
         verified: true,
-        // `role` is required (1940000000_backfill_and_require_users_role) and
-        // must be set on the create itself.
-        role: 'member',
     })
+    return { id: created.id, ...defaults }
 }
 
 export async function authSuperuser(config: {
@@ -569,13 +614,8 @@ async function main() {
     const pb = await authSuperuser(config)
     await seedAppName(pb)
     await ensureAdminAppUser(pb, config)
-    // Before seedForUser: package seeds resolve their "teammate" rows from the
-    // other users present, so the collaborator has to exist by then.
-    // Demo mode is a single-visitor tour — a second signed-in member there
-    // would show up in rosters and pickers as a stranger.
-    if (!config.isDemo) {
-        await ensureCollaboratorUser(pb, collaboratorPassword(config))
-    }
+    // The companion is created inside seedForUser (both entry points need it),
+    // so there is nothing to provision here.
     const login = await seedForUser(pb, config)
     log('Seeding complete!')
     printLoginSummary(config, login)


### PR DESCRIPTION
The nightly demo reset wiped less than it re-seeded, so tinycld.org accumulated orphaned rows indefinitely. The delete side was already user-scoped; the leak came from the seeds, which resolved "the other person" for shared fixtures by querying `users` for `id != me` and then wrote mailboxes, memberships and shares owned by real accounts.

## Changes

- `SeedContext` gains an optional `companion`, created by `seedForUser` so both `seed-db` and `reset-demo` get one. Test mode reuses the existing collaborator; demo mode gets a dedicated `demo-teammate` account (`is_demo`, random password — it is never signed into).
- `reset-demo` wipes both users and closes four gaps:
  - **cards and calendar were never wiped at all.** `calendar_calendars` was listed with an `ownerField` of `created_by`, a column it does not have — a silent no-op. Both are now resolved through their membership junction, which also catches the deliberately teammate-owned board and calendars the user only edits/views.
  - **`label_assignments` was never wiped.** Polymorphic `record_id`, no FK, nothing cascades — mail creates one per labeled thread and they survived every run.
  - **`drive_shares` was keyed on `user`**, which the seed sets to the *recipient*. Now `created_by`.
  - **The personal calendar** from calendar's lifecycle hook is created on user-*create* only. The demo users persist across resets, so once deleted it never returned; it is now re-provisioned.

## Verification

Against a live PocketBase: three consecutive resets produce identical wipe counts (46 companion / 347 demo) and a byte-identical collection census — a stable fixed point, which is the actual proof nothing leaks. A real non-demo user created with their own drive folder, contact and calendar membership survives a reset fully intact.

`tinycld-pkg check` passes (1515 tests).

## Companion PRs

Merge this first — the sibling seeds read `SeedContext.companion`.

tinycld/mail · tinycld/calendar · tinycld/cards · tinycld/drive · tinycld/text · tinycld/calc

## Note

`cards_projects.slug` is globally unique but the board slugs are hardcoded constants, so cards can only be seeded once per deployment — a demo seed on a DB that already ran a *test* seed fails. Pre-existing, does not affect the nightly reset (which wipes the boards first), but demo and test fixtures cannot coexist in one database.