### PR TITLE
Sheets fill their width and hang from the edge nearest the trigger

### DIFF
--- a/core/tests/unit/menu.test.tsx
+++ b/core/tests/unit/menu.test.tsx
@@ -200,7 +200,7 @@ describe('Menu (phone)', () => {
         return sheet
     }
 
-    it('renders its rows in a sheet hanging from the top edge by default', () => {
+    it('renders its rows in a sheet hanging from the edge nearest the trigger', () => {
         const onSelect = vi.fn()
         const { container, getByText } = render(
             <Menu isOpen onOpenChange={() => {}} anchor={{ x: 10, y: 10 }} testID="sheet">
@@ -217,7 +217,19 @@ describe('Menu (phone)', () => {
         expect(onSelect).toHaveBeenCalledTimes(1)
     })
 
-    it('rests on the bottom edge when the caller asks for it', () => {
+    it('rests on the bottom edge for a trigger low on the screen', () => {
+        // No sheetSide passed: the side is derived from the anchor, which sits
+        // in the bottom half of the 844-tall phone window.
+        const { container } = render(
+            <Menu isOpen onOpenChange={() => {}} anchor={{ x: 10, y: 800 }} testID="sheet">
+                <Menu.Item label="Rename" onSelect={() => {}} />
+            </Menu>
+        )
+        expect(sheetOf(container).className).toContain('bottom-0')
+    })
+
+    it('lets an explicit sheetSide override the derived edge', () => {
+        // A top-half anchor would derive 'top'; the caller asked for bottom.
         const { container } = render(
             <Menu
                 isOpen

--- a/core/tests/unit/place-popover.test.ts
+++ b/core/tests/unit/place-popover.test.ts
@@ -1,4 +1,4 @@
-import { placePopover, placeSubmenu } from '@tinycld/core/ui/popover/place'
+import { placePopover, placeSubmenu, sheetSideForAnchor } from '@tinycld/core/ui/popover/place'
 import { describe, expect, it } from 'vitest'
 
 const viewport = { width: 1000, height: 600 }
@@ -97,5 +97,29 @@ describe('placeSubmenu', () => {
         const lowRow = { ...row, y: 560 }
         const result = placeSubmenu({ parent, row: lowRow, size, viewport })
         expect(result.top).toBe(600 - 150 - 8)
+    })
+})
+
+describe('sheetSideForAnchor', () => {
+    const height = 800
+
+    it('hangs from the top for a trigger in the top half', () => {
+        // A header button — the boards Filter case that motivated this.
+        expect(sheetSideForAnchor({ x: 0, y: 60, width: 80, height: 32 }, height)).toBe('top')
+    })
+
+    it('rests on the bottom for a trigger in the bottom half', () => {
+        expect(sheetSideForAnchor({ x: 0, y: 700, width: 80, height: 32 }, height)).toBe('bottom')
+    })
+
+    it('measures from the anchor CENTRE, not its top edge', () => {
+        // A tall trigger whose top is above the midpoint but whose bulk is
+        // below it belongs to the bottom half.
+        expect(sheetSideForAnchor({ x: 0, y: 380, width: 80, height: 200 }, height)).toBe('bottom')
+    })
+
+    it('treats a zero-size point anchor by its position', () => {
+        expect(sheetSideForAnchor({ x: 10, y: 10, width: 0, height: 0 }, height)).toBe('top')
+        expect(sheetSideForAnchor({ x: 10, y: 790, width: 0, height: 0 }, height)).toBe('bottom')
     })
 })

--- a/core/tests/unit/sheet-side.test.tsx
+++ b/core/tests/unit/sheet-side.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, render as renderBare } from '@testing-library/react'
 import { OverlayProvider } from '@tinycld/core/ui/overlay'
-import { Sheet } from '@tinycld/core/ui/sheet'
+import { Sheet, sheetBodyContentStyle } from '@tinycld/core/ui/sheet'
 import type { ReactElement } from 'react'
 import { Text } from 'react-native'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -51,5 +51,33 @@ describe('Sheet side', () => {
         expect(surface.className).toContain('rounded-b-2xl')
         expect(surface.className).not.toContain('bottom-0')
         expect(handleIsAfterContent(surface)).toBe(true)
+    })
+})
+
+describe('Sheet.Body', () => {
+    afterEach(cleanup)
+
+    it('stretches its content to the sheet width', () => {
+        // The surfaces that BECOME a sheet (Popover, Menu, Dialog) are often
+        // authored around a popover's narrow box, and content laid out at that
+        // intrinsic width leaves a phone-width sheet hugging its left edge.
+        // Stretching makes filling the default, so a body has to opt OUT
+        // rather than every caller remembering to opt in.
+        //
+        // Asserted on the prop rather than a computed style: these tests run
+        // against tests/react-native-stub.cjs, which renders `rn-*` custom
+        // elements and applies no layout, so there is no cross-axis alignment
+        // to read back off the DOM.
+        const { container } = render(
+            <Sheet isOpen onClose={() => {}} testID="sheet">
+                <Sheet.Body testID="body">
+                    <Text testID="content">Body</Text>
+                </Sheet.Body>
+            </Sheet>
+        )
+        const body = container.querySelector<HTMLElement>('[testid="body"]')
+        if (!body) throw new Error('sheet body not rendered')
+        expect(sheetBodyContentStyle).toMatchObject({ alignItems: 'stretch' })
+        expect(body.contains(container.querySelector('[testid="content"]'))).toBe(true)
     })
 })

--- a/core/ui/emoji-picker/EmojiPicker.tsx
+++ b/core/ui/emoji-picker/EmojiPicker.tsx
@@ -1,12 +1,12 @@
 import type { FlashListRef } from '@shopify/flash-list'
-import { Popover } from '@tinycld/core/ui/popover'
+import { Popover, usePopoverContext } from '@tinycld/core/ui/popover'
 import { type ReactElement, useCallback, useRef, useState } from 'react'
 import { View } from 'react-native'
 import { CategoryNav } from './CategoryNav'
 import { CATEGORY_ORDER } from './categories'
 import { EmojiPickerGrid } from './EmojiPickerGrid'
 import { EmojiSearch } from './EmojiSearch'
-import { PICKER_WIDTH } from './layout'
+import { columnsForWidth, EMOJI_PER_ROW, PICKER_WIDTH } from './layout'
 import type { EmojiRow } from './rows'
 import { useEmojiData } from './use-emoji-data'
 import { useEmojiPicker } from './use-emoji-picker'
@@ -65,7 +65,16 @@ export function EmojiPicker({
  */
 function PickerBody({ isOpen, onPick }: { isOpen: boolean; onPick: (glyph: string) => void }) {
     const { table, isLoading } = useEmojiData(isOpen)
-    const { query, setQuery, tone, setTone, rows, isSearching, recordUse } = useEmojiPicker(table)
+    // A popover is sized to PICKER_WIDTH, so its column count is known up
+    // front; a sheet is as wide as the screen, so the grid measures itself and
+    // chunks to fit rather than leaving a phone-width surface two-thirds empty.
+    const { isSheet } = usePopoverContext()
+    const [measuredWidth, setMeasuredWidth] = useState(0)
+    const perRow = isSheet && measuredWidth > 0 ? columnsForWidth(measuredWidth) : EMOJI_PER_ROW
+    const { query, setQuery, tone, setTone, rows, isSearching, recordUse } = useEmojiPicker(
+        table,
+        perRow
+    )
     const listRef = useRef<FlashListRef<EmojiRow> | null>(null)
     const [visibleCategory, setVisibleCategory] = useState<string | null>(null)
 
@@ -89,7 +98,12 @@ function PickerBody({ isOpen, onPick }: { isOpen: boolean; onPick: (glyph: strin
     )
 
     return (
-        <View>
+        <View
+            onLayout={e => {
+                const { width } = e.nativeEvent.layout
+                setMeasuredWidth(prev => (prev === width ? prev : width))
+            }}
+        >
             <EmojiSearch
                 query={query}
                 onQueryChange={setQuery}
@@ -103,6 +117,7 @@ function PickerBody({ isOpen, onPick }: { isOpen: boolean; onPick: (glyph: strin
             />
             <EmojiPickerGrid
                 rows={rows}
+                perRow={perRow}
                 listRef={listRef}
                 onVisibleCategoryChange={setVisibleCategory}
                 tone={tone}

--- a/core/ui/emoji-picker/EmojiPickerGrid.tsx
+++ b/core/ui/emoji-picker/EmojiPickerGrid.tsx
@@ -17,6 +17,8 @@ export interface EmojiPickerGridProps {
     /** The tone applied to any emoji that takes one. */
     tone: ToneChoice
     onSelect: (glyph: string) => void
+    /** Cells per row — the count `rows` was chunked at. */
+    perRow: number
     /** Shown in place of the grid while the lazy table is in flight. */
     isLoading?: boolean
     emptyLabel?: string
@@ -35,6 +37,7 @@ export function EmojiPickerGrid({
     onVisibleCategoryChange,
     tone,
     onSelect,
+    perRow,
     isLoading = false,
     emptyLabel = 'No emoji found',
 }: EmojiPickerGridProps) {
@@ -43,9 +46,9 @@ export function EmojiPickerGrid({
             item.kind === 'header' ? (
                 <SectionHeader category={item.category} />
             ) : (
-                <EmojiRowCells emoji={item.emoji} tone={tone} onSelect={onSelect} />
+                <EmojiRowCells emoji={item.emoji} perRow={perRow} tone={tone} onSelect={onSelect} />
             ),
-        [tone, onSelect]
+        [tone, onSelect, perRow]
     )
 
     // The topmost visible row's section, so the nav highlights what you are
@@ -97,17 +100,31 @@ function SectionHeader({ category }: { category: string }) {
     )
 }
 
+/**
+ * One row of cells. A FULL row spreads: it is chunked to exactly the number of
+ * cells the surface fits, so the remainder from that integer division belongs
+ * between them — packed left at a fixed EMOJI_SIZE, a wide sheet shows a grid
+ * hugging its left edge with a bite of empty space at the right. A short last
+ * row keeps the default packing, so it continues the column rhythm above it
+ * instead of stranding three cells at opposite edges.
+ */
 function EmojiRowCells({
     emoji,
+    perRow,
     tone,
     onSelect,
 }: {
     emoji: readonly EmojiRecord[]
+    perRow: number
     tone: ToneChoice
     onSelect: (glyph: string) => void
 }) {
+    const isFull = emoji.length === perRow
     return (
-        <View className="flex-row" style={{ height: ROW_HEIGHT }}>
+        <View
+            className={`flex-row ${isFull ? 'justify-between' : ''}`}
+            style={{ height: ROW_HEIGHT }}
+        >
             {emoji.map(record => (
                 <EmojiCell key={record.u} record={record} tone={tone} onSelect={onSelect} />
             ))}

--- a/core/ui/emoji-picker/__tests__/rows.test.ts
+++ b/core/ui/emoji-picker/__tests__/rows.test.ts
@@ -39,6 +39,18 @@ describe('toRows', () => {
     it('returns nothing for no sections', () => {
         expect(toRows([])).toEqual([])
     })
+
+    it('chunks at a caller-supplied width, for the wider sheet grid', () => {
+        const rows = toRows([{ category: 'objects', emoji: many(20) }], 12)
+        expect(rows.filter(r => r.kind === 'emoji')).toHaveLength(2) // 12 + 8
+        expect(cells(rows[1])).toHaveLength(12)
+        expect(cells(rows[2])).toHaveLength(8)
+    })
+
+    it('never chunks at zero or a fraction, which would not terminate', () => {
+        expect(cells(toRows([{ category: 'o', emoji: many(3) }], 0)[1])).toHaveLength(1)
+        expect(cells(toRows([{ category: 'o', emoji: many(9) }], 4.7)[1])).toHaveLength(4)
+    })
 })
 
 describe('toSearchRows', () => {
@@ -50,6 +62,12 @@ describe('toSearchRows', () => {
 
     it('returns nothing for no results', () => {
         expect(toSearchRows([])).toEqual([])
+    })
+
+    it('chunks at a caller-supplied width too', () => {
+        const rows = toSearchRows(many(10), 5)
+        expect(rows).toHaveLength(2)
+        expect(cells(rows[0])).toHaveLength(5)
     })
 
     it('keys distinctly from category rows, so a re-render cannot collide', () => {

--- a/core/ui/emoji-picker/layout.ts
+++ b/core/ui/emoji-picker/layout.ts
@@ -15,6 +15,16 @@ export const PICKER_WIDTH = EMOJI_PER_ROW * EMOJI_SIZE + GRID_PADDING * 2
 /** Height of the scrolling grid alone — the header and nav sit above it. */
 export const GRID_HEIGHT = 400 - 44 - 40
 
+/**
+ * How many cells fit a surface of the given width, at least one. A popover is
+ * sized to PICKER_WIDTH and gets EMOJI_PER_ROW back; a sheet is as wide as the
+ * screen and gets more, so the grid fills it instead of hugging the left edge.
+ */
+export function columnsForWidth(width: number): number {
+    const usable = width - GRID_PADDING * 2
+    return Math.max(1, Math.floor(usable / EMOJI_SIZE))
+}
+
 /** Row height in the virtualized list. */
 export const ROW_HEIGHT = EMOJI_SIZE
 

--- a/core/ui/emoji-picker/rows.ts
+++ b/core/ui/emoji-picker/rows.ts
@@ -1,8 +1,12 @@
 // The category-grouped table flattened into list rows.
 //
 // FlashList wants a flat array; the picker wants sections with sticky-ish
-// headers and 8 emoji per row. This turns one into the other, and is pure so
+// headers and N emoji per row. This turns one into the other, and is pure so
 // it can be tested without rendering anything.
+//
+// The column count is a PARAMETER rather than the module constant it used to
+// be: a popover is sized to fit 8 cells, but a sheet is as wide as the screen
+// and fits more, and a grid chunked at 8 leaves it hugging the left edge.
 
 import type { EmojiRecord } from './emoji-data'
 import { EMOJI_PER_ROW } from './layout'
@@ -20,13 +24,14 @@ interface Section {
  * Sections -> rows. A section with no emoji contributes nothing, not an empty
  * header: "Frequently used" is absent until someone has used something.
  */
-export function toRows(sections: readonly Section[]): EmojiRow[] {
+export function toRows(sections: readonly Section[], perRow: number = EMOJI_PER_ROW): EmojiRow[] {
+    const columns = Math.max(1, Math.floor(perRow))
     const rows: EmojiRow[] = []
     for (const section of sections) {
         if (section.emoji.length === 0) continue
         rows.push({ kind: 'header', category: section.category, key: `h:${section.category}` })
-        for (let i = 0; i < section.emoji.length; i += EMOJI_PER_ROW) {
-            const chunk = section.emoji.slice(i, i + EMOJI_PER_ROW)
+        for (let i = 0; i < section.emoji.length; i += columns) {
+            const chunk = section.emoji.slice(i, i + columns)
             rows.push({
                 kind: 'emoji',
                 emoji: chunk,
@@ -38,10 +43,14 @@ export function toRows(sections: readonly Section[]): EmojiRow[] {
 }
 
 /** Search results as rows: no headers, just the grid. */
-export function toSearchRows(results: readonly EmojiRecord[]): EmojiRow[] {
+export function toSearchRows(
+    results: readonly EmojiRecord[],
+    perRow: number = EMOJI_PER_ROW
+): EmojiRow[] {
+    const columns = Math.max(1, Math.floor(perRow))
     const rows: EmojiRow[] = []
-    for (let i = 0; i < results.length; i += EMOJI_PER_ROW) {
-        const chunk = results.slice(i, i + EMOJI_PER_ROW)
+    for (let i = 0; i < results.length; i += columns) {
+        const chunk = results.slice(i, i + columns)
         rows.push({ kind: 'emoji', emoji: chunk, key: `s:${chunk[0].u}` })
     }
     return rows

--- a/core/ui/emoji-picker/use-emoji-picker.ts
+++ b/core/ui/emoji-picker/use-emoji-picker.ts
@@ -15,7 +15,7 @@ import { toRows, toSearchRows } from './rows'
 import type { EmojiTable } from './use-emoji-data'
 import { useFrequentEmoji } from './use-frequent-emoji'
 
-export function useEmojiPicker(table: EmojiTable | null) {
+export function useEmojiPicker(table: EmojiTable | null, perRow?: number) {
     const [query, setQuery] = useState('')
     const [tone, setTone] = useUserPreference<ToneChoice>('core', 'emoji_skin_tone', NEUTRAL_TONE)
     const { frequent, record } = useFrequentEmoji()
@@ -31,7 +31,7 @@ export function useEmojiPicker(table: EmojiTable | null) {
 
     const rows = useMemo(() => {
         if (!table) return []
-        if (results) return toSearchRows(results)
+        if (results) return toSearchRows(results, perRow)
 
         const byCategory = new Map(table.categories.map(section => [section.c, section.e]))
         // A remembered pick may carry a tone; the table is keyed by the
@@ -48,9 +48,10 @@ export function useEmojiPicker(table: EmojiTable | null) {
                     category === FREQUENT_CATEGORY
                         ? frequentRecords
                         : (byCategory.get(category) ?? []),
-            }))
+            })),
+            perRow
         )
-    }, [table, results, frequent])
+    }, [table, results, frequent, perRow])
 
     return {
         query,

--- a/core/ui/menu/index.tsx
+++ b/core/ui/menu/index.tsx
@@ -32,7 +32,8 @@ import { Platform, Pressable, Text, View } from 'react-native'
 /**
  * A list of commands on a Popover: `role="menu"`, arrow keys and typeahead,
  * one submenu level, and rows that close the whole surface when chosen. On
- * the mobile breakpoint the same rows render in a Sheet.
+ * the mobile breakpoint the same rows render in a Sheet, hanging from the edge
+ * nearest the trigger.
  *
  * Rows are props, not children: a row is a label with an icon, a shortcut
  * and a state, and a sheet must be able to draw the same row as a touch
@@ -52,9 +53,8 @@ export interface MenuProps {
     /** Title of the sheet the menu becomes on a phone. */
     title?: string
     /**
-     * The edge that sheet rests on. Default `top`, since most menu triggers sit
-     * near the top of the screen; pass `bottom` for a menu opened from the
-     * bottom of a screen.
+     * The edge that sheet rests on. Defaults to the edge nearest the trigger,
+     * derived from the measured anchor; pass a side to override that.
      */
     sheetSide?: SheetSide
     className?: string
@@ -85,7 +85,7 @@ function MenuRoot({
     presentation = 'auto',
     width,
     title,
-    sheetSide = 'top',
+    sheetSide,
     className,
     testID,
     children,

--- a/core/ui/popover/index.tsx
+++ b/core/ui/popover/index.tsx
@@ -24,7 +24,7 @@ import {
     StyleSheet,
     View,
 } from 'react-native'
-import { type Placement, placePopover, type Rect, type Size } from './place'
+import { type Placement, placePopover, type Rect, type Size, sheetSideForAnchor } from './place'
 
 // The native layer is a statusBarTranslucent RN Modal whose origin is the true
 // top of the screen, while `measureInWindow` reports Y from below the status
@@ -71,11 +71,23 @@ export interface PopoverProps {
     placement?: Placement
     /** `auto` is a sheet on the mobile breakpoint and a popover elsewhere. */
     presentation?: PopoverPresentation
-    /** A fixed width for the surface; otherwise it fits its content, at least 200 wide. */
+    /**
+     * A fixed width for the surface; otherwise it fits its content, at least
+     * 200 wide. POPOVER MODE ONLY — a sheet is as wide as the screen, and this
+     * is ignored there. A body that needs a fixed width in a popover and a
+     * fluid one in a sheet reads `usePopoverContext().isSheet` and drops its
+     * own width, the way FilterPanel and the emoji grid do; do not reach for
+     * this prop to size sheet content.
+     */
     width?: number
     /** Title of the sheet the surface becomes on a phone. */
     title?: string
-    /** The edge that sheet rests on. Default `bottom`. */
+    /**
+     * The edge that sheet rests on. Defaults to the edge NEAREST THE TRIGGER,
+     * derived from the measured anchor: a trigger in the top half of the
+     * viewport gets a top sheet, one in the bottom half a bottom sheet. Pass a
+     * side to override that.
+     */
     sheetSide?: SheetSide
     /** Padding of the sheet's scrolled content. */
     sheetContentClassName?: string
@@ -105,7 +117,7 @@ export function Popover({
     presentation = 'auto',
     width,
     title,
-    sheetSide = 'bottom',
+    sheetSide,
     sheetContentClassName,
     className,
     testID,
@@ -131,6 +143,7 @@ export function Popover({
 
     const triggerElement = useTriggerElement(trigger, triggerRef, isOpen, setOpen)
     const resolvedAnchor: PopoverAnchor = anchor ?? triggerRef
+    const derivedSide = useSheetSide(resolvedAnchor, isSheet && isOpen)
 
     if (isSheet) {
         return (
@@ -140,7 +153,7 @@ export function Popover({
                     isOpen={isOpen}
                     onClose={close}
                     title={title}
-                    side={sheetSide}
+                    side={sheetSide ?? derivedSide}
                     testID={testID}
                 >
                     <PopoverContext.Provider value={SHEET_CONTEXT(isOpen, close)}>
@@ -172,6 +185,50 @@ export function Popover({
             </PopoverLayer>
         </>
     )
+}
+
+/**
+ * The edge a sheet should rest on, measured from the trigger it opened from.
+ *
+ * Falls back to `bottom` — the edge a thumb reaches — while the anchor is
+ * unmeasured or when there is no anchor at all. Measurement runs on open only:
+ * a sheet is a full-width surface, so unlike a popover it has nothing to
+ * re-place when the window resizes, and re-deriving the side mid-life would
+ * flip a sheet across the screen while the user is reading it.
+ */
+function useSheetSide(anchor: PopoverAnchor, isActive: boolean): SheetSide {
+    const [side, setSide] = useState<SheetSide>('bottom')
+    // Read through a ref, not a subscription: the side is decided once per
+    // open, so tracking the height would re-run this on every resize frame
+    // and could flip an open sheet across the screen mid-read.
+    const viewportHeightRef = useRef(0)
+    viewportHeightRef.current = useWindowSizeStore(s => s.height)
+
+    useLayoutEffect(() => {
+        if (!isActive) return
+        const height = viewportHeightRef.current
+        if (isPoint(anchor)) {
+            setSide(sheetSideForAnchor({ x: anchor.x, y: anchor.y, width: 0, height: 0 }, height))
+            return
+        }
+        const node = anchor.current
+        if (!node) return
+        if (Platform.OS === 'web') {
+            const rect = (node as unknown as HTMLElement).getBoundingClientRect()
+            setSide(
+                sheetSideForAnchor(
+                    { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
+                    height
+                )
+            )
+            return
+        }
+        node.measureInWindow((x, y, w, h) => {
+            setSide(sheetSideForAnchor({ x, y, width: w, height: h }, height))
+        })
+    }, [isActive, anchor])
+
+    return side
 }
 
 function SHEET_CONTEXT(isOpen: boolean, close: () => void): PopoverContextValue {

--- a/core/ui/popover/place.ts
+++ b/core/ui/popover/place.ts
@@ -171,3 +171,20 @@ export function placeSubmenu({
 
     return { top, left }
 }
+
+/**
+ * Which edge a sheet should rest on for a given trigger: the one NEAREST it.
+ *
+ * A sheet that slides in from the far edge reads as unrelated to the control
+ * that opened it — the boards Filter button sits in the header and its panel
+ * used to rise from the bottom of the screen, crossing the whole viewport to
+ * answer a tap at the top. Measuring the anchor's CENTRE (not its top) keeps a
+ * tall trigger straddling the midpoint from flipping on a few pixels.
+ *
+ * Pure, so `core/tests/unit/place-popover.test.ts` pins it rather than an e2e
+ * run that happens to open a menu near the middle of a screen.
+ */
+export function sheetSideForAnchor(anchor: Rect, viewportHeight: number): 'top' | 'bottom' {
+    const centre = anchor.y + anchor.height / 2
+    return centre < viewportHeight / 2 ? 'top' : 'bottom'
+}

--- a/core/ui/sheet/index.tsx
+++ b/core/ui/sheet/index.tsx
@@ -275,7 +275,17 @@ function SheetDescription({ text }: { text?: string }) {
     return <Text className="text-[13px] text-muted">{text}</Text>
 }
 
-/** The part that scrolls once the sheet reaches its cap. */
+/**
+ * The part that scrolls once the sheet reaches its cap.
+ *
+ * Content is STRETCHED to the sheet's full width. A sheet is as wide as the
+ * screen, but the surfaces that become one — a Popover, a Menu, a Dialog —
+ * are often authored around a popover's narrow measured box, and a body laid
+ * out at that intrinsic width leaves a phone-width sheet mostly empty with its
+ * content hugging the left edge. Stretching makes filling the default, so a
+ * body only has to opt OUT (see `usePopoverContext().isSheet`) rather than
+ * every caller having to remember to opt in.
+ */
 function SheetBody({
     children,
     contentClassName,
@@ -292,11 +302,19 @@ function SheetBody({
             keyboardShouldPersistTaps="handled"
             className="grow-0 shrink"
             contentContainerClassName={contentClassName ?? 'px-5 pb-5 gap-3'}
+            contentContainerStyle={sheetBodyContentStyle}
         >
             {children}
         </ScrollView>
     )
 }
+
+/**
+ * Cross-axis stretch for the scrolled content, so children fill the sheet's
+ * width instead of sizing to themselves. Exported for the unit test, which
+ * runs against the react-native stub and so has no computed layout to read.
+ */
+const sheetBodyContentStyle = { alignItems: 'stretch' } as const
 
 /** The button row, pinned under the body — above the home indicator when the sheet rests on the bottom edge. */
 function SheetFooter({ children, className }: { children: ReactNode; className?: string }) {
@@ -316,4 +334,4 @@ function SheetFooter({ children, className }: { children: ReactNode; className?:
 const Sheet = Object.assign(SheetRoot, { Body: SheetBody, Footer: SheetFooter })
 
 export type { SheetProps }
-export { Sheet }
+export { Sheet, sheetBodyContentStyle }

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -98,8 +98,17 @@ The engine (`core/ui/overlay/`, internal) owns:
   to the side with more room and caps height to what that side has; the
   content scrolls internally.
 - On the mobile breakpoint a Popover renders as a sheet unless
-  `presentation="popover"` is pinned. `sheetSide` (`top|bottom`, default
-  `bottom`) picks the edge that sheet rests on.
+  `presentation="popover"` is pinned. The edge that sheet rests on is derived
+  from the measured anchor — a trigger in the top half of the viewport gets a
+  top sheet, one in the bottom half a bottom sheet — so a surface opens from
+  the edge nearest the control that opened it. `sheetSide` (`top|bottom`)
+  overrides that; there is normally no reason to pass it.
+- `width` is **popover-only**. A sheet is as wide as the screen, and
+  `Sheet.Body` stretches its content to fill it, so a body fills by default. A
+  body that wants a fixed width in a popover and a fluid one in a sheet reads
+  `usePopoverContext().isSheet` and drops its own width — boards' `FilterPanel`
+  and the emoji grid are the two worked examples. Do not size sheet content
+  with `width`.
 
 Placement is a pure function, `placePopover()` in `core/ui/popover/place.ts`,
 with unit tests. Do not put positioning arithmetic anywhere else.
@@ -140,22 +149,43 @@ the whole chain when chosen.
   in the right-click (web) and long-press (native) gestures; the menubar and
   the calc grid menus are controlled Menus in the single-open registry.
 - On the mobile breakpoint a Menu renders its items as a sheet hanging from
-  the **top** edge, since most menu triggers sit near the top of the screen;
-  pass `sheetSide="bottom"` for a menu opened from the bottom of a screen. Pin
-  `presentation="popover"` for a menu of two or three items beside its
-  trigger, where a sheet would be heavier than the choice.
+  the edge nearest its trigger, derived from the measured anchor exactly as a
+  Popover's is. Pin `presentation="popover"` for a menu of two or three items
+  beside its trigger, where a sheet would be heavier than the choice.
 
 ## Sheet
 
 `Sheet` is the edge surface the other three render on a phone: it rests on the
-bottom edge by default, or hangs from the top with `side="top"` (a Menu's
-default). The corners, the border, the drag pill and the dismiss gesture all
+bottom edge by default, or hangs from the top with `side="top"` (which Popover
+and Menu derive from where the trigger sits). The corners, the border, the drag pill and the dismiss gesture all
 face away from that edge. Packages use it directly only for something that is
 a sheet on every breakpoint (the mobile More menu, the notification drawer,
-the file picker). It replaces `BottomDrawer`, keeps its gesture and its "rests
+the file picker). `Sheet.Body` stretches its content to the sheet's full width,
+so a body authored around a popover's narrow box fills it rather than hugging
+the left edge. It replaces `BottomDrawer`, keeps its gesture and its "rests
 on the tab bar" behavior, and adds the title/body/footer structure so a Dialog
 rendered as a sheet looks like a sheet, not a dialog squashed to the bottom
 edge.
+
+## Drawer (the right-edge panel)
+
+`Drawer` (`core/ui/drawer`) predates this engine and is not built on it — it is
+gluestack's modal creator with an `anchor` prop. It is listed here because it is
+the one edge a `Sheet` cannot cover: `Sheet` is `top | bottom` only, and every
+`Drawer` in the ecosystem is `anchor="right"` (help, comments, members, mail's
+mailbox, drive's detail panel, calc's pivot and conditional-format). If you need
+a right-edge panel, use `Drawer` — do not hand-roll a third one.
+
+On native it can be swiped toward its own edge to dismiss, via
+`useSwipeToDismiss` (`core/ui/swipe-dismiss`), the same hook the boards card
+peek uses. The hook is anchor-aware, so a drawer on any edge gets the gesture
+from the anchor it already declares. Its thresholds and spring match `Sheet`'s
+so every edge surface settles identically, and `should-dismiss.ts` holds the
+threshold as a pure function because the gesture's `onEnd` is a UI-thread
+worklet and cannot call one.
+
+Migrating `Drawer` onto the overlay engine is still open; until then it keeps
+its own Escape handling and its own hard unmount on close.
 
 ## Testing
 


### PR DESCRIPTION
Three fixes to the overlay layer, from UX reports against boards on native.

**A sheet's body fills its width.** A Menu or Popover that becomes a sheet on a phone kept the narrow width it was authored around, leaving the surface mostly empty with content hugging the left edge. `Sheet.Body` now stretches its content, so filling is the default and opting out is the deliberate act.

**A sheet hangs from the edge nearest its trigger.** The edge was decided by whether you reached for `Menu` or `Popover` (top vs bottom defaults), not by where the trigger was — so boards' header Filter button opened a panel from the bottom of the screen. `Popover` already measures its anchor, so the side is now derived from it; an explicit `sheetSide` still wins. This retires `Menu`'s hardcoded default, so both surfaces share one rule. `sheetSide` had no call sites in the ecosystem, so nothing had to change to adopt it.

**The emoji grid fills the sheet.** It chunked rows at a fixed 8 cells sized for a 272px popover. The column count is now a parameter of the pure row helpers, derived from measured width in sheet mode.

Fixes are in core so every menu adapts, rather than patched per caller.

## Testing

1742 unit tests pass; biome, tsc and core-isolation clean. New cases cover the anchor→edge derivation (including the centre-not-top-edge rule and the explicit override), the sheet body stretch, and the emoji column-count parameter.

Not exercised in a running app — the reported symptoms are visual and native, so a look on device is still worth having.

## Note

The boards half of this work is in tinycld/boards#87, which depends on these core changes.