### PR TITLE
fix(realtime): resync a peer whose send buffer overflowed

### DIFF
--- a/core/server/realtime/fanout_overflow_test.go
+++ b/core/server/realtime/fanout_overflow_test.go
@@ -1,0 +1,152 @@
+package realtime
+
+import (
+	"testing"
+	"time"
+)
+
+// A peer whose send buffer was full when an update was fanned out must be
+// brought back into sync, not silently left behind.
+//
+// Yjs emits each change as a delta exactly ONCE. Nothing retransmits it, and
+// the reconnect handshake is a state vector — it asks for what the CLIENT is
+// missing, so it cannot recover a frame the SERVER already considered sent. A
+// dropped fan-out frame therefore left that peer permanently short of the edit,
+// still editing and rendering a document that disagreed with everyone else's,
+// with no error anywhere. Under load — a busy full-suite run, a slow tab — that
+// is exactly how a description came back missing the words someone watched
+// themselves type.
+//
+// The repair is the mirror's whole state, which a CRDT merges as a no-op when
+// the peer was only briefly behind.
+
+// fillSendBuffer saturates c.send so the next deliver to it must fail.
+func fillSendBuffer(t *testing.T, c *Client) {
+	t.Helper()
+	for i := 0; i < sendBufferSize; i++ {
+		select {
+		case c.send <- []byte{0}:
+		default:
+			t.Fatalf("send buffer full after %d of %d frames", i, sendBufferSize)
+		}
+	}
+}
+
+func TestFanOutResyncsAPeerWhoseBufferOverflowed(t *testing.T) {
+	kind := "test-kind-fanout-overflow"
+	RegisterRoomKindWith(kind, RoomKindOptions{
+		Authorize:       allowAllAuth,
+		RuntimeProvider: stubDocRuntime{},
+	})
+	t.Cleanup(func() { unregisterRoomKindForTest(kind) })
+
+	b := NewBroker()
+	sender := &Client{joinedAt: time.Now()}
+	slow := &Client{joinedAt: time.Now()}
+	b.join(kind, "room-overflow", sender)
+	b.join(kind, "room-overflow", slow)
+
+	room := b.lookupRoomForTest(kind, "room-overflow")
+	if room == nil {
+		t.Fatal("room not created")
+	}
+
+	// The peer was full when the update was fanned out and has since drained —
+	// a client that was briefly wedged and caught up, which is the case worth
+	// repairing. One that never drains is already doomed: the transport's
+	// liveness checks close it and its reconnect resyncs from scratch.
+	frame := make([]byte, frameOverhead+3)
+	frame[clientIDLen] = byte(MsgDocUpdate)
+	copy(frame[frameOverhead:], []byte{0xAA, 0xBB, 0xCC})
+
+	room.resyncStarved([]*Client{slow}, frame)
+
+	select {
+	case got := <-slow.send:
+		if MessageType(got[clientIDLen]) != MsgSyncReply {
+			t.Errorf("the starved peer got %v, want a %v catch-up",
+				MessageType(got[clientIDLen]), MsgSyncReply)
+		}
+	default:
+		t.Fatal("the starved peer was left without the update it missed")
+	}
+	if room.serverDoc.(*stubHandle).encodeCalls == 0 {
+		t.Error("the room never encoded its state to repair the starved peer")
+	}
+}
+
+func TestFanOutReportsAnOverflowingPeer(t *testing.T) {
+	// The plumbing the repair hangs off: a full buffer must be REPORTED, not
+	// swallowed. deliver returning nothing is what made a lost update
+	// indistinguishable from a delivered one.
+	c := &Client{send: make(chan []byte, 1)}
+	if !deliver(c, []byte{1}) {
+		t.Fatal("deliver reported a failure for a frame it accepted")
+	}
+	if deliver(c, []byte{2}) {
+		t.Error("deliver reported success for a frame it dropped")
+	}
+}
+
+func TestFanOutDoesNotResyncOnAnAwarenessDrop(t *testing.T) {
+	// Awareness is ephemeral: the next publish supersedes whatever was
+	// dropped, so paying for a full document encode there would be waste on
+	// every cursor move a busy room makes.
+	kind := "test-kind-fanout-awareness"
+	RegisterRoomKindWith(kind, RoomKindOptions{
+		Authorize:       allowAllAuth,
+		RuntimeProvider: stubDocRuntime{},
+	})
+	t.Cleanup(func() { unregisterRoomKindForTest(kind) })
+
+	b := NewBroker()
+	sender := &Client{joinedAt: time.Now()}
+	slow := &Client{joinedAt: time.Now()}
+	b.join(kind, "room-aware", sender)
+	b.join(kind, "room-aware", slow)
+
+	room := b.lookupRoomForTest(kind, "room-aware")
+	if room == nil {
+		t.Fatal("room not created")
+	}
+	before := room.serverDoc.(*stubHandle).encodeCalls
+	fillSendBuffer(t, slow)
+
+	frame := make([]byte, frameOverhead)
+	frame[clientIDLen] = byte(MsgAwarenessUpdate)
+	room.route(sender, frame)
+
+	if room.serverDoc.(*stubHandle).encodeCalls != before {
+		t.Error("a dropped awareness frame triggered a document resync")
+	}
+}
+
+func TestFanOutSkipsAPeerThatLeftDuringTheRepair(t *testing.T) {
+	// The repair runs with the room lock RELEASED, so the starved peer may
+	// have gone by the time it runs — and room.remove closes its send channel
+	// under that same lock. Writing to it then panics the whole process.
+	kind := "test-kind-fanout-departed"
+	RegisterRoomKindWith(kind, RoomKindOptions{
+		Authorize:       allowAllAuth,
+		RuntimeProvider: stubDocRuntime{},
+	})
+	t.Cleanup(func() { unregisterRoomKindForTest(kind) })
+
+	b := NewBroker()
+	resident := &Client{joinedAt: time.Now()}
+	leaver := &Client{joinedAt: time.Now()}
+	b.join(kind, "room-departed", resident)
+	b.join(kind, "room-departed", leaver)
+
+	room := b.lookupRoomForTest(kind, "room-departed")
+	if room == nil {
+		t.Fatal("room not created")
+	}
+	fillSendBuffer(t, leaver)
+	room.remove(leaver)
+
+	frame := make([]byte, frameOverhead+1)
+	frame[clientIDLen] = byte(MsgDocUpdate)
+	// Must not panic on the closed channel of a departed member.
+	room.route(resident, frame)
+}

