### PR TITLE
feat(oauth): classify the four remaining cards collections

### DIFF
--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -123,6 +123,28 @@ var collectionScopes = map[string]collectionAccess{
 	"cards_comments":        {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
 	"cards_attachments":     {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
 
+	// The junction collections, same reasoning as the content rows above:
+	// each one's access rules resolve membership before any of this is
+	// reached, so the grant decides whether an OAuth caller may use the
+	// collection at all — not which rows.
+	//
+	// cards_card_links is worth one moment of thought, being the only cards
+	// collection that spans two boards. Its create rule already demands write
+	// on the source board and membership on the target, so a token cannot
+	// link boards its holder could not link through the app. Reading one
+	// discloses the far card's id and nothing else — the far card stays
+	// governed by cards_cards' own rule.
+	"cards_card_links":        {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_comment_reactions": {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+	"cards_card_watchers":     {read: scopeRule{ScopeCardsRead}, write: scopeRule{ScopeCardsWrite}},
+
+	// READ-ONLY, and unlike the sharing surface below this is not a policy
+	// choice — it is the schema. cards_activity is server-written history:
+	// its create, update and delete rules are all nil (pb-migrations
+	// 1980000008), so no client of any kind writes it. Granting write here
+	// would name a capability that does not exist and cannot be exercised.
+	"cards_activity": {read: scopeRule{ScopeCardsRead}},
+
 	// READ-ONLY for OAuth callers, deliberately, and NOT because the rules are
 	// weak — they already confine both to owners. These two are the SHARING
 	// surface: a write to cards_project_members adds a person to a board, and a

--- a/core/server/oauth/route_classification_test.go
+++ b/core/server/oauth/route_classification_test.go
@@ -170,6 +170,12 @@ func TestCardsContentCollectionsAreReadWrite(t *testing.T) {
 	for _, collection := range []string{
 		"cards_projects", "cards_lists", "cards_cards", "cards_labels",
 		"cards_checklist_items", "cards_comments", "cards_attachments",
+		// The junctions. cards_card_links spans two boards, which is why it
+		// is worth naming here rather than assuming it rides along: its own
+		// create rule demands write on the source and membership on the
+		// target, so the scope grant adds nothing a caller could not already
+		// do in the app.
+		"cards_card_links", "cards_comment_reactions", "cards_card_watchers",
 	} {
 		path := "/api/collections/" + collection + "/records"
 		read := ScopeForRoute("GET", path)
@@ -222,6 +228,35 @@ func TestCardsSharingSurfaceIsReadOnlyForOAuth(t *testing.T) {
 						"must not be able to reshare a board or mint a public link",
 						method, p, scope)
 				}
+			}
+		}
+	}
+}
+
+// cards_activity is READ-ONLY, and unlike the sharing surface above that is
+// not a policy judgement — it is the schema. Its create, update and delete
+// rules are all nil (pb-migrations/1980000008), so history is written by the
+// server alone and no client of any kind appends to it.
+//
+// Asserted separately from the sharing surface because the reasons differ and
+// should not be conflated: relaxing the sharing entries would be a deliberate
+// security decision, whereas granting write here would name a capability that
+// does not exist and could never succeed.
+func TestCardsActivityIsReadOnlyForOAuth(t *testing.T) {
+	path := "/api/collections/cards_activity/records"
+
+	if !ScopeForRoute("GET", path).satisfiedBy([]string{ScopeCardsRead}) {
+		t.Errorf("GET %s: cards:read must admit reading card history", path)
+	}
+	for _, method := range []string{"POST", "PATCH", "PUT", "DELETE"} {
+		p := path
+		if method != "POST" {
+			p += "/abc123"
+		}
+		for _, scope := range []string{ScopeCardsWrite, ScopeCardsRead} {
+			if ScopeForRoute(method, p).satisfiedBy([]string{scope}) {
+				t.Errorf("%s %s must not be reachable with %q — activity is "+
+					"server-written and its write rules are nil", method, p, scope)
 			}
 		}
 	}


### PR DESCRIPTION
Anything absent from `collectionScopes` returns `nil` — denied — so
`cards_card_links`, `cards_comment_reactions`, `cards_card_watchers` and
`cards_activity` were unreachable for OAuth callers. That is what currently
defers CLI commands for links, reactions and watching.

## The three junctions: read + write

Same reasoning as the content rows they sit beside, which the table's existing
comment already states: every one carries a `project`, and the access rules
resolve membership through `cards_project_members` before any of this is
consulted. So the grant decides whether an OAuth caller may use the collection
at all — **not which rows** it may touch.

`cards_card_links` is the one worth a second look, being the only cards
collection that spans two boards. Its create rule already demands write on the
source board and membership on the target, so a token cannot link boards its
holder could not link through the app. Reading a link discloses the far card's
id and nothing more — the far card stays governed by `cards_cards`' own rule.

## `cards_activity`: read only

Unlike the sharing surface, this is **not** a policy judgement — it is the
schema. Its create, update and delete rules are all `nil`
(`pb-migrations/1980000008`), so history is server-written and no client of any
kind appends to it. Granting write would name a capability that does not exist
and could never succeed.

Asserted in its own test so the two reasons are not conflated: relaxing the
sharing entries would be a deliberate security decision, whereas this one
simply describes what the collection is.

## Unchanged

The sharing surface — `cards_project_members` and `cards_share_links` — stays
read-only. A write there grants other people access to a board, which is a
categorically larger thing than "change my cards", and that is what
`cards:write` says on the consent screen.

## Tests

`TestCardsContentCollectionsAreReadWrite` gains the three junctions;
`TestCardsActivityIsReadOnlyForOAuth` is new and checks every write verb, not
just POST. Both were verified to **fail** without the table entries rather
than assumed to bite.

Full `oauth` Go suite passes.