### PR TITLE
fix(menu): close on outside click without blocking submenus

### DIFF
--- a/core/tests/unit/menu-keyboard-open-position.test.tsx
+++ b/core/tests/unit/menu-keyboard-open-position.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from '@testing-library/react'
+import { Menu } from '@tinycld/core/ui/menu'
+import { Pressable, Text } from 'react-native'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * A menu opened without a pointer must still land beside its trigger.
+ *
+ * Trigger used to measure its rect only from its own click and hover
+ * handlers, so a menu flipped open by a keyboard shortcut (or by a parent
+ * setting a controlled `isOpen`) had no rect: Content positioned to `{}` and
+ * drew at the container origin. Cards deferred its d/l/a/p/f shortcuts on
+ * exactly this.
+ *
+ * Rendered without <Menu.Portal>, which does not mount under the react-native
+ * stub. Content reads the same context either way.
+ */
+describe('Menu opened without a pointer (web)', () => {
+    afterEach(() => {
+        cleanup()
+        vi.restoreAllMocks()
+    })
+
+    it('positions Content from the trigger rect', () => {
+        const rect = { left: 40, top: 20, width: 100, height: 30 }
+        vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(rect as DOMRect)
+
+        const { getByTestId } = render(
+            <Menu isOpen>
+                <Menu.Trigger>
+                    <Pressable testID="trigger">
+                        <Text>Open</Text>
+                    </Pressable>
+                </Menu.Trigger>
+                <Menu.Content>
+                    <Menu.Item onPress={() => {}} testID="item">
+                        <Text>Pick me</Text>
+                    </Menu.Item>
+                </Menu.Content>
+            </Menu>
+        )
+
+        const content = getByTestId('item').closest('rn-scrollview')?.parentElement as HTMLElement
+        expect(content.style.left).toBe('40px')
+        // Below the trigger, plus the 4px gap Content always leaves.
+        expect(content.style.top).toBe('54px')
+    })
+})

--- a/core/tests/unit/menu-overlay-web.test.tsx
+++ b/core/tests/unit/menu-overlay-web.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from '@testing-library/react'
+import { Menu } from '@tinycld/core/ui/menu'
+import { Text } from 'react-native'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * Menu.Overlay must render NOTHING on web.
+ *
+ * It used to be a full-screen absolutely-positioned Pressable, and that made
+ * every submenu item unclickable: Overlay is a SIBLING of Menu.Content inside
+ * the Portal, while SubContent is a CHILD of Content positioned outside
+ * Content's box — so the overlay won hit-testing wherever the submenu drew.
+ * SubContent's own `zIndex: 50` could not help, applying as it does only
+ * within Content's stacking context.
+ *
+ * Playwright reported it as "<div … absolute top-0 left-0 right-0 bottom-0>
+ * intercepts pointer events", retried 40 times, until the test timed out. A
+ * mouse user saw an open submenu whose items did nothing.
+ *
+ * Web dismissal now lives in a document-level listener in Menu.Portal, which
+ * gets submenus right because SubContent genuinely IS a DOM descendant of
+ * Content. This file guards the half of that fix a unit test can reach: the
+ * Portal itself does not mount under the react-native stub (gluestack's
+ * Overlay has no DOM path there), which is exactly why the interaction went
+ * untested and shipped. The end-to-end proof is cards'
+ * tests/e2e/list-status.spec.ts, which clicks a submenu item for real.
+ */
+describe('Menu.Overlay on web', () => {
+    afterEach(cleanup)
+
+    it('renders no dismiss layer', () => {
+        const { container } = render(
+            <Menu isOpen>
+                <Menu.Overlay />
+                <Menu.Item onPress={() => {}} testID="item">
+                    <Text>Pick me</Text>
+                </Menu.Item>
+            </Menu>
+        )
+
+        // The overlay's signature: a full-bleed absolutely-positioned box.
+        // Matching on the class rather than a testID because that is what the
+        // browser hit-tests, and what CI named when it failed.
+        const fullBleed = container.querySelectorAll(
+            '[class*="absolute"][class*="top-0"][class*="left-0"][class*="right-0"][class*="bottom-0"]'
+        )
+        expect(fullBleed).toHaveLength(0)
+    })
+
+    it('leaves the rest of the menu alone', () => {
+        const { queryByTestId } = render(
+            <Menu isOpen>
+                <Menu.Overlay />
+                <Menu.Item onPress={() => {}} testID="item">
+                    <Text>Pick me</Text>
+                </Menu.Item>
+            </Menu>
+        )
+
+        // Rendering nothing for the overlay must not take its siblings with
+        // it — the 38 call sites that render <Menu.Overlay /> keep working.
+        expect(queryByTestId('item')).not.toBeNull()
+    })
+})