--- a/core/server/realtime/realtime.go
+++ b/core/server/realtime/realtime.go
@@ -122,22 +122,36 @@ func NewBroker() *Broker {
 // registered via the legacy RegisterRoomKind has no DocRuntime and no
 // hooks, so the room behaves as a pure relay (the prior behavior).
 func (b *Broker) join(kind, id string, c *Client) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
 	key := roomKey{kind, id}
-	room, ok := b.rooms[key]
-	if !ok {
-		// optionsFor returning ErrUnknownRoomKind is normally
-		// impossible here because handleConnect already authorized
-		// against the same registry. If it does happen (e.g. the
-		// kind was unregistered between authorize and join), we
-		// fall back to a zero-options room — no server doc, no
-		// hooks — which is the safest behavior.
-		opts, _ := optionsFor(kind)
-		room = newRoom(b, key, opts)
-		b.rooms[key] = room
+	for {
+		b.mu.Lock()
+		room, ok := b.rooms[key]
+		if !ok {
+			// optionsFor returning ErrUnknownRoomKind is normally
+			// impossible here because handleConnect already authorized
+			// against the same registry. If it does happen (e.g. the
+			// kind was unregistered between authorize and join), we
+			// fall back to a zero-options room — no server doc, no
+			// hooks — which is the safest behavior.
+			opts, _ := optionsFor(kind)
+			room = newRoom(b, key, opts)
+			b.rooms[key] = room
+		}
+		admitted := room.add(c)
+		b.mu.Unlock()
+		if admitted {
+			return
+		}
+		// The room's last member just left and its teardown — the final
+		// persistence flush included — is still running. Joining it would
+		// put this client in a room whose save hooks are already
+		// deregistered and whose server doc is about to close, silently
+		// discarding every edit. Wait for removeRoom to free the key,
+		// then construct a fresh room that bootstraps from the state the
+		// flush wrote. b.mu is NOT held while waiting: removeRoom needs
+		// it to make progress.
+		time.Sleep(2 * time.Millisecond)
 	}
-	room.add(c)
 }
 
 // removeRoom is called by a Room when its last client leaves. It clears

--- a/core/server/realtime/realtime.go
+++ b/core/server/realtime/realtime.go
@@ -27,6 +27,7 @@ package realtime
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -195,14 +196,23 @@ type Client struct {
 	// resolving a drive_shares row (which an anon doesn't have).
 	shareRole string
 
-	// readOnly caches the connection's write authorization, resolved once
-	// by the room kind's OnConnect handler (which has DB access) rather
-	// than re-querying on every inbound frame. The broker's WritePredicate
-	// reads this in the hot route path, so it must be a pure field access.
+	// readOnly caches the connection's write authorization, resolved by the
+	// room kind's OnConnect handler (which has DB access) rather than by
+	// re-querying on every inbound frame. The broker's WritePredicate reads
+	// it in the hot route path, so it must stay a cheap non-blocking read.
 	// Defaults false; OnConnect calls SetReadOnly to set the real value
 	// before the first MsgDocUpdate can arrive (OnConnect runs during the
 	// connection handshake, before the read loop processes frames).
-	readOnly bool
+	//
+	// Atomic because it is no longer written only during the handshake. A
+	// kind whose permission data is written by a MULTI-STATEMENT flow can
+	// resolve read-only for a connection that merely arrived early, and it
+	// must be able to correct that later — cards' board creation writes the
+	// project row and the owner's membership row separately, and a socket
+	// opened in between would otherwise drop that owner's every edit for the
+	// life of the connection. A later SetReadOnly therefore races the reads
+	// in HasWriter / HasOtherWriter, which run on OTHER clients' goroutines.
+	readOnly atomic.Bool
 
 	// send buffers frames the broker has decided this client should
 	// receive. The transport reader pulls from this channel and writes
@@ -264,12 +274,14 @@ func (c *Client) IsAnonymous() bool { return c.displayName != "" }
 // as resolved by the room kind's OnConnect handler. The broker's
 // WritePredicate consults this on every inbound MsgDocUpdate; it is a
 // pure field read (no DB) so the hot path stays cheap.
-func (c *Client) ReadOnly() bool { return c.readOnly }
+func (c *Client) ReadOnly() bool { return c.readOnly.Load() }
 
-// SetReadOnly records the connection's write authorization. Intended to
-// be called once from a room kind's OnConnect (ServerHelloFn) handler,
-// which runs during the handshake before any frame is routed.
-func (c *Client) SetReadOnly(ro bool) { c.readOnly = ro }
+// SetReadOnly records the connection's write authorization. Normally called
+// from a room kind's OnConnect (ServerHelloFn) handler, which runs during the
+// handshake before any frame is routed — but a kind may also call it later to
+// CORRECT a conservative answer (see the field's note), so it is safe to call
+// from a WritePredicate while other goroutines are reading.
+func (c *Client) SetReadOnly(ro bool) { c.readOnly.Store(ro) }
 
 // NewClientForTest constructs a Client suitable for passing to a
 // ServerHelloFn or similar callback in consumer-package tests. Only

--- a/core/server/realtime/room.go
+++ b/core/server/realtime/room.go
@@ -396,12 +396,76 @@ func (r *Room) route(from *Client, frame []byte) {
 // process on "send on closed channel". deliver never blocks (it drops on a
 // full buffer), so holding the lock across the loop costs a few buffered
 // writes, not a wait on any client.
+//
+// Peers that could NOT take the frame are collected and repaired afterwards,
+// outside the lock — see resyncStarved, which re-checks membership under it
+// before writing to any of them, for the same reason the loop above holds it.
 func (r *Room) fanOut(from *Client, frame []byte) {
+	var starved []*Client
+	r.mu.Lock()
+	for c := range r.members {
+		if c == from {
+			continue
+		}
+		if !deliver(c, frame) {
+			starved = append(starved, c)
+		}
+	}
+	r.mu.Unlock()
+
+	if len(starved) > 0 {
+		r.resyncStarved(starved, frame)
+	}
+}
+
+// resyncStarved repairs peers whose send buffer was full when a frame was
+// fanned out to them.
+//
+// A dropped frame is not merely a late frame. Yjs emits each change as a delta
+// exactly once and nothing retransmits it, so a peer that misses one is
+// permanently short of that edit — it keeps editing and rendering a document
+// that silently disagrees with everyone else's, and the divergence is invisible
+// until someone reads the record back. Sending the mirror's whole state closes
+// that: a CRDT merging state it already holds is a no-op, so this is safe to
+// send to a peer that was only briefly behind.
+//
+// Runs with r.mu RELEASED. EncodeStateAsUpdate takes the document's own lock,
+// and the flush path already takes that lock before touching the room, so
+// calling it under r.mu would invert the order.
+//
+// Only document updates are repairable this way. A dropped awareness frame is
+// ephemeral — the next publish supersedes it — so those keep the old behavior.
+func (r *Room) resyncStarved(starved []*Client, frame []byte) {
+	if r.serverDoc == nil || len(frame) < frameOverhead {
+		return
+	}
+	if MessageType(frame[clientIDLen]) != MsgDocUpdate {
+		return
+	}
+	state, err := r.serverDoc.EncodeStateAsUpdate()
+	if err != nil {
+		log.Error(
+			"EncodeStateAsUpdate failed; a peer is left missing an update",
+			"kind", r.key.kind, "roomID", r.key.id, "err", err,
+		)
+		return
+	}
+	catchUp := makeServerSyncReply(state)
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for c := range r.members {
-		if c != from {
-			deliver(c, frame)
+	for _, c := range starved {
+		// Re-check membership: the client may have left while the lock was
+		// released, and its send channel is closed under this same lock.
+		if _, ok := r.members[c]; !ok {
+			continue
+		}
+		if !deliver(c, catchUp) {
+			// Still full. The transport's liveness checks will close this
+			// connection, and its reconnect resyncs from scratch.
+			log.Warn(
+				"peer too far behind to catch up; leaving it to the transport",
+				"kind", r.key.kind, "roomID", r.key.id,
+			)
 		}
 	}
 }
@@ -528,15 +592,23 @@ func readVarUint(b []byte) (uint64, bool) {
 	return 0, false
 }
 
-// deliver pushes a frame to a client's send buffer. If the buffer is
-// full, the frame is dropped — the read loop in register.go is expected
-// to detect a stuck client via separate liveness checks.
-func deliver(c *Client, frame []byte) {
+// deliver pushes a frame to a client's send buffer, reporting whether it
+// was accepted. If the buffer is full the frame is dropped — the read loop
+// in register.go is expected to detect a stuck client via separate liveness
+// checks.
+//
+// Callers must not treat a false as merely a slow client. For a document
+// update it means that peer has permanently missed a change: Yjs emits each
+// delta once, so nothing will resend it and the peer's document silently
+// diverges from everyone else's. fanOut repairs that rather than ignoring it.
+func deliver(c *Client, frame []byte) bool {
 	select {
 	case c.send <- frame:
+		return true
 	default:
 		// Buffer overflow: drop. A persistently slow client will be
 		// disconnected by the transport's idle/keepalive logic.
+		return false
 	}
 }
 

--- a/core/server/realtime/room.go
+++ b/core/server/realtime/room.go
@@ -32,6 +32,16 @@ type Room struct {
 	serverDoc DocHandle
 
 	mu sync.Mutex
+	// draining flips true — under mu, atomically with the membership
+	// delete that emptied the room — the moment teardown is committed.
+	// From then on add refuses new members, because everything that
+	// follows (OnEmpty's final flush, per-kind state teardown, closing
+	// serverDoc, removeRoom) assumes nobody is inside. A client admitted
+	// in that window would land in a half-torn-down room: its persistence
+	// hooks already deregistered, its server doc about to close — every
+	// edit silently unpersisted and sync served from nothing. Broker.join
+	// retries until removeRoom frees the key, then builds a fresh room.
+	draining bool
 	// nextSeq is the per-room monotonic seq counter for journal
 	// Append calls. After construction it is mutated only by route
 	// while holding r.mu. During newRoom it is written without the
@@ -105,12 +115,19 @@ func newRoom(b *Broker, key roomKey, opts RoomKindOptions) *Room {
 	return r
 }
 
-func (r *Room) add(c *Client) {
+// add admits a client, reporting whether the room accepted it. A false
+// means the room's last member just left and teardown is in progress;
+// the caller must wait for the key to free and join a fresh room.
+func (r *Room) add(c *Client) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.draining {
+		return false
+	}
 	c.room = r
 	c.send = make(chan []byte, sendBufferSize)
-	r.mu.Lock()
 	r.members[c] = struct{}{}
-	r.mu.Unlock()
+	return true
 }
 
 // remove drops a client from the room and releases the empty room back
@@ -121,13 +138,23 @@ func (r *Room) add(c *Client) {
 // When this drops the last member, the room invokes its OnEmpty
 // callback (synchronously) before closing the server-side DocHandle.
 // OnEmpty is allowed to take time (e.g. a final persistence flush);
-// the broker's removeRoom call is what frees the room key, and that
-// is intentionally deferred until OnEmpty returns so a quick rejoin
-// of the same room observes a fresh slate.
+// the broker's removeRoom call is what frees the room key. Until then
+// the draining flag keeps a quick rejoin out of this room — join spins
+// until the key frees and then constructs a fresh room, whose bootstrap
+// re-reads exactly the state the final flush wrote.
 func (r *Room) remove(c *Client) {
 	r.mu.Lock()
 	delete(r.members, c)
 	empty := len(r.members) == 0
+	if empty {
+		// Committing to teardown and refusing further joins is ONE
+		// locked step. Without it, `empty` goes stale the moment the
+		// lock drops: a rejoin (a page reload reconnects while OnEmpty's
+		// final flush is still writing) would land in this room, and the
+		// teardown below would then rip the doc and the persistence
+		// hooks out from under a live member.
+		r.draining = true
+	}
 	// Closed while STILL HOLDING r.mu, together with the delete above.
 	//
 	// A sender only ever reaches a client it found in r.members, and it

--- a/core/server/realtime/save_coordinator.go
+++ b/core/server/realtime/save_coordinator.go
@@ -259,10 +259,11 @@ func (c *SaveCoordinator) OnDocUpdate(driveItemID string) {
 	})
 }
 
-// OnRoomEmpty is the realtime.RoomKindOptions.OnEmpty hook. Fires
-// the final synchronous save and waits up to teardownTimeout for it
-// to complete. Returns when (a) the save finished or (b) the timeout
-// elapsed; in both cases the broker is free to close the DocHandle.
+// OnRoomEmpty is the realtime.RoomKindOptions.OnEmpty hook. Waits out
+// any in-flight timer-driven save, then fires the final synchronous
+// save if the room is (still) dirty. Returns when (a) the save
+// finished or (b) teardownTimeout elapsed — measured across both waits
+// — and in both cases the broker is free to close the DocHandle.
 func (c *SaveCoordinator) OnRoomEmpty(driveItemID string) {
 	c.mu.Lock()
 	rs := c.rooms[driveItemID]
@@ -274,7 +275,34 @@ func (c *SaveCoordinator) OnRoomEmpty(driveItemID string) {
 		return
 	}
 
+	deadline := time.Now().Add(c.teardownTimeout)
+
+	// Wait out any in-flight timer-driven save BEFORE reading dirty.
+	// triggerSave clears dirty before running its flush unlocked, so a
+	// bare read here mistakes "being saved right now" for "already
+	// saved" — and the caller tears the room down on our return, closing
+	// the DocHandle under the running flush. Worse, that flush may FAIL
+	// and re-mark dirty, which only a post-wait read can observe; the
+	// retry it schedules will find the room already deregistered and
+	// silently do nothing, so this final flush is the edit's last chance
+	// to reach durable storage.
 	rs.mu.Lock()
+	for rs.saveInFlight {
+		rs.mu.Unlock()
+		if time.Now().After(deadline) {
+			c.logger.Error("realtime: teardown timed out waiting for an in-flight save",
+				"driveItemID", driveItemID, "timeout", c.teardownTimeout)
+			rs.mu.Lock()
+			rs.closed = true
+			rs.mu.Unlock()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+		rs.mu.Lock()
+	}
+	// Still holding rs.mu from the loop's final check: the in-flight
+	// save (if any) has fully finished — including arming any retry
+	// timer — so stopping timers and reading dirty here races nothing.
 	if rs.debounceTimer != nil {
 		rs.debounceTimer.Stop()
 		rs.debounceTimer = nil
@@ -317,7 +345,10 @@ func (c *SaveCoordinator) OnRoomEmpty(driveItemID string) {
 			// truncated, so this was the common path, not the edge.
 			c.truncateJournal(driveItemID, snapshotSeq)
 		}
-	case <-time.After(c.teardownTimeout):
+	case <-time.After(time.Until(deadline)):
+		// The deadline is shared with the in-flight wait above, so a
+		// teardown never stalls the broker longer than teardownTimeout
+		// in total.
 		c.logger.Error("realtime: teardown save timed out", "driveItemID", driveItemID, "timeout", c.teardownTimeout)
 	}
 

--- a/core/server/realtime/teardown_race_test.go
+++ b/core/server/realtime/teardown_race_test.go
@@ -1,0 +1,138 @@
+package realtime
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A client that reconnects while the room it just left is still tearing down
+// must NOT be admitted into the dying room.
+//
+// The teardown window is real and wide: OnEmpty runs a final persistence
+// flush — database writes, slow under load — and the room stays in the
+// broker's map the whole time. A page reload reconnects exactly then. A
+// client admitted into that room lands in a shell whose save hooks are
+// already deregistered and whose server doc is about to close: sync requests
+// come back empty, and every subsequent edit is relayed but never journaled,
+// never applied, never saved. That is precisely how a card description came
+// back blank — gone from the record AND the fragment — after a reload under
+// full-suite load.
+func TestJoinDuringTeardownWaitsForAFreshRoom(t *testing.T) {
+	kind := "test-kind-join-during-teardown"
+	var creates atomic.Int32
+	teardownStarted := make(chan struct{})
+	releaseTeardown := make(chan struct{})
+	RegisterRoomKindWith(kind, RoomKindOptions{
+		Authorize:       allowAllAuth,
+		RuntimeProvider: stubDocRuntime{},
+		OnRoomCreate:    func(string, DocHandle, *Room) { creates.Add(1) },
+		OnEmpty: func(string) {
+			close(teardownStarted)
+			<-releaseTeardown
+		},
+	})
+	t.Cleanup(func() { unregisterRoomKindForTest(kind) })
+
+	b := NewBroker()
+	first := &Client{joinedAt: time.Now()}
+	b.join(kind, "room-x", first)
+	original := b.lookupRoomForTest(kind, "room-x")
+	if original == nil {
+		t.Fatal("room not created")
+	}
+
+	go original.remove(first)
+	<-teardownStarted
+
+	second := &Client{joinedAt: time.Now()}
+	joined := make(chan struct{})
+	go func() {
+		b.join(kind, "room-x", second)
+		close(joined)
+	}()
+
+	select {
+	case <-joined:
+		t.Fatal("a client was admitted into a room whose teardown was already committed")
+	case <-time.After(50 * time.Millisecond):
+		// Correct: the join is waiting for the teardown to finish.
+	}
+
+	close(releaseTeardown)
+	select {
+	case <-joined:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the join never completed after teardown finished")
+	}
+
+	fresh := b.lookupRoomForTest(kind, "room-x")
+	if fresh == original {
+		t.Fatal("the rejoin landed in the torn-down room instead of a fresh one")
+	}
+	if fresh == nil || fresh.serverDoc == nil {
+		t.Fatal("the fresh room has no server doc — persistence would be dead for its lifetime")
+	}
+	if got := creates.Load(); got != 2 {
+		t.Fatalf("OnRoomCreate fired %d times, want 2 (once per room incarnation)", got)
+	}
+}
+
+// OnRoomEmpty must wait out an in-flight timer-driven save before deciding
+// whether there is anything left to flush.
+//
+// triggerSave clears dirty BEFORE running its flush unlocked. A teardown
+// racing that window read dirty==false, concluded "already saved", and let
+// the broker close the DocHandle under the running flush. If that flush then
+// FAILED (a busy SQLite under parallel load), its dirty re-mark went to a
+// room the coordinator had already deregistered: the retry it scheduled
+// found nothing and silently did nothing. The teardown flush below is that
+// edit's last chance to reach durable storage.
+func TestOnRoomEmptyWaitsOutAnInFlightSaveAndFlushesItsFailure(t *testing.T) {
+	var calls atomic.Int32
+	flushEntered := make(chan struct{})
+	releaseFlush := make(chan struct{})
+	c := NewSaveCoordinator(func(string, DocHandle) error {
+		if calls.Add(1) == 1 {
+			close(flushEntered)
+			<-releaseFlush
+			return errors.New("synthetic flush failure")
+		}
+		return nil
+	})
+	c.SetLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.debounceEvery = 5 * time.Millisecond
+	c.ceilingEvery = time.Minute
+	c.teardownTimeout = 2 * time.Second
+
+	c.OnRoomCreate("room", &stubHandle{}, nil)
+	c.OnDocUpdate("room")
+	<-flushEntered // the debounce fired; the save is now in flight
+
+	done := make(chan struct{})
+	go func() {
+		c.OnRoomEmpty("room")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("OnRoomEmpty returned while a save was still in flight")
+	case <-time.After(50 * time.Millisecond):
+		// Correct: teardown is waiting for the in-flight save.
+	}
+
+	close(releaseFlush)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnRoomEmpty never returned after the in-flight save finished")
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("flush ran %d times, want 2 — the failed in-flight save was never flushed at teardown", got)
+	}
+}


### PR DESCRIPTION
A full send buffer dropped the frame silently. For a document update that is not a late frame: Yjs emits each change as a delta exactly once, nothing retransmits it, and the reconnect handshake is a state vector that only asks for what the *client* is missing. A peer that missed one stayed permanently short of that edit, with no error anywhere.

`deliver` now reports whether the frame was accepted, and `fanOut` repairs starved peers by sending the mirror's whole state (a no-op for a CRDT that already holds it). The repair runs with `r.mu` released — `EncodeStateAsUpdate` takes the document lock and the flush path takes it before the room — and re-checks membership under the lock before writing, since `remove()` closes a departing client's channel under that same lock.

`readOnly` becomes an `atomic.Bool`: it is no longer written only during the handshake, so a later correction races the reads in `HasWriter`/`HasOtherWriter` on other clients' goroutines.

Awareness drops keep the old behavior — the next publish supersedes them.

Found while investigating the cards description e2e flake. The second commit fixes what the investigation concluded is the flake's root cause (see below).

Tests: `core/server/realtime/fanout_overflow_test.go`, verified to fail without the fix. `go test -race ./realtime/...` clean.

---

**Second commit — join during teardown created a zombie room.** When the last client left, teardown (the final persistence flush included) ran while the room was still in the broker's map. A client reconnecting in that window — a page reload under load — was admitted into the dying room: save hooks already deregistered, server doc about to close. Sync requests came back empty and every edit made there was relayed but never journaled, applied, or saved; when the zombie emptied, nothing flushed, and the next room re-seeded from records that never got the text. The room now commits to draining atomically with emptying, `add()` refuses members while draining, and `join()` waits for the key to free before building a fresh room.

Also fixes `OnRoomEmpty` racing `triggerSave`: teardown could read `dirty==false` mid-save, conclude "already saved", and let the broker close the DocHandle under the running flush — and a failing in-flight flush re-marked dirty on a room the coordinator had already dropped. Teardown now waits out the in-flight save and re-reads `dirty`.

Tests: `core/server/realtime/teardown_race_test.go`, both verified to fail without the fix.