### PR TITLE
fix(editor): native compose close and send hang on an unanswered editor request

### DIFF
--- a/core/lib/editor/__tests__/init-dispatch.test.ts
+++ b/core/lib/editor/__tests__/init-dispatch.test.ts
@@ -4,22 +4,32 @@ import { shouldPostInit } from '../use-webview-editor'
 /**
  * Init used to be latched one-shot per mount. A warm editor is handed between
  * surfaces by re-initializing it, so the latch becomes generation tracking —
- * post each generation exactly once, and never before the page is ready.
+ * post each generation exactly once per page boot, and never before the page
+ * is ready.
  */
 describe('init dispatch', () => {
     it('posts the first init once the page is ready', () => {
-        expect(shouldPostInit(null, 0, true)).toBe(true)
+        expect(shouldPostInit(null, 0, 1)).toBe(true)
     })
 
     it('waits for the page, since nothing would receive it', () => {
-        expect(shouldPostInit(null, 0, false)).toBe(false)
+        expect(shouldPostInit(null, 0, 0)).toBe(false)
     })
 
     it('does not repost the generation it already sent', () => {
-        expect(shouldPostInit(0, 0, true)).toBe(false)
+        expect(shouldPostInit({ generation: 0, epoch: 1 }, 0, 1)).toBe(false)
     })
 
     it('posts a bumped generation, which is how a handover happens', () => {
-        expect(shouldPostInit(0, 1, true)).toBe(true)
+        expect(shouldPostInit({ generation: 0, epoch: 1 }, 1, 1)).toBe(true)
+    })
+
+    /**
+     * Re-parenting the warm editor's WebView on a handover recreates the native
+     * view and the page boots again, having lost the init it was sent moments
+     * before. Not reposting left the editor at its empty stage one.
+     */
+    it('reposts the same generation to a page that booted again', () => {
+        expect(shouldPostInit({ generation: 3, epoch: 1 }, 3, 2)).toBe(true)
     })
 })

--- a/core/lib/editor/message-bus/types.ts
+++ b/core/lib/editor/message-bus/types.ts
@@ -132,6 +132,7 @@ export type EditorMessageNamespace =
     | 'core'
     | 'find-replace'
     | 'format'
+    | 'html'
     | 'markdown'
     | 'suggestion'
     | 'ui'

--- a/core/lib/editor/rich/__tests__/document-webview-host.test.ts
+++ b/core/lib/editor/rich/__tests__/document-webview-host.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type { EditorMessage } from '../../message-bus/types'
+import { DocumentWebViewHost } from '../document-webview-host'
+
+/**
+ * Liveness: a push has to reach an editor that exists. Before the host tracked
+ * this, a set made while the WebView was still booting was posted into nothing
+ * — the body of a reopened mail draft, the roster-independent part of every
+ * "content never appears" report on native.
+ */
+
+function makeHost(options: { canPost?: boolean } = {}) {
+    const sent: EditorMessage[] = []
+    const host = new DocumentWebViewHost<string>(
+        {
+            namespace: 'markdown',
+            types: { set: 'set', get: 'get', result: 'result' },
+            initial: '',
+            decodeResult: payload => {
+                const value = (payload as { value?: unknown } | undefined)?.value
+                return typeof value === 'string' ? value : null
+            },
+            encodeSet: value => ({ value }),
+        },
+        {
+            postMessage: message => {
+                sent.push(message)
+                return options.canPost ?? true
+            },
+        }
+    )
+    return { host, sent }
+}
+
+describe('DocumentWebViewHost liveness', () => {
+    it('holds a set until the page reports an editor, then delivers it', () => {
+        const { host, sent } = makeHost()
+        host.set('draft body')
+        expect(sent).toEqual([])
+        host.markLive()
+        expect(sent).toEqual([
+            { namespace: 'markdown', type: 'set', payload: { value: 'draft body' } },
+        ])
+    })
+
+    it('delivers only the latest of several sets made while not live', () => {
+        const { host, sent } = makeHost()
+        host.set('first')
+        host.set('second')
+        host.markLive()
+        expect(sent.map(m => m.payload)).toEqual([{ value: 'second' }])
+    })
+
+    it('posts immediately once live', () => {
+        const { host, sent } = makeHost()
+        host.markLive()
+        host.set('typed')
+        expect(sent).toHaveLength(1)
+    })
+
+    it('holds again after the editor goes stale, for the next one', () => {
+        const { host, sent } = makeHost()
+        host.markLive()
+        host.markStale()
+        host.set('for the rebuilt editor')
+        expect(sent).toEqual([])
+        host.markLive()
+        expect(sent).toHaveLength(1)
+    })
+
+    /**
+     * A handover rebuilds the editor for a different surface, whose document
+     * comes from init. A push the displaced surface left undelivered must not
+     * overwrite it.
+     */
+    it('drops an undelivered set on a handover', () => {
+        const { host, sent } = makeHost()
+        host.set('previous surface')
+        host.seedGeneration(1, 'next surface')
+        host.markLive()
+        expect(sent).toEqual([])
+    })
+
+    it('holds pushes across a handover until the rebuilt editor mounts', () => {
+        const { host, sent } = makeHost()
+        host.markLive()
+        host.seedGeneration(1, 'next surface')
+        host.set('for the new editor')
+        expect(sent).toEqual([])
+        host.markLive()
+        expect(sent.map(m => m.payload)).toEqual([{ value: 'for the new editor' }])
+    })
+
+    it('answers a get from the last known value while no editor is live', async () => {
+        const { host, sent } = makeHost()
+        host.set('held')
+        await expect(host.get()).resolves.toBe('held')
+        expect(sent).toEqual([])
+    })
+})

--- a/core/lib/editor/rich/__tests__/html-webview-host.test.ts
+++ b/core/lib/editor/rich/__tests__/html-webview-host.test.ts
@@ -19,6 +19,7 @@ function makeHost(options: { timeoutMs?: number; canPost?: boolean } = {}) {
         },
         timeoutMs: options.timeoutMs,
     })
+    host.markLive()
     return { host, sent }
 }
 

