### PR TITLE
feat(notify): cards notification preferences

### DIFF
--- a/app/a/(app)/settings/personal.tsx
+++ b/app/a/(app)/settings/personal.tsx
@@ -472,6 +472,7 @@ const NOTIF_GROUPS: {
             { key: 'cards_mention', label: 'Mentions on a card' },
             { key: 'cards_assigned', label: 'Cards assigned to you' },
             { key: 'cards_reply', label: 'Replies to your comments' },
+            { key: 'cards_reaction', label: 'Reactions to your comments' },
             { key: 'cards_watched', label: 'Changes to cards you watch' },
             { key: 'cards_due', label: 'Due-date reminders' },
         ],

--- a/app/a/(app)/settings/personal.tsx
+++ b/app/a/(app)/settings/personal.tsx
@@ -467,6 +467,16 @@ const NOTIF_GROUPS: {
         types: [{ key: 'drive_file_shared', label: 'Files shared with you' }],
     },
     {
+        label: 'Cards',
+        types: [
+            { key: 'cards_mention', label: 'Mentions on a card' },
+            { key: 'cards_assigned', label: 'Cards assigned to you' },
+            { key: 'cards_reply', label: 'Replies to your comments' },
+            { key: 'cards_watched', label: 'Changes to cards you watch' },
+            { key: 'cards_due', label: 'Due-date reminders' },
+        ],
+    },
+    {
         label: 'General',
         types: [
             { key: 'org_invite', label: 'Organization invites' },

--- a/core/components/NotificationDrawer.tsx
+++ b/core/components/NotificationDrawer.tsx
@@ -8,7 +8,7 @@ import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import type { Notifications } from '@tinycld/core/types/pbSchema'
 import { BottomDrawer } from '@tinycld/core/ui/bottom-drawer'
 import { useRouter } from 'expo-router'
-import { Bell, Calendar, Check, File, Mail, Shield, X } from 'lucide-react-native'
+import { Bell, Calendar, Check, File, Mail, Shield, SquareKanban, X } from 'lucide-react-native'
 import { useEffect, useMemo, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 import { railWidth } from './workspace/PackageRail'
@@ -19,6 +19,7 @@ const PACKAGE_ICONS: Record<string, typeof Bell> = {
     calendar: Calendar,
     mail: Mail,
     drive: File,
+    cards: SquareKanban,
     core: Shield,
 }
 

--- a/core/lib/notify/events.ts
+++ b/core/lib/notify/events.ts
@@ -12,6 +12,7 @@ export type NotificationEvents = {
     'drive.save_failed': { reason: string }
     'drive.template_saved': { name: string }
     'cards.attachment_failed': { card: string; name: string }
+    'cards.card_moved': { board: string; key: string }
     'import.complete': { source: 'google-takeout' | 'csv'; count: number }
     'import.failed': { source: string; error: string }
     'mutation.error': { operation: string; error: string }

--- a/core/lib/notify/registry.ts
+++ b/core/lib/notify/registry.ts
@@ -23,6 +23,7 @@ export const eventRegistry: Record<NotifyEventName, EventConfig> = {
     'drive.save_failed': { channels: ['toast'], variant: 'error' },
     'drive.template_saved': { channels: ['toast'], variant: 'success' },
     'cards.attachment_failed': { channels: ['toast'], variant: 'error' },
+    'cards.card_moved': { channels: ['toast'], variant: 'success' },
     'import.complete': { channels: ['toast', 'bell'], variant: 'success' },
     'import.failed': { channels: ['toast', 'bell'], variant: 'error' },
     'mutation.error': { channels: ['toast'], variant: 'error' },

--- a/core/lib/use-notification-preferences.ts
+++ b/core/lib/use-notification-preferences.ts
@@ -29,6 +29,14 @@ export interface NotificationPreferences {
      * the comment path for `cards_comments`.
      */
     cards_mention: boolean
+    /** A card was assigned to you (server/notifications.go in cards). */
+    cards_assigned: boolean
+    /** Someone replied to your comment on a card. */
+    cards_reply: boolean
+    /** A card you watch gained a comment, moved, was completed or archived. */
+    cards_watched: boolean
+    /** A card you watch or are assigned is due soon or overdue. */
+    cards_due: boolean
 }
 
 const DEFAULT_PREFS: NotificationPreferences = {
@@ -41,6 +49,10 @@ const DEFAULT_PREFS: NotificationPreferences = {
     system_error: true,
     comment_mention: true,
     cards_mention: true,
+    cards_assigned: true,
+    cards_reply: true,
+    cards_watched: true,
+    cards_due: true,
 }
 
 export type MailNotifyMode = 'batched' | 'important_only'

--- a/core/lib/use-notification-preferences.ts
+++ b/core/lib/use-notification-preferences.ts
@@ -33,6 +33,8 @@ export interface NotificationPreferences {
     cards_assigned: boolean
     /** Someone replied to your comment on a card. */
     cards_reply: boolean
+    /** Someone reacted to your comment on a card. */
+    cards_reaction: boolean
     /** A card you watch gained a comment, moved, was completed or archived. */
     cards_watched: boolean
     /** A card you watch or are assigned is due soon or overdue. */
@@ -51,6 +53,7 @@ const DEFAULT_PREFS: NotificationPreferences = {
     cards_mention: true,
     cards_assigned: true,
     cards_reply: true,
+    cards_reaction: true,
     cards_watched: true,
     cards_due: true,
 }


### PR DESCRIPTION
Preference switches for the cards notification types (`cards_mention`, `cards_assigned`, `cards_reply`, `cards_reaction`, `cards_watched`, `cards_due`), the notification drawer icon, and the move toast. Pairs with the cards Tier 1 and Tier 2 branches.