### PR TITLE
OAuth scopes and notification keys for boards' sprints

### DIFF
--- a/app/a/(app)/settings/personal.tsx
+++ b/app/a/(app)/settings/personal.tsx
@@ -475,6 +475,7 @@ const NOTIF_GROUPS: {
             { key: 'boards_reaction', label: 'Reactions to your comments' },
             { key: 'boards_watched', label: 'Changes to cards you watch' },
             { key: 'boards_due', label: 'Due-date reminders' },
+            { key: 'boards_sprint', label: 'Sprint starts and completes' },
         ],
     },
     {

--- a/core/lib/notify/events.ts
+++ b/core/lib/notify/events.ts
@@ -13,6 +13,7 @@ export type NotificationEvents = {
     'drive.template_saved': { name: string }
     'boards.attachment_failed': { card: string; name: string }
     'boards.card_moved': { board: string; key: string }
+    'boards.sprint_completed': { sprint: string; completed: number; rolled: number }
     'import.complete': { source: 'google-takeout' | 'csv'; count: number }
     'import.failed': { source: string; error: string }
     'mutation.error': { operation: string; error: string }

--- a/core/lib/notify/registry.ts
+++ b/core/lib/notify/registry.ts
@@ -24,6 +24,7 @@ export const eventRegistry: Record<NotifyEventName, EventConfig> = {
     'drive.template_saved': { channels: ['toast'], variant: 'success' },
     'boards.attachment_failed': { channels: ['toast'], variant: 'error' },
     'boards.card_moved': { channels: ['toast'], variant: 'success' },
+    'boards.sprint_completed': { channels: ['toast'], variant: 'success' },
     'import.complete': { channels: ['toast', 'bell'], variant: 'success' },
     'import.failed': { channels: ['toast', 'bell'], variant: 'error' },
     'mutation.error': { channels: ['toast'], variant: 'error' },

--- a/core/lib/use-notification-preferences.ts
+++ b/core/lib/use-notification-preferences.ts
@@ -39,6 +39,12 @@ export interface NotificationPreferences {
     boards_watched: boolean
     /** A card you watch or are assigned is due soon or overdue. */
     boards_due: boolean
+    /**
+     * A sprint on one of your boards started or completed (boards'
+     * server/notifications.go). Sent to every board member rather than to
+     * card watchers, since a sprint is a board-level event.
+     */
+    boards_sprint: boolean
 }
 
 const DEFAULT_PREFS: NotificationPreferences = {
@@ -56,6 +62,7 @@ const DEFAULT_PREFS: NotificationPreferences = {
     boards_reaction: true,
     boards_watched: true,
     boards_due: true,
+    boards_sprint: true,
 }
 
 export type MailNotifyMode = 'batched' | 'important_only'

--- a/core/package.json
+++ b/core/package.json
@@ -95,7 +95,7 @@
         "expo-screen-orientation": "~55.0.18",
         "lib0": "^0.2.117",
         "lucide-react-native": "^1.7.0",
-        "pbtsdb": ">=0.6.3",
+        "pbtsdb": ">=0.7.3",
         "pocketbase": "^0.26.8",
         "react": "19.2.0",
         "react-dom": "19.2.0",

--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -138,12 +138,27 @@ var collectionScopes = map[string]collectionAccess{
 	"boards_comment_reactions": {read: scopeRule{ScopeBoardsRead}, write: scopeRule{ScopeBoardsWrite}},
 	"boards_card_watchers":     {read: scopeRule{ScopeBoardsRead}, write: scopeRule{ScopeBoardsWrite}},
 
+	// The planning collections. Both are board content in every sense the
+	// block above relies on: each row names a `project`, the rules resolve
+	// membership through it, and a write is "change my cards" on the consent
+	// screen. boards_epics shipped WITHOUT an entry here, which default-denied
+	// it for every OAuth caller — the reason the CLI never grew an epic
+	// command. boards_sprints is granted from the start so the sprint
+	// commands can exist at all.
+	"boards_epics":   {read: scopeRule{ScopeBoardsRead}, write: scopeRule{ScopeBoardsWrite}},
+	"boards_sprints": {read: scopeRule{ScopeBoardsRead}, write: scopeRule{ScopeBoardsWrite}},
+
 	// READ-ONLY, and unlike the sharing surface below this is not a policy
 	// choice — it is the schema. boards_activity is server-written history:
 	// its create, update and delete rules are all nil (pb-migrations
 	// 1980000008), so no client of any kind writes it. Granting write here
 	// would name a capability that does not exist and cannot be exercised.
 	"boards_activity": {read: scopeRule{ScopeBoardsRead}},
+
+	// Same shape: a sprint's daily scope/done snapshot is written by the
+	// server's sweep and its lifecycle endpoints, never by a client, so the
+	// collection has no write rules to grant against.
+	"boards_sprint_snapshots": {read: scopeRule{ScopeBoardsRead}},
 
 	// READ-ONLY for OAuth callers, deliberately, and NOT because the rules are
 	// weak — they already confine both to owners. These two are the SHARING
@@ -231,6 +246,15 @@ var endpointPrefixScopes = []struct {
 	scopes         scopeRule
 }{
 	{"DELETE", "/api/drive/share-link/", scopeRule{ScopeDriveWrite}},
+
+	// Boards' per-record POST families. `/cards/{id}/move` was unclassified
+	// when it shipped, so `card move --board` over an OAuth token was
+	// default-denied while the same command worked for a session — the
+	// failure mode TestEveryRegisteredRouteIsClassified describes. Both
+	// families mutate board content the caller must already be a writer on
+	// (the handlers restate that check in Go), so boards:write is the grant.
+	{"POST", "/api/boards/cards/", scopeRule{ScopeBoardsWrite}},
+	{"POST", "/api/boards/sprints/", scopeRule{ScopeBoardsWrite}},
 }
 
 // exemptPaths need no scope: public probes, and the OAuth endpoints a client

--- a/core/server/oauth/route_classification_test.go
+++ b/core/server/oauth/route_classification_test.go
@@ -176,6 +176,10 @@ func TestCardsContentCollectionsAreReadWrite(t *testing.T) {
 		// target, so the scope grant adds nothing a caller could not already
 		// do in the app.
 		"boards_card_links", "boards_comment_reactions", "boards_card_watchers",
+		// The planning collections. boards_epics shipped with no entry and
+		// was default-denied for the life of the feature; naming it here is
+		// what keeps the next collection from repeating that.
+		"boards_epics", "boards_sprints",
 	} {
 		path := "/api/collections/" + collection + "/records"
 		read := ScopeForRoute("GET", path)
@@ -242,22 +246,60 @@ func TestCardsSharingSurfaceIsReadOnlyForOAuth(t *testing.T) {
 // should not be conflated: relaxing the sharing entries would be a deliberate
 // security decision, whereas granting write here would name a capability that
 // does not exist and could never succeed.
-func TestCardsActivityIsReadOnlyForOAuth(t *testing.T) {
-	path := "/api/collections/boards_activity/records"
+//
+// boards_sprint_snapshots is the same shape — a sprint's daily scope/done row,
+// written by the server's sweep and lifecycle endpoints — and is asserted in
+// the same loop for the same reason.
+func TestCardsServerWrittenCollectionsAreReadOnlyForOAuth(t *testing.T) {
+	for _, collection := range []string{"boards_activity", "boards_sprint_snapshots"} {
+		path := "/api/collections/" + collection + "/records"
 
-	if !ScopeForRoute("GET", path).satisfiedBy([]string{ScopeBoardsRead}) {
-		t.Errorf("GET %s: boards:read must admit reading card history", path)
-	}
-	for _, method := range []string{"POST", "PATCH", "PUT", "DELETE"} {
-		p := path
-		if method != "POST" {
-			p += "/abc123"
+		if !ScopeForRoute("GET", path).satisfiedBy([]string{ScopeBoardsRead}) {
+			t.Errorf("GET %s: boards:read must admit reading it", path)
 		}
-		for _, scope := range []string{ScopeBoardsWrite, ScopeBoardsRead} {
-			if ScopeForRoute(method, p).satisfiedBy([]string{scope}) {
-				t.Errorf("%s %s must not be reachable with %q — activity is "+
-					"server-written and its write rules are nil", method, p, scope)
+		for _, method := range []string{"POST", "PATCH", "PUT", "DELETE"} {
+			p := path
+			if method != "POST" {
+				p += "/abc123"
 			}
+			for _, scope := range []string{ScopeBoardsWrite, ScopeBoardsRead} {
+				if ScopeForRoute(method, p).satisfiedBy([]string{scope}) {
+					t.Errorf("%s %s must not be reachable with %q — the collection is "+
+						"server-written and its write rules are nil", method, p, scope)
+				}
+			}
+		}
+	}
+}
+
+// Boards' per-record POST endpoints are classified by prefix, since an id sits
+// in the middle of the path. The move endpoint shipped unclassified, so
+// `card move --board` over an OAuth token was denied while a session succeeded
+// — exactly the split the CLI's testserver cannot see. Both families are
+// content writes the handler re-authorizes in Go, so boards:write is the grant
+// and boards:read alone must not open them.
+func TestCardsRecordEndpointsAreClassified(t *testing.T) {
+	for _, path := range []string{
+		"/api/boards/cards/abc123/move",
+		"/api/boards/sprints/abc123/start",
+		"/api/boards/sprints/abc123/complete",
+	} {
+		rule := ScopeForRoute("POST", path)
+		if len(rule) == 0 {
+			t.Errorf("POST %s is default-denied", path)
+			continue
+		}
+		if !rule.satisfiedBy([]string{ScopeBoardsWrite}) {
+			t.Errorf("POST %s: boards:write must admit it (got %q)", path, rule)
+		}
+		if rule.satisfiedBy([]string{ScopeBoardsRead}) {
+			t.Errorf("POST %s: boards:read alone must NOT admit a write", path)
+		}
+	}
+	// The bare family prefix is a different route and must not ride along.
+	for _, path := range []string{"/api/boards/cards/", "/api/boards/sprints/"} {
+		if len(ScopeForRoute("POST", path)) != 0 {
+			t.Errorf("POST %s: the bare prefix must stay default-denied", path)
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
         "lucide-react-native": "^1.7.0",
         "markdown-it": "^14.1.1",
         "numfmt": "^3.2.6",
-        "pbtsdb": "^0.7.2",
+        "pbtsdb": "^0.7.3",
         "pocketbase": "^0.26.8",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-dropcursor": "^1.8.2",


### PR DESCRIPTION
Core-side groundwork for the boards sprints feature.

- OAuth scope map: `boards_epics` and `boards_sprints` (read + write), `boards_sprint_snapshots` (read-only, server-written), and the `POST /api/boards/cards/` and `POST /api/boards/sprints/` endpoint prefixes as `boards:write`. `boards_epics` and the move endpoint were missing before, so the CLI could not reach them over OAuth.
- Notification preference `boards_sprint` with its row in personal settings ("Sprint starts and completes").
- Toast event `boards.sprint_completed` for the Complete sprint dialog.

Boards' sprint PRs (tinycld/boards) depend on this being released.