--- a/core/lib/editor/rich/__tests__/html-webview-host.test.ts
+++ b/core/lib/editor/rich/__tests__/html-webview-host.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { EditorMessage } from '../../message-bus/types'
+import { HtmlWebViewHost } from '../html-webview-host'
+import { HTML_GET, HTML_RESULT, HTML_SET } from '../webview/source/protocol'
+
+/**
+ * The html channel is what mail's compose window reads on close and on send.
+ * Before it existed those calls went over TenTap's bridge, which our page never
+ * answers, and the compose window's close button did nothing on native — so
+ * the settle-no-matter-what behaviour is the point of these tests.
+ */
+
+function makeHost(options: { timeoutMs?: number; canPost?: boolean } = {}) {
+    const sent: EditorMessage[] = []
+    const host = new HtmlWebViewHost({
+        postMessage: message => {
+            sent.push(message)
+            return options.canPost ?? true
+        },
+        timeoutMs: options.timeoutMs,
+    })
+    return { host, sent }
+}
+
+function resultMessage(html: string, text: string, requestId?: string): EditorMessage {
+    return { namespace: 'html', type: HTML_RESULT, payload: { html, text }, requestId }
+}
+
+describe('HtmlWebViewHost', () => {
+    it('posts a get on the html namespace and resolves with both parts', async () => {
+        const { host, sent } = makeHost()
+        const pending = host.get()
+        expect(sent[0]).toMatchObject({ namespace: 'html', type: HTML_GET })
+        host.handleMessage(resultMessage('<p>hi</p>', 'hi', sent[0]?.requestId))
+        await expect(pending).resolves.toEqual({ html: '<p>hi</p>', text: 'hi' })
+    })
+
+    it('resolves rather than rejects when the WebView never answers', async () => {
+        vi.useFakeTimers()
+        try {
+            const { host } = makeHost({ timeoutMs: 50 })
+            const pending = host.get()
+            vi.advanceTimersByTime(51)
+            // A close handler awaiting this must always get to close().
+            await expect(pending).resolves.toEqual({ html: '', text: '' })
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('settles immediately when the WebView is not mounted', async () => {
+        const { host } = makeHost({ canPost: false })
+        await expect(host.get()).resolves.toEqual({ html: '', text: '' })
+    })
+
+    it('posts setHtml as a set carrying only the html', () => {
+        const { host, sent } = makeHost()
+        host.setHtml('<p>draft</p>')
+        expect(sent[0]).toEqual({
+            namespace: 'html',
+            type: HTML_SET,
+            payload: { html: '<p>draft</p>' },
+        })
+    })
+
+    it('falls back to the html it was told to set, with no guessed text', async () => {
+        const { host } = makeHost({ canPost: false })
+        host.setHtml('<p>draft</p>')
+        await expect(host.get()).resolves.toEqual({ html: '<p>draft</p>', text: '' })
+    })
+
+    it('ignores a malformed result', async () => {
+        const { host } = makeHost({ canPost: false })
+        expect(
+            host.handleMessage({ namespace: 'html', type: HTML_RESULT, payload: { html: 1 } })
+        ).toBe(true)
+        await expect(host.get()).resolves.toEqual({ html: '', text: '' })
+    })
+
+    it('ignores the markdown channel', () => {
+        const { host } = makeHost()
+        expect(
+            host.handleMessage({ namespace: 'markdown', type: HTML_RESULT, payload: null })
+        ).toBe(false)
+    })
+})

--- a/core/lib/editor/rich/__tests__/markdown-webview-host.test.ts
+++ b/core/lib/editor/rich/__tests__/markdown-webview-host.test.ts
@@ -18,6 +18,9 @@ function makeHost(options: { timeoutMs?: number; canPost?: boolean } = {}) {
         },
         timeoutMs: options.timeoutMs,
     })
+    // The page has an editor listening — the ordinary state these tests
+    // exercise. Liveness itself is covered in document-webview-host.test.ts.
+    host.markLive()
     return { host, sent }
 }
 

--- a/core/lib/editor/rich/__tests__/webview-html-channel.test.ts
+++ b/core/lib/editor/rich/__tests__/webview-html-channel.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+//
+// Tiptap needs a DOM to mount an editor; core's suite defaults to node.
+import { Editor } from '@tiptap/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeMessage } from '../../message-bus/types'
+import { buildRichEditorExtensions } from '../extensions'
+import { handleHtmlMessage } from '../webview/source/Editor'
+import { HTML_GET, HTML_RESULT, HTML_SET } from '../webview/source/protocol'
+
+/**
+ * Drives the page's html handler against a real Tiptap instance — exactly what
+ * happens on a `html.set` / `html.get` from the native host. The device path
+ * has no other mechanical coverage, and a page that silently ignores a `get`
+ * is precisely the bug that made mail's compose close hang.
+ */
+
+let editor: Editor | null = null
+const postMessage = vi.fn<(s: string) => void>()
+
+beforeEach(() => {
+    postMessage.mockReset()
+    window.ReactNativeWebView = { postMessage }
+    editor = new Editor({ extensions: buildRichEditorExtensions() })
+})
+
+afterEach(() => {
+    editor?.destroy()
+    editor = null
+    window.ReactNativeWebView = undefined
+})
+
+function posted() {
+    return postMessage.mock.calls.map(([raw]) => JSON.parse(raw) as unknown)
+}
+
+describe('WebView html channel', () => {
+    it('answers a get with the html and text, echoing the requestId', () => {
+        if (!editor) throw new Error('editor not mounted')
+        editor.commands.setContent('<p>Hello <strong>there</strong></p>')
+        handleHtmlMessage(editor, makeMessage('html', HTML_GET, null, 'html-7'), false)
+        expect(posted()).toEqual([
+            {
+                namespace: 'html',
+                type: HTML_RESULT,
+                requestId: 'html-7',
+                payload: { html: '<p>Hello <strong>there</strong></p>', text: 'Hello there' },
+            },
+        ])
+    })
+
+    it('replaces the document on a set', () => {
+        if (!editor) throw new Error('editor not mounted')
+        handleHtmlMessage(editor, makeMessage('html', HTML_SET, { html: '<p>draft</p>' }), false)
+        expect(editor.getText()).toBe('draft')
+        handleHtmlMessage(editor, makeMessage('html', HTML_SET, { html: '' }), false)
+        expect(editor.getText()).toBe('')
+    })
+
+    it('leaves a collaborative document alone on a set', () => {
+        if (!editor) throw new Error('editor not mounted')
+        editor.commands.setContent('<p>shared</p>')
+        handleHtmlMessage(editor, makeMessage('html', HTML_SET, { html: '<p>mine</p>' }), true)
+        expect(editor.getText()).toBe('shared')
+    })
+})