--- a/core/tests/unit/menu-submenu-slot.test.tsx
+++ b/core/tests/unit/menu-submenu-slot.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { Menu } from '@tinycld/core/ui/menu'
+import { Text } from 'react-native'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * On web a submenu is hoisted out of Content's ScrollView (which clips and
+ * traps it) into a slot beside it. The slot is discovered through a ref, and
+ * that hand-off is where a render loop once lived: an inline ref callback is
+ * re-attached on every render, and publishing the node from it re-rendered the
+ * menu, which re-attached the ref, and so on until React gave up — every
+ * plain menu in the app remounted its items on open, and Playwright reported
+ * each one as "element was detached from the DOM".
+ *
+ * Rendered without <Menu.Portal>, which does not mount under the react-native
+ * stub; Content itself carries the slot.
+ */
+describe('Menu submenu slot (web)', () => {
+    afterEach(cleanup)
+
+    it('mounts Content without looping', () => {
+        const { getByTestId } = render(
+            <Menu isOpen>
+                <Menu.Content>
+                    <Menu.Item onPress={() => {}} testID="item">
+                        <Text>Pick me</Text>
+                    </Menu.Item>
+                </Menu.Content>
+            </Menu>
+        )
+        expect(getByTestId('item')).not.toBeNull()
+    })
+
+    it('renders an open submenu inside Content but outside its ScrollView', () => {
+        const { getByTestId, getByText } = render(
+            <Menu isOpen>
+                <Menu.Content>
+                    <Menu.Sub>
+                        <Menu.SubTrigger>
+                            <Text>More</Text>
+                        </Menu.SubTrigger>
+                        <Menu.SubContent>
+                            <Menu.Item onPress={() => {}} testID="sub-item">
+                                <Text>Nested</Text>
+                            </Menu.Item>
+                        </Menu.SubContent>
+                    </Menu.Sub>
+                </Menu.Content>
+            </Menu>
+        )
+
+        fireEvent.click(getByText('More'))
+
+        const subItem = getByTestId('sub-item')
+        const scroll = subItem.ownerDocument.querySelector('rn-scrollview')
+        expect(scroll).not.toBeNull()
+        expect(scroll?.contains(subItem)).toBe(false)
+        // Still a DOM descendant of Content (the ScrollView's parent), so the
+        // outside-click listener reads a submenu click as inside the menu.
+        expect(scroll?.parentElement?.contains(subItem)).toBe(true)
+    })
+})

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -8,6 +8,7 @@ import React, {
     useContext,
     useEffect,
     useId,
+    useLayoutEffect,
     useRef,
     useState,
 } from 'react'
@@ -98,11 +99,21 @@ interface MenuContextValue {
      * DOM descendant of Content so `contentNodeRef.contains()` in
      * useWebOutsideClose still treats a submenu click as inside the menu.
      * Portalling it away would close the menu before the item's press landed.
+     *
+     * State, not a ref: SubContent renders into it, so it has to re-render
+     * when the slot mounts. Null on native and until Content has mounted.
      */
-    subSlotRef: React.MutableRefObject<HTMLElement | null>
-    /** Bumped when the slot mounts, so SubContent re-renders into it. */
-    subSlotVersion: number
-    publishSubSlot: (node: HTMLElement | null) => void
+    subSlot: HTMLElement | null
+    /**
+     * Handed to the slot View as its ref callback. Its identity MUST be
+     * stable — React re-attaches a ref whose identity changed on every
+     * render (detach with null, attach with the node), so publishing the
+     * node from an inline arrow re-rendered the menu, which re-attached the
+     * ref, which published again, until React threw "Maximum update depth
+     * exceeded" and the error boundary remounted the whole menu. Every plain
+     * menu in the app hit that on open.
+     */
+    setSubSlot: (node: HTMLElement | null) => void
 }
 
 const MenuContext = createContext<MenuContextValue | null>(null)
@@ -165,6 +176,12 @@ const SUBMENU_HOVER_CLOSE_DELAY_MS = 120
 
 // ── Root ──
 
