### PR TITLE
Keep deep links intact on a cold load

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,15 +11,18 @@ import '~/lib/configure-core'
 import '~/global.css'
 import { AppErrorBoundary } from '@tinycld/core/components/AppErrorBoundary'
 import { NewVersionToast } from '@tinycld/core/components/NewVersionToast'
+import { useAuth } from '@tinycld/core/lib/auth'
 import { BundleSentinel } from '@tinycld/core/lib/bundle-sentinel'
 import { EditorSingletonProvider } from '@tinycld/core/lib/editor/warm'
 import { installFatalRollbackHandler } from '@tinycld/core/lib/install-fatal-rollback'
 import { CONNECT_HREF, PICK_ORG_HREF } from '@tinycld/core/lib/org-routes'
+import { usePackageProviders } from '@tinycld/core/lib/packages/provider-loader'
 import { initSentry } from '@tinycld/core/lib/sentry'
 import { useAppUpdates } from '@tinycld/core/lib/use-app-updates'
 import { useChunkLoadRecovery } from '@tinycld/core/lib/use-chunk-load-recovery'
 import { useVersionCheck } from '@tinycld/core/lib/use-version-check'
 import { Slot, usePathname } from 'expo-router'
+import { View } from 'react-native'
 import { BlankScreen, ConnectSlot, GateFailedScreen } from '~/lib/gate-screens'
 import { MarkBundleHealthy } from '~/lib/use-mark-bundle-healthy'
 import { useServerAddressGate } from '~/lib/use-server-address-gate'
@@ -66,9 +69,34 @@ export default function Layout() {
                 calls useEditorNeeded(), so an app whose user never opens an
                 editing package pays nothing for this. */}
             <EditorSingletonProvider>
-                <Slot />
+                <ReadySlot />
             </EditorSingletonProvider>
             <NewVersionToast />
         </Providers>
     )
+}
+
+// The route tree mounts only once the auth store has hydrated AND every
+// package provider module has loaded.
+//
+// Expo Router derives the browser URL from the navigators that are MOUNTED,
+// not from the navigation state. app/a/(app)/_layout cannot mount the package
+// tabs until it knows who is signed in (package screens require a user), and
+// the tabs sit inside the package providers, which are dynamic imports. With
+// the tree mounted before either settles there is a window where the root
+// navigator is up and the tabs are not — and the URL sync writes the deepest
+// mounted route, the bare app root, over a deep link like
+// /a/boards?focused=HOME-1. The state itself keeps the link and the URL comes
+// back once the tabs mount, but the address bar visibly bounces through /a on
+// every cold load. Waiting here means the tabs mount in the same commit as the
+// root navigator, so the sync only ever sees the whole tree. Both waits are
+// short — one storage read, one chunk fetch that starts alongside it.
+function ReadySlot() {
+    const { isInitializing } = useAuth({ throwIfAnon: false })
+    const providers = usePackageProviders()
+    if (providers.status === 'failed') return <GateFailedScreen error={providers.error} />
+    if (isInitializing || providers.status === 'loading') {
+        return <View className="flex-1 bg-background" />
+    }
+    return <Slot />
 }

--- a/core/components/workspace/PackageProviderWrapper.tsx
+++ b/core/components/workspace/PackageProviderWrapper.tsx
@@ -1,22 +1,15 @@
-import { packageProviders } from '@tinycld/core/lib/packages/derive-components'
-import {
-    type ComponentType,
-    type LazyExoticComponent,
-    type ReactNode,
-    Suspense,
-    useMemo,
-} from 'react'
+import { getLoadedPackageProviders } from '@tinycld/core/lib/packages/provider-loader'
+import { type ReactNode, useMemo } from 'react'
 
