### PR TITLE
feat(menu): caller-controlled sheet edge, default top

### DIFF
--- a/core/tests/unit/menu.test.tsx
+++ b/core/tests/unit/menu.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment happy-dom
 
 import { cleanup, fireEvent, render as renderBare } from '@testing-library/react'
+import { useWindowSizeStore } from '@tinycld/core/lib/stores/window-size-store'
 import { Menu } from '@tinycld/core/ui/menu'
 import { OverlayProvider } from '@tinycld/core/ui/overlay'
 import type { ReactElement } from 'react'
 import { Pressable, Text } from 'react-native'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Every surface renders through the overlay host, which the app mounts once.
 const render = (ui: ReactElement) => renderBare(<OverlayProvider>{ui}</OverlayProvider>)
@@ -181,5 +182,53 @@ describe('Menu (web)', () => {
         fireEvent.click(getByText('Show done'))
         expect(onToggle).toHaveBeenCalledTimes(1)
         expect(queryByText('Show done')).not.toBeNull()
+    })
+})
+
+describe('Menu (phone)', () => {
+    // The stub reports a desktop window; the breakpoint reads the size store,
+    // so a phone is one store write away.
+    beforeEach(() => useWindowSizeStore.getState().setSize(390, 844))
+    afterEach(() => {
+        cleanup()
+        useWindowSizeStore.getState().setSize(1024, 768)
+    })
+
+    const sheetOf = (root: ParentNode) => {
+        const sheet = root.querySelector<HTMLElement>('[testid="sheet"]')
+        if (!sheet) throw new Error('menu did not render as a sheet')
+        return sheet
+    }
+
+    it('renders its rows in a sheet hanging from the top edge by default', () => {
+        const onSelect = vi.fn()
+        const { container, getByText } = render(
+            <Menu isOpen onOpenChange={() => {}} anchor={{ x: 10, y: 10 }} testID="sheet">
+                <Menu.Item label="Rename" onSelect={onSelect} />
+                <Menu.Item label="Delete" isDestructive onSelect={() => {}} />
+            </Menu>
+        )
+        const sheet = sheetOf(container)
+        expect(sheet.className).toContain('top-0')
+        // Sheet rows are touch targets, not web menu items.
+        expect(sheet.contains(getByText('Rename'))).toBe(true)
+        expect(sheet.contains(getByText('Delete'))).toBe(true)
+        fireEvent.click(getByText('Rename'))
+        expect(onSelect).toHaveBeenCalledTimes(1)
+    })
+
+    it('rests on the bottom edge when the caller asks for it', () => {
+        const { container } = render(
+            <Menu
+                isOpen
+                onOpenChange={() => {}}
+                anchor={{ x: 10, y: 10 }}
+                sheetSide="bottom"
+                testID="sheet"
+            >
+                <Menu.Item label="Rename" onSelect={() => {}} />
+            </Menu>
+        )
+        expect(sheetOf(container).className).toContain('bottom-0')
     })
 })

--- a/core/tests/unit/sheet-side.test.tsx
+++ b/core/tests/unit/sheet-side.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render as renderBare } from '@testing-library/react'
+import { OverlayProvider } from '@tinycld/core/ui/overlay'
+import { Sheet } from '@tinycld/core/ui/sheet'
+import type { ReactElement } from 'react'
+import { Text } from 'react-native'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const render = (ui: ReactElement) => renderBare(<OverlayProvider>{ui}</OverlayProvider>)
+
+const surfaceOf = (root: ParentNode) => {
+    const surface = root.querySelector<HTMLElement>('[testid="sheet"]')
+    if (!surface) throw new Error('sheet surface not rendered')
+    return surface
+}
+
+// The drag pill sits at the edge the user pulls away from: last child of a
+// top sheet, first of a bottom one.
+const handleIsAfterContent = (surface: HTMLElement) => {
+    const handle = surface.querySelector('[testid="sheet-handle"]')
+    const content = surface.querySelector('[testid="content"]')
+    if (!handle || !content) throw new Error('handle or content missing')
+    return Boolean(content.compareDocumentPosition(handle) & Node.DOCUMENT_POSITION_FOLLOWING)
+}
+
+describe('Sheet side', () => {
+    afterEach(cleanup)
+
+    it('rests on the bottom edge by default, pill first', () => {
+        const { container } = render(
+            <Sheet isOpen onClose={() => {}} testID="sheet">
+                <Text testID="content">Body</Text>
+            </Sheet>
+        )
+        const surface = surfaceOf(container)
+        expect(surface.className).toContain('bottom-0')
+        expect(surface.className).toContain('rounded-t-2xl')
+        expect(surface.className).not.toContain('top-0')
+        expect(handleIsAfterContent(surface)).toBe(false)
+    })
+
+    it('hangs from the top edge with side="top", pill last', () => {
+        const { container } = render(
+            <Sheet isOpen onClose={() => {}} side="top" testID="sheet">
+                <Text testID="content">Body</Text>
+            </Sheet>
+        )
+        const surface = surfaceOf(container)
+        expect(surface.className).toContain('top-0')
+        expect(surface.className).toContain('rounded-b-2xl')
+        expect(surface.className).not.toContain('bottom-0')
+        expect(handleIsAfterContent(surface)).toBe(true)
+    })
+})

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -7,6 +7,7 @@ import {
     type PopoverPresentation,
     placeSubmenu,
     type Rect,
+    type SheetSide,
     type Size,
     usePopoverContext,
 } from '@tinycld/core/ui/popover'