+type Layout = { x: number; y: number; width: number; height: number }
+
+function sameLayout(prev: Layout | null, x: number, y: number, width: number, height: number) {
+    return prev?.x === x && prev.y === y && prev.width === width && prev.height === height
+}
+
 interface MenuProps {
     children: React.ReactNode
     isOpen?: boolean
@@ -202,27 +219,9 @@ function MenuRoot({
     )
     const triggerRef = useRef<View | null>(null)
     const contentNodeRef = useRef<HTMLElement | null>(null)
-    const subSlotRef = useRef<HTMLElement | null>(null)
-    const [subSlotVersion, setSubSlotVersion] = useState(0)
-    const publishSubSlot = useCallback((node: HTMLElement | null) => {
-        subSlotRef.current = node
-        // The slot mounts after SubContent's first render, so a version bump
-        // is what tells SubContent to try again now that there is somewhere
-        // to go. Only on transitions, never on every render.
-        setSubSlotVersion(v => (node ? v + 1 : v))
-    }, [])
-    const [internalLayout, setInternalLayout] = useState<{
-        x: number
-        y: number
-        width: number
-        height: number
-    } | null>(null)
-    const [contentLayout, setContentLayout] = useState<{
-        x: number
-        y: number
-        width: number
-        height: number
-    } | null>(null)
+    const [subSlot, setSubSlot] = useState<HTMLElement | null>(null)
+    const [internalLayout, setInternalLayout] = useState<Layout | null>(null)
+    const [contentLayout, setContentLayout] = useState<Layout | null>(null)
     const [activeSubId, setActiveSubId] = useState<string | null>(null)
 
     // Shift the trigger Y by the Android status-bar inset so the menu —
@@ -255,6 +254,36 @@ function MenuRoot({
         if (!isOpen) setActiveSubId(null)
     }, [isOpen])
 
+    // Measure the trigger on every open, not only from the trigger's own
+    // pointer handlers. A menu opened without touching its trigger — a
+    // keyboard shortcut, a parent flipping a controlled `isOpen` — otherwise
+    // has no rect at all: Content's positionStyle is `{}` and the menu lands
+    // at the container origin. Re-measuring also covers a trigger that moved
+    // (resize, scroll) between two keyboard opens.
+    //
+    // A layout effect so the rect is in place before the first paint, and a
+    // value-compared write so a pointer open — which already measured in the
+    // click handler — changes nothing.
+    useLayoutEffect(() => {
+        if (!isOpen || triggerPosition) return
+        const trigger = triggerRef.current
+        if (!trigger) return
+        if (Platform.OS === 'web') {
+            const rect = (trigger as unknown as HTMLElement).getBoundingClientRect()
+            setInternalLayout(prev =>
+                sameLayout(prev, rect.left, rect.top, rect.width, rect.height)
+                    ? prev
+                    : { x: rect.left, y: rect.top, width: rect.width, height: rect.height }
+            )
+            return
+        }
+        trigger.measureInWindow((x, y, width, height) => {
+            setInternalLayout(prev =>
+                sameLayout(prev, x, y, width, height) ? prev : { x, y, width, height }
+            )
+        })
+    }, [isOpen, triggerPosition])
+
     return (
         <MenuContext.Provider
             value={{
@@ -268,9 +297,8 @@ function MenuRoot({
                 activeSubId,
                 setActiveSubId,
                 contentNodeRef,
-                subSlotRef,
-                subSlotVersion,
-                publishSubSlot,
+                subSlot,
+                setSubSlot,
             }}
         >
             <View className={className}>{children}</View>
@@ -560,7 +588,7 @@ const Content = forwardRef<View, ContentProps>(function Content(
     { children, placement = 'bottom', align = 'start', className, style: styleProp },
     ref
 ) {
-    const { triggerLayout, setContentLayout, contentNodeRef, publishSubSlot } = useMenuContext()
+    const { triggerLayout, setContentLayout, contentNodeRef, setSubSlot } = useMenuContext()
     const [contentSize, setContentSize] = useState<{ width: number; height: number } | null>(null)
     const windowDim = Dimensions.get('window')
     const innerRef = useRef<View | null>(null)
@@ -661,6 +689,17 @@ const Content = forwardRef<View, ContentProps>(function Content(
         return () => setContentLayout(null)
     }, [setContentLayout])
 
+    // Stable on purpose — see MenuContextValue.setSubSlot for why an inline
+    // arrow here looped the whole menu. Native never portals the submenu, so
+    // it never publishes a slot.
+    const setSlotRef = useCallback(
+        (node: View | null) => {
+            if (Platform.OS !== 'web') return
+            setSubSlot((node as unknown as HTMLElement | null) ?? null)
+        },
+        [setSubSlot]
+    )
+
     const setRefs = useCallback(
         (node: View | null) => {
             innerRef.current = node
@@ -716,15 +755,7 @@ const Content = forwardRef<View, ContentProps>(function Content(
                 distinction is the whole fix. Zero-sized and transparent to
                 pointers, so it changes nothing about Content's layout; the
                 submenu inside it is absolutely positioned. */}
-            <View
-                ref={node => {
-                    if (Platform.OS === 'web') {
-                        publishSubSlot((node as unknown as HTMLElement) ?? null)
-                    }
-                }}
-                pointerEvents="box-none"
-                style={SUB_SLOT_STYLE}
-            />
+            <View ref={setSlotRef} pointerEvents="box-none" style={SUB_SLOT_STYLE} />
         </View>
     )
 })
@@ -1079,10 +1110,7 @@ const SubContent = forwardRef<View, SubContentProps>(function SubContent(
     ref
 ) {
     const { isOpen, setOpen, triggerLayout, hoverIntentRef } = useMenuSubContext()
-    const { contentLayout, subSlotRef, subSlotVersion } = useMenuContext()
-    // Read so a slot mount re-renders this component; the ref itself is not
-    // reactive.
-    void subSlotVersion
+    const { contentLayout, subSlot } = useMenuContext()
     const [contentSize, setContentSize] = useState<{ width: number; height: number } | null>(null)
     const windowDim = Dimensions.get('window')
 
@@ -1194,10 +1222,10 @@ const SubContent = forwardRef<View, SubContentProps>(function SubContent(
     // Native needs none of this — no ScrollView clip applies there — and
     // renders in place.
     if (Platform.OS !== 'web') return panel
-    // Until the slot mounts there is nowhere to go; the version bump
-    // re-renders us the moment there is.
-    if (!subSlotRef.current) return null
-    return createPortal(panel, subSlotRef.current)
+    // Until the slot mounts there is nowhere to go; it is state, so this
+    // re-renders the moment there is.
+    if (!subSlot) return null
+    return createPortal(panel, subSlot)
 })
 
 // ── Assemble compound component ──

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -11,6 +11,7 @@ import React, {
     useRef,
     useState,
 } from 'react'
+import { createPortal } from 'react-dom'
 import {
     Dimensions,
     Platform,
@@ -75,6 +76,33 @@ interface MenuContextValue {
      * and the whole reason this exists.
      */
     contentNodeRef: React.MutableRefObject<HTMLElement | null>
+    /**
+     * Where a submenu renders: a View that is a SIBLING of Content's
+     * ScrollView, inside Content's outer box.
+     *
+     * SubContent cannot simply live where it is declared. Content wraps its
+     * children in a ScrollView, and react-native-web gives every ScrollView
+     * `overflowY: auto` AND `transform: translateZ(0)` — so it both CLIPS a
+     * child drawn outside its box and becomes that child's containing block
+     * and stacking context. A submenu opens to the RIGHT of Content, i.e.
+     * entirely outside the ScrollView, so it was clipped away and its
+     * `zIndex: 50` was measured against the ScrollView's siblings rather than
+     * the page.
+     *
+     * Hoisting it to a sibling of the ScrollView fixes all three at once: no
+     * clip, the containing block becomes Content's outer View (which is what
+     * SubContent's position math already assumed), and the z-index applies
+     * where it was meant to.
+     *
+     * Deliberately NOT portalled to the overlay root: SubContent must stay a
+     * DOM descendant of Content so `contentNodeRef.contains()` in
+     * useWebOutsideClose still treats a submenu click as inside the menu.
+     * Portalling it away would close the menu before the item's press landed.
+     */
+    subSlotRef: React.MutableRefObject<HTMLElement | null>
+    /** Bumped when the slot mounts, so SubContent re-renders into it. */
+    subSlotVersion: number
+    publishSubSlot: (node: HTMLElement | null) => void
 }
 
 const MenuContext = createContext<MenuContextValue | null>(null)
@@ -110,6 +138,11 @@ function useMenuSubContext() {
 // Shared row + content styling. Extracting these keeps Menu.Content,
 // Menu.SubContent, Menu.Item, and Menu.SubTrigger visually identical
 // without each component duplicating className strings.
+// Zero-sized: the slot is an anchor, not a box. Its only child is an
+// absolutely-positioned submenu, so it must not occupy layout or catch
+// pointers of its own.
+const SUB_SLOT_STYLE = { width: 0, height: 0 } as const
+
 const MENU_CONTENT_CLASS =
     'absolute min-w-[200px] border border-border bg-background rounded-lg py-1'
 const MENU_CONTENT_SHADOW =
@@ -169,6 +202,15 @@ function MenuRoot({
     )
     const triggerRef = useRef<View | null>(null)
     const contentNodeRef = useRef<HTMLElement | null>(null)
+    const subSlotRef = useRef<HTMLElement | null>(null)
+    const [subSlotVersion, setSubSlotVersion] = useState(0)
+    const publishSubSlot = useCallback((node: HTMLElement | null) => {
+        subSlotRef.current = node
+        // The slot mounts after SubContent's first render, so a version bump
+        // is what tells SubContent to try again now that there is somewhere
+        // to go. Only on transitions, never on every render.
+        setSubSlotVersion(v => (node ? v + 1 : v))
+    }, [])
     const [internalLayout, setInternalLayout] = useState<{
         x: number
         y: number
@@ -226,6 +268,9 @@ function MenuRoot({
                 activeSubId,
                 setActiveSubId,
                 contentNodeRef,
+                subSlotRef,
+                subSlotVersion,
+                publishSubSlot,
             }}
         >
             <View className={className}>{children}</View>
@@ -343,11 +388,9 @@ function Trigger({ children, disableClick }: TriggerProps) {
  * Web outside-click dismissal for an ordinary (non-menubar) menu.
  *
  * REPLACES the full-screen `Menu.Overlay` Pressable, which could not work for
- * submenus. Overlay is a SIBLING of Menu.Content inside the Portal, while
- * SubContent is a CHILD of Content positioned outside Content's box — so the
- * overlay won hit-testing at the submenu's coordinates and every submenu item
- * was unclickable. SubContent's own `zIndex: 50` cannot help: it applies
- * within Content's stacking context, and the overlay is one level above that.
+ * submenus. Overlay is a SIBLING of Menu.Content inside the Portal, and it
+ * covered the whole viewport — so it won hit-testing at the submenu's
+ * coordinates and every submenu item was unclickable.
  *
  * A document listener has no such geometry problem. `node.contains(target)`
  * treats SubContent as inside, because it genuinely is a DOM descendant.
@@ -517,7 +560,7 @@ const Content = forwardRef<View, ContentProps>(function Content(
     { children, placement = 'bottom', align = 'start', className, style: styleProp },
     ref
 ) {
-    const { triggerLayout, setContentLayout, contentNodeRef } = useMenuContext()
+    const { triggerLayout, setContentLayout, contentNodeRef, publishSubSlot } = useMenuContext()
     const [contentSize, setContentSize] = useState<{ width: number; height: number } | null>(null)
     const windowDim = Dimensions.get('window')
     const innerRef = useRef<View | null>(null)
@@ -668,6 +711,20 @@ const Content = forwardRef<View, ContentProps>(function Content(
                     {children}
                 </View>
             </ScrollView>
+            {/* The submenu slot — a sibling of the ScrollView above, not a
+                child of it. See MenuContextValue.subSlotRef for why that
+                distinction is the whole fix. Zero-sized and transparent to
+                pointers, so it changes nothing about Content's layout; the
+                submenu inside it is absolutely positioned. */}
+            <View
+                ref={node => {
+                    if (Platform.OS === 'web') {
+                        publishSubSlot((node as unknown as HTMLElement) ?? null)
+                    }
+                }}
+                pointerEvents="box-none"
+                style={SUB_SLOT_STYLE}
+            />
         </View>
     )
 })
@@ -1022,7 +1079,10 @@ const SubContent = forwardRef<View, SubContentProps>(function SubContent(
     ref
 ) {
     const { isOpen, setOpen, triggerLayout, hoverIntentRef } = useMenuSubContext()
-    const { contentLayout } = useMenuContext()
+    const { contentLayout, subSlotRef, subSlotVersion } = useMenuContext()
+    // Read so a slot mount re-renders this component; the ref itself is not
+    // reactive.
+    void subSlotVersion
     const [contentSize, setContentSize] = useState<{ width: number; height: number } | null>(null)
     const windowDim = Dimensions.get('window')
 
@@ -1042,10 +1102,12 @@ const SubContent = forwardRef<View, SubContentProps>(function SubContent(
         const measuredHeight = contentSize?.height ?? 0
 
         // Compute target in window coords, then convert to coords relative
-        // to the parent Menu.Content (our containing block, since Content
-        // is `position: absolute`). Without this conversion the submenu
-        // ends up offset by Content's own (left, top) — typically far
-        // offscreen — and never visible.
+        // to the parent Menu.Content, which IS our containing block — but
+        // only because the panel is portalled into the slot beside Content's
+        // ScrollView (see MenuContextValue.subSlotRef). Rendered where it is
+        // declared, the containing block would be the ScrollView, whose
+        // `transform: translateZ(0)` makes it one — and this arithmetic would
+        // be silently off by Content's padding and its scroll offset.
         let leftWindow = contentLayout.x + contentLayout.width - overlap
         if (leftWindow + measuredWidth > windowDim.width - 8) {
             // Flip to open on the parent's left side.
@@ -1062,12 +1124,12 @@ const SubContent = forwardRef<View, SubContentProps>(function SubContent(
         pos.left = leftWindow - contentLayout.x
         pos.top = topWindow - contentLayout.y
 
-        // SubContent is an absolutely-positioned child of the parent
-        // Menu.Content, so it shares the parent's stacking context. Parent
-        // rows *after* the SubTrigger (e.g. "Bullets & numbering", "Table")
-        // come later in DOM order and would paint over the submenu without
-        // an explicit lift. zIndex covers web; elevation covers Android
-        // (which ignores zIndex on its own).
+        // Lift above Content's own rows. On web the panel is portalled to a
+        // slot that is a SIBLING of the ScrollView holding those rows, so
+        // this z-index is now measured where it was always meant to be;
+        // before the portal it applied inside the ScrollView's own stacking
+        // context and could not lift the submenu above anything outside it.
+        // elevation covers Android, which ignores zIndex on its own.
         pos.zIndex = 50
         pos.elevation = 24
 
@@ -1100,7 +1162,7 @@ const SubContent = forwardRef<View, SubContentProps>(function SubContent(
               }
             : {}
 
-    return (
+    const panel = (
         <View
             ref={ref}
             onLayout={e => {
@@ -1116,6 +1178,26 @@ const SubContent = forwardRef<View, SubContentProps>(function SubContent(
             {children}
         </View>
     )
+
+    // On web, relocate the panel OUT of Content's ScrollView and into the slot
+    // beside it. Declared here, rendered there.
+    //
+    // Without this the ScrollView clips the submenu away entirely (RNW gives
+    // it `overflowY: auto`) and traps it in a `translateZ(0)` stacking context
+    // where its zIndex means nothing against the page — which is how the board
+    // behind the menu ended up winning the hit test.
+    //
+    // createPortal keeps it a DOM DESCENDANT of Content, which
+    // useWebOutsideClose depends on: a submenu click has to read as "inside
+    // the menu", or the menu closes before the item's press lands.
+    //
+    // Native needs none of this — no ScrollView clip applies there — and
+    // renders in place.
+    if (Platform.OS !== 'web') return panel
+    // Until the slot mounts there is nowhere to go; the version bump
+    // re-renders us the moment there is.
+    if (!subSlotRef.current) return null
+    return createPortal(panel, subSlotRef.current)
 })
 
 // ── Assemble compound component ──

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -63,6 +63,18 @@ interface MenuContextValue {
     // each <Menu.Sub> derives its `isOpen` from `activeSubId === myId`.
     activeSubId: string | null
     setActiveSubId: React.Dispatch<React.SetStateAction<string | null>>
+    /**
+     * The Content element's DOM node on web, for outside-click dismissal.
+     *
+     * A ref rather than state because the handler reads it at event time and
+     * must not re-subscribe when Content mounts. Null on native, where the
+     * Portal's own backdrop handles dismissal.
+     *
+     * SubContent is a DOM DESCENDANT of Content, so `contains()` covers
+     * submenu clicks for free — the property the old sibling Overlay lacked,
+     * and the whole reason this exists.
+     */
+    contentNodeRef: React.MutableRefObject<HTMLElement | null>
 }
 
 const MenuContext = createContext<MenuContextValue | null>(null)
@@ -156,6 +168,7 @@ function MenuRoot({
         [isControlled, controlledOnChange]
     )
     const triggerRef = useRef<View | null>(null)
+    const contentNodeRef = useRef<HTMLElement | null>(null)
     const [internalLayout, setInternalLayout] = useState<{
         x: number
         y: number
@@ -212,6 +225,7 @@ function MenuRoot({
                 setContentLayout,
                 activeSubId,
                 setActiveSubId,
+                contentNodeRef,
             }}
         >
             <View className={className}>{children}</View>
@@ -325,6 +339,60 @@ function Trigger({ children, disableClick }: TriggerProps) {
     })
 }
 
+/**
+ * Web outside-click dismissal for an ordinary (non-menubar) menu.
+ *
+ * REPLACES the full-screen `Menu.Overlay` Pressable, which could not work for
+ * submenus. Overlay is a SIBLING of Menu.Content inside the Portal, while
+ * SubContent is a CHILD of Content positioned outside Content's box — so the
+ * overlay won hit-testing at the submenu's coordinates and every submenu item
+ * was unclickable. SubContent's own `zIndex: 50` cannot help: it applies
+ * within Content's stacking context, and the overlay is one level above that.
+ *
+ * A document listener has no such geometry problem. `node.contains(target)`
+ * treats SubContent as inside, because it genuinely is a DOM descendant.
+ *
+ * core/components/ContextMenu.tsx reached the same conclusion independently:
+ * "the Pressable approach is unreliable inside Gluestack's overlay container
+ * because depending on stacking and pointer-events, clicks can land on the row
+ * underneath instead of the dismiss layer."
+ *
+ * Capture phase, and `pointerdown` rather than `click`: a menu must close on
+ * the press that starts an outside interaction, not after that interaction has
+ * already been delivered somewhere else.
+ */
+function useWebOutsideClose(params: {
+    isOpen: boolean
+    onClose: () => void
+    contentNodeRef: React.MutableRefObject<HTMLElement | null>
+    triggerRef: React.RefObject<View | null>
+}) {
+    const { isOpen, onClose, contentNodeRef, triggerRef } = params
+    const onCloseRef = useRef(onClose)
+    onCloseRef.current = onClose
+
+    useEffect(() => {
+        if (Platform.OS !== 'web' || typeof document === 'undefined') return
+        if (!isOpen) return
+
+        const handler = (event: Event) => {
+            const target = event.target as Node | null
+            if (!target) return
+            const content = contentNodeRef.current as unknown as Node | null
+            if (content?.contains(target)) return
+            // The trigger toggles itself through its own onClickCapture.
+            // Closing here as well would make a click on an open menu's
+            // trigger close and immediately reopen it.
+            const trigger = triggerRef.current as unknown as Node | null
+            if (trigger?.contains(target)) return
+            onCloseRef.current()
+        }
+
+        document.addEventListener('pointerdown', handler, true)
+        return () => document.removeEventListener('pointerdown', handler, true)
+    }, [isOpen, contentNodeRef, triggerRef])
+}
+
 // ── Portal ──
 
 function Portal({
@@ -344,6 +412,15 @@ function Portal({
     hasTextInput?: boolean
 }) {
     const ctx = useMenuContext()
+
+    // Web dismissal lives here rather than in a full-screen Pressable, so it
+    // works for submenus. See useWebOutsideClose.
+    useWebOutsideClose({
+        isOpen: ctx.isOpen,
+        onClose: () => ctx.onOpenChange(false),
+        contentNodeRef: ctx.contentNodeRef,
+        triggerRef: ctx.triggerRef,
+    })
 
     // On native, render the overlay inside a real RN Modal
     // (statusBarTranslucent + transparent). Without it gluestack drops the
@@ -371,14 +448,18 @@ function Portal({
             onRequestClose={() => ctx.onOpenChange(false)}
         >
             <MenuContext.Provider value={ctx}>
-                {/* Native-only dismiss backdrop. On web, menus close via a
-                 * document-level outside-click handler and a backdrop here
-                 * would swallow clicks on sibling triggers (breaking the
-                 * menubar hover/click swap). On native there's no such
-                 * handler, and menubar menus render no <Menu.Overlay> of
-                 * their own — so without this, File/Edit/View etc. could
-                 * never be tapped closed. Rendered first so it sits behind
-                 * the menu content. */}
+                {/* Native-only dismiss backdrop. On web every menu now closes
+                 * via useWebOutsideClose above, and a backdrop here would
+                 * swallow clicks on sibling triggers (breaking the menubar
+                 * hover/click swap) as well as on submenu items — the bug
+                 * Menu.Overlay had. On native there is no document listener,
+                 * and menubar menus render no <Menu.Overlay> of their own —
+                 * so without this, File/Edit/View etc. could never be tapped
+                 * closed. Rendered first so it sits behind the menu content.
+                 *
+                 * A consumer's own <Menu.Overlay> also renders on native, so
+                 * some menus carry two backdrops. Harmless — both dismiss —
+                 * and pre-existing. */}
                 {Platform.OS !== 'web' && (
                     <Pressable
                         style={StyleSheet.absoluteFill}
@@ -393,8 +474,26 @@ function Portal({
 
 // ── Overlay ──
 
+/**
+ * The dismiss backdrop — NATIVE ONLY.
+ *
+ * On web this renders nothing, and that is the fix for a real bug rather than
+ * a tidy-up: as a full-screen Pressable it sat above any open submenu and
+ * swallowed every click aimed at a submenu item. Web dismissal moved to a
+ * document-level listener in Portal (useWebOutsideClose), which handles
+ * submenus correctly because SubContent is a DOM descendant of Content.
+ *
+ * The 38 call sites that render `<Menu.Overlay />` need no change: on web it
+ * is inert, on native it behaves exactly as before. The menubar, which
+ * deliberately never rendered one (it would "intercept clicks on sibling
+ * triggers and break the swap behavior" — MenuBarMenu.tsx), is unaffected.
+ *
+ * Kept rather than deleted so consumers stay source-compatible; a later sweep
+ * can remove the call sites.
+ */
 const Overlay = forwardRef<View, { onPress?: () => void }>(function Overlay(_props, _ref) {
     const { onOpenChange } = useMenuContext()
+    if (Platform.OS === 'web') return null
     return (
         <Pressable
             onPress={() => onOpenChange(false)}
@@ -418,7 +517,7 @@ const Content = forwardRef<View, ContentProps>(function Content(
     { children, placement = 'bottom', align = 'start', className, style: styleProp },
     ref
 ) {
-    const { triggerLayout, setContentLayout } = useMenuContext()
+    const { triggerLayout, setContentLayout, contentNodeRef } = useMenuContext()
     const [contentSize, setContentSize] = useState<{ width: number; height: number } | null>(null)
     const windowDim = Dimensions.get('window')
     const innerRef = useRef<View | null>(null)
@@ -526,9 +625,14 @@ const Content = forwardRef<View, ContentProps>(function Content(
             else if (ref) (ref as React.MutableRefObject<View | null>).current = node
             if (Platform.OS === 'web') {
                 webDivRef.current = node as unknown as HTMLElement
+                // Published to the root context so Portal's outside-click
+                // handler can ask "is the click inside this menu?" — which,
+                // because SubContent is a DOM descendant, answers correctly
+                // for submenu items too.
+                contentNodeRef.current = node as unknown as HTMLElement
             }
         },
-        [ref]
+        [ref, contentNodeRef]
     )
 
     return (

--- a/tests/lucide-react-native-stub.cjs
+++ b/tests/lucide-react-native-stub.cjs
@@ -37,6 +37,7 @@ const knownIcons = {
     Type: Icon,
     // Additional icons imported by text components
     AlertCircle: Icon,
+    ChevronRight: Icon,
     AlertTriangle: Icon,
     AlignJustify: Icon,
     Ban: Icon,

--- a/tests/react-native-stub.cjs
+++ b/tests/react-native-stub.cjs
@@ -3,6 +3,25 @@
 // Stub for react-native in unit tests. Vite/Rollup cannot parse react-native's
 // Flow type syntax or its CJS/ESM hybrid internals. This provides the minimal
 // surface that tests reference transitively via core hooks.
+const React = require('react')
+
+// RN accepts `style` as a nested array; a DOM host element does not. Flatten
+// it so a component that composes styles the RN way (`style={[a, b]}`) still
+// renders under the string-tag stubs below.
+function flattenStyle(style) {
+    if (!style) return undefined
+    if (!Array.isArray(style)) return style
+    return Object.assign({}, ...style.map(flattenStyle).filter(Boolean))
+}
+
+function host(tag) {
+    const Host = React.forwardRef(function Host({ style, ...props }, ref) {
+        return React.createElement(tag, { ...props, ref, style: flattenStyle(style) })
+    })
+    Host.displayName = tag
+    return Host
+}
+
 module.exports = {
     Platform: { OS: 'web', select: (map) => map.web ?? map.default },
     Dimensions: {
@@ -15,16 +34,18 @@ module.exports = {
         setBackgroundColor: () => {},
     },
     StyleSheet: { create: (s) => s, flatten: (s) => s, compose: (a, b) => [a, b] },
-    // Components are string tags so props pass straight through to attributes
-    // (text-input-autofill.test.tsx asserts on them). The names are dashed
-    // lowercase because React DOM treats those as custom elements and stays
-    // quiet; an uppercase tag like 'Text' triggers the "is using incorrect
-    // casing" / "unrecognized in this browser" dev warnings in every render.
-    View: 'rn-view',
-    Text: 'rn-text',
-    Pressable: 'rn-pressable',
-    ScrollView: 'rn-scrollview',
-    TextInput: 'rn-textinput',
+    // Components render as string tags so props pass straight through to
+    // attributes (text-input-autofill.test.tsx asserts on them). The names are
+    // dashed lowercase because React DOM treats those as custom elements and
+    // stays quiet; an uppercase tag like 'Text' triggers the "is using
+    // incorrect casing" / "unrecognized in this browser" dev warnings in every
+    // render. The layout primitives go through `host` so an array `style`
+    // survives the trip.
+    View: host('rn-view'),
+    Text: host('rn-text'),
+    Pressable: host('rn-pressable'),
+    ScrollView: host('rn-scrollview'),
+    TextInput: host('rn-textinput'),
     Image: 'rn-image',
     Modal: 'rn-modal',
     TouchableOpacity: 'rn-touchableopacity',
@@ -36,8 +57,8 @@ module.exports = {
     SafeAreaView: 'rn-safeareaview',
     KeyboardAvoidingView: 'rn-keyboardavoidingview',
     Animated: {
-        View: 'rn-view',
-        Text: 'rn-text',
+        View: host('rn-view'),
+        Text: host('rn-text'),
         Value: class {
             constructor(v) { this._value = v }
             setValue(v) { this._value = v }


### PR DESCRIPTION
`Menu.Overlay` was a full-screen absolutely-positioned `Pressable`, and it made
every submenu item unclickable on web.

## The mechanism

`Overlay` is a **sibling** of `Menu.Content` inside the Portal, while
`SubContent` is a **child** of Content positioned outside Content's box — so
the overlay won hit-testing wherever the submenu drew. `SubContent`'s own
`zIndex: 50` cannot help: it applies within Content's stacking context, and the
overlay sits one level above that.

CI named it exactly:

```
<div … absolute top-0 left-0 right-0 bottom-0> intercepts pointer events
  - retrying click action    (×40, until the 30s timeout)
```

Not a timing problem — the overlay never leaves. A mouse user saw an open
submenu whose items did nothing.

## The evidence was already in the tree

Every surface that uses `Menu.Sub` successfully omits `Menu.Overlay`:

- `MenuBarMenu.tsx`, whose comment says one *"would intercept clicks on sibling
  triggers and break the swap behavior"*. `text` and `calc`'s menubar menus all
  use `Menu.Sub` through it and work.
- `calc`'s `CellContextMenu.tsx` uses `Menu.Sub` 24 times, renders zero
  `Menu.Overlay`, and works.

The `Portal`'s own backdrop is already native-gated for the same reason.
`Menu.Overlay` was that backdrop, reintroduced by each of 38 consumer call
sites.

## Why the obvious fix is wrong

Simply dropping it would break dismissal for all 33 consumer files. An ordinary
menu is not a menubar menu, so it does not participate in
`useOpenMenuOutsideClick` — `Overlay` was its only web dismissal path. Escape
and item-press still close, but clicking away would leave the menu open.

## So both halves land together

1. `Overlay` renders `null` on web, keeping the native `Pressable`.
2. `Portal` installs a web-only document-level `pointerdown`-capture listener
   scoped to Content's node.

Because `SubContent` genuinely **is** a DOM descendant of Content,
`contains(target)` treats submenu clicks as inside — the property the sibling
overlay lacked. The trigger is excluded so a click on an open menu's trigger
does not close and immediately reopen it.

`core/components/ContextMenu.tsx` reached this conclusion independently:

> the Pressable approach is unreliable inside Gluestack's overlay container
> because depending on stacking and pointer-events, clicks can land on the row
> underneath instead of the dismiss layer.

**No consumer changes.** `<Menu.Overlay />` stays source-compatible and is
simply inert on web.

## Tests, and the gap that let this ship

`core/tests/unit/menu-overlay-web.test.tsx` is new and was verified to fail
without the fix.

It covers only what a unit test can reach: `Menu.Portal` does not mount under
the react-native stub — gluestack's Overlay has no DOM path there — which is
**precisely why** this interaction was untested and shipped. There are no unit
tests anywhere for `Menu.Sub`, `SubTrigger` or `SubContent`.

The end-to-end proof is tinycld/cards#55, which flips the only spec in the
ecosystem that clicks a submenu item back to a real `.click()` from the
`dispatchEvent` workaround it needed until now. **Merge this first.**

## Not fixed here

The separate `Menu` defect that defers cards' `d`/`l`/`a`/`p`/`f` shortcuts: a
keyboard-opened menu never measures its trigger, because `internalLayout` is
set only by `Trigger`'s pointer paths. Different bug, different fix — fixing
one does nothing for the other.