-type ProviderComp =
-    | ComponentType<{ children: ReactNode }>
-    | LazyExoticComponent<ComponentType<{ children: ReactNode }>>
-
-const stableProviderChain: { slug: string; Provider: ProviderComp }[] = Object.entries(
-    packageProviders
-)
-    .filter((entry): entry is [string, ProviderComp] => entry[1] != null)
-    .map(([slug, Provider]) => ({ slug, Provider }))
-
+/**
+ * Wraps the package area in every package's app-wide provider.
+ *
+ * The providers come from the loader, already resolved: the root layout mounts
+ * the route tree only after loadPackageProviders() settles, so nothing here can
+ * suspend. That matters beyond speed — a Suspense fallback here once let the
+ * root navigator mount while the package tabs were still pending, and Expo
+ * Router's URL sync wrote the bare app root over the deep link that was loading.
+ */
 export function PackageProviderWrapper({ children }: { children: ReactNode }) {
     // Rebuild the provider-chain elements only when `children` changes. A bare
     // reduceRight on every render gives each provider node a fresh element
@@ -25,13 +18,12 @@ export function PackageProviderWrapper({ children }: { children: ReactNode }) {
     // on every tab navigation (the layout above re-renders twice per nav). Memoizing on
     // a stable `children` lets React skip this entire subtree when a parent
     // re-renders for an unrelated reason.
-    const chain = useMemo(
+    return useMemo(
         () =>
-            stableProviderChain.reduceRight<ReactNode>(
+            getLoadedPackageProviders().reduceRight<ReactNode>(
                 (acc, { slug, Provider }) => <Provider key={slug}>{acc}</Provider>,
                 children
             ),
         [children]
     )
-    return <Suspense fallback={null}>{chain}</Suspense>
 }

--- a/core/lib/editor/warm/editor-singleton.tsx
+++ b/core/lib/editor/warm/editor-singleton.tsx
@@ -1,5 +1,6 @@
 import {
     createContext,
+    memo,
     type ReactNode,
     useCallback,
     useContext,
@@ -76,44 +77,75 @@ export function EditorSingletonProvider({ children }: { children: ReactNode }) {
     const [isBooted, setIsBooted] = useState(false)
     const declareNeed = useCallback(() => setIsBooted(true), [])
 
+    // What the booted editor publishes upward: null until it exists. Held here
+    // rather than provided from inside BootedEditor so the element tree above
+    // `children` never changes shape. Booting used to swap the wrapper from a
+    // bare context provider to <BootedEditor>, and a different element type at
+    // the same position means React unmounts everything beneath it — the
+    // ENTIRE route tree, every mounted screen and navigator, torn down and
+    // rebuilt the first time a package declared need. React Navigation clears a
+    // navigator's saved state when it unmounts, so that remount also reset
+    // route params (a deep link's `?focused=` vanished on arrival).
+    const [booted, setBooted] = useState<BootedValue | null>(null)
+
     const value = useMemo<EditorSingletonValue>(
-        () => ({ store, drafts, result: null, declareNeed, setOptions: () => {} }),
-        [store, drafts, declareNeed]
+        () => ({
+            store,
+            drafts,
+            result: booted?.result ?? null,
+            declareNeed,
+            setOptions: booted?.setOptions ?? noopSetOptions,
+        }),
+        [store, drafts, booted, declareNeed]
     )
 
-    // Before any declaration there is no editor and no hook to build one — the
-    // provider is a pass-through carrying only the latch. Splitting the booted
-    // half into its own component is what keeps `useRichEditor` from being
-    // called at all until then, since a hook cannot sit behind a branch.
-    if (!isBooted) {
-        return (
-            <EditorSingletonContext.Provider value={value}>
-                {children}
-            </EditorSingletonContext.Provider>
-        )
-    }
-
+    // `children` is always the first child of the same provider, booted or not,
+    // so this provider re-rendering (on boot, and on every editor generation)
+    // reconciles it in place: same element identity, no work below it. Only
+    // context consumers update.
     return (
-        <BootedEditor store={store} drafts={drafts} declareNeed={declareNeed}>
+        <EditorSingletonContext.Provider value={value}>
             {children}
-        </BootedEditor>
+            <BootedEditorGate isBooted={isBooted} store={store} onChange={setBooted} />
+        </EditorSingletonContext.Provider>
     )
 }
 
-function BootedEditor({
-    store,
-    drafts,
-    declareNeed,
-    children,
-}: {
+interface BootedValue {
+    result: EditorResult
+    setOptions: (options: UseRichEditorOptions) => void
+}
+
+function noopSetOptions() {}
+
+interface BootedEditorProps {
     store: WarmEditorStore
-    drafts: DraftStore
-    declareNeed: () => void
-    children: ReactNode
-}) {
+    onChange: (value: BootedValue) => void
+}
+
+// Before any declaration there is no editor and no hook to build one — the
+// gate renders nothing. Splitting the booted half into its own component is
+// what keeps `useRichEditor` from being called at all until then, since a hook
+// cannot sit behind a branch.
+//
+// memo() is load-bearing, not an optimisation. Every publish re-renders the
+// provider above, and without it that re-render would reach BootedEditor,
+// whose `useRichEditor` hands back a fresh result per render — which would
+// publish again, and spin. Its props never change identity, so the memo stops
+// the provider's re-render here and BootedEditor renders only on its own
+// store's snapshots.
+const BootedEditorGate = memo(function BootedEditorGate({
+    isBooted,
+    ...props
+}: BootedEditorProps & { isBooted: boolean }) {
+    if (!isBooted) return null
+    return <BootedEditor {...props} />
+})
+
+function BootedEditor({ store, onChange }: BootedEditorProps) {
     // The live configuration, held in a ref and read through the store's
-    // generation: putting it in state would re-render this provider — and so
-    // the entire route tree beneath it — on every handover.
+    // generation: putting it in state would re-render this component on every
+    // handover for nothing.
     const optionsRef = useRef<UseRichEditorOptions>({})
     const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot)
 
@@ -137,16 +169,24 @@ function BootedEditor({
         store.setReady(isReady)
     }, [store, isReady])
 
-    // `setOptions` is stable on its own, so the only member of this value that
-    // changes identity is `result`. That matters: a consumer derives its
-    // acquire/release callbacks from this object, and acquiring bumps the
-    // generation, which rebuilds the editor, which produces a new `result`. If
-    // that fed back into the callbacks' identity, an effect depending on
+    // `setOptions` is stable on its own, so the only member of the published
+    // value that changes identity is `result`. That matters: a consumer derives
+    // its acquire/release callbacks from the context value, and acquiring bumps
+    // the generation, which rebuilds the editor, which produces a new `result`.
+    // If that fed back into the callbacks' identity, an effect depending on
     // acquire would re-acquire and spin — which it did, at ~50 generations a
     // second.
     const setOptions = useCallback((next: UseRichEditorOptions) => {
         optionsRef.current = next
     }, [])
+
+    // Hand the editor up to the provider, which is where consumers read it
+    // from. An effect, not render-time work, because it sets the parent's
+    // state; it fires once per editor generation, which is exactly when the
+    // context value has to change anyway.
+    useEffect(() => {
+        onChange({ result, setOptions })
+    }, [result, setOptions, onChange])
 
     // A parked editor must not keep the last surface's text.
     //
@@ -165,18 +205,10 @@ function BootedEditor({
         if (isParked && !isCollab) editorHandle.setContent('')
     }, [isParked, isCollab, editorHandle])
 
-    const value = useMemo<EditorSingletonValue>(
-        () => ({ store, drafts, result, declareNeed, setOptions }),
-        [store, drafts, result, declareNeed, setOptions]
-    )
-
     return (
-        <EditorSingletonContext.Provider value={value}>
-            {children}
-            <ParkedEditorViewport isParked={snapshot.holder === null}>
-                <result.EditorComponent />
-            </ParkedEditorViewport>
-        </EditorSingletonContext.Provider>
+        <ParkedEditorViewport isParked={isParked}>
+            <result.EditorComponent />
+        </ParkedEditorViewport>
     )
 }
 

--- a/core/lib/packages/__tests__/derive.test.ts
+++ b/core/lib/packages/__tests__/derive.test.ts
@@ -12,7 +12,10 @@ describe('deriveSidebars / deriveProviders', () => {
             { manifest: { slug: 'mail' } },
         ]
         expect(deriveSidebars(entries)).toEqual({ contacts: SB, mail: null })
-        expect(deriveProviders([{ manifest: { slug: 'x' }, provider: PV }])).toEqual({ x: PV })
+        const loader = { load: async () => ({ default: PV }) }
+        expect(deriveProviders([{ manifest: { slug: 'x' }, provider: loader }])).toEqual({
+            x: loader,
+        })
     })
 })
 

--- a/core/lib/packages/config-types.ts
+++ b/core/lib/packages/config-types.ts
@@ -16,8 +16,23 @@ export type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never
 interface PackageSidebarProps {
     isCollapsed: boolean
 }
-interface PackageProviderProps {
+export interface PackageProviderProps {
     children: ReactNode
+}
+/**
+ * A package's app-wide provider, as a module loader rather than a component.
+ *
+ * Dynamic on purpose: a static import would pull the provider's module graph
+ * (and through it, screens) into the collections module's eager import graph,
+ * which used to form a require cycle. Not `lazy()` either: the workspace needs
+ * every provider on every signed-in boot, and a lazy component suspends the
+ * whole package area on its first render — long enough for the root navigator
+ * to mount without it and write the bare app root over a deep link. Core
+ * resolves the loaders before the route tree mounts instead
+ * (lib/packages/provider-loader.ts).
+ */
+export interface PackageProviderLoader {
+    load: () => Promise<{ default: ComponentType<PackageProviderProps> }>
 }
 export interface PackageSettingsPanel {
     slug: string
@@ -105,10 +120,7 @@ export interface PackageEntry<S extends SchemaDeclaration, R> {
         | ComponentType<PackageSidebarProps>
         | LazyExoticComponent<ComponentType<PackageSidebarProps>>
         | null
-    provider?:
-        | ComponentType<PackageProviderProps>
-        | LazyExoticComponent<ComponentType<PackageProviderProps>>
-        | null
+    provider?: PackageProviderLoader | null
     settings?: PackageSettingsPanel[]
     systemSettings?: PackageSystemSettingsPanel[]
     sidebarContributions?: SidebarContribution[]

--- a/core/lib/packages/derive-components.ts
+++ b/core/lib/packages/derive-components.ts
@@ -1,6 +1,7 @@
 import { tinycldConfig } from '@tinycld/app-generated/tinycld-config'
-import type { ComponentType, LazyExoticComponent, ReactNode } from 'react'
+import type { ComponentType, LazyExoticComponent } from 'react'
 import type {
+    PackageProviderLoader,
     PackageSettingsPanel,
     PackageSystemSettingsPanel,
     SidebarContribution,
@@ -9,16 +10,12 @@ import type {
 interface SidebarProps {
     isCollapsed: boolean
 }
-interface ProviderProps {
-    children: ReactNode
-}
 type SidebarComp = ComponentType<SidebarProps> | LazyExoticComponent<ComponentType<SidebarProps>>
-type ProviderComp = ComponentType<ProviderProps> | LazyExoticComponent<ComponentType<ProviderProps>>
 
 type ComponentEntryLike = {
     manifest: { slug: string }
     sidebar?: SidebarComp | null
-    provider?: ProviderComp | null
+    provider?: PackageProviderLoader | null
 }
 
 /** slug → sidebar component (null when the package contributes none). */
@@ -30,11 +27,11 @@ export function deriveSidebars(
     return out
 }
 
-/** slug → context provider component (null when the package contributes none). */
+/** slug → context provider loader (null when the package contributes none). */
 export function deriveProviders(
     entries: readonly ComponentEntryLike[]
-): Record<string, ProviderComp | null> {
-    const out: Record<string, ProviderComp | null> = {}
+): Record<string, PackageProviderLoader | null> {
+    const out: Record<string, PackageProviderLoader | null> = {}
     for (const e of entries) out[e.manifest.slug] = e.provider ?? null
     return out
 }

--- a/core/lib/packages/provider-loader.ts
+++ b/core/lib/packages/provider-loader.ts
@@ -1,0 +1,92 @@
+import { log } from '@tinycld/core/lib/logger'
+import { type ComponentType, useSyncExternalStore } from 'react'
+import type { PackageProviderLoader, PackageProviderProps } from './config-types'
+import { packageProviders } from './derive-components'
+
+export interface LoadedPackageProvider {
+    slug: string
+    Provider: ComponentType<PackageProviderProps>
+}
+
+export type PackageProvidersState =
+    | { status: 'loading' }
+    | { status: 'ready'; providers: LoadedPackageProvider[] }
+    | { status: 'failed'; error: string }
+
+let state: PackageProvidersState = { status: 'loading' }
+let inFlight: Promise<LoadedPackageProvider[]> | null = null
+const listeners = new Set<() => void>()
+
+function publish(next: PackageProvidersState) {
+    state = next
+    for (const notify of listeners) notify()
+}
+
+/**
+ * Resolve every package's provider module. Idempotent: one load per boot,
+ * shared by every caller.
+ *
+ * Rejects (as well as publishing 'failed') so a chunk-load failure still
+ * surfaces as an unhandled rejection, which is what useChunkLoadRecovery
+ * listens for to reload a tab whose asset hashes were pruned by a deploy.
+ */
+export function loadPackageProviders(): Promise<LoadedPackageProvider[]> {
+    if (!inFlight) {
+        const loaders = Object.entries(packageProviders).filter(
+            (entry): entry is [string, PackageProviderLoader] => entry[1] != null
+        )
+        inFlight = Promise.all(
+            loaders.map(async ([slug, loader]) => ({
+                slug,
+                Provider: (await loader.load()).default,
+            }))
+        ).then(
+            providers => {
+                publish({ status: 'ready', providers })
+                return providers
+            },
+            (err: unknown) => {
+                log.error('core.packages.provider-load', err)
+                publish({
+                    status: 'failed',
+                    error: err instanceof Error ? err.message : String(err),
+                })
+                throw err
+            }
+        )
+    }
+    return inFlight
+}
+
+function subscribe(listener: () => void) {
+    listeners.add(listener)
+    // Starts the load from the first subscriber's effect rather than at module
+    // init, so importing this module has no side effect.
+    void loadPackageProviders()
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+function getSnapshot() {
+    return state
+}
+
+/** The provider load, live. Subscribing starts it. */
+export function usePackageProviders(): PackageProvidersState {
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/**
+ * The loaded providers, for render paths that only run behind the root
+ * layout's gate. Throwing rather than returning an empty list: rendering the
+ * workspace without its providers would silently drop package context.
+ */
+export function getLoadedPackageProviders(): LoadedPackageProvider[] {
+    if (state.status !== 'ready') {
+        throw new Error(
+            'Package providers are not loaded. The workspace must mount behind the root layout gate, which awaits loadPackageProviders().'
+        )
+    }
+    return state.providers
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -274,7 +274,7 @@ export default manifest
 | `migrations.directory` | `*.js` migrations symlinked into `server/pb_migrations/`. |
 | `hooks.directory` | PocketBase JS hooks symlinked into `server/pb_hooks/`. |
 | `collections` | `register` + `types` export subpaths; wires pbtsdb collections and the schema type. |
-| `sidebar` / `provider` | A package may contribute a sidebar component **or** a context provider that wraps app children. |
+| `sidebar` / `provider` | A package may contribute a sidebar component **or** a context provider that wraps app children. The provider is emitted as a `{ load: () => import(...) }` thunk — not `lazy()` — and core resolves every provider before the route tree mounts (`core/lib/packages/provider-loader.ts`), so the package area never suspends on it. |
 | `settings[]` | Personal Settings panel contributions (`slug`, `label`, `component`). See [Extension points](#extension-points-settings-panels-and-sidebar-slots) below. |
 | `slots[]` | Names of sidebar slots this package exposes for *other* packages to render into. Free-form strings; duplicates within one manifest are a generator error. Render with `<SidebarSlot target="<this-slug>" slot="<name>" />` from `@tinycld/core/components/sidebar-primitives`. |
 | `sidebarContributions[]` | Inverse of `slots`: this package's contributions into *another* package's slot. Each `{ target, slot, component, order? }` is generator-validated. |
@@ -596,7 +596,7 @@ It warns (but does not fail) when:
 
 ### Extension points: settings panels and sidebar slots
 
-The generator threads two manifest-declared extension points through the same lazy-import pipeline. Both share the same lifecycle: **manifest field → `gen-config.ts` emits a `lazy(() => import(...))` entry → runtime derivation in `core/lib/packages/derive-components.ts` → host UI calls a React helper that consumes the registry → component loads under `<Suspense>` on first render.**
+The generator threads two manifest-declared extension points through the same lazy-import pipeline. (Package `provider`s are the exception: they are needed on every signed-in boot, so they are loaded up front by `core/lib/packages/provider-loader.ts` rather than `lazy()`-suspended in place.) Both share the same lifecycle: **manifest field → `gen-config.ts` emits a `lazy(() => import(...))` entry → runtime derivation in `core/lib/packages/derive-components.ts` → host UI calls a React helper that consumes the registry → component loads under `<Suspense>` on first render.**
 
 **Settings panels** (`manifest.settings: [{ slug, label, component }]`):
 

--- a/scripts/__tests__/gen-config.test.ts
+++ b/scripts/__tests__/gen-config.test.ts
@@ -92,11 +92,14 @@ describe('buildConfigSource', () => {
         expect(src).toContain('as googleTakeoutImportRegister')
     })
 
-    it('emits a lazy provider entry for hasProvider packages', () => {
-        // Providers are emitted lazily (matching sidebar/settings) so the
-        // generated config doesn't pull every package's provider module —
-        // and its transitive screen tree — into pocketbase.ts's eager import
-        // graph, which used to form a require cycle.
+    it('emits a provider load thunk for hasProvider packages', () => {
+        // Providers are emitted as a dynamic-import thunk so the generated
+        // config doesn't pull every package's provider module — and its
+        // transitive screen tree — into pocketbase.ts's eager import graph,
+        // which used to form a require cycle. Not lazy(): core awaits the
+        // thunks before mounting the route tree, because a lazy provider
+        // suspends the package area on first render and the URL sync then
+        // writes the bare app root over a deep link.
         const withProvider: ConfigPkg = {
             packageName: '@tinycld/drive',
             slug: 'drive',
@@ -114,9 +117,9 @@ describe('buildConfigSource', () => {
             manifest: { name: 'Drive', slug: 'drive', version: '0.1.0', description: 'd' },
         }
         const src = buildConfigSource([withProvider])
-        expect(src).toContain("import { lazy } from 'react'")
+        expect(src).not.toContain("import { lazy } from 'react'")
         expect(src).not.toContain("from '@tinycld/drive/provider'")
-        expect(src).toContain("provider: lazy(() => import('@tinycld/drive/provider')),")
+        expect(src).toContain("provider: { load: () => import('@tinycld/drive/provider') },")
     })
 
     it('joins multiple package schemas into the MergedPackageSchema intersection', () => {

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -111,7 +111,6 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
     const needsLazy = pkgs.some(
         p =>
             p.hasSidebar ||
-            p.hasProvider ||
             p.settings.length > 0 ||
             p.systemSettings.length > 0 ||
             p.sidebarContributions.length > 0
@@ -143,7 +142,9 @@ export function buildConfigSource(pkgs: ConfigPkg[]): string {
             lines.push(`        sidebar: lazy(() => import('${p.packageName}/sidebar')),`)
         }
         if (p.hasProvider) {
-            lines.push(`        provider: lazy(() => import('${p.packageName}/provider')),`)
+            // A load thunk, not lazy(): core resolves every provider before the
+            // route tree mounts (see PackageProviderLoader in config-types.ts).
+            lines.push(`        provider: { load: () => import('${p.packageName}/provider') },`)
         }
         if (p.settings.length > 0) {
             lines.push('        settings: [')


### PR DESCRIPTION
Opening a URL like `/a/boards?focused=HOME-1` bounced through `/a` and then landed on `/a/boards` with the query gone. Two causes, both in the shell:

- The editor singleton provider changed its wrapper element type on boot, which remounted the entire route tree and reset route params.
- The URL sync only sees mounted navigators, and the package tabs mounted later than the root navigator (auth hydration, then a Suspense on `lazy()` package providers). Providers are now a `{ load }` thunk resolved up front, and the root layout holds the route tree until auth and that load settle.

Known residual: a production web build with async routes can still write `/a` once while the workspace layout's route chunk loads, then restores the link. Removing that means either turning off `asyncRoutes` for web or patching Expo Router's URL sync.

Companion: tinycld/boards PR for the `?focused=` handling and the e2e spec.