### PR TITLE
Return to the attempted route after signing in

### DIFF
--- a/core/components/workspace/AuthGate.tsx
+++ b/core/components/workspace/AuthGate.tsx
@@ -1,5 +1,26 @@
+import { setPendingRoute } from '@tinycld/core/lib/pending-route'
+import { useUnstableGlobalHref } from 'expo-router'
+import { useEffect } from 'react'
 import { LoginModal } from './LoginModal'
 
 export function AuthGate() {
+    // Second of two capture points. pending-route.ts snapshots the web entry URL
+    // at import time, because a deep-linked signed-out load collapses the address
+    // bar to the bare app root before this component ever renders. This one
+    // covers the cases where the MOUNTED route really is the destination: an
+    // in-place session expiry, and the OAuth consent screen (which renders the
+    // gate itself and needs its ?user_code= back).
+    //
+    // The two can't fight: setPendingRoute rejects the app root, so the '/a' this
+    // sees on a collapsed deep link is discarded and the entry snapshot stands.
+    //
+    // useUnstableGlobalHref, not usePathname — mail/drive/boards encode view
+    // state in the query string.
+    const href = useUnstableGlobalHref()
+
+    useEffect(() => {
+        setPendingRoute(href)
+    }, [href])
+
     return <LoginModal />
 }

--- a/core/components/workspace/LoginModal.tsx
+++ b/core/components/workspace/LoginModal.tsx
@@ -3,8 +3,10 @@ import { ReviewModeHints } from '@tinycld/core/components/connect/ReviewModeHint
 import { requestPasswordReset } from '@tinycld/core/lib/account-password'
 import { useAuth } from '@tinycld/core/lib/auth'
 import { navigateToOrg } from '@tinycld/core/lib/org-url'