--- a/core/lib/editor/rich/document-webview-host.ts
+++ b/core/lib/editor/rich/document-webview-host.ts
@@ -1,0 +1,174 @@
+import type { EditorMessage, EditorMessageNamespace } from '../message-bus/types'
+import { makeMessage } from '../message-bus/types'
+
+/**
+ * Host side of a document channel: correlates `get` requests with the
+ * WebView's `result` responses, and pushes `set`s the other way.
+ *
+ * Two channels share this shape — 'markdown' (card descriptions) and 'html'
+ * (mail) — differing only in the namespace and the payload they carry, so the
+ * mechanics live here once and each channel is a thin subclass.
+ *
+ * TenTap ships `asyncMessages` for this shape, but it is not usable here — its
+ * promise has no timeout and no reject path, so a WebView that dies mid-request
+ * leaks a pending promise forever. Both channels sit on a save path (a
+ * description save, a draft save on compose close), so that failure mode would
+ * hang a save — or, in mail's case, leave the compose window unclosable.
+ *
+ * The timeout therefore RESOLVES with the last known value rather than
+ * rejecting. A save path that throws loses the user's text; returning the last
+ * value we saw degrades to a slightly stale save, which is recoverable.
+ */
+
+/** Long enough to cover a slow first paint, short enough not to stall a save. */
+const DEFAULT_TIMEOUT_MS = 3000
+
+type PostMessage = (message: EditorMessage) => boolean
+
+export interface DocumentWebViewHostOptions {
+    postMessage: PostMessage
+    timeoutMs?: number
+}
+
+interface ChannelShape<T> {
+    namespace: EditorMessageNamespace
+    /** Message types on the namespace. */
+    types: { set: string; get: string; result: string }
+    /** Value reported before any round-trip or seed. */
+    initial: T
+    /** Decode a `result` payload; null when it is malformed. */
+    decodeResult: (payload: unknown) => T | null
+    /** Encode the payload a `set` carries. */
+    encodeSet: (value: T) => unknown
+}
+
+interface Pending<T> {
+    resolve: (value: T) => void
+    timer: ReturnType<typeof setTimeout>
+}
+
+export class DocumentWebViewHost<T> {
+    private readonly postMessage: PostMessage
+    private readonly timeoutMs: number
+    private readonly shape: ChannelShape<T>
+    private readonly pending = new Map<string, Pending<T>>()
+    private nextId = 0
+    /**
+     * Last value the WebView reported. Seeded from the initial content so a
+     * timeout before the first successful round-trip still returns the
+     * document the user opened rather than an empty one.
+     */
+    private lastKnown: T
+    /** Which warm-editor generation `lastKnown` belongs to. See seedGeneration. */
+    private seededGeneration: number | null = null
+    private destroyed = false
+
+    constructor(shape: ChannelShape<T>, options: DocumentWebViewHostOptions) {
+        this.shape = shape
+        this.lastKnown = shape.initial
+        this.postMessage = options.postMessage
+        this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    }
+
+    /** Seed the fallback value, e.g. with the editor's initial content. */
+    seed(value: T): void {
+        this.lastKnown = value
+    }
+
+    /**
+     * Seed the fallback for a warm editor that has just been handed to another
+     * surface.
+     *
+     * Distinct from {@link seed} because a handover has to invalidate requests
+     * the PREVIOUS surface left in flight. Those resolve from `lastKnown` on
+     * timeout, so re-seeding alone would hand one surface's text to the other's
+     * pending save. Repeat calls for the same generation are ignored, which is
+     * what lets a caller drive this from an effect.
+     */
+    seedGeneration(generation: number, value: T): void {
+        if (generation === this.seededGeneration) return
+        this.seededGeneration = generation
+        // Anything still pending belongs to the surface being displaced. Settle
+        // it with the text it was opened with rather than letting it time out
+        // against the incoming surface's seed.
+        for (const [id, entry] of this.pending) {
+            clearTimeout(entry.timer)
+            entry.resolve(this.lastKnown)
+            this.pending.delete(id)
+        }
+        this.lastKnown = value
+    }
+
+    /**
+     * Ask the WebView for the current document.
+     *
+     * Resolves with the last known value — never rejects — if the WebView is
+     * not mounted, does not answer in time, or the host is torn down first.
+     */
+    get(): Promise<T> {
+        if (this.destroyed) return Promise.resolve(this.lastKnown)
+        const requestId = `${this.shape.namespace}-${this.nextId++}`
+        return new Promise<T>(resolve => {
+            const settle = (value: T) => {
+                const entry = this.pending.get(requestId)
+                if (entry) {
+                    clearTimeout(entry.timer)
+                    this.pending.delete(requestId)
+                }
+                resolve(value)
+            }
+            const timer = setTimeout(() => settle(this.lastKnown), this.timeoutMs)
+            this.pending.set(requestId, { resolve, timer })
+
+            const sent = this.postMessage(
+                makeMessage(this.shape.namespace, this.shape.types.get, null, requestId)
+            )
+            // The WebView isn't mounted yet — nothing will ever answer, so
+            // don't make the caller wait out the timeout.
+            if (!sent) settle(this.lastKnown)
+        })
+    }
+
+    /** Replace the WebView's document. */
+    set(value: T): void {
+        if (this.destroyed) return
+        this.lastKnown = value
+        this.postMessage(
+            makeMessage(this.shape.namespace, this.shape.types.set, this.shape.encodeSet(value))
+        )
+    }
+
+    /**
+     * Feed a WebView message in. Returns true if it was a message on this
+     * channel that the host consumed, so callers can stop routing it further.
+     */
+    handleMessage(message: EditorMessage): boolean {
+        if (message.namespace !== this.shape.namespace) return false
+        if (message.type !== this.shape.types.result) return false
+        const value = this.shape.decodeResult(message.payload)
+        if (value === null) return true
+        this.lastKnown = value
+        // A response with no requestId is unsolicited — record the value but
+        // don't try to settle a request that doesn't exist.
+        if (message.requestId === undefined) return true
+        const entry = this.pending.get(message.requestId)
+        if (!entry) return true
+        clearTimeout(entry.timer)
+        this.pending.delete(message.requestId)
+        entry.resolve(value)
+        return true
+    }
+
+    /**
+     * Drain every in-flight request on unmount so no caller is left awaiting a
+     * promise the WebView can no longer answer.
+     */
+    destroy(): void {
+        this.destroyed = true
+        for (const [, entry] of this.pending) {
+            clearTimeout(entry.timer)
+            entry.resolve(this.lastKnown)
+        }
+        this.pending.clear()
+    }
+}

