### PR TITLE
fix(editor): stash an unfinished edit when the surface unmounts

### DIFF
--- a/core/components/editor/LazyEditor.tsx
+++ b/core/components/editor/LazyEditor.tsx
@@ -746,9 +746,18 @@ export function useLazyEditor({
     // re-run the cleanup on every handover and commit a live session.
     const commitOnUnmountRef = useRef<() => void>(() => {})
     commitOnUnmountRef.current = () => {
-        if (!commitOnDisplace || settledRef.current || !isEditing) return
+        if (settledRef.current || !isEditing) return
         if (!hasHeldRef.current) return
-        submitRef.current()
+        // Whichever way this surface finishes, it must not finish SILENTLY. A
+        // committing surface writes; one that only stashes hands its text to
+        // the draft store, exactly as it would on an ordinary displacement.
+        // Doing nothing here is what loses a revision outright: the surface is
+        // gone, and with it the only copy of what was typed.
+        if (commitOnDisplace) {
+            submitRef.current()
+            return
+        }
+        endSession({ stash: true })
     }
     useEffect(() => () => commitOnUnmountRef.current(), [])
 

--- a/core/components/editor/__tests__/lazy-editor-blur.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-blur.test.tsx
@@ -6,15 +6,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UseRichEditorOptions } from '../../../lib/editor/rich/options'
 
 /**
- * A blur while a dialog the editor opened holds the focus must NOT end the
- * session — the editor has to survive until the picked image or link lands in
- * it.
+ * Blur does not END a session — whatever took the focus.
  *
- * There are two ways for a caller to say a dialog is open. `slots.setDialogOpen`
- * suits chrome that learns about it while rendering; the `isDialogOpen` prop
- * suits a caller that already owns the state, which otherwise has to push it
- * back up through a useEffect — the useState+useEffect pairing the style guide
- * names as the signal to switch primitives.
+ * A dialog the editor opened is the motivating case: the editor has to survive
+ * until the picked image or link lands in it. It used to need telling, through
+ * a `setDialogOpen` slot and an `isDialogOpen` prop; now nothing does, because
+ * losing focus no longer closes anything.
+ *
+ * Whether a blur WRITES is a separate question, and the surface opts into that
+ * with `saveOnBlur` — see lazy-editor-save-on-blur.test.tsx. These cases all
+ * run without it, so they assert the lifecycle alone.
  */
 
 // Captures the options LazyEditor hands the editor, so the test can fire the

--- a/core/components/editor/__tests__/lazy-editor-displacement.test.tsx
+++ b/core/components/editor/__tests__/lazy-editor-displacement.test.tsx
@@ -114,6 +114,28 @@ describe('displacement', () => {
         expect(onCommit).toHaveBeenCalledWith('edited text')
     })
 
+    /**
+     * The unmount path must stash too, not only commit.
+     *
+     * A parent-owned surface is UNMOUNTED by the same commit that hands the
+     * editor on, so it never renders again to notice the displacement — and for
+     * a surface that stashes rather than commits, doing nothing on unmount
+     * loses the revision outright. The surface is gone, and with it the only
+     * copy of what was typed. Cards' inline comment edit is the case.
+     */
+    it('stashes an unfinished edit when a non-committing surface goes away', async () => {
+        const onCommit = vi.fn()
+        const onRelease = vi.fn()
+        const { unmount } = render(<Probe onCommit={onCommit} onRelease={onRelease} />)
+
+        await act(async () => {
+            unmount()
+        })
+
+        expect(onRelease).toHaveBeenCalledWith('edited text')
+        expect(onCommit).not.toHaveBeenCalled()
+    })
+
     it('stashes instead, for a surface that does not commit', async () => {
         const onCommit = vi.fn()
         const onRelease = vi.fn()


### PR DESCRIPTION
Companion to tinycld/cards#43, which needs this to defer a comment's write to an explicit Save.

## The bug

`LazyEditor`'s unmount cleanup only handled `commitOnDisplace`. A surface that commits wrote its text on the way out; a surface that only stashes did nothing at all.

That is a silent data loss for a **parent-owned** surface. It is unmounted by the same commit that hands the editor on, so it never renders again to notice it was displaced — the effect that would have stashed its draft never runs. The surface is gone, and with it the only copy of what was typed.

Cards' inline comment edit is exactly this shape: the parent mounts one editor for whichever comment is open, so clicking a second comment tears the first down.

## The change

The unmount path now branches instead of returning early: a committing surface submits, and any other stashes through `endSession({ stash: true })` — the same thing an ordinary displacement does.

This is what lets a consumer defer the write to an explicit Save without losing the revision to a steal.

## Tests

`lazy-editor-displacement.test.tsx` gains a case for a non-committing surface unmounting mid-edit, verified to fail without the fix.