### PR TITLE
ci: default e2e to two workers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,6 +34,31 @@ export default defineConfig({
     // attempt is always captured for diagnosis. Inherited by every package's
     // config.
     retries: 0,
+    // Two workers, overriding Playwright's default of 50% OF CPUS.
+    //
+    // That default is not a CI special case, whatever the folklore says — see
+    // resolveWorkers in playwright's common/config.js, which reads
+    // `os.cpus().length` and takes the percentage. A standard 2-core GitHub
+    // runner therefore resolves to ONE worker, and the cards e2e log said so
+    // exactly: "Running 140 tests using 1 worker", 16.7 minutes for a suite
+    // that takes 4.7 locally in parallel.
+    //
+    // Measured on cards before generalizing here: two workers on the same
+    // 2-core runner ran the same 140 tests in 11.9 minutes (139 passed, 1
+    // skipped — the same split as the serial run), a ~29% saving with no new
+    // failures.
+    //
+    // WHY A FIXED 2 RATHER THAN A PERCENTAGE. The runner has 2 cores, so any
+    // percentage at or below 100% resolves to 1 there, while a developer
+    // machine with 14 cores would take 7 and pay seven cold Metro compiles
+    // (see the reporter note above — each worker pays one on its first test).
+    // A fixed 2 is the number that helps CI, which is where the wall clock
+    // actually hurts, and it caps that startup cost on a laptop too.
+    //
+    // A package that needs different parallelism overrides this in its own
+    // config; a suite whose specs are not independent should be FIXED rather
+    // than serialized, for the reason `retries: 0` above gives.
+    workers: 2,
     // Scoped to tests/e2e/ specifically. The tests/install/ tree has
     // its own playwright.config.ts and is invoked separately by the
     // docker smoke-test workflow — leaving testDir at the playwright


### PR DESCRIPTION
Makes `workers: 2` the shared default for every package's Playwright config, after measuring it on cards.

## Why CI was serializing

Playwright resolves `workers` to **50% of CPUs** by default. This is not a CI special case, despite the common belief — `resolveWorkers` in its `common/config.js` reads `os.cpus().length` and takes the percentage, and the only `process.env.CI` branch in that file picks the *reporter*.

A standard 2-core GitHub runner therefore resolves to **one worker**, and the cards e2e log said so exactly:

```
Running 140 tests using 1 worker
... 16.7m
```

The same 140 tests run in 4.7 minutes locally, in parallel.

## Measured before generalizing

Two workers on the same 2-core runner, cards PR #57:

| | workers | time | result |
|---|---|---|---|
| before | 1 | 16.7m | 139 passed, 1 skipped |
| after | 2 | 11.9m | 139 passed, 1 skipped |

~29% faster, identical pass/skip split, no new failures.

## Why a fixed 2 rather than a percentage

The runner has 2 cores, so any percentage at or below 100% still resolves to 1 there. Meanwhile a 14-core laptop would take 7 workers and pay **seven cold Metro compiles** — each worker pays one on its first test, which the `reporter` note in this file already documents. A fixed 2 is the number that helps CI, where the wall clock actually hurts, and it caps that startup cost locally too.

## Scope and what is unverified

Three suites run Playwright today: **cards** (34 specs), **the app shell** (17) and **contacts** (4). Only cards has been measured at two workers.

I could not run the app shell's suite locally to confirm: the workspace's cards checkout is mid-`rename-boards`, so the generated `server/pb_migrations` symlinks dangle and the e2e web server will not boot. This PR's own e2e run exercises the app-shell suite directly, so it is the real check — worth watching before merging.

Cards' specs isolate by building uniquely-named boards; only 2 of the app shell's 17 specs use that pattern, so a latent order dependency is possible. If one surfaces, the fix is to make those specs independent rather than to serialize the suite — the same reasoning the `retries: 0` note in this file gives for flakes. A package needing different parallelism can override in its own config.