### PR TITLE
Pin web toasts bottom-left, clear of the rail

### DIFF
--- a/core/components/NotificationDrawer.tsx
+++ b/core/components/NotificationDrawer.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'expo-router'
 import { Bell, Calendar, Check, File, Mail, Shield, SquareKanban, X } from 'lucide-react-native'
 import { useEffect, useMemo, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
-import { railWidth } from './workspace/PackageRail'
+import { railWidth } from './workspace/rail-width'
 
 const DRAWER_WIDTH = 340
 

--- a/core/components/Toast.tsx
+++ b/core/components/Toast.tsx
@@ -1,37 +1,62 @@
+import { railWidth } from '@tinycld/core/components/workspace/rail-width'
+import { useBreakpoint } from '@tinycld/core/components/workspace/useBreakpoint'
 import { type Toast as ToastType, useToastStore } from '@tinycld/core/lib/stores/toast-store'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
 import { AlertTriangle, CheckCircle, Info, X, XCircle } from 'lucide-react-native'
 import { useEffect, useRef } from 'react'
-import { Animated, Platform, Pressable, Text, View } from 'react-native'
+import { Animated, Platform, Pressable, Text, View, type ViewStyle } from 'react-native'
+
+type ToastEdge = 'top' | 'bottom'
+
+// Where the stack is pinned. The container is `box-none`, but each card is an
+// opaque surface (it carries a dismiss button), so for a card's lifetime —
+// 4–8s — nothing underneath it is clickable. That makes placement the whole
+// question: it must be a region no package puts time-critical controls in.
+//
+// Desktop/tablet web goes bottom-left, clear of the rail. Top-right was where
+// every package's header action cluster lives, so a toast raised by an action
+// landed exactly on the controls a user reaches for next (boards' 6s "Sprint
+// completed" card sat on the sprint-scope pill). Bottom-right is mail's compose
+// window. Bottom-left past the rail covers only the tail of a sidebar list.
+// Native and mobile-web keep the banner-style top placement: a bottom stack
+// there would sit on the mobile tab bar.
+function useToastPlacement(): { edge: ToastEdge; style: ViewStyle } {
+    const insets = useDeviceInsets()
+    const breakpoint = useBreakpoint()
+
+    if (Platform.OS !== 'web') {
+        // Toasts sit at the app root, above every layout that insets its own
+        // content, so they must clear the sensor housing themselves — 8pt is
+        // well inside a landscape inset. Same max()-not-add rule as
+        // useSafeAreaPadding (these are `left`/`right` offsets rather than
+        // padding, so they cannot use the hook directly).
+        return {
+            edge: 'top',
+            style: { top: 60, right: Math.max(8, insets.right), left: Math.max(8, insets.left) },
+        }
+    }
+    if (breakpoint === 'mobile') {
+        return { edge: 'top', style: { top: 16, right: 16, width: 360 } }
+    }
+    return { edge: 'bottom', style: { bottom: 16, left: railWidth(insets.left) + 16, width: 360 } }
+}
 
 export function ToastRenderer() {
     const toasts = useToastStore(s => s.toasts)
     // Before the early return — hooks cannot be called conditionally.
-    const insets = useDeviceInsets()
+    const placement = useToastPlacement()
 
     if (toasts.length === 0) return null
 
     return (
         <View
-            style={{
-                position: 'absolute',
-                top: Platform.OS === 'web' ? 16 : 60,
-                // Toasts sit at the app root, above every layout that insets its
-                // own content, so they must clear the sensor housing themselves —
-                // 8pt is well inside a landscape inset. Same max()-not-add rule
-                // as useSafeAreaPadding (these are `left`/`right` offsets rather
-                // than padding, so they cannot use the hook directly).
-                right: Platform.OS === 'web' ? 16 : Math.max(8, insets.right),
-                left: Platform.OS === 'web' ? undefined : Math.max(8, insets.left),
-                width: Platform.OS === 'web' ? 360 : undefined,
-                zIndex: 10000,
-                gap: 8,
-            }}
+            testID="toast-stack"
+            style={{ position: 'absolute', zIndex: 10000, gap: 8, ...placement.style }}
             pointerEvents="box-none"
         >
             {toasts.map(toast => (
-                <ToastCard key={toast.id} toast={toast} />
+                <ToastCard key={toast.id} toast={toast} edge={placement.edge} />
             ))}
         </View>
     )
@@ -51,7 +76,7 @@ const VARIANT_ICONS = {
     error: XCircle,
 } as const
 
-function ToastCard({ toast }: { toast: ToastType }) {
+function ToastCard({ toast, edge }: { toast: ToastType; edge: ToastEdge }) {
     const removeToast = useToastStore(s => s.removeToast)
     const bgColor = useThemeColor('surface-secondary')
     const borderColor = useThemeColor('border')
@@ -59,7 +84,8 @@ function ToastCard({ toast }: { toast: ToastType }) {
     const variantColor = useThemeColor(VARIANT_COLORS[toast.variant])
 
     const opacity = useRef(new Animated.Value(0)).current
-    const translateY = useRef(new Animated.Value(-20)).current
+    // Slide in from the edge the stack is pinned to.
+    const translateY = useRef(new Animated.Value(edge === 'top' ? -20 : 20)).current
 
     useEffect(() => {
         Animated.parallel([

--- a/core/components/workspace/PackageRail.tsx
+++ b/core/components/workspace/PackageRail.tsx
@@ -18,37 +18,8 @@ import {
 } from 'lucide-react-native'
 import { Pressable, ScrollView, View } from 'react-native'
 import { getIcon } from './package-icon-map'
+import { railWidth } from './rail-width'
 import { UserMenu } from './UserMenu'
-
-// The rail's visible icon column. Its 44pt touch targets are centred in it, so
-// there is ~10pt of slack on each side before an icon reaches the rail's edge.
-const RAIL_WIDTH = 64
-
-// The rail's ACTUAL on-screen width: the icon column plus however much the
-// left safe-area inset pushes it inward.
-//
-// insetLeft arrives side-corrected (WorkspaceLayout passes useDeviceInsets):
-// ~59pt only in the landscape rotation that puts the sensor housing on the
-// left, 0 in the other rotation and in portrait. So the rail is 123pt with the
-// housing beside it and exactly RAIL_WIDTH everywhere else — the extra chrome
-// exists only when hardware forces it.
-//
-// An earlier version capped the shift at 12pt to keep the width uniform, on the
-// theory that the housing "does not intrude into the display's usable area
-// beside it". It does: 12pt against a ~59pt housing left the top icons ~47pt
-// underneath it, unreadable and untappable. The cap cannot apply to the shift
-// alone either — the 44pt (w-11) icons need RAIL_WIDTH of space AFTER the
-// padding, so width and shift move together.
-//
-// The background is unaffected either way — it always reaches the physical edge,
-// so there is never a light gutter.
-//
-// Exported because anything positioned against the rail's right edge — the
-// notification drawer — has to agree with it; a hardcoded 64 there leaves a gap
-// once the rail widens in landscape.
-export function railWidth(insetLeft: number): number {
-    return RAIL_WIDTH + insetLeft
-}
 
 // insetLeft is the side-corrected left safe-area inset (nonzero only when the
 // sensor housing is physically on the left). The rail absorbs it rather than

--- a/core/components/workspace/rail-width.ts
+++ b/core/components/workspace/rail-width.ts
@@ -1,0 +1,31 @@
+// The rail's visible icon column. Its 44pt touch targets are centred in it, so
+// there is ~10pt of slack on each side before an icon reaches the rail's edge.
+const RAIL_WIDTH = 64
+
+// The rail's ACTUAL on-screen width: the icon column plus however much the
+// left safe-area inset pushes it inward.
+//
+// insetLeft arrives side-corrected (WorkspaceLayout passes useDeviceInsets):
+// ~59pt only in the landscape rotation that puts the sensor housing on the
+// left, 0 in the other rotation and in portrait. So the rail is 123pt with the
+// housing beside it and exactly RAIL_WIDTH everywhere else — the extra chrome
+// exists only when hardware forces it.
+//
+// An earlier version capped the shift at 12pt to keep the width uniform, on the
+// theory that the housing "does not intrude into the display's usable area
+// beside it". It does: 12pt against a ~59pt housing left the top icons ~47pt
+// underneath it, unreadable and untappable. The cap cannot apply to the shift
+// alone either — the 44pt (w-11) icons need RAIL_WIDTH of space AFTER the
+// padding, so width and shift move together.
+//
+// The background is unaffected either way — it always reaches the physical edge,
+// so there is never a light gutter.
+//
+// Anything positioned against the rail's right edge — the notification drawer,
+// the toast stack — has to agree with it; a hardcoded 64 there leaves a gap
+// once the rail widens in landscape. Kept in its own module so those consumers
+// (and their unit tests) do not have to load the rail's icon map to read a
+// number.
+export function railWidth(insetLeft: number): number {
+    return RAIL_WIDTH + insetLeft
+}

--- a/core/tests/unit/toast-placement.test.tsx
+++ b/core/tests/unit/toast-placement.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from '@testing-library/react'
+import { ToastRenderer } from '@tinycld/core/components/Toast'
+import { useToastStore } from '@tinycld/core/lib/stores/toast-store'
+import { useWindowSizeStore } from '@tinycld/core/lib/stores/window-size-store'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}))
+
+/**
+ * Each toast card is an opaque surface, so whatever is under it is unclickable
+ * for the card's lifetime. The stack used to pin top-right on web — the one
+ * region every package fills with header actions — and a boards spec caught a
+ * 6s "Sprint completed" card sitting on the sprint-scope pill it was about to
+ * click. Desktop web now pins bottom-left, past the package rail; mobile-width
+ * web keeps the top banner so it stays clear of the mobile tab bar.
+ */
+describe('ToastRenderer placement (web)', () => {
+    beforeEach(() => {
+        useToastStore.setState({ toasts: [] })
+        useToastStore
+            .getState()
+            .addToast({ title: 'Sprint 1 completed', variant: 'success', duration: 6000 })
+    })
+
+    afterEach(() => {
+        cleanup()
+        useToastStore.setState({ toasts: [] })
+    })
+
+    function stackStyle(width: number) {
+        useWindowSizeStore.setState({ width, height: 800 })
+        const { container } = render(<ToastRenderer />)
+        const stack = container.querySelector('[testid="toast-stack"]') as HTMLElement | null
+        if (!stack) throw new Error('toast stack did not render')
+        return stack.style
+    }
+
+    it('pins bottom-left, clear of the 64px rail, at desktop width', () => {
+        const style = stackStyle(1280)
+        expect(style.bottom).toBe('16px')
+        expect(style.left).toBe('80px')
+        expect(style.top).toBe('')
+        expect(style.right).toBe('')
+    })
+
+    it('pins bottom-left at tablet width too', () => {
+        const style = stackStyle(900)
+        expect(style.bottom).toBe('16px')
+        expect(style.top).toBe('')
+    })
+
+    it('keeps the top banner at mobile width', () => {
+        const style = stackStyle(375)
+        expect(style.top).toBe('16px')
+        expect(style.bottom).toBe('')
+    })
+})

--- a/tests/lucide-react-native-stub.cjs
+++ b/tests/lucide-react-native-stub.cjs
@@ -72,6 +72,10 @@ const knownIcons = {
     // oauth: ConnectedAppsSection's revoke button
     Trash2: Icon,
     File: Icon,
+    // core Toast's VARIANT_ICONS table (AlertTriangle and X are seeded above)
+    CheckCircle: Icon,
+    Info: Icon,
+    XCircle: Icon,
 }
 
 const handler = {


### PR DESCRIPTION
Each toast card is an opaque surface, so nothing under it is clickable while it is up (4–8s). The stack was pinned top-right on desktop web, which is where every package puts its header actions, so a toast raised by an action covered the controls a user reaches for next. boards' `sprint-lifecycle.spec.ts` caught its 6s "Sprint completed" card sitting on the sprint-scope pill.

- Desktop/tablet web now pin the stack bottom-left, past the package rail. Bottom-right is mail's compose window; bottom-left only covers the tail of a sidebar list.
- Native and mobile-width web keep the top banner (a bottom stack would sit on the mobile tab bar). Cards slide in from the edge they are pinned to.
- `railWidth` moves to `workspace/rail-width.ts` so consumers (and their tests) don't load the rail's generated icon map.
- New placement unit test; the shared lucide stub seeds the toast's variant icons.

Verified: core `tinycld-pkg check` green, ecosystem lint clean, and the boards spec passes with the toast on screen.