--- a/core/lib/editor/rich/document-webview-host.ts
+++ b/core/lib/editor/rich/document-webview-host.ts
@@ -61,6 +61,14 @@ export class DocumentWebViewHost<T> {
     private lastKnown: T
     /** Which warm-editor generation `lastKnown` belongs to. See seedGeneration. */
     private seededGeneration: number | null = null
+    /**
+     * Whether the page currently has an editor listening (see markLive). A
+     * push sent while it does not lands on nothing — the WebView may not be
+     * mounted, the page may be booting, or the editor may be mid-rebuild — so
+     * it is held here and delivered on the next markLive instead.
+     */
+    private isLive = false
+    private pendingSet: T | null = null
     private destroyed = false
 
     constructor(shape: ChannelShape<T>, options: DocumentWebViewHostOptions) {
@@ -96,17 +104,45 @@ export class DocumentWebViewHost<T> {
             entry.resolve(this.lastKnown)
             this.pending.delete(id)
         }
+        // A push the displaced surface left undelivered was meant for ITS
+        // editor. The incoming surface's document comes from init.
+        this.pendingSet = null
         this.lastKnown = value
+        // The page rebuilds its editor for the new generation; until that one
+        // reports mounted there is nothing to push to.
+        this.isLive = false
+    }
+
+    /**
+     * The page reports an editor is constructed and listening. Delivers the
+     * push held while there was none.
+     */
+    markLive(): void {
+        this.isLive = true
+        if (this.pendingSet === null) return
+        const value = this.pendingSet
+        this.pendingSet = null
+        this.post(value)
+    }
+
+    /**
+     * The editor the page had is gone or about to be — the page is booting
+     * again, or a handover is rebuilding it. Pushes are held until the next
+     * markLive.
+     */
+    markStale(): void {
+        this.isLive = false
     }
 
     /**
      * Ask the WebView for the current document.
      *
-     * Resolves with the last known value — never rejects — if the WebView is
-     * not mounted, does not answer in time, or the host is torn down first.
+     * Resolves with the last known value — never rejects — if there is no
+     * live editor to ask, the WebView is not mounted, it does not answer in
+     * time, or the host is torn down first.
      */
     get(): Promise<T> {
-        if (this.destroyed) return Promise.resolve(this.lastKnown)
+        if (this.destroyed || !this.isLive) return Promise.resolve(this.lastKnown)
         const requestId = `${this.shape.namespace}-${this.nextId++}`
         return new Promise<T>(resolve => {
             const settle = (value: T) => {
@@ -129,10 +165,22 @@ export class DocumentWebViewHost<T> {
         })
     }
 
-    /** Replace the WebView's document. */
+    /**
+     * Replace the WebView's document — now if an editor is listening, else as
+     * soon as one is. A push before the page is live used to be dropped, which
+     * is how a draft reopened into mail's compose window showed an empty body.
+     */
     set(value: T): void {
         if (this.destroyed) return
         this.lastKnown = value
+        if (!this.isLive) {
+            this.pendingSet = value
+            return
+        }
+        this.post(value)
+    }
+
+    private post(value: T): void {
         this.postMessage(
             makeMessage(this.shape.namespace, this.shape.types.set, this.shape.encodeSet(value))
         )

--- a/core/lib/editor/rich/html-webview-host.ts
+++ b/core/lib/editor/rich/html-webview-host.ts
@@ -1,0 +1,54 @@
+import { DocumentWebViewHost, type DocumentWebViewHostOptions } from './document-webview-host'
+import {
+    HTML_GET,
+    HTML_RESULT,
+    HTML_SET,
+    type HtmlResultPayload,
+    type HtmlSetPayload,
+} from './webview/source/protocol'
+
+/**
+ * What the page reports on an html `get`. The text is what Tiptap's getText()
+ * yields for the same document; it rides along because the host cannot derive
+ * it from the HTML, and every caller that wants one wants the other.
+ */
+export type HtmlDocument = HtmlResultPayload
+
+export type HtmlWebViewHostOptions = DocumentWebViewHostOptions
+
+/**
+ * Host side of the html channel: the `getHTML` / `getText` / `setContent`
+ * surface of the shared editor handle on native. Mail's compose window is the
+ * main caller — closing it reads the body to decide whether to save a draft,
+ * and sending reads both parts. The request/response mechanics and their
+ * failure modes are documented on {@link DocumentWebViewHost}.
+ */
+export class HtmlWebViewHost extends DocumentWebViewHost<HtmlDocument> {
+    constructor(options: HtmlWebViewHostOptions) {
+        super(
+            {
+                namespace: 'html',
+                types: { set: HTML_SET, get: HTML_GET, result: HTML_RESULT },
+                initial: { html: '', text: '' },
+                decodeResult: payload => {
+                    const result = payload as Partial<HtmlResultPayload> | undefined
+                    if (typeof result?.html !== 'string' || typeof result.text !== 'string') {
+                        return null
+                    }
+                    return { html: result.html, text: result.text }
+                },
+                encodeSet: ({ html }): HtmlSetPayload => ({ html }),
+            },
+            options
+        )
+    }
+
+    /**
+     * Replace the document with an HTML string. The plain-text fallback is
+     * cleared rather than guessed: the host has no parser, and the next
+     * successful round-trip restores it.
+     */
+    setHtml(html: string): void {
+        this.set({ html, text: '' })
+    }
+}

--- a/core/lib/editor/rich/markdown-webview-host.ts
+++ b/core/lib/editor/rich/markdown-webview-host.ts
@@ -1,155 +1,33 @@
-import { type EditorMessage, makeMessage } from '../message-bus/types'
+import { DocumentWebViewHost, type DocumentWebViewHostOptions } from './document-webview-host'
 import {
     MARKDOWN_GET,
     MARKDOWN_RESULT,
     MARKDOWN_SET,
     type MarkdownResultPayload,
+    type MarkdownSetPayload,
 } from './webview/source/protocol'
 
+export type MarkdownWebViewHostOptions = DocumentWebViewHostOptions
+
 /**
- * Host side of the markdown channel: correlates `get` requests with the
- * WebView's `result` responses.
- *
- * TenTap ships `asyncMessages` for this shape, but it is not usable here — its
- * promise has no timeout and no reject path, so a WebView that dies mid-request
- * leaks a pending promise forever. `getMarkdown` sits on the save path, so that
- * failure mode would hang a save.
- *
- * The timeout therefore RESOLVES with the last known markdown rather than
- * rejecting. A save path that throws loses the user's text; returning the last
- * value we saw degrades to a slightly stale save, which is recoverable.
+ * Host side of the markdown channel — the save path for card descriptions.
+ * The request/response mechanics and their failure modes are documented on
+ * {@link DocumentWebViewHost}.
  */
-
-/** Long enough to cover a slow first paint, short enough not to stall a save. */
-const DEFAULT_TIMEOUT_MS = 3000
-
-type PostMessage = (message: EditorMessage) => boolean
-
-export interface MarkdownWebViewHostOptions {
-    postMessage: PostMessage
-    timeoutMs?: number
-}
-
-interface Pending {
-    resolve: (markdown: string) => void
-    timer: ReturnType<typeof setTimeout>
-}
-
-export class MarkdownWebViewHost {
-    private readonly postMessage: PostMessage
-    private readonly timeoutMs: number
-    private readonly pending = new Map<string, Pending>()
-    private nextId = 0
-    /**
-     * Last markdown the WebView reported. Seeded from the initial content so a
-     * timeout before the first successful round-trip still returns the
-     * document the user opened rather than an empty string.
-     */
-    private lastKnown = ''
-    /** Which warm-editor generation `lastKnown` belongs to. See seedGeneration. */
-    private seededGeneration: number | null = null
-    private destroyed = false
-
+export class MarkdownWebViewHost extends DocumentWebViewHost<string> {
     constructor(options: MarkdownWebViewHostOptions) {
-        this.postMessage = options.postMessage
-        this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
-    }
-
-    /** Seed the fallback value, e.g. with the editor's initial content. */
-    seed(markdown: string): void {
-        this.lastKnown = markdown
-    }
-
-    /**
-     * Seed the fallback for a warm editor that has just been handed to another
-     * surface.
-     *
-     * Distinct from {@link seed} because a handover has to invalidate requests
-     * the PREVIOUS surface left in flight. Those resolve from `lastKnown` on
-     * timeout, so re-seeding alone would hand one surface's text to the other's
-     * pending save. Repeat calls for the same generation are ignored, which is
-     * what lets a caller drive this from an effect.
-     */
-    seedGeneration(generation: number, markdown: string): void {
-        if (generation === this.seededGeneration) return
-        this.seededGeneration = generation
-        // Anything still pending belongs to the surface being displaced. Settle
-        // it with the text it was opened with rather than letting it time out
-        // against the incoming surface's seed.
-        for (const [id, entry] of this.pending) {
-            clearTimeout(entry.timer)
-            entry.resolve(this.lastKnown)
-            this.pending.delete(id)
-        }
-        this.lastKnown = markdown
-    }
-
-    /**
-     * Ask the WebView for the current document.
-     *
-     * Resolves with the last known value — never rejects — if the WebView is
-     * not mounted, does not answer in time, or the host is torn down first.
-     */
-    get(): Promise<string> {
-        if (this.destroyed) return Promise.resolve(this.lastKnown)
-        const requestId = `md-${this.nextId++}`
-        return new Promise<string>(resolve => {
-            const settle = (markdown: string) => {
-                const entry = this.pending.get(requestId)
-                if (entry) {
-                    clearTimeout(entry.timer)
-                    this.pending.delete(requestId)
-                }
-                resolve(markdown)
-            }
-            const timer = setTimeout(() => settle(this.lastKnown), this.timeoutMs)
-            this.pending.set(requestId, { resolve, timer })
-
-            const sent = this.postMessage(makeMessage('markdown', MARKDOWN_GET, null, requestId))
-            // The WebView isn't mounted yet — nothing will ever answer, so
-            // don't make the caller wait out the timeout.
-            if (!sent) settle(this.lastKnown)
-        })
-    }
-
-    /** Replace the WebView's document. */
-    set(markdown: string): void {
-        if (this.destroyed) return
-        this.lastKnown = markdown
-        this.postMessage(makeMessage('markdown', MARKDOWN_SET, { markdown }))
-    }
-
-    /**
-     * Feed a WebView message in. Returns true if it was a markdown message this
-     * host consumed, so callers can stop routing it further.
-     */
-    handleMessage(message: EditorMessage): boolean {
-        if (message.namespace !== 'markdown') return false
-        if (message.type !== MARKDOWN_RESULT) return false
-        const markdown = (message.payload as MarkdownResultPayload | undefined)?.markdown
-        if (typeof markdown !== 'string') return true
-        this.lastKnown = markdown
-        // A response with no requestId is unsolicited — record the value but
-        // don't try to settle a request that doesn't exist.
-        if (message.requestId === undefined) return true
-        const entry = this.pending.get(message.requestId)
-        if (!entry) return true
-        clearTimeout(entry.timer)
-        this.pending.delete(message.requestId)
-        entry.resolve(markdown)
-        return true
-    }
-
-    /**
-     * Drain every in-flight request on unmount so no caller is left awaiting a
-     * promise the WebView can no longer answer.
-     */
-    destroy(): void {
-        this.destroyed = true
-        for (const [, entry] of this.pending) {
-            clearTimeout(entry.timer)
-            entry.resolve(this.lastKnown)
-        }
-        this.pending.clear()
+        super(
+            {
+                namespace: 'markdown',
+                types: { set: MARKDOWN_SET, get: MARKDOWN_GET, result: MARKDOWN_RESULT },
+                initial: '',
+                decodeResult: payload => {
+                    const markdown = (payload as MarkdownResultPayload | undefined)?.markdown
+                    return typeof markdown === 'string' ? markdown : null
+                },
+                encodeSet: (markdown): MarkdownSetPayload => ({ markdown }),
+            },
+            options
+        )
     }
 }

--- a/core/lib/editor/rich/use-rich-editor.native.tsx
+++ b/core/lib/editor/rich/use-rich-editor.native.tsx
@@ -17,6 +17,7 @@ import { TriggerItemsWebViewHost } from './trigger-items-webview-host'
 import type { SerializableTriggerConfig, TriggerItem } from './triggers'
 import { editorHtml } from './webview/build/editorHtml'
 import {
+    APP_EDITOR_MOUNTED,
     APP_ESCAPE,
     APP_FILE_TOKEN,
     APP_SUBMIT_SHORTCUT,
@@ -312,12 +313,16 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     // surfaces holding identical text leaves initialContent unchanged, and the
     // seed still has to move — along with any request the displaced surface left
     // in flight.
+    //
+    // Both hosts, whatever the format: a handover rebuilds the page's editor,
+    // and each host has to stop pushing until the replacement reports mounted.
     useEffect(() => {
-        if (contentFormat === 'markdown') {
-            markdownHost.seedGeneration(generation, initialContent ?? '')
-        } else {
-            htmlHost.seedGeneration(generation, { html: initialContent ?? '', text: '' })
-        }
+        const isMarkdown = contentFormat === 'markdown'
+        markdownHost.seedGeneration(generation, isMarkdown ? (initialContent ?? '') : '')
+        htmlHost.seedGeneration(generation, {
+            html: isMarkdown ? '' : (initialContent ?? ''),
+            text: '',
+        })
     }, [markdownHost, htmlHost, contentFormat, initialContent, generation])
 
     const triggerItemsHostRef = useRef<TriggerItemsWebViewHost | null>(null)
@@ -327,10 +332,11 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         })
     }
     const triggerItemsHost = triggerItemsHostRef.current
-    // Assigned from `result` further down — declared here because the roster
-    // effect below is written before `useWebViewEditor` is called, and effects
-    // run after the whole body regardless.
-    const [isPageReady, setIsPageReady] = useState(false)
+    // Bumped on every APP_EDITOR_MOUNTED — each generation's editor, and each
+    // page boot's. Declared here because the roster effect below is written
+    // before `useWebViewEditor` is called, and effects run after the whole
+    // body regardless. 0 until the first editor exists.
+    const [liveEpoch, setLiveEpoch] = useState(0)
 
     // Push each roster whenever it changes. The effect depends on the
     // SERIALIZED rosters rather than the array: a live query hands back a fresh
@@ -341,19 +347,19 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         () => JSON.stringify((triggers ?? []).map(t => [t.id, t.allItems])),
         [triggers]
     )
-    // Gated on the page being ready, not just on the roster changing. The
+    // Gated on an editor being live, not just on the roster changing. The
     // editor mounts well before a members query resolves, so the first roster
     // is pushed at a WebView that cannot receive it; and a page reload gives
     // the page a fresh, empty store while the host still remembers sending the
-    // roster. Re-running when readiness flips (and clearing the memo first, so
+    // roster. Re-running on every live epoch (and clearing the memo first, so
     // an unchanged roster is not skipped as a duplicate) covers both.
     useEffect(() => {
-        if (!isPageReady) return
+        if (liveEpoch === 0) return
         triggerItemsHost.reset()
         for (const [id, items] of JSON.parse(rosterSignature) as [string, TriggerItem[]][]) {
             triggerItemsHost.push(id, items)
         }
-    }, [rosterSignature, triggerItemsHost, isPageReady])
+    }, [rosterSignature, triggerItemsHost, liveEpoch])
 
     // TenTap's stock bridges still drive the toolbar commands and focus. Their
     // Tiptap counterparts live in our page, which registers the same schema.