@@ -50,6 +51,12 @@ export interface MenuProps {
     width?: number
     /** Title of the sheet the menu becomes on a phone. */
     title?: string
+    /**
+     * The edge that sheet rests on. Default `top`, since most menu triggers sit
+     * near the top of the screen; pass `bottom` for a menu opened from the
+     * bottom of a screen.
+     */
+    sheetSide?: SheetSide
     className?: string
     testID?: string
     children: ReactNode
@@ -78,6 +85,7 @@ function MenuRoot({
     presentation = 'auto',
     width,
     title,
+    sheetSide = 'top',
     className,
     testID,
     children,
@@ -103,6 +111,7 @@ function MenuRoot({
             presentation={presentation}
             width={width}
             title={title}
+            sheetSide={sheetSide}
             sheetContentClassName="pb-2"
             className={className}
             testID={testID}

--- a/core/ui/popover/index.tsx
+++ b/core/ui/popover/index.tsx
@@ -1,7 +1,7 @@
 import { useBreakpoint } from '@tinycld/core/components/workspace/useBreakpoint'
 import { useWindowSizeStore } from '@tinycld/core/lib/stores/window-size-store'
 import { OverlayPortal, useLayerFocus, useOverlayLayer } from '@tinycld/core/ui/overlay'
-import { Sheet } from '@tinycld/core/ui/sheet'
+import { Sheet, type SheetSide } from '@tinycld/core/ui/sheet'
 import React, {
     createContext,
     type ReactElement,
@@ -75,6 +75,8 @@ export interface PopoverProps {
     width?: number
     /** Title of the sheet the surface becomes on a phone. */
     title?: string
+    /** The edge that sheet rests on. Default `bottom`. */
+    sheetSide?: SheetSide
     /** Padding of the sheet's scrolled content. */
     sheetContentClassName?: string
     className?: string
@@ -103,6 +105,7 @@ export function Popover({
     presentation = 'auto',
     width,
     title,
+    sheetSide = 'bottom',
     sheetContentClassName,
     className,
     testID,
@@ -133,7 +136,13 @@ export function Popover({
         return (
             <>
                 {triggerElement}
-                <Sheet isOpen={isOpen} onClose={close} title={title} testID={testID}>
+                <Sheet
+                    isOpen={isOpen}
+                    onClose={close}
+                    title={title}
+                    side={sheetSide}
+                    testID={testID}
+                >
                     <PopoverContext.Provider value={SHEET_CONTEXT(isOpen, close)}>
                         <Sheet.Body contentClassName={sheetContentClassName ?? 'px-4 pb-4'}>
                             {children}
@@ -464,4 +473,5 @@ const SURFACE_SHADOW =
 const SCROLL_CONTENT_STYLE = { flexGrow: 1 } as const
 const SUB_SLOT_STYLE = { position: 'absolute', top: 0, left: 0, width: 0, height: 0 } as const
 
+export type { SheetSide } from '@tinycld/core/ui/sheet'
 export { type Placement, placePopover, placeSubmenu, type Rect, type Size } from './place'

--- a/core/ui/sheet/index.tsx
+++ b/core/ui/sheet/index.tsx
@@ -1,9 +1,14 @@
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
-import { LayerEscape, OverlayPortal, useOverlayLayer } from '@tinycld/core/ui/overlay'
+import {
+    LayerEscape,
+    OverlayPortal,
+    useHasSheetHost,
+    useOverlayLayer,
+} from '@tinycld/core/ui/overlay'
 import { X } from 'lucide-react-native'
 import type { ReactNode } from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import {
     KeyboardAvoidingView,
     Platform,
@@ -26,21 +31,39 @@ const SPRING_CONFIG = { damping: 28, stiffness: 220, mass: 0.8 }
 // Off-screen fallback before the sheet has measured itself (first open frame).
 const INITIAL_OFFSCREEN = 1000
 
+/** The edge a sheet rests on and slides in from. */
+export type SheetSide = 'top' | 'bottom'
+
+// The rounded corners and the border face away from the edge the sheet rests on.
+const SIDE_CLASS: Record<SheetSide, string> = {
+    bottom: 'absolute left-0 right-0 bottom-0 rounded-t-2xl border-t border-border',
+    top: 'absolute left-0 right-0 top-0 rounded-b-2xl border-b border-border',
+}
+
+// Footer padding depends on which edge the sheet rests on; the footer is a
+// descendant, so the side reaches it by context rather than a prop.
+const SheetSideContext = createContext<SheetSide>('bottom')
+
 /**
- * The bottom surface: what a Dialog, a Menu and a Popover become on a phone,
+ * The edge surface: what a Dialog, a Menu and a Popover become on a phone,
  * and what the mobile More menu, the notification drawer and the file picker
- * are on every breakpoint.
+ * are on every breakpoint. It rests on the bottom edge by default; `side="top"`
+ * hangs it from the top edge instead, which a Menu prefers because most menu
+ * triggers sit near the top of the screen.
  *
  * Rendered into the `sheet` overlay host — the mobile chrome's content
- * region, which ends at the top of the tab bar — so the sheet rests exactly
- * on the bar with no offset. Where no such host is mounted it falls back to
- * the root host. Backdrop first, sheet second: the sheet paints above the
- * backdrop by sibling order, no z-index needed.
+ * region, which ends at the top of the tab bar and starts below the status
+ * bar — so a bottom sheet rests exactly on the bar and a top sheet clears the
+ * status bar, with no offset either way. Where no such host is mounted it
+ * falls back to the root host and insets its own top edge. Backdrop first,
+ * sheet second: the sheet paints above the backdrop by sibling order, no
+ * z-index needed.
  *
- * Drag down past a threshold (or a fast flick) dismisses; a short drag snaps
- * back; the backdrop and Escape dismiss. Height is intrinsic to the content,
- * capped at `maxHeightPercent` of the host; a `Sheet.Body` inside scrolls
- * once that cap bites while the title row and `Sheet.Footer` stay put.
+ * Drag away from the edge past a threshold (or a fast flick) dismisses; a
+ * short drag snaps back; the backdrop and Escape dismiss. Height is intrinsic
+ * to the content, capped at `maxHeightPercent` of the host; a `Sheet.Body`
+ * inside scrolls once that cap bites while the title row and `Sheet.Footer`
+ * stay put.
  */
 interface SheetProps {
     isOpen: boolean
@@ -49,6 +72,8 @@ interface SheetProps {
     /** Renders a title row with a close button. */
     title?: string
     description?: string
+    /** The edge the sheet rests on. Default 'bottom'. */
+    side?: SheetSide
     /** Max height as a fraction of the host (0–1). Default 0.85. */
     maxHeightPercent?: number
     /** Background theme token for the sheet surface. Default 'background'. */
@@ -64,6 +89,7 @@ function SheetRoot({
     children,
     title,
     description,
+    side = 'bottom',
     maxHeightPercent = 0.85,
     surface = 'background',
     hideHandle = false,
@@ -72,9 +98,15 @@ function SheetRoot({
     const overlayBg = useThemeColor('overlay-backdrop')
     const surfaceBg = useThemeColor(surface)
     const handleColor = useThemeColor('border')
+    const insets = useDeviceInsets()
+    const hasSheetHost = useHasSheetHost()
 
+    // Sign of the off-screen direction: a bottom sheet leaves downward
+    // (positive translateY), a top sheet upward. Captured by the worklets
+    // below as a plain number, like SPRING_CONFIG.
+    const dir = side === 'top' ? -1 : 1
     const sheetHeight = useSharedValue(INITIAL_OFFSCREEN)
-    const translateY = useSharedValue(INITIAL_OFFSCREEN)
+    const translateY = useSharedValue(dir * INITIAL_OFFSCREEN)
     const backdropOpacity = useSharedValue(0)
     const [mounted, setMounted] = useState(false)
     const surfaceRef = useRef<View | null>(null)
@@ -87,12 +119,12 @@ function SheetRoot({
             translateY.value = withSpring(0, SPRING_CONFIG)
             backdropOpacity.value = withTiming(1, { duration: 200 })
         } else if (mounted) {
-            translateY.value = withSpring(sheetHeight.value, SPRING_CONFIG)
+            translateY.value = withSpring(dir * sheetHeight.value, SPRING_CONFIG)
             backdropOpacity.value = withTiming(0, { duration: 150 })
             const timeout = setTimeout(() => setMounted(false), 300)
             return () => clearTimeout(timeout)
         }
-    }, [isOpen, translateY, backdropOpacity, mounted, sheetHeight])
+    }, [isOpen, translateY, backdropOpacity, mounted, sheetHeight, dir])
 
     // The backdrop covers the host, so an outside press is a backdrop press;
     // the layer joins the stack for Escape and the Android back button only.
@@ -106,15 +138,17 @@ function SheetRoot({
     const panGesture = Gesture.Pan()
         .activeOffsetY(10)
         .onUpdate(e => {
-            translateY.value = Math.max(0, e.translationY)
+            // Only movement away from the edge moves the sheet.
+            translateY.value = dir * Math.max(0, dir * e.translationY)
         })
         .onEnd(e => {
             // Threshold inlined (kept in sync with shouldDismissDrawer, which the
-            // unit test pins): dragged past 100px or flicked down faster than
-            // 500px/s dismisses. This runs on the UI thread, so it must not call
-            // a non-worklet JS function — hence the literal comparison here.
-            if (e.translationY > 100 || e.velocityY > 500) {
-                translateY.value = withSpring(sheetHeight.value, SPRING_CONFIG)
+            // unit test pins): dragged past 100px or flicked away from the edge
+            // faster than 500px/s dismisses. This runs on the UI thread, so it
+            // must not call a non-worklet JS function — hence the literal
+            // comparison here.
+            if (dir * e.translationY > 100 || dir * e.velocityY > 500) {
+                translateY.value = withSpring(dir * sheetHeight.value, SPRING_CONFIG)
                 backdropOpacity.value = withTiming(0, { duration: 150 })
                 runOnJS(close)()
             } else {
@@ -129,6 +163,10 @@ function SheetRoot({
     const backdropStyle = useAnimatedStyle(() => ({
         opacity: backdropOpacity.value,
     }))
+
+    // The sheet host already sits below the status bar; only the root-host
+    // fallback puts a top sheet's edge under it.
+    const paddingTop = side === 'top' && !hasSheetHost ? insets.top : 0
 
     if (!mounted) return null
 
@@ -158,18 +196,32 @@ function SheetRoot({
                             onLayout={e => {
                                 sheetHeight.value = e.nativeEvent.layout.height
                             }}
-                            className="absolute left-0 right-0 bottom-0 rounded-t-2xl border-t border-border"
+                            className={SIDE_CLASS[side]}
                             style={[
                                 {
                                     maxHeight: `${maxHeightPercent * 100}%`,
                                     backgroundColor: surfaceBg,
+                                    paddingTop,
                                 },
                                 sheetStyle,
                             ]}
                         >
-                            <Handle isVisible={!hideHandle} color={handleColor} />
-                            <SheetHeader title={title} description={description} onClose={close} />
-                            {children}
+                            <SheetSideContext.Provider value={side}>
+                                <Handle
+                                    isVisible={!hideHandle && side === 'bottom'}
+                                    color={handleColor}
+                                />
+                                <SheetHeader
+                                    title={title}
+                                    description={description}
+                                    onClose={close}
+                                />
+                                {children}
+                                <Handle
+                                    isVisible={!hideHandle && side === 'top'}
+                                    color={handleColor}
+                                />
+                            </SheetSideContext.Provider>
                         </Animated.View>
                     </GestureDetector>
                 </KeyboardAvoidingView>
@@ -178,10 +230,11 @@ function SheetRoot({
     )
 }
 
+/** The drag pill, drawn at the edge the user pulls away from. */
 function Handle({ isVisible, color }: { isVisible: boolean; color: string }) {
     if (!isVisible) return null
     return (
-        <View className="items-center py-2.5">
+        <View className="items-center py-2.5" testID="sheet-handle">
             <View className="w-9 h-1 rounded-sm" style={{ backgroundColor: color }} />
         </View>
     )
@@ -245,13 +298,15 @@ function SheetBody({
     )
 }
 
-/** The button row, pinned under the body, above the home indicator. */
+/** The button row, pinned under the body — above the home indicator when the sheet rests on the bottom edge. */
 function SheetFooter({ children, className }: { children: ReactNode; className?: string }) {
     const insets = useDeviceInsets()
+    const side = useContext(SheetSideContext)
+    const paddingBottom = side === 'bottom' ? Math.max(12, insets.bottom) : 12
     return (
         <View
             className={`flex-row justify-end items-center gap-2 px-5 pt-3 border-t border-border ${className ?? ''}`}
-            style={{ paddingBottom: Math.max(12, insets.bottom) }}
+            style={{ paddingBottom }}
         >
             {children}
         </View>

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -98,7 +98,8 @@ The engine (`core/ui/overlay/`, internal) owns:
   to the side with more room and caps height to what that side has; the
   content scrolls internally.
 - On the mobile breakpoint a Popover renders as a sheet unless
-  `presentation="popover"` is pinned.
+  `presentation="popover"` is pinned. `sheetSide` (`top|bottom`, default
+  `bottom`) picks the edge that sheet rests on.
 
 Placement is a pure function, `placePopover()` in `core/ui/popover/place.ts`,
 with unit tests. Do not put positioning arithmetic anywhere else.
@@ -138,18 +139,23 @@ the whole chain when chosen.
 - Controlled use and `anchor` work as on Popover. `ContextMenu` wraps a Menu
   in the right-click (web) and long-press (native) gestures; the menubar and
   the calc grid menus are controlled Menus in the single-open registry.
-- On the mobile breakpoint a Menu renders its items as a sheet. Pin
+- On the mobile breakpoint a Menu renders its items as a sheet hanging from
+  the **top** edge, since most menu triggers sit near the top of the screen;
+  pass `sheetSide="bottom"` for a menu opened from the bottom of a screen. Pin
   `presentation="popover"` for a menu of two or three items beside its
   trigger, where a sheet would be heavier than the choice.
 
 ## Sheet
 
-`Sheet` is the bottom surface the other three render on a phone. Packages use
-it directly only for something that is a sheet on every breakpoint (the
-mobile More menu, the notification drawer, the file picker). It replaces
-`BottomDrawer`, keeps its gesture and its "rests on the tab bar" behavior, and
-adds the title/body/footer structure so a Dialog rendered as a sheet looks
-like a sheet, not a dialog squashed to the bottom edge.
+`Sheet` is the edge surface the other three render on a phone: it rests on the
+bottom edge by default, or hangs from the top with `side="top"` (a Menu's
+default). The corners, the border, the drag pill and the dismiss gesture all
+face away from that edge. Packages use it directly only for something that is
+a sheet on every breakpoint (the mobile More menu, the notification drawer,
+the file picker). It replaces `BottomDrawer`, keeps its gesture and its "rests
+on the tab bar" behavior, and adds the title/body/footer structure so a Dialog
+rendered as a sheet looks like a sheet, not a dialog squashed to the bottom
+edge.
 
 ## Testing
 


### PR DESCRIPTION
On the mobile breakpoint a Menu renders in a Sheet that was always anchored to the bottom edge, far from most menu triggers.

- `Sheet` gains `side="top" | "bottom"` (default `bottom`, so Dialog and the always-sheet surfaces are unchanged). A top sheet hangs from the top edge with corners, border, drag pill and dismiss gesture facing away from it; `Sheet.Footer` pads the home indicator only on a bottom sheet.
- `Popover` forwards `sheetSide` (default `bottom`).
- `Menu` exposes `sheetSide`, defaulting to `top`. No callers changed; context menus and menubar menus pin `presentation="popover"` and are unaffected.
- Tests: `sheet-side.test.tsx` pins the per-side anchor classes and pill order; `menu.test.tsx` gains phone-breakpoint coverage of sheet mode.
- `docs/overlays.md` updated.

Not yet verified on a device: drag-up-to-dismiss on a top sheet.