### PR TITLE
Fix the realtime send race and commit edits on displacement

### DIFF
--- a/core/components/ResponsiveToolbar.tsx
+++ b/core/components/ResponsiveToolbar.tsx
@@ -37,6 +37,22 @@ interface ResponsiveToolbarProps {
     height?: number
 }
 
+/**
+ * Keep DOM focus where it is when this control is pressed.
+ *
+ * A toolbar acts on something else — usually a text editor — and on web the
+ * browser blurs whatever holds focus on mousedown, collapsing that editor's
+ * selection before the press is even handled. Preventing the default keeps the
+ * selection, so an action still has something to apply to.
+ *
+ * Web-only: native has no DOM focus model, and `Platform.select` here would
+ * hand React Native an unknown prop.
+ */
+const FOCUS_GUARD =
+    Platform.OS === 'web'
+        ? { onMouseDown: (e: { preventDefault: () => void }) => e.preventDefault() }
+        : {}
+
 // ── Native: simple flex-row, no overflow logic ──
 
 function NativeToolbar({ items, rightItems, height = 44 }: ResponsiveToolbarProps) {
@@ -240,7 +256,23 @@ function OverflowMenu({ items }: { items: ToolbarItem[] }) {
     return (
         <Menu>
             <Menu.Trigger>
-                <Pressable className="p-2 rounded-full" accessibilityLabel="More actions">
+                <Pressable
+                    className="p-2 rounded-full"
+                    accessibilityLabel="More actions"
+                    // The same guard every toolbar button carries, and for the
+                    // same reason: on web a press moves DOM focus off whatever
+                    // held it, and when that is a rich-text editor the browser
+                    // collapses its selection first. An action chosen from this
+                    // menu would then apply to nothing — pick Bold with a word
+                    // selected and the word is no longer selected by the time
+                    // the command runs.
+                    //
+                    // It matters MORE here than on the buttons it replaces: at
+                    // narrow widths every format button folds into this menu, so
+                    // without it the whole toolbar stops working exactly where
+                    // there is least room to notice.
+                    {...FOCUS_GUARD}
+                >
                     <EllipsisVertical size={18} color={mutedColor} />
                 </Pressable>
             </Menu.Trigger>

--- a/core/components/ToolbarIconButton.tsx
+++ b/core/components/ToolbarIconButton.tsx
@@ -4,6 +4,9 @@ import type React from 'react'
 import { forwardRef } from 'react'
 import { Platform, Pressable, type View } from 'react-native'
 
+/** Hoisted so the button below is not handed a new identity every render. */
+const preventDefault = (event: React.MouseEvent) => event.preventDefault()
+
 interface ToolbarIconButtonProps {
     icon: LucideIcon
     label: string
@@ -26,6 +29,16 @@ export const ToolbarIconButton = forwardRef<View, ToolbarIconButtonProps>(
                     aria-label={label}
                     disabled={disabled}
                     onClick={onPress as unknown as React.MouseEventHandler}
+                    // Keep DOM focus where it is.
+                    //
+                    // A toolbar acts on something else — usually a text editor —
+                    // and pressing a <button> blurs that editor on mousedown,
+                    // collapsing its selection before the click is handled. The
+                    // action then applies to nothing: Bold with a word selected
+                    // leaves the word unbolded. Every hand-rolled button in the
+                    // toolbars does this; doing it here covers the ones built
+                    // from ToolbarItem, which could not opt in themselves.
+                    onMouseDown={preventDefault}
                     style={{
                         display: 'inline-flex',
                         alignItems: 'center',

--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -15,7 +15,7 @@ import type { EditorCommands, EditorHandle, EditorToolbarState } from '../../lib
 import { useWarmEditor } from '../../lib/editor/warm'
 import type { SurfaceId } from '../../lib/editor/warm/warm-editor-store'
 import { captureException } from '../../lib/errors'
-import { isNoOpEdit, shouldCommitOnBlur } from './commit-policy'
+import { isNoOpEdit } from './commit-policy'
 
 /** The coordinate fields a React Native press event carries. */
 export interface PressPoint {
@@ -53,8 +53,6 @@ export interface LazyEditorSlots {
     toolbarState: EditorToolbarState
     submit: () => void
     cancel: () => void
-    /** Tell the swap a dialog holds the focus, so a blur is not the session ending. */
-    setDialogOpen: (open: boolean) => void
 }
 
 export interface LazyEditorHeaderState {
@@ -132,8 +130,21 @@ export interface LazyEditorProps {
     editorOptions: UseRichEditorOptions
     surfaceId: SurfaceId
     canEdit: boolean
-    /** True for an edit of existing content; false for a composer. */
-    commitOnBlur?: boolean
+    /**
+     * Write when ANOTHER surface takes the shared editor.
+     *
+     * There is one editor app-wide, so clicking a second surface hands it over
+     * unconditionally — the first surface keeps its session but loses the
+     * instance. This decides what happens to what it was holding: an edit of
+     * existing content commits (the reader clicked away from a finished edit),
+     * while a composer keeps its text as a stashed draft via `onRelease`.
+     *
+     * Being displaced is unambiguous — someone else is editing now — which is
+     * why the session hangs off it rather than off focus. Losing focus happens
+     * for reasons that have nothing to do with finishing: a toolbar's overflow
+     * menu, a link dialog, a click on the panel behind.
+     */
+    commitOnDisplace?: boolean
     onCommit: (content: string) => void
     /** Absent when there is nothing to revert (a collaborative description). */
     onCancel?: () => void
@@ -149,19 +160,6 @@ export interface LazyEditorProps {
      * Not called on a commit — `onCommit` already carries the content.
      */
     onRelease?: (content: string) => void
-    /**
-     * True while a dialog the editor opened holds the focus, so a blur is not
-     * the session ending — the editor must survive until the picked image or
-     * link lands in it.
-     *
-     * Two ways to say this, and a caller should pick one. `slots.setDialogOpen`
-     * suits a caller that learns about the dialog from inside the rendered
-     * chrome. This prop suits one that already knows: a card description owns
-     * both dialogs' open state itself, and pushing it back up through an effect
-     * only to receive it again is the useState+useEffect pairing the style
-     * guide names as the signal to switch primitives. When supplied, this wins.
-     */
-    isDialogOpen?: boolean
     /**
      * Open the session on mount instead of waiting for a press.
      *
@@ -267,11 +265,10 @@ export function useLazyEditor({
     editorOptions,
     surfaceId,
     canEdit,
-    commitOnBlur = false,
+    commitOnDisplace = false,
     onCommit,
     onCancel,
     onRelease,
-    isDialogOpen: dialogOpenProp,
     startOpen = false,
     openAt,
     stayOpenOnCommit = false,
@@ -281,35 +278,26 @@ export function useLazyEditor({
     accessibilityLabel = 'Edit',
 }: LazyEditorProps): LazyEditorRenderSlots {
     const [isEditing, setIsEditing] = useState(startOpen)
-    const [dialogOpenState, setIsDialogOpen] = useState(false)
-    // The prop wins when given, so a caller that already owns the dialog state
-    // does not have to echo it back through setDialogOpen.
-    const isDialogOpen = dialogOpenProp ?? dialogOpenState
     // The revert/no-op baseline, snapshotted when the session opens so a
     // realtime update mid-edit cannot become the comparison target.
     const baselineRef = useRef(value)
-    const hasFocusedRef = useRef(false)
     const settledRef = useRef(false)
 
     const submitRef = useRef<() => void>(() => {})
-    const blurRef = useRef<() => void>(() => {})
 
     // The consumer's own focus handlers are CHAINED rather than replaced: a
     // caller uses them to drive its chrome (a card description swaps its section
     // label for a formatting toolbar on focus), and silently dropping them
     // leaves that chrome permanently in its idle state.
     //
-    // These wrappers carry the entire commit policy — hasFocusedRef gates
-    // shouldCommitOnBlur, blurRef fires the blur-commit, submitRef answers ⌘↵ —
-    // so BOTH the warm instance and the cold fallback must receive them. Giving
-    // them only to `own` left the policy inert on the warm path, which is the
-    // only path native ever takes: blur never committed and ⌘↵ never submitted.
+    // `submitRef` answers ⌘↵ through here, so BOTH the warm instance and the
+    // cold fallback must receive these. Giving them only to `own` left the
+    // policy inert on the warm path, which is the only path native ever takes.
     const chainedOptions: UseRichEditorOptions = {
         ...editorOptions,
         contentFormat,
         initialContent: value,
         onFocus: () => {
-            hasFocusedRef.current = true
             // The editor has genuinely landed and taken the caret, so the swap
             // is over and blur handling comes back on. Keyed on the real focus
             // event rather than on the effect that requests focus: the request
@@ -318,10 +306,15 @@ export function useLazyEditor({
             isSwappingRef.current = false
             editorOptions.onFocus?.()
         },
-        onBlur: () => {
-            editorOptions.onBlur?.()
-            blurRef.current()
-        },
+        // Chained, but no longer a session event.
+        //
+        // Losing focus used to END the session — and for an edit of existing
+        // content, WRITE it. That made every focusable control a hazard: a
+        // toolbar's overflow menu, a dialog, anything portalled. A session now
+        // ends only when another surface takes the editor, on Escape, or when
+        // the caller closes it. The consumer's own handler still fires, because
+        // it drives chrome that legitimately follows focus.
+        onBlur: () => editorOptions.onBlur?.(),
         onSubmitShortcut: () => {
             editorOptions.onSubmitShortcut?.()
             submitRef.current()
@@ -341,6 +334,22 @@ export function useLazyEditor({
     // captured `active` there would test a holding this surface no longer has.
     const activeRef = useRef(active)
     activeRef.current = active
+    // The last editor this surface actually held.
+    //
+    // `activeRef` goes null the moment another surface takes over, but a
+    // DISPLACED surface still has to read its own uncommitted text out of the
+    // instance it was using — that read is the only copy. Blur got away with
+    // reading `activeRef` because it fired during the DOM move, while the
+    // holding was still ours; an effect runs after the store has already moved
+    // on. Held separately so it survives that.
+    const lastHeldRef = useRef<typeof active>(null)
+    const lastHeldGenerationRef = useRef<number | null>(null)
+    /** Which holding's text has already been stashed — see endSession. */
+    const stashedGenerationRef = useRef<number | null>(null)
+    if (active != null) {
+        lastHeldRef.current = active
+        lastHeldGenerationRef.current = lease.generation
+    }
 
     // Opening a session and RECLAIMING the instance for one already open are
     // different things, and only the first may touch the guards.
@@ -351,8 +360,9 @@ export function useLazyEditor({
     // and a later Escape would "revert" to that rather than to what was
     // persisted — so the reclaim path leaves all three alone.
     const openSession = useCallback(() => {
+        // A fresh session has not held the editor yet, whatever the last one did.
+        hasHeldRef.current = false
         baselineRef.current = value
-        hasFocusedRef.current = false
         settledRef.current = false
         // Set BEFORE the acquire, which is what moves the DOM node and so what
         // raises the blur this suppresses.
@@ -515,8 +525,20 @@ export function useLazyEditor({
             // the ONLY copy of an uncommitted draft — the composer's text used
             // to survive because its own editor stayed mounted, and it no
             // longer does.
-            const held = activeRef.current
-            if (stash && onRelease && held) {
+            // Falls back to the last instance this surface held: a displaced
+            // surface no longer holds one, and its text would otherwise be
+            // unreadable — see lastHeldRef.
+            const held = activeRef.current ?? lastHeldRef.current
+            // Stash ONCE per holding.
+            //
+            // A parent-owned surface re-arms `settledRef` after a handover so it
+            // can send again, which makes that flag useless as a guard here —
+            // and every later pass reads an editor that now belongs to someone
+            // else, so it reads EMPTY and `stash` treats empty as a clear. The
+            // first pass saved the draft; the second and third deleted it.
+            const alreadyStashed = stashedGenerationRef.current === lastHeldGenerationRef.current
+            if (stash && onRelease && held && !alreadyStashed) {
+                stashedGenerationRef.current = lastHeldGenerationRef.current
                 const editor = held.editor
                 // The generation at the moment this surface still held the
                 // instance. A blur caused BY a steal runs after the editor has
@@ -524,11 +546,23 @@ export function useLazyEditor({
                 // it now returns THEIR text — the composer would stash the
                 // comment someone just clicked into and redisplay it as its own
                 // draft. Discard the read if the instance moved.
-                const generationAtStash = lease.generation
+                // The generation the text we are about to read belongs to.
+                //
+                // Snapshotted when this surface HELD the editor, not when it
+                // noticed it had lost it: a displacement is observed after the
+                // store has already moved on, so comparing against the live
+                // `lease.generation` discards every displaced read as stale —
+                // which is precisely the text this exists to save.
+                const generationAtStash = lastHeldGenerationRef.current ?? lease.generation
                 void (async () => {
                     try {
                         const content = await readContent(editor)
-                        if (lease.generation !== generationAtStash) return
+                        // Was the instance still ours when the read started? A
+                        // handover REBUILDS the editor, so a generation past the
+                        // one our text belonged to means these bytes are the
+                        // incoming surface's — the composer would otherwise
+                        // stash the comment someone just clicked into.
+                        if (lease.generation > generationAtStash + 1) return
                         onRelease(content)
                     } catch (err) {
                         // The session still ends — a broken read is not a
@@ -538,7 +572,7 @@ export function useLazyEditor({
                         // with the baseline restores what was last persisted
                         // instead of silently showing an empty composer.
                         captureException('editor.lazy.readOnRelease', err, { surfaceId })
-                        if (lease.generation === generationAtStash) {
+                        if (lease.generation <= generationAtStash + 1) {
                             onRelease(baselineRef.current)
                         }
                     }
@@ -647,6 +681,77 @@ export function useLazyEditor({
         onCancel?.()
     }, [endSession, onCancel])
 
+    // Another surface took the editor.
+    //
+    // This is what "clicking a second comment finishes the first" actually is.
+    // It used to happen only as a SIDE EFFECT of blur: handing the instance over
+    // moves its DOM node, the move blurs it, and the blur handler committed or
+    // stashed. That made every stray focus loss — a toolbar menu, a dialog —
+    // indistinguishable from a genuine handover, which is the bug this whole
+    // change exists to fix. Said directly here instead.
+    //
+    // A NULL holder is not a steal. The editor is unheld between a release and
+    // the next acquire, and before this surface's own `startOpen` acquire lands;
+    // treating that as a handover would commit an edit nobody left, including
+    // during the boot.
+    // Whether this surface has actually held the editor during this session.
+    //
+    // Being displaced means LOSING something, so a surface that never had it
+    // cannot be displaced. Without this the effect fires on the render where a
+    // surface has just acquired but the store's holder has not propagated yet —
+    // it reads someone else's id and commits the session that was opening,
+    // settling it before a caret ever landed.
+    // Held means it actually had an EDITOR, not merely that the store named it.
+    //
+    // `holder` is set the instant a surface acquires, but `result` stays null
+    // until the singleton has booted — so a surface can be the holder with
+    // nothing to type into. Arming on `holder` alone let a displacement land on
+    // a session that had never rendered an editor, which ended it before the
+    // boot could hand one over. It only showed up under load, where the boot is
+    // slow enough to lose the race.
+    const hasHeldRef = useRef(false)
+    if (lease.holder === surfaceId && lease.result != null) hasHeldRef.current = true
+
+    const holder = lease.holder
+    useEffect(() => {
+        if (!isEditing || settledRef.current) return
+        if (!hasHeldRef.current) return
+        if (holder == null || holder === surfaceId) return
+        if (commitOnDisplace) {
+            submitRef.current()
+            return
+        }
+        endSession({ stash: true })
+        // A parent-owned session outlives the handover — the caller that mounted
+        // it decides when editing is over — so the guards `endSession` just set
+        // have to come back with it. Without this the composer's NEXT send is
+        // refused as already-settled and silently does nothing.
+        if (startOpen) settledRef.current = false
+    }, [isEditing, holder, surfaceId, commitOnDisplace, endSession, startOpen])
+
+    // The surface is going away with an unfinished edit.
+    //
+    // The displacement effect above cannot see this case. A surface whose
+    // session is owned by a PARENT — cards mounts one inline comment editor, for
+    // whichever id is being edited — is UNMOUNTED by the same commit that hands
+    // the editor on, so it never renders again to notice it was displaced.
+    // Clicking a second comment is exactly that: `setEditingCommentId(B)` tears
+    // down A, and A's edit would be lost.
+    //
+    // Blur happened to cover it, because the DOM move fires synchronously before
+    // React unmounts anything. That is the accident this replaces.
+    //
+    // Empty deps and read through a ref, matching `useWarmEditor`'s own release:
+    // this must fire on unmount and nothing else. Depending on the values would
+    // re-run the cleanup on every handover and commit a live session.
+    const commitOnUnmountRef = useRef<() => void>(() => {})
+    commitOnUnmountRef.current = () => {
+        if (!commitOnDisplace || settledRef.current || !isEditing) return
+        if (!hasHeldRef.current) return
+        submitRef.current()
+    }
+    useEffect(() => () => commitOnUnmountRef.current(), [])
+
     // Everything the handle calls, read at call time rather than captured.
     //
     // A handle is HELD across renders — a keyboard shortcut registered once, a
@@ -706,39 +811,6 @@ export function useLazyEditor({
     )
 
     submitRef.current = submit
-    blurRef.current = () => {
-        // A blur raised by the node being re-attached is not the user leaving —
-        // see isSwappingRef. Acting on it would commit or end a session that has
-        // only just started.
-        if (isSwappingRef.current) return
-        if (
-            shouldCommitOnBlur({
-                commitOnBlur,
-                hasFocused: hasFocusedRef.current,
-                isSettled: settledRef.current,
-                isDialogOpen,
-            })
-        ) {
-            submit()
-            return
-        }
-        // A surface with no blur-commit still ends its session on blur — and
-        // this is the one exit that leaves uncommitted text, so it is the one
-        // that stashes.
-        if (!commitOnBlur && hasFocusedRef.current && !isDialogOpen) {
-            endSession({ stash: true })
-            // A parent-owned session survived that call, so the guards it just
-            // set have to come back with it: `settled` would otherwise refuse
-            // the next send, and `hasFocused` must re-arm so a LATER blur can
-            // stash again. Re-focusing the composer resets the latter anyway;
-            // clearing it here keeps a blurred-but-open surface from stashing
-            // twice off one focus.
-            if (startOpen) {
-                settledRef.current = false
-                hasFocusedRef.current = false
-            }
-        }
-    }
 
     // The whole rule, in one condition. Wanting to edit is not enough — this
     // surface must actually HOLD a usable editor, because there is only one and
@@ -787,7 +859,6 @@ export function useLazyEditor({
         toolbarState: active.toolbarState,
         submit,
         cancel,
-        setDialogOpen: setIsDialogOpen,
     }
 
     return {

--- a/core/components/editor/__tests__/commit-policy.test.ts
+++ b/core/components/editor/__tests__/commit-policy.test.ts
@@ -1,53 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { isNoOpEdit, shouldCommitOnBlur } from '../commit-policy'
+import { isNoOpEdit } from '../commit-policy'
 
 /**
- * Each of these rules was found on a device, and each protects a write. They
- * live in core so a second consumer inherits the fixes rather than
- * rediscovering them.
+ * The blur-commit rules that used to live here are gone with the behaviour: a
+ * session no longer ends on focus loss, so there is nothing left for them to
+ * decide. What a submitted value MEANS is still policy, and still shared.
  */
-describe('commit on blur', () => {
-    const base = { commitOnBlur: true, hasFocused: true, isSettled: false, isDialogOpen: false }
-
-    it('commits when a focused session loses focus', () => {
-        expect(shouldCommitOnBlur(base)).toBe(true)
-    })
-
-    /**
-     * The composer has no blur-commit: leaving it must not post a comment.
-     */
-    it('never commits a surface that does not commit on blur', () => {
-        expect(shouldCommitOnBlur({ ...base, commitOnBlur: false })).toBe(false)
-    })
-
-    /**
-     * The editor opens with autofocus at a placeholder height, and until the
-     * page reports its real content height the caret can land outside the
-     * visible box and blur immediately. Since a blur COMMITS, that saved a
-     * comment nobody had touched.
-     */
-    it('never commits before the session has held focus', () => {
-        expect(shouldCommitOnBlur({ ...base, hasFocused: false })).toBe(false)
-    })
-
-    /**
-     * Save and the blur-commit race each other: pressing Save blurs the editor.
-     * Both writing would submit twice.
-     */
-    it('does not commit again once the session has settled', () => {
-        expect(shouldCommitOnBlur({ ...base, isSettled: true })).toBe(false)
-    })
-
-    /**
-     * The image picker and link prompt both steal focus. Treating that as the
-     * end of the session unmounts the surface the picked image is about to be
-     * inserted into.
-     */
-    it('does not commit while a dialog holds the focus', () => {
-        expect(shouldCommitOnBlur({ ...base, isDialogOpen: true })).toBe(false)
-    })
-})
-
 describe('no-op edits', () => {
     it('treats an unchanged value as nothing to write', () => {
         expect(isNoOpEdit('same text', 'same text')).toBe(true)

--- a/core/components/editor/__tests__/lazy-editor-blur.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-blur.test.tsx
@@ -54,10 +54,9 @@ vi.mock('../../../lib/editor/warm', () => ({
 const { useLazyEditor } = await import('../LazyEditor')
 
 let startEditing: (() => void) | null = null
-let setDialogOpen: ((open: boolean) => void) | null = null
 let isEditing = false
 
-function Probe({ isDialogOpen }: { isDialogOpen?: boolean }) {
+function Probe() {
     const slots = useLazyEditor({
         readView: <Text>read view</Text>,
         value: 'persisted',
@@ -65,12 +64,8 @@ function Probe({ isDialogOpen }: { isDialogOpen?: boolean }) {
         editorOptions: {},
         surfaceId: 'description:card1',
         canEdit: true,
-        isDialogOpen,
         onCommit: () => {},
-        renderEditor: s => {
-            setDialogOpen = s.setDialogOpen
-            return <Text>editing surface</Text>
-        },
+        renderEditor: () => <Text>editing surface</Text>,
         renderHeader: state => {
             isEditing = state.isEditing
             return null
@@ -92,49 +87,44 @@ function focusThenBlur() {
 beforeEach(() => {
     captured = null
     startEditing = null
-    setDialogOpen = null
     isEditing = false
     vi.clearAllMocks()
 })
 
 afterEach(cleanup)
 
-describe('LazyEditor dialog handling', () => {
-    it('ends the session on blur when no dialog is open', () => {
+describe('LazyEditor blur handling', () => {
+    /**
+     * Blur is not an exit.
+     *
+     * It used to end the session — and for an edit of existing content, WRITE
+     * it — which made every focusable control a hazard: a toolbar's overflow
+     * menu, a dialog, anything portalled took focus and finished the edit
+     * behind the user's back. A session now ends only when another surface
+     * takes the editor, on Escape, or when the caller closes it.
+     *
+     * The three dialog cases that used to live here are gone with the
+     * behaviour: `isDialogOpen` existed to stop a dialog's focus grab ending a
+     * session, and nothing needs stopping any more.
+     */
+    it('keeps the session open when the editor loses focus', () => {
         render(<Probe />)
         act(() => startEditing?.())
         expect(isEditing).toBe(true)
 
         focusThenBlur()
 
-        expect(isEditing).toBe(false)
-    })
-
-    it('keeps the session alive on blur while the isDialogOpen prop is true', () => {
-        render(<Probe isDialogOpen />)
-        act(() => startEditing?.())
-
-        focusThenBlur()
-
         expect(isEditing).toBe(true)
     })
 
-    it('keeps the session alive on blur after slots.setDialogOpen(true)', () => {
+    /**
+     * Including under a dialog. `isDialogOpen` used to exist for exactly this —
+     * an image picker or link prompt takes focus, and that blur would have
+     * ended the session under it. Nothing needs telling any more.
+     */
+    it('keeps it open when a dialog takes the focus', () => {
         render(<Probe />)
         act(() => startEditing?.())
-        act(() => setDialogOpen?.(true))
-
-        focusThenBlur()
-
-        expect(isEditing).toBe(true)
-    })
-
-    // The prop is authoritative when supplied, so a caller that owns the state
-    // cannot be contradicted by a stale setDialogOpen call.
-    it('lets the prop win over setDialogOpen', () => {
-        render(<Probe isDialogOpen />)
-        act(() => startEditing?.())
-        act(() => setDialogOpen?.(false))
 
         focusThenBlur()
 

--- a/core/components/editor/__tests__/lazy-editor-displacement.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-displacement.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import { Text, View } from 'react-native'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WarmEditorLease } from '../../../lib/editor/warm/types'
+
+/**
+ * Being displaced — another surface taking the one shared editor.
+ *
+ * This is how an edit finishes when the reader clicks somewhere else, and it
+ * used to happen only as a SIDE EFFECT of blur: handing the instance over moved
+ * its DOM node, the move blurred it, and the blur handler committed. That made
+ * every stray focus loss indistinguishable from a real handover, which is why
+ * pressing a toolbar menu silently finished an edit.
+ *
+ * The lease is mocked because the two guards below are about STATE the store
+ * passes through, and both windows they protect are a frame wide — a real
+ * editor cannot be held in either on demand.
+ */
+
+let holder: string | null = 'comment:a'
+let result: unknown = null
+
+const warmEditor = {
+    getHTML: vi.fn(async () => '<p>warm</p>'),
+    getText: vi.fn(async () => 'warm'),
+    getMarkdown: vi.fn(async () => 'edited text'),
+    setContent: vi.fn(),
+    setMarkdown: vi.fn(),
+    focus: vi.fn(),
+    clear: vi.fn(),
+    getSelection: vi.fn(async () => null),
+}
+
+const warmResult = {
+    editor: warmEditor,
+    EditorComponent: () => null,
+    commands: {},
+    toolbarState: {},
+}
+
+const lease: WarmEditorLease = {
+    isWarm: true,
+    ready: true,
+    get holder() {
+        return holder as never
+    },
+    acquire: vi.fn(),
+    release: vi.fn(),
+    get result() {
+        return result as never
+    },
+    generation: 1,
+}
+
+vi.mock('../../../lib/editor/warm', () => ({
+    useWarmEditor: () => lease,
+}))
+
+const { useLazyEditor } = await import('../LazyEditor')
+
+function Probe({
+    onCommit,
+    onRelease,
+    commitOnDisplace,
+}: {
+    onCommit: (content: string) => void
+    onRelease?: (content: string) => void
+    commitOnDisplace?: boolean
+}) {
+    const slots = useLazyEditor({
+        readView: <Text>read view</Text>,
+        value: 'persisted',
+        contentFormat: 'markdown',
+        editorOptions: {},
+        surfaceId: 'comment:a',
+        canEdit: true,
+        startOpen: true,
+        commitOnDisplace,
+        onCommit,
+        onRelease,
+        renderEditor: () => <Text>editing surface</Text>,
+        testID: 'probe',
+    })
+    return <View>{slots.body}</View>
+}
+
+beforeEach(() => {
+    holder = 'comment:a'
+    result = warmResult
+    vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('displacement', () => {
+    /**
+     * Unmounting with an unfinished edit commits it.
+     *
+     * This is the route a parent-owned surface actually takes. Cards mounts one
+     * inline comment editor, for whichever id is being edited, so clicking a
+     * second comment sets that id and UNMOUNTS the first in the same commit —
+     * it never renders again to notice it was displaced. Blur used to cover this
+     * by firing synchronously during the DOM move.
+     */
+    it('commits an unfinished edit when the surface goes away', async () => {
+        const onCommit = vi.fn()
+        const { unmount } = render(<Probe onCommit={onCommit} commitOnDisplace />)
+
+        await act(async () => {
+            unmount()
+        })
+
+        expect(onCommit).toHaveBeenCalledWith('edited text')
+    })
+
+    it('stashes instead, for a surface that does not commit', async () => {
+        const onCommit = vi.fn()
+        const onRelease = vi.fn()
+        const { rerender } = render(<Probe onCommit={onCommit} onRelease={onRelease} />)
+
+        holder = 'comment:b'
+        result = null
+        await act(async () => {
+            rerender(<Probe onCommit={onCommit} onRelease={onRelease} />)
+        })
+
+        expect(onRelease).toHaveBeenCalledWith('edited text')
+        expect(onCommit).not.toHaveBeenCalled()
+    })
+
+    /**
+     * A null holder is the editor PARKED, not stolen. It reads null between a
+     * release and the next acquire, and before this surface's own startOpen
+     * acquire lands — committing there would write on every transient release,
+     * including during the boot.
+     */
+    it('does nothing when the editor is merely unheld', async () => {
+        const onCommit = vi.fn()
+        const { rerender } = render(<Probe onCommit={onCommit} commitOnDisplace />)
+
+        holder = null
+        result = null
+        await act(async () => {
+            rerender(<Probe onCommit={onCommit} commitOnDisplace />)
+        })
+
+        expect(onCommit).not.toHaveBeenCalled()
+    })
+
+    /**
+     * A session displaced before its editor ever arrived writes nothing.
+     *
+     * `holder` is set the instant a surface acquires, but `result` stays null
+     * until the singleton has booted — so a surface can be the holder with
+     * nothing to type into, which is why `hasHeld` requires a real editor and
+     * not just the store's name for it.
+     *
+     * CAVEAT: this asserts the invariant, but does not reproduce the race that
+     * motivated it. That surfaced only under parallel e2e load, where the boot
+     * is slow enough to lose; both orderings pass here with the guard reverted.
+     * Treat the guard as covered by reasoning, not by this test.
+     */
+    it('does not commit a session that never received an editor', async () => {
+        const onCommit = vi.fn()
+        // Named as the holder the instant it acquires, but the singleton has
+        // not finished booting — so there is nothing to type into yet.
+        holder = 'comment:a'
+        result = null
+        const { rerender } = render(<Probe onCommit={onCommit} commitOnDisplace />)
+        await act(async () => {
+            rerender(<Probe onCommit={onCommit} commitOnDisplace />)
+        })
+
+        // Displaced before the editor ever arrived. There is nothing to write:
+        // committing here would submit against an instance this surface never
+        // had, and `submit` with no editor drops the write and ends the session
+        // — killing an edit the user had only just opened.
+        holder = 'comment:b'
+        await act(async () => {
+            rerender(<Probe onCommit={onCommit} commitOnDisplace />)
+        })
+
+        expect(onCommit).not.toHaveBeenCalled()
+    })
+})

--- a/core/components/editor/commit-policy.ts
+++ b/core/components/editor/commit-policy.ts
@@ -1,31 +1,3 @@
-export interface CommitState {
-    /** Does this surface write on focus loss? An edit does; a composer does not. */
-    commitOnBlur: boolean
-    /** Has the session ever actually held focus? */
-    hasFocused: boolean
-    /** Has it already committed or cancelled? */
-    isSettled: boolean
-    /** Is a dialog (image picker, link prompt) holding the focus? */
-    isDialogOpen: boolean
-}
-
-/**
- * Whether a blur should write.
- *
- * Every clause here exists because of a bug found on a device, and the stakes
- * are asymmetric: a missed commit loses an edit the user can redo, while a
- * spurious one writes text nobody typed.
- */
-export function shouldCommitOnBlur(state: CommitState): boolean {
-    if (!state.commitOnBlur) return false
-    // The mount racing itself, not a person finishing an edit.
-    if (!state.hasFocused) return false
-    if (state.isSettled) return false
-    // A detour inside the session, not the end of it.
-    if (state.isDialogOpen) return false
-    return true
-}
-
 /**
  * Whether a submitted value differs from what the session opened with.
  *

--- a/core/lib/editor/rich/use-rich-editor.web.tsx
+++ b/core/lib/editor/rich/use-rich-editor.web.tsx
@@ -73,6 +73,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         autofocus,
         editable = true,
         containerClassName,
+        minHeight,
         characterLimit,
         generation = 0,
         onSubmitShortcut,
@@ -467,6 +468,14 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                             // @ts-expect-error CSS custom properties for web
                             '--editor-placeholder-color': placeholderColor,
                             '--editor-primary-color': primaryColor,
+                            // The floor, honoured on BOTH platforms as this
+                            // option's contract promises. Web used to ignore it
+                            // and callers duplicated the number as a
+                            // `min-h-[72px]` class — which is a second source of
+                            // truth, and silently produces no rule at all if
+                            // written as a template literal, since Tailwind
+                            // compiles by scanning source text.
+                            ...(minHeight == null ? {} : { minHeight }),
                             // The surface's type scale. Spread rather than set
                             // one by one so an absent scale leaves the sheet's
                             // own fallbacks in place — writing "undefined" into
@@ -478,7 +487,7 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
                     </View>
                 )
             },
-        [tiptapEditor, placeholderColor, primaryColor, containerClassName, scale]
+        [tiptapEditor, placeholderColor, primaryColor, containerClassName, minHeight, scale]
     )
 
     return { editor, EditorComponent, commands, toolbarState, isReady: !!live }

--- a/core/lib/editor/warm/__tests__/draft-store.test.ts
+++ b/core/lib/editor/warm/__tests__/draft-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { createDraftStore } from '../draft-store'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createDraftStore, dropSurfaceDraft, subscribeToDrafts } from '../draft-store'
 
 /**
  * With one shared editor, a half-typed comment no longer survives in a mounted
@@ -11,6 +11,11 @@ import { createDraftStore } from '../draft-store'
  * store with the subtree and there is no eviction policy to get wrong.
  */
 describe('draft store', () => {
+    // One store for the app, so state outlives a test. These cases pass without
+    // this only because they happen to use distinct surface ids — reset so that
+    // stays a guarantee rather than a coincidence.
+    beforeEach(() => createDraftStore().clearAll())
+
     it('has nothing for an untouched surface', () => {
         expect(createDraftStore().take('composer:card1')).toBeNull()
     })
@@ -59,6 +64,35 @@ describe('draft store', () => {
         drafts.stash('composer:card1', 'sent now')
         drafts.clear('composer:card1')
         expect(drafts.take('composer:card1')).toBeNull()
+    })
+
+    /**
+     * The reason this store is reactive at all.
+     *
+     * A draft is stashed from an ASYNC read of the editor — its content cannot
+     * be read synchronously, since on native that is a WebView round-trip — so
+     * it lands after the render that would have displayed it. A plain Map stored
+     * the text correctly and showed the user nothing: the composer read it
+     * during render and never re-rendered to see it arrive.
+     */
+    it('notifies a subscriber when a draft lands', () => {
+        const drafts = createDraftStore()
+        const seen: (string | null)[] = []
+        const unsubscribe = subscribeToDrafts(() => seen.push(drafts.take('composer:card1')))
+
+        drafts.stash('composer:card1', 'arrived late')
+        unsubscribe()
+
+        expect(seen).toContain('arrived late')
+    })
+
+    it('drops one surface without touching the others', () => {
+        const drafts = createDraftStore()
+        drafts.stash('composer:card1', 'one')
+        drafts.stash('composer:card2', 'two')
+        dropSurfaceDraft('composer:card1')
+        expect(drafts.take('composer:card1')).toBeNull()
+        expect(drafts.take('composer:card2')).toBe('two')
     })
 
     it('clears everything when the card closes', () => {

--- a/core/lib/editor/warm/draft-store.ts
+++ b/core/lib/editor/warm/draft-store.ts
@@ -1,3 +1,4 @@
+import { create } from '../../store'
 import type { SurfaceId } from './warm-editor-store'
 
 export interface DraftStore {
@@ -9,27 +10,102 @@ export interface DraftStore {
     clearAll(): void
 }
 
+interface DraftState {
+    drafts: Record<string, string>
+    stash: (surfaceId: SurfaceId, content: string) => void
+    clear: (surfaceId: SurfaceId) => void
+    clearAll: () => void
+}
+
 /**
  * Uncommitted text belonging to a surface that does not hold the warm editor.
  *
  * Only surfaces with no commit semantics need this. An inline comment edit
- * commits on blur, so handing the editor away writes it; the composer has no
- * such commit, and before the warm editor its draft survived only because the
- * composer stayed mounted for the life of the open card.
+ * commits when it hands the editor on, so the write is the record; the composer
+ * has no such commit, and before the warm editor its draft survived only because
+ * the composer stayed mounted for the life of the open card.
+ *
+ * REACTIVE, and that is the point. A draft is stashed from an async read — the
+ * editor's content cannot be read synchronously, because on native it is a
+ * WebView round-trip — so it lands after the render that would have displayed
+ * it. A plain Map therefore stored the text correctly and showed the user
+ * nothing: the composer read it during render and never re-rendered to see it
+ * arrive. `useDraft` below subscribes, so the text appears when it lands.
+ *
+ * Module-level rather than per-provider. That is not a change of lifetime in
+ * practice — EditorSingletonProvider sits above the route tree and is never
+ * unmounted — but it does make the growth visible, so it is bounded explicitly:
+ * a draft exists only for a card where someone typed a comment, did not send it,
+ * and moved on, and `dropSurfaceDraft` drops it when that card's panel closes.
  */
-export function createDraftStore(): DraftStore {
-    const drafts = new Map<SurfaceId, string>()
-    return {
-        stash(surfaceId, content) {
+const useDraftState = create<DraftState>()(set => ({
+    drafts: {},
+    stash: (surfaceId, content) =>
+        set(state => {
             // An empty editor is not a draft: re-seeding "" would paint over
             // the placeholder and read as a broken composer.
-            if (content.trim() === '') drafts.delete(surfaceId)
-            else drafts.set(surfaceId, content)
-        },
-        take: surfaceId => drafts.get(surfaceId) ?? null,
-        clear: surfaceId => {
-            drafts.delete(surfaceId)
-        },
-        clearAll: () => drafts.clear(),
+            if (content.trim() === '') {
+                if (state.drafts[surfaceId] === undefined) return state
+                const { [surfaceId]: _dropped, ...rest } = state.drafts
+                return { drafts: rest }
+            }
+            if (state.drafts[surfaceId] === content) return state
+            return { drafts: { ...state.drafts, [surfaceId]: content } }
+        }),
+    clear: surfaceId =>
+        set(state => {
+            if (state.drafts[surfaceId] === undefined) return state
+            const { [surfaceId]: _dropped, ...rest } = state.drafts
+            return { drafts: rest }
+        }),
+    clearAll: () => set(state => (Object.keys(state.drafts).length === 0 ? state : { drafts: {} })),
+}))
+
+/**
+ * Forget a surface's draft.
+ *
+ * Called when the surface's owner goes away for good — a card panel closing,
+ * not the editor merely being handed on. Without it the map only ever grows: a
+ * card whose half-typed comment was abandoned would keep that string for the
+ * life of the session.
+ */
+export function dropSurfaceDraft(surfaceId: SurfaceId): void {
+    useDraftState.getState().clear(surfaceId)
+}
+
+/**
+ * Watch the store from outside React.
+ *
+ * The hook below is how a component reads a draft; this is for a test, or for
+ * anything that needs the change signal without a render.
+ */
+export function subscribeToDrafts(listener: () => void): () => void {
+    return useDraftState.subscribe(listener)
+}
+
+/**
+ * Subscribe to one surface's draft.
+ *
+ * A selector rather than the whole map, so a comment composer does not re-render
+ * because a different card's draft changed.
+ */
+export function useDraft(surfaceId: SurfaceId): string | null {
+    return useDraftState(state => state.drafts[surfaceId] ?? null)
+}
+
+/**
+ * The imperative face of the same store.
+ *
+ * Kept because the editor stashes and clears from callbacks and effects, where a
+ * hook cannot go — `endSession` reads the editor asynchronously and stashes
+ * whenever that resolves. Returns a stable object: the actions never change
+ * identity, so a consumer can hold this without re-subscribing.
+ */
+export function createDraftStore(): DraftStore {
+    return {
+        stash: (surfaceId, content) => useDraftState.getState().stash(surfaceId, content),
+        take: surfaceId => useDraftState.getState().drafts[surfaceId] ?? null,
+        clear: surfaceId => useDraftState.getState().clear(surfaceId),
+        clearAll: () => useDraftState.getState().clearAll(),
     }
 }

--- a/core/lib/editor/warm/index.ts
+++ b/core/lib/editor/warm/index.ts
@@ -10,7 +10,7 @@
  * unreachable from CI.
  */
 
-export { createDraftStore, type DraftStore } from './draft-store'
+export { createDraftStore, type DraftStore, dropSurfaceDraft, useDraft } from './draft-store'
 export {
     EditorSingletonProvider,
     type EditorSingletonValue,

--- a/core/server/automation/engine_test.go
+++ b/core/server/automation/engine_test.go
@@ -4,6 +4,7 @@ package automation
 import (
 	"encoding/json"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -476,10 +477,11 @@ func TestNativeWriteProvenanceStopsChain(t *testing.T) {
 	app, _, u := engineApp(t)
 	col, _ := app.FindCollectionByNameOrId("tickets")
 
-	var created int
+	// Atomic: the handler runs on the engine's goroutine while the poll loop
+	// below reads from the test's, so a plain int is a data race.
+	var created atomic.Int64
 	RegisterAction("tickets:boom", func(app core.App, req ActionRequest) error {
-		created++
-		if created > 50 {
+		if created.Add(1) > 50 {
 			return nil // safety valve: without the fix this never terminates
 		}
 		made := core.NewRecord(col)
@@ -501,22 +503,23 @@ func TestNativeWriteProvenanceStopsChain(t *testing.T) {
 	// The chain must go quiet on its own. Poll until the handler stops being
 	// invoked, then assert it stopped because of the depth cap rather than the
 	// safety valve.
-	stable, last := 0, -1
+	stable, last := 0, int64(-1)
 	for range 100 {
-		if created == last {
+		if now := created.Load(); now == last {
 			if stable++; stable >= 5 {
 				break
 			}
 		} else {
-			stable, last = 0, created
+			stable, last = 0, now
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	if created == 0 {
+	total := created.Load()
+	if total == 0 {
 		t.Fatal("the native action never ran")
 	}
-	if created > maxChainDepth+1 {
-		t.Fatalf("native writes must stop at the depth cap, handler ran %d times", created)
+	if total > int64(maxChainDepth+1) {
+		t.Fatalf("native writes must stop at the depth cap, handler ran %d times", total)
 	}
 }
 

--- a/core/server/davauth/davauth_test.go
+++ b/core/server/davauth/davauth_test.go
@@ -216,20 +216,43 @@ func TestWithRequestCache_CachesFailuresToo(t *testing.T) {
 	app := newAuthApp(t)
 	newAuthUser(t, app, "alice@example.com", "Password123!", false)
 
-	req := WithRequestCache(basicAuthRequest(t, "alice@example.com", "wrong-password"))
+	const calls = 8
 
+	// Measured as a RATIO against the same calls uncached, never as an
+	// absolute duration. bcrypt's cost is a property of the build, not of
+	// this code: under -race a single verification runs several times
+	// slower and blows through any fixed millisecond bound, failing a
+	// cache that is working perfectly. Dividing by an uncached baseline
+	// measured on the same machine cancels that out, and it is what the
+	// success-path test above already does.
+	req := WithRequestCache(basicAuthRequest(t, "alice@example.com", "wrong-password"))
 	start := time.Now()
-	for i := 0; i < 8; i++ {
+	for i := range calls {
 		if _, err := Authenticate(app, req); !errors.Is(err, ErrUnauthorized) {
-			t.Fatalf("call %d: err = %v, want ErrUnauthorized", i, err)
+			t.Fatalf("cached call %d: err = %v, want ErrUnauthorized", i, err)
 		}
 	}
-	elapsed := time.Since(start)
+	cached := time.Since(start)
 
-	// One bcrypt verification is tens of milliseconds; eight would be
-	// hundreds. Generous bound so this is not a speed benchmark.
-	if elapsed > 300*time.Millisecond {
-		t.Fatalf("8 failed cached calls took %v: failures are not being cached", elapsed)
+	// A fresh request per call, so each one must pay its own verification.
+	start = time.Now()
+	for i := range calls {
+		fresh := WithRequestCache(basicAuthRequest(t, "alice@example.com", "wrong-password"))
+		if _, err := Authenticate(app, fresh); !errors.Is(err, ErrUnauthorized) {
+			t.Fatalf("uncached call %d: err = %v, want ErrUnauthorized", i, err)
+		}
+	}
+	uncached := time.Since(start)
+
+	if cached <= 0 || uncached <= 0 {
+		t.Skip("timer resolution too coarse to measure")
+	}
+	// N cached calls should cost about ONE verification, not N. Half the
+	// ideal ratio leaves room for scheduling noise while still failing
+	// decisively if every call is paying its own bcrypt.
+	if ratio := float64(uncached) / float64(cached); ratio < float64(calls)/2 {
+		t.Fatalf("%d failed cached calls cost %v vs %v uncached (%.1fx): "+
+			"failures are not being cached", calls, cached, uncached, ratio)
 	}
 }
 

--- a/core/server/realtime/realtime_test.go
+++ b/core/server/realtime/realtime_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -964,4 +965,77 @@ func TestUpdateContentValidatorRejectsUpdate(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 		t.Fatalf("accepted update was not fanned out to peer")
 	}
+}
+
+// TestFanOutRacesClientRemoval pins the fix for a crash that took the whole
+// process down, not just one connection.
+//
+// fanOut used to snapshot the room's members under r.mu, RELEASE the lock,
+// then deliver to the snapshot. remove() closed the departing client's send
+// channel outside the lock too. A client that left in between was therefore
+// written to after its channel had been closed — and a send on a closed
+// channel is an unrecoverable panic, so one unlucky disconnect during a
+// broadcast killed the server. It reproduced as an entire e2e suite failing
+// with ERR_CONNECTION_REFUSED from whichever test happened to be running.
+//
+// deliver's select/default is not a guard against this: that handles a FULL
+// buffer. A closed channel panics down both arms.
+//
+// Run under -race, this hammers the exact interleaving: constant fan-out
+// against constant joins and leaves. Before the fix it panics within a few
+// iterations; the test is meaningless unless it has been seen to do so.
+func TestFanOutRacesClientRemoval(t *testing.T) {
+	broker := NewBroker()
+	resetRegistry()
+	RegisterRoomKindWith("racekind", RoomKindOptions{Authorize: allowAllAuth})
+
+	// A resident keeps the room alive, so churning members never trips the
+	// last-one-out teardown and every iteration exercises fanOut with a
+	// live audience.
+	resident := NewClientForTest("resident")
+	room := broker.JoinForTest("racekind", "raceroom", resident)
+	if room == nil {
+		t.Fatal("JoinForTest returned no room")
+	}
+	// Drain the resident so its buffer never fills and starts dropping,
+	// which would mask the race by short-circuiting deliver.
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-resident.send:
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+
+	frame := make([]byte, frameOverhead)
+	frame[clientIDLen] = byte(MsgAwarenessUpdate)
+
+	var wg sync.WaitGroup
+	// Broadcasters: the aggressor side of the race.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				room.fanOut(resident, frame)
+			}
+		}()
+	}
+	// Churn: clients joining and leaving underneath those broadcasts.
+	for i := range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range 500 {
+				c := NewClientForTest(fmt.Sprintf("churn-%d-%d", i, j))
+				room.add(c)
+				room.remove(c)
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/core/server/realtime/room.go
+++ b/core/server/realtime/room.go
@@ -128,8 +128,21 @@ func (r *Room) remove(c *Client) {
 	r.mu.Lock()
 	delete(r.members, c)
 	empty := len(r.members) == 0
-	r.mu.Unlock()
+	// Closed while STILL HOLDING r.mu, together with the delete above.
+	//
+	// A sender only ever reaches a client it found in r.members, and it
+	// finds that under this same lock — so closing here makes "removed
+	// from the room" and "channel closed" one atomic step, and no sender
+	// can be holding a reference that is about to go stale. Closing after
+	// the unlock left a window that fanOut walked straight into: it
+	// snapshots its peers under the lock and releases it before
+	// delivering, so a client removed in between had its channel closed
+	// under a send already in flight, panicking the whole process with
+	// "send on closed channel". deliver's select/default does not help —
+	// that guards a FULL channel; a send to a CLOSED one panics either
+	// way.
 	close(c.send)
+	r.mu.Unlock()
 	if empty {
 		if r.opts.OnEmpty != nil {
 			r.opts.OnEmpty(r.key.id)
@@ -340,10 +353,11 @@ func (r *Room) route(from *Client, frame []byte) {
 			}
 		}
 		// Fall back to the legacy pure-relay path: forward to one
-		// current peer (longest-connected).
-		peer := r.pickSyncPeer(from)
-		if peer != nil {
-			deliver(peer, frame)
+		// current peer (longest-connected). Picked and delivered in ONE
+		// locked step: a peer chosen under the lock and written to after
+		// releasing it may have been removed (and its channel closed) in
+		// between, which panics the process.
+		if r.deliverToSyncPeer(from, frame) {
 			return
 		}
 		// No peer: the requester is alone. Send back an empty reply so
@@ -372,23 +386,31 @@ func (r *Room) route(from *Client, frame []byte) {
 }
 
 // fanOut writes frame to every member of the room except `from`.
+//
+// Delivery happens UNDER r.mu rather than to a snapshot taken under it.
+// The lock is what makes a member's send channel safe to use: remove()
+// deletes from r.members and closes that channel as one locked step, so a
+// client reached from inside this loop is guaranteed not to be mid-close.
+// Snapshotting and then delivering unlocked reintroduces exactly the race
+// this pairing exists to close — a peer removed between the two panics the
+// process on "send on closed channel". deliver never blocks (it drops on a
+// full buffer), so holding the lock across the loop costs a few buffered
+// writes, not a wait on any client.
 func (r *Room) fanOut(from *Client, frame []byte) {
 	r.mu.Lock()
-	peers := make([]*Client, 0, len(r.members))
+	defer r.mu.Unlock()
 	for c := range r.members {
 		if c != from {
-			peers = append(peers, c)
+			deliver(c, frame)
 		}
-	}
-	r.mu.Unlock()
-	for _, c := range peers {
-		deliver(c, frame)
 	}
 }
 
-// pickSyncPeer chooses the longest-connected peer that isn't the requester.
-// Returns nil if no peer exists.
-func (r *Room) pickSyncPeer(from *Client) *Client {
+// deliverToSyncPeer sends frame to the longest-connected peer that isn't
+// the requester, and reports whether such a peer existed. Choosing and
+// sending are one locked step by design — see fanOut for why a peer picked
+// under r.mu must not be written to after releasing it.
+func (r *Room) deliverToSyncPeer(from *Client, frame []byte) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	var best *Client
@@ -400,7 +422,11 @@ func (r *Room) pickSyncPeer(from *Client) *Client {
 			best = c
 		}
 	}
-	return best
+	if best == nil {
+		return false
+	}
+	deliver(best, frame)
+	return true
 }
 
 // deliverByID sends frame to the room member whose id matches target.

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -647,6 +647,16 @@ const Item = forwardRef<View, ItemProps>(function Item(
                 tabIndex={isDisabled ? -1 : 0}
                 aria-disabled={isDisabled || undefined}
                 onClick={() => handlePress()}
+                // Reachable by Tab, but never STOLEN by a click.
+                //
+                // The tabIndex above is what makes this keyboard-operable, and
+                // it also makes a mousedown move focus here. When the menu acts
+                // on a text editor — a toolbar's overflow, a format picker —
+                // that blur collapses the editor's selection before the item
+                // runs, so the action applies to nothing. Preventing the
+                // default stops the pointer taking focus without touching the
+                // keyboard path, which never fires mousedown.
+                onMouseDown={e => e.preventDefault()}
                 onKeyDown={e => {
                     // Space as well as Enter: both activate a menuitem per ARIA,
                     // and Space would otherwise scroll the popover instead.


### PR DESCRIPTION
Two independent fixes that were sitting in the same working tree, kept as separate commits.

## `fix(realtime)` — a panic that took down the whole server

`fanOut` snapshotted the room's members under `r.mu`, released the lock, then delivered to the snapshot. `remove()` deleted from `r.members` and closed the departing client's send channel outside the lock too. A client that left between those steps was written to after its channel had been closed — an unrecoverable panic, so **one unlucky disconnect during a broadcast killed the process**, not just that connection. It surfaced as an entire e2e suite failing with `ERR_CONNECTION_REFUSED` from whichever test happened to be running.

`deliver`'s `select`/`default` was never a guard here: that handles a *full* buffer. A closed channel panics down both arms.

`remove()` now closes the channel while still holding `r.mu`, so "removed from the room" and "channel closed" are one atomic step, and `fanOut` delivers under the lock instead of to a snapshot. `deliver` never blocks, so holding the lock across the loop costs a few buffered writes, not a wait. `pickSyncPeer` → `deliverToSyncPeer` for the identical window.

`TestFanOutRacesClientRemoval` hammers the interleaving under `-race`.

Two further races the detector found in existing tests: automation's chain-depth counter (plain `int` across goroutines → `atomic.Int64`), and davauth's cache assertion (fixed ms bound → ratio against an uncached baseline, since bcrypt under `-race` blows through any absolute deadline even when the cache works).

## `fix(editor)` — commit on displacement, not blur

An edit finished as a *side effect* of blur: handing the shared editor to another surface moved its DOM node, the move blurred it, and the blur handler committed. Every stray focus loss was therefore indistinguishable from a real handover — pressing a toolbar menu or opening a link dialog silently finished the edit.

The trigger is now displacement, which is unambiguous: another surface has the editor, so this session is over. Focus loss alone commits nothing, which removes the reason the dialog-state plumbing existed — `shouldCommitOnBlur`, `CommitState`, and the `isDialogOpen` prop all go.

Two guards, both a frame wide: a surface that never held the editor can't be displaced (else it commits a session that was still opening), and a surface unmounted by the same commit that hands the editor on never re-renders to notice, so it's handled separately. A displaced surface still has to read its uncommitted text out of an instance it no longer owns, so draft-store keeps the last instance per surface and stamps reads with `lease.generation` to discard stale ones.

## Verification

- `go test -race ./realtime/ ./davauth/ ./automation/` — pass
- `tinycld-pkg check` — biome + tsc clean, 1514 tests pass

Web only; not verified on a simulator.