@@ -374,6 +380,11 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
             if (message.namespace !== 'app') return
             if (message.type === APP_SUBMIT_SHORTCUT) submitRef.current?.()
             else if (message.type === APP_ESCAPE) escapeRef.current?.()
+            else if (message.type === APP_EDITOR_MOUNTED) {
+                markdownHost.markLive()
+                htmlHost.markLive()
+                setLiveEpoch(epoch => epoch + 1)
+            }
         },
         [markdownHost, htmlHost, yjsHost, awarenessHost]
     )
@@ -419,11 +430,18 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
 
     posterRef.current = result.postMessage ?? null
 
-    // Mirror the bridge's readiness into state so the roster effect above can
-    // depend on it. Compared before setting: this runs on every render, and an
-    // unconditional set would loop.
-    const isReadyNow = result.isReady === true
-    if (isReadyNow !== isPageReady) setIsPageReady(isReadyNow)
+    // The page booted again (a remounted WebView, a killed content process),
+    // so the editor the channels were talking to is gone. Until the page posts
+    // APP_EDITOR_MOUNTED for the replacement, pushes are held rather than sent
+    // into the gap. Runs in the same commit as the init post that asks for
+    // that replacement, so it always precedes the mounted signal. (A handover
+    // goes stale the same way, from seedGeneration above.)
+    const pageEpoch = result.pageEpoch ?? 0
+    useEffect(() => {
+        if (pageEpoch === 0) return
+        markdownHost.markStale()
+        htmlHost.markStale()
+    }, [markdownHost, htmlHost, pageEpoch])
 
     // Publish the handle a host overlay needs to anchor to this editor. The
     // popover is rendered as a sibling (often in another subtree entirely), so

--- a/core/lib/editor/rich/use-rich-editor.native.tsx
+++ b/core/lib/editor/rich/use-rich-editor.native.tsx
@@ -10,6 +10,7 @@ import { publishUiMessage, registerEditorOverlay } from '../overlay'
 import type { EditorHandle, EditorResult } from '../types'
 import { useWebViewEditor } from '../use-webview-editor'
 import { AwarenessWebViewHost } from './awareness-webview-host'
+import { HtmlWebViewHost } from './html-webview-host'
 import { MarkdownWebViewHost } from './markdown-webview-host'
 import type { UseRichEditorOptions } from './options'
 import { TriggerItemsWebViewHost } from './trigger-items-webview-host'
@@ -286,6 +287,23 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
 
     useEffect(() => () => markdownHost.destroy(), [markdownHost])
 
+    // The html channel carries the handle's getHTML / getText / setContent.
+    // TenTap's own bridge has the same surface, but our page bypasses that
+    // protocol, so a request over it is never answered — and its promise has no
+    // timeout, which is how mail's compose close came to hang on native.
+    const htmlHostRef = useRef<HtmlWebViewHost | null>(null)
+    if (htmlHostRef.current === null) {
+        htmlHostRef.current = new HtmlWebViewHost({
+            postMessage: message => posterRef.current?.(message as never) ?? false,
+        })
+        if (contentFormat === 'html' && initialContent) {
+            htmlHostRef.current.seed({ html: initialContent, text: '' })
+        }
+    }
+    const htmlHost = htmlHostRef.current
+
+    useEffect(() => () => htmlHost.destroy(), [htmlHost])
+
     // A warm editor is reused across surfaces, so the timeout fallback has to
     // follow the current one. Without this a slow getMarkdown during a handover
     // resolves with the PREVIOUS surface's text — and that value gets saved.
@@ -295,9 +313,12 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
     // seed still has to move — along with any request the displaced surface left
     // in flight.
     useEffect(() => {
-        if (contentFormat !== 'markdown') return
-        markdownHost.seedGeneration(generation, initialContent ?? '')
-    }, [markdownHost, contentFormat, initialContent, generation])
+        if (contentFormat === 'markdown') {
+            markdownHost.seedGeneration(generation, initialContent ?? '')
+        } else {
+            htmlHost.seedGeneration(generation, { html: initialContent ?? '', text: '' })
+        }
+    }, [markdownHost, htmlHost, contentFormat, initialContent, generation])
 
     const triggerItemsHostRef = useRef<TriggerItemsWebViewHost | null>(null)
     if (triggerItemsHostRef.current === null) {
@@ -334,9 +355,10 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         }
     }, [rosterSignature, triggerItemsHost, isPageReady])
 
-    // TenTap's stock bridges still drive the toolbar commands and the
-    // getHTML/getText/setContent/focus surface that mail relies on. Their
+    // TenTap's stock bridges still drive the toolbar commands and focus. Their
     // Tiptap counterparts live in our page, which registers the same schema.
+    // Reading and replacing the document goes over our own channels instead —
+    // see the markdown and html hosts above.
     const bridgeExtensions = useMemo(() => [...TenTapStartKit, CoreBridge.configureCSS('')], [])
 
     const onDocumentScroll = useCallback(() => {
@@ -348,11 +370,12 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
             if (awarenessHost?.handleMessage(message as never)) return
             if (yjsHost?.handleMessage(message as never)) return
             if (markdownHost.handleMessage(message as never)) return
+            if (htmlHost.handleMessage(message as never)) return
             if (message.namespace !== 'app') return
             if (message.type === APP_SUBMIT_SHORTCUT) submitRef.current?.()
             else if (message.type === APP_ESCAPE) escapeRef.current?.()
         },
-        [markdownHost, yjsHost, awarenessHost]
+        [markdownHost, htmlHost, yjsHost, awarenessHost]
     )
 
     const result = useWebViewEditor({
@@ -420,16 +443,19 @@ export function useRichEditor(options: UseRichEditorOptions = {}): EditorResult 
         })
     }, [overlayKey, webViewRef, measureRef, editorInstanceId])
 
-    // Layer the markdown channel onto the shared handle. Everything else —
-    // getHTML, setContent, focus, clear — is TenTap's, unchanged, which is what
-    // keeps mail's HTML path working.
+    // Layer both document channels onto the shared handle. Only focus is left
+    // to TenTap's bridge, the one request of its protocol our page answers.
     const editor: EditorHandle = useMemo(
         () => ({
             ...result.editor,
+            getHTML: () => htmlHost.get().then(document => document.html),
+            getText: () => htmlHost.get().then(document => document.text),
+            setContent: (html: string) => htmlHost.setHtml(html),
+            clear: () => htmlHost.setHtml(''),
             getMarkdown: () => markdownHost.get(),
             setMarkdown: (markdown: string) => markdownHost.set(markdown),
         }),
-        [result.editor, markdownHost]
+        [result.editor, markdownHost, htmlHost]
     )
 
     return { ...result, editor }

--- a/core/lib/editor/rich/webview/source/Editor.tsx
+++ b/core/lib/editor/rich/webview/source/Editor.tsx
@@ -30,6 +30,10 @@ import {
     decodeUpdate,
     EDITOR_READY,
     encodeUpdate,
+    HTML_GET,
+    HTML_RESULT,
+    HTML_SET,
+    type HtmlSetPayload,
     MARKDOWN_GET,
     MARKDOWN_RESULT,
     MARKDOWN_SET,
@@ -555,6 +559,10 @@ function useHostMessages(editor: TiptapEditor | null, isCollab: boolean) {
                 handleMarkdownMessage(editor, parsed, isCollab)
                 return
             }
+            if (parsed.namespace === 'html') {
+                handleHtmlMessage(editor, parsed, isCollab)
+                return
+            }
             if (parsed.namespace === 'app' && parsed.type === APP_FILE_TOKEN) {
                 const auth = parsed.payload as RichEditorFileAuth | undefined
                 if (auth && typeof auth.token === 'string' && typeof auth.baseURL === 'string') {
@@ -601,6 +609,36 @@ function handleMarkdownMessage(
         // escapes, and this value is what gets persisted.
         const markdown = repairMarkdown(editor.getMarkdown())
         postToNative(makeMessage('markdown', MARKDOWN_RESULT, { markdown }, message.requestId))
+    }
+}
+
+/**
+ * The html channel: the same two operations for the editor's other wire
+ * format. Exported so the round-trip can be tested against a real Tiptap
+ * instance without a WebView.
+ */
+export function handleHtmlMessage(
+    editor: TiptapEditor,
+    message: EditorMessage,
+    isCollab: boolean
+): void {
+    if (message.type === HTML_SET) {
+        // Same no-op as the markdown set: under collaboration the shared doc is
+        // the source of truth.
+        if (isCollab) return
+        const { html } = message.payload as HtmlSetPayload
+        editor.commands.setContent(html, { emitUpdate: false })
+        return
+    }
+    if (message.type === HTML_GET) {
+        postToNative(
+            makeMessage(
+                'html',
+                HTML_RESULT,
+                { html: editor.getHTML(), text: editor.getText() },
+                message.requestId
+            )
+        )
     }
 }
 

--- a/core/lib/editor/rich/webview/source/Editor.tsx
+++ b/core/lib/editor/rich/webview/source/Editor.tsx
@@ -17,6 +17,7 @@ import { buildRichEditorExtensions } from '../../extensions'
 import { repairMarkdown } from '../../markdown-repair'
 import { getFileAuth, setFileAuth, subscribeFileAuth } from './file-auth-store'
 import {
+    APP_EDITOR_MOUNTED,
     APP_ESCAPE,
     APP_FILE_TOKEN,
     APP_PARK,
@@ -582,6 +583,9 @@ function useHostMessages(editor: TiptapEditor | null, isCollab: boolean) {
 
         window.addEventListener('message', onMessage)
         document.addEventListener('message', onMessage)
+        // After subscribing, never before: the host holds document pushes
+        // until it hears this, so the ordering is what makes them land.
+        postToNative(makeMessage('app', APP_EDITOR_MOUNTED, null))
         return () => {
             window.removeEventListener('message', onMessage)
             document.removeEventListener('message', onMessage)

--- a/core/lib/editor/rich/webview/source/protocol.ts
+++ b/core/lib/editor/rich/webview/source/protocol.ts
@@ -37,6 +37,17 @@ export const EDITOR_READY = 'editor-ready'
 /** host → WebView, the one-shot init payload. */
 export const APP_INIT = 'init'
 /**
+ * WebView → host: the Tiptap instance init asked for exists and is listening.
+ *
+ * Distinct from EDITOR_READY, which is stage one — a page with no editor yet.
+ * Anything addressed to the document (a set on either channel) must wait for
+ * this: earlier it lands on nothing, and it is posted from the SAME effect that
+ * subscribes the document handlers, so a message sent after it is heard.
+ * Re-posted for every editor the page constructs — each generation, and each
+ * boot.
+ */
+export const APP_EDITOR_MOUNTED = 'editor-mounted'
+/**
  * host → WebView: drop back to stage one — no Tiptap, no document, no
  * awareness — while keeping the page itself booted.
  *

--- a/core/lib/editor/rich/webview/source/protocol.ts
+++ b/core/lib/editor/rich/webview/source/protocol.ts
@@ -19,6 +19,19 @@ export const MARKDOWN_GET = 'get'
 /** WebView → host, echoes the get's requestId. */
 export const MARKDOWN_RESULT = 'result'
 
+/**
+ * The 'html' namespace is the same shape for the editor's other wire format.
+ * Mail's messages are HTML and always will be, and it reads the plain text
+ * alongside (an emptiness check, the text/plain part of a send), so one `get`
+ * answers with both rather than costing two round-trips.
+ */
+/** host → WebView. Replaces the document. */
+export const HTML_SET = 'set'
+/** host → WebView, carries a requestId. */
+export const HTML_GET = 'get'
+/** WebView → host, echoes the get's requestId. */
+export const HTML_RESULT = 'result'
+
 /** WebView → host, posted once the page mounts, before Tiptap is constructed. */
 export const EDITOR_READY = 'editor-ready'
 /** host → WebView, the one-shot init payload. */
@@ -286,6 +299,15 @@ export interface MarkdownSetPayload {
 
 export interface MarkdownResultPayload {
     markdown: string
+}
+
+export interface HtmlSetPayload {
+    html: string
+}
+
+export interface HtmlResultPayload {
+    html: string
+    text: string
 }
 
 export interface YjsUpdatePayload {

--- a/core/lib/editor/types.ts
+++ b/core/lib/editor/types.ts
@@ -263,4 +263,10 @@ export interface EditorResult {
     // editor handle (e.g. commentBridge, findReplaceEditor) until this
     // flips true.
     isReady?: boolean
+    // How many times the WebView page has booted (native only; absent on
+    // web). 0 until its first `editor-ready`. A boot beyond the first means
+    // the page reloaded — a remounted WebView, a terminated content process —
+    // and holds nothing the host pushed before, so anything stateful the host
+    // keeps in the page has to be re-sent.
+    pageEpoch?: number
 }

--- a/core/lib/editor/use-webview-editor.tsx
+++ b/core/lib/editor/use-webview-editor.tsx
@@ -146,20 +146,34 @@ export interface UseWebViewEditorOptions {
     onMessage?: (message: EditorMessage) => void
 }
 
+/** Which init the host last posted, and to which boot of the page. */
+export interface PostedInit {
+    generation: number
+    epoch: number
+}
+
 /**
  * Whether the host should post this init payload.
  *
  * Replaces the previous one-shot latch. A warm editor is reconfigured by
  * re-sending init, so the rule is "each generation exactly once, never before
  * the page reports ready" rather than "only ever once".
+ *
+ * `epoch` counts the page's boots — it starts at 0 (not yet ready) and each
+ * `editor-ready` bumps it. A page that boots again has lost everything init
+ * built, so the SAME generation must go out again. That happens more than a
+ * crash: re-parenting the warm editor's WebView on a handover recreates the
+ * native view, and the page reloads while the host still remembers sending
+ * this generation — which left the editor at its empty stage one.
  */
 export function shouldPostInit(
-    lastPostedGeneration: number | null,
+    lastPosted: PostedInit | null,
     incomingGeneration: number,
-    isReady: boolean
+    epoch: number
 ): boolean {
-    if (!isReady) return false
-    return lastPostedGeneration === null || incomingGeneration > lastPostedGeneration
+    if (epoch === 0) return false
+    if (lastPosted === null) return true
+    return incomingGeneration > lastPosted.generation || epoch !== lastPosted.epoch
 }
 
 // Shared TenTap-customSource wrapper. Encapsulates:
@@ -279,7 +293,11 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     // (TenTap's StateUpdate-driven flag) for this: that one only flips
     // when the WebView sends a `stateUpdate`, which our custom Editor
     // only sends after init arrives — chicken-and-egg.
-    const [webviewReady, setWebviewReady] = useState(false)
+    //
+    // A counter rather than a flag, because the page can boot more than once
+    // per mount of this hook (see shouldPostInit), and a second boot has to
+    // re-trigger the init post.
+    const [pageEpoch, setPageEpoch] = useState(0)
     // Mount timestamp for the phase timings below. A WebView editor is an
     // expensive thing to create — a browser cold start plus a bundle — and the
     // three marks (page-ready, init-sent, first-height) are what tell you WHICH
@@ -309,31 +327,34 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
     const heightStore = heightStoreRef.current
     const setContentHeight = heightStore.set
 
-    // Which generation has been posted, rather than whether ANY init was — the
-    // warm editor reconfigures itself by posting a new one.
-    const lastInitGenerationRef = useRef<number | null>(null)
+    // Which generation has been posted, and to which page boot, rather than
+    // whether ANY init was — the warm editor reconfigures itself by posting a
+    // new one, and a rebooted page needs the current one again.
+    const lastInitRef = useRef<PostedInit | null>(null)
     useEffect(() => {
         const generation = (initPayload as { generation?: unknown })?.generation
         // Consumers that predate the warm path (mail, text) send no generation;
         // treat those as a single one-shot init, exactly as before.
         const incoming = typeof generation === 'number' ? generation : 0
-        if (!shouldPostInit(lastInitGenerationRef.current, incoming, webviewReady)) return
+        if (!shouldPostInit(lastInitRef.current, incoming, pageEpoch)) return
         const webview = bridge.webviewRef?.current
         if (!webview) return
         const message = makeMessage('app', 'init', initPayload)
         try {
             log.debug('core.editor.webview', 'init-sent', {
                 sinceMountMs: Date.now() - mountAtRef.current,
+                generation: incoming,
+                epoch: pageEpoch,
             })
             webview.postMessage(JSON.stringify(message))
-            lastInitGenerationRef.current = incoming
+            lastInitRef.current = { generation: incoming, epoch: pageEpoch }
         } catch (err) {
             // postMessage can fail mid-handshake; the next render's
-            // webviewReady or bridge identity change will retry. The generation
+            // pageEpoch or bridge identity change will retry. The generation
             // is deliberately NOT recorded here, so the retry still fires.
             captureException('editor.postInit', err, { generation: incoming })
         }
-    }, [bridge, webviewReady, initPayload])
+    }, [bridge, pageEpoch, initPayload])
 
     const editor: EditorHandle = useMemo(
         () => ({
@@ -406,15 +427,18 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
             }
             // The WebView's bootstrap posts {type:'editor-ready'} as
             // its first message, before TipTap mounts. That's the
-            // signal we use to gate the init post — see webviewReady
+            // signal we use to gate the init post — see pageEpoch
             // above. TenTap's onMessage also sees this (we run
             // alongside its dispatch), but it doesn't flip any
             // bridgeState flag from it.
             if (parsed.type === 'editor-ready') {
-                log.debug('core.editor.webview', 'page-ready', {
-                    sinceMountMs: Date.now() - mountAtRef.current,
+                setPageEpoch(epoch => {
+                    log.debug('core.editor.webview', 'page-ready', {
+                        sinceMountMs: Date.now() - mountAtRef.current,
+                        epoch: epoch + 1,
+                    })
+                    return epoch + 1
                 })
-                setWebviewReady(true)
                 return
             }
             if (parsed.namespace === 'ui') {
@@ -561,6 +585,7 @@ export function useWebViewEditor(options: UseWebViewEditorOptions): EditorResult
         measureRef,
         postMessage,
         isReady: bridgeState.isReady === true,
+        pageEpoch,
     }
 }
 


### PR DESCRIPTION
Three ways the native editor came up empty or unresponsive, all in the shared WebView editor in core.

**Mail compose: X and Send did nothing, reopened drafts were blank.** The close handler awaits `editor.getText()` to decide whether to save a draft. On native that request went over TenTap's bridge, which core's own page bypasses and never answers, and TenTap's promise has no timeout. Add an `html` channel between the native host and the page, mirroring the markdown one: `set`, and `get` answering with html and plain text in one round-trip. The handle's `getHTML` / `getText` / `setContent` / `clear` use it, with a resolve-on-timeout fallback so a dead WebView cannot block a close or send. The markdown host's mechanics move into a shared `DocumentWebViewHost`; both channels are thin subclasses.

**Card description editor: content never appeared when editing.** Handing the warm editor to a card re-parents its WebView, which on native recreates the view and reloads the page after the host had already posted init for the new generation. The host saw the second `editor-ready`, remembered sending that generation, and never re-sent it, so the page sat at its empty stage one. Page boots are now tracked as an epoch and the current init is re-posted on every boot.

**Any content pushed before the page had an editor was dropped.** Mail pushes a reopened draft's body at compose mount, before the WebView exists. The page now posts `editor-mounted` from the effect that subscribes its document handlers, and each document host holds a push until it hears that. Hosts go stale on a boot or a handover, and the mention roster is re-pushed per mounted editor.

Tests cover the html channel end to end against a real Tiptap instance, the host liveness rules, and the init re-post on a rebooted page. No package code changes.