### PR TITLE
Classify boards' export and import routes

### DIFF
--- a/core/server/oauth/middleware.go
+++ b/core/server/oauth/middleware.go
@@ -218,6 +218,8 @@ var endpointScopes = map[string]scopeRule{
 	"GET /api/calendar/export":          {ScopeCalendarRead},
 	"POST /api/calendar/import":         {ScopeCalendarWrite},
 	"GET /api/boards/search":            {ScopeBoardsRead},
+	"GET /api/boards/export":            {ScopeBoardsRead},
+	"POST /api/boards/import":           {ScopeBoardsWrite},
 
 	// The federated search narrows itself: it drops the sources a caller's
 	// grant does not cover and returns the rest. So ANY read scope admits the

--- a/core/server/oauth/route_classification_test.go
+++ b/core/server/oauth/route_classification_test.go
@@ -303,3 +303,31 @@ func TestCardsRecordEndpointsAreClassified(t *testing.T) {
 		}
 	}
 }
+
+// Boards' file transfer routes, classified exactly as contacts' and calendar's
+// are: the export reads a whole board, the import writes one.
+//
+// The read/write split is the assertion that matters. An export handed
+// boards:write would be reachable by a token a user granted only to change
+// cards, and an import admitted by boards:read alone would let a read-only
+// integration create a board full of content.
+func TestBoardsTransferEndpointsAreClassified(t *testing.T) {
+	export := ScopeForRoute("GET", "/api/boards/export")
+	if len(export) == 0 {
+		t.Fatal("GET /api/boards/export is default-denied")
+	}
+	if !export.satisfiedBy([]string{ScopeBoardsRead}) {
+		t.Errorf("GET /api/boards/export: boards:read must admit it (got %q)", export)
+	}
+
+	imp := ScopeForRoute("POST", "/api/boards/import")
+	if len(imp) == 0 {
+		t.Fatal("POST /api/boards/import is default-denied")
+	}
+	if !imp.satisfiedBy([]string{ScopeBoardsWrite}) {
+		t.Errorf("POST /api/boards/import: boards:write must admit it (got %q)", imp)
+	}
+	if imp.satisfiedBy([]string{ScopeBoardsRead}) {
+		t.Error("POST /api/boards/import: boards:read alone must NOT admit a write")
+	}
+}


### PR DESCRIPTION
Adds `GET /api/boards/export` and `POST /api/boards/import` to `endpointScopes`.

A bespoke Go endpoint absent from that table is default-denied by `ScopeForRoute` — it works for a session and 403s for an OAuth token, which is the failure `/api/boards/cards/{id}/move` shipped with. This needs to land before the boards-side CLI command, or `tinycld boards export` is broken on arrival.

The read/write split is what the new test asserts: an export handed `boards:write` would be reachable by a token granted only to change cards, and an import admitted by `boards:read` alone would let a read-only integration create a board full of content.

Pairs with `feat/boards-export` in the boards repo.