+import { takePendingRoute } from '@tinycld/core/lib/pending-route'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
+import { router } from 'expo-router'
 import { useState } from 'react'
 import {
     ActivityIndicator,
@@ -85,9 +87,19 @@ function LoginForm({
             setError(result.error)
             setIsSubmitting(false)
         } else if (result.user) {
-            // Single-org deployment: org identity comes from the deployment, not
-            // the user — send every signed-in user to the app root.
-            navigateToOrg()
+            // Return to whatever route the gate interrupted — a deep link, or
+            // the screen an expired session flipped out from under the user.
+            // Recorded by AuthGate; replace (not push) so the sign-in overlay
+            // isn't a back-button destination.
+            const pending = takePendingRoute()
+            if (pending) {
+                router.replace(pending)
+            } else {
+                // Nothing to return to. Single-org deployment: org identity
+                // comes from the deployment, not the user — send every
+                // signed-in user to the app root.
+                navigateToOrg()
+            }
         }
     }
 

--- a/core/lib/__tests__/pending-route.test.ts
+++ b/core/lib/__tests__/pending-route.test.ts
@@ -1,0 +1,112 @@
+import { CONNECT_HREF, PICK_ORG_HREF } from '@tinycld/core/lib/org-routes'
+import {
+    clearPendingRoute,
+    setPendingRoute,
+    takePendingRoute,
+} from '@tinycld/core/lib/pending-route'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('pending-route', () => {
+    beforeEach(() => {
+        clearPendingRoute()
+    })
+
+    it('returns the recorded route and clears it, so a later sign-in starts clean', () => {
+        setPendingRoute('/a/settings')
+        expect(takePendingRoute()).toBe('/a/settings')
+        expect(takePendingRoute()).toBeNull()
+    })
+
+    it('preserves the query string, which encodes package view state', () => {
+        setPendingRoute('/a/boards?focused=HOME-1')
+        expect(takePendingRoute()).toBe('/a/boards?focused=HOME-1')
+    })
+
+    it('keeps the OAuth consent code so the device flow can resume', () => {
+        setPendingRoute('/p/oauth/authorize?user_code=ABCD-1234')
+        expect(takePendingRoute()).toBe('/p/oauth/authorize?user_code=ABCD-1234')
+    })
+
+    it('clears a recorded route', () => {
+        setPendingRoute('/a/settings')
+        clearPendingRoute()
+        expect(takePendingRoute()).toBeNull()
+    })
+
+    it('returns null when nothing was recorded', () => {
+        expect(takePendingRoute()).toBeNull()
+    })
+
+    // Landing routes: restoring these just re-enters the redirect that the
+    // no-pending fallback already performs.
+    it.each([
+        '/',
+        '/a',
+        CONNECT_HREF,
+        PICK_ORG_HREF,
+        '/p/demo',
+    ])('ignores the landing/pre-auth route %s', href => {
+        setPendingRoute(href)
+        expect(takePendingRoute()).toBeNull()
+    })
+
+    it('ignores the root even when it carries a query string', () => {
+        setPendingRoute('/?foo=1')
+        expect(takePendingRoute()).toBeNull()
+    })
+
+    // Open-redirect guard. '//evil.example.com' is the one the existing backTo
+    // consumers miss: a browser reads it as an absolute off-site URL.
+    it.each([
+        'https://evil.example.com',
+        '//evil.example.com',
+        'evil.example.com',
+        'javascript:alert(1)',
+    ])('refuses the off-site href %s', href => {
+        setPendingRoute(href)
+        expect(takePendingRoute()).toBeNull()
+    })
+
+    it('does not overwrite a good route with a rejected one', () => {
+        setPendingRoute('/a/settings')
+        setPendingRoute('//evil.example.com')
+        expect(takePendingRoute()).toBe('/a/settings')
+    })
+})
+
+// The web entry URL is snapshotted at import time, because a deep-linked
+// signed-out load collapses the address bar to the bare app root before the
+// sign-in form renders (see pending-route.ts). These re-import the module with
+// a stubbed location to exercise that boot-time capture.
+describe('pending-route entry-URL capture', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.resetModules()
+    })
+
+    async function importWithLocation(pathname: string, search = '') {
+        vi.stubGlobal('location', { pathname, search })
+        vi.resetModules()
+        return await import('@tinycld/core/lib/pending-route')
+    }
+
+    it('captures a deep entry URL at import time', async () => {
+        const mod = await importWithLocation('/a/settings/personal')
+        expect(mod.takePendingRoute()).toBe('/a/settings/personal')
+    })
+
+    it('keeps the query string of the entry URL', async () => {
+        const mod = await importWithLocation('/a/boards', '?focused=HOME-1')
+        expect(mod.takePendingRoute()).toBe('/a/boards?focused=HOME-1')
+    })
+
+    it('captures nothing when the app is opened at the root', async () => {
+        const mod = await importWithLocation('/')
+        expect(mod.takePendingRoute()).toBeNull()
+    })
+
+    it('captures nothing when the app root is what loaded', async () => {
+        const mod = await importWithLocation('/a')
+        expect(mod.takePendingRoute()).toBeNull()
+    })
+})

--- a/core/lib/pending-route.ts
+++ b/core/lib/pending-route.ts
@@ -1,0 +1,68 @@
+import { APP_PREFIX, CONNECT_HREF, PICK_ORG_HREF } from '@tinycld/core/lib/org-routes'
+
+/**
+ * The route a signed-out user was trying to reach, held until they sign in.
+ *
+ * WHY THIS IS CAPTURED AT MODULE LOAD RATHER THAN WHEN THE GATE RENDERS:
+ * expo-router derives the browser URL from the navigators that are MOUNTED, and
+ * app/a/(app)/_layout can't mount the package tabs for a signed-out user. So on
+ * a deep link the address bar collapses to the bare app root BEFORE the sign-in
+ * form appears — the same "bounces through /a on every cold load" effect
+ * described in app/_layout.tsx's ReadySlot comment. Reading the href at gate
+ * time therefore yields '/a', not the link the user clicked. The entry URL is
+ * only reliably available before any of that runs, so it is snapshotted here at
+ * import time and consumed after sign-in.
+ *
+ * Deliberately NOT persisted: a destination written to disk outlives the intent
+ * behind it and would teleport the user mid-launch days later. Native cold-start
+ * deep links don't need it — expo-router hands the launch URL to the route tree
+ * in the same session this module is loaded in.
+ */
+let pendingRoute: string | null = null
+
+/** Routes that are already the post-login landing, or are pre-auth plumbing. */
+const NEVER_RESTORED = new Set<string>(['/', APP_PREFIX, CONNECT_HREF, PICK_ORG_HREF, '/p/demo'])
+
+/**
+ * True for an href worth returning to after sign-in.
+ *
+ * The leading-slash test is the same open-redirect guard the `backTo` consumers
+ * use (app/a/connect.tsx), plus the `//` case they miss: a browser reads a
+ * protocol-relative `//evil.example.com` as an absolute off-site URL.
+ */
+function isRestorable(href: string): boolean {
+    if (!href.startsWith('/') || href.startsWith('//')) return false
+    return !NEVER_RESTORED.has(href.split('?', 1)[0])
+}
+
+export function setPendingRoute(href: string): void {
+    if (isRestorable(href)) pendingRoute = href
+}
+
+/** Read and clear, so a later sign-out → sign-in can't resurrect a stale target. */
+export function takePendingRoute(): string | null {
+    const route = pendingRoute
+    pendingRoute = null
+    return route
+}
+
+export function clearPendingRoute(): void {
+    pendingRoute = null
+}
+
+/**
+ * Snapshot the URL the app was opened at, on web, before expo-router rewrites
+ * it. Runs at import time; a no-op off-web and in any non-browser context
+ * (SSR, unit tests), where `location` is absent.
+ *
+ * Native's launch URL arrives through +native-intent.ts and reaches the route
+ * tree directly, so there is nothing to snapshot here for it — the same
+ * captureCurrentRoute() call from the gate covers the cases where the mounted
+ * route IS the destination.
+ */
+function captureEntryUrl(): void {
+    if (typeof location === 'undefined') return
+    setPendingRoute(`${location.pathname}${location.search}`)
+}
+
+captureEntryUrl()

--- a/core/lib/stores/auth-store.ts
+++ b/core/lib/stores/auth-store.ts
@@ -1,5 +1,6 @@
 import { captureException } from '@tinycld/core/lib/errors'
 import { unregisterExpoPushToken } from '@tinycld/core/lib/expo-push'
+import { clearPendingRoute } from '@tinycld/core/lib/pending-route'
 import {
     authStoreReady,
     getUserFromAuthStore,
@@ -195,6 +196,9 @@ export const useAuthStore = create<AuthStoreState>()((set, get) => ({
         // the same device doesn't inherit the previous user's last-opened
         // file references.
         useWorkspaceStore.setState({ lastPackageHref: {} })
+        // Same reason: a route recorded for the signed-out user must not become
+        // the next user's post-sign-in destination.
+        clearPendingRoute()
         // Drop per-session in-memory caches (pbtsdb stores + React Query,
         // incl. the pb file token) so the next user signing in on this SPA
         // instance can't read the previous user's rows or reuse their token.

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -98,8 +98,11 @@ export function packageScreen(page: Page, pkg: string): Locator {
     return page.getByTestId(`pkg-active-${pkg}`)
 }
 
-export async function login(page: Page) {
-    await page.goto('/')
+// `startAt` lets a spec begin at a deep route instead of '/', to exercise the
+// "sign in, land back on the route you asked for" path. Defaults to '/', so
+// every existing caller is unaffected.
+export async function login(page: Page, options: { startAt?: string } = {}) {
+    await page.goto(options.startAt ?? '/')
     // Idempotent: a helper earlier in the same test (createInvitedUser) may
     // have left the fixture session authenticated, in which case '/' redirects
     // straight into the shell and NO login form exists — filling it would hang

--- a/tests/e2e/login-return-to.spec.ts
+++ b/tests/e2e/login-return-to.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+import { appShell, login } from './helpers'
+
+// Opening a deep link while signed out used to lose the destination: the gate
+// is an overlay, so the URL survived the sign-in form, but LoginModal then
+// pushed '/' unconditionally and the landing redirect sent the user to the
+// first nav package instead of the thing they clicked.
+//
+// The target is a settings route because settings is committed in the app shell
+// itself, so this spec holds in any assembly — a feature-package route would
+// skip whenever that package isn't linked. /settings/personal specifically: it
+// is a leaf that renders itself, where bare /a/settings redirects to a section.
+test('signing in from a deep link lands on the attempted route', async ({ page }) => {
+    await login(page, { startAt: '/a/settings/personal' })
+
+    // Screen first, URL second: a URL changes when the router ACCEPTS a
+    // navigation, before the target screen commits, so asserting the URL alone
+    // would race the still-loading route (see the appShell note in helpers.ts).
+    // The document title is stamped by the screen's own DocumentTitle, so it
+    // only matches once that screen is actually mounted.
+    await expect(appShell(page)).toBeVisible()
+    await expect(page).toHaveTitle(/Settings — Personal$/, { timeout: 20_000 })
+    await expect(page).toHaveURL(/\/a\/settings\/personal(?:[/?]|$)/)
+})
+
+// The no-pending-route fallback. '/' is filtered out when the gate records it,
+// so signing in at the root must still take the landing redirect to the first
+// nav package — behavior unchanged by this feature.
+test('signing in at the root still lands on the default package', async ({ page }) => {
+    await login(page)
+
+    await expect(appShell(page)).toBeVisible()
+    // Landed somewhere real, not stranded on the bare root or app prefix.
+    await expect(page).not.toHaveURL(/\/a\/?$/)
+})


### PR DESCRIPTION
Opening a deep link while signed out dropped the user on the default landing package instead of the route they clicked — on web and native.

## Cause

The sign-in form is an overlay, not a route: `AuthGate` renders `LoginModal` over whatever screen is mounted. On success it called `navigateToOrg()` unconditionally, which pushes `/` and lets the landing redirect pick the first nav package, discarding the destination.

## Change

Record the attempted route, consume it after sign-in, and fall back to `navigateToOrg()` when there is nothing to return to.

Capture needs two sources:

- **Web** — expo-router derives the URL from the navigators that are *mounted*, and `app/a/(app)/_layout` can't mount the package tabs for a signed-out user, so the address bar collapses to `/a` before the form renders (the bounce described in `ReadySlot`). The entry URL is snapshotted at module load, before that happens.
- **`AuthGate`** — records the mounted href, covering the cases where that route really is the destination: an in-place session expiry, and the OAuth consent screen.

They can't fight: the app root is filtered out, so the collapsed `/a` is discarded and the entry snapshot stands.

Also fixes the OAuth device flow — `authorize.tsx` documents that it expects to re-render in place after sign-in, but was being ejected mid-consent.

## Notes

- Not persisted — a destination written to disk outlives the intent behind it. Single-use, and cleared on logout beside the existing `lastPackageHref` wipe so it can't leak to the next user.
- Restoration is guarded against open redirects, including the protocol-relative `//host` form the existing `backTo` consumers admit.
- `accept-invite` / `reset-password` still land on `/` — the emailed link *is* the destination.

## Tests

- 20 unit tests (`pending-route.test.ts`): single-use semantics, query-string preservation, filtered landing/pre-auth routes, off-site hrefs, and the boot-time entry capture.
- New e2e spec: deep link → sign in → lands on the attempted route, plus a regression test that signing in at the root still reaches the default package.
- `login()` gains an optional `startAt` (defaults to `/`), so existing callers are unchanged.