### PR TITLE
One swipe-to-dismiss threshold for every edge, and a swipeable Drawer

### DIFF
--- a/core/tests/unit/swipe-dismiss.test.ts
+++ b/core/tests/unit/swipe-dismiss.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { shouldDismissSwipe } from '../../ui/swipe-dismiss/should-dismiss'
+
+// The drag-to-dismiss decision is the one piece of non-RN logic in
+// useSwipeToDismiss worth pinning: a slow short drag should snap back, while a
+// long drag OR a fast flick should dismiss. Mirrors the thresholds the pan
+// gesture inlines.
+//
+// `dir` is the sign of the off-screen direction, so every case is asserted in
+// BOTH orientations — a helper shared by right/bottom panels (+1) and left/top
+// ones (-1) is only correct if the sign genuinely mirrors it.
+const AWAY = 1 // a 'right' or 'bottom' panel: it leaves in the positive direction
+const TOWARD = -1 // a 'left' or 'top' panel: it leaves in the negative direction
+
+describe('shouldDismissSwipe', () => {
+    it('keeps the panel open for a short, slow drag', () => {
+        expect(shouldDismissSwipe(40, 100, AWAY)).toBe(false)
+        expect(shouldDismissSwipe(-40, -100, TOWARD)).toBe(false)
+    })
+
+    it('treats the thresholds as exclusive, so exactly at them does not dismiss', () => {
+        expect(shouldDismissSwipe(100, 500, AWAY)).toBe(false)
+        expect(shouldDismissSwipe(-100, -500, TOWARD)).toBe(false)
+    })
+
+    it('dismisses when dragged past the distance threshold', () => {
+        expect(shouldDismissSwipe(101, 0, AWAY)).toBe(true)
+        expect(shouldDismissSwipe(300, 0, AWAY)).toBe(true)
+        expect(shouldDismissSwipe(-101, 0, TOWARD)).toBe(true)
+        expect(shouldDismissSwipe(-300, 0, TOWARD)).toBe(true)
+    })
+
+    it('dismisses on a fast flick even with little travel', () => {
+        expect(shouldDismissSwipe(10, 501, AWAY)).toBe(true)
+        expect(shouldDismissSwipe(0, 900, AWAY)).toBe(true)
+        expect(shouldDismissSwipe(-10, -501, TOWARD)).toBe(true)
+        expect(shouldDismissSwipe(0, -900, TOWARD)).toBe(true)
+    })
+
+    // The case that matters for a two-directional helper: dragging a panel
+    // back INTO the edge it rests on must never dismiss it, however hard it is
+    // flicked. Without the sign this reads as a large positive travel and
+    // closes the panel the user was pushing shut.
+    it('never dismisses on a drag or flick toward the edge', () => {
+        expect(shouldDismissSwipe(-300, -800, AWAY)).toBe(false)
+        expect(shouldDismissSwipe(-20, -800, AWAY)).toBe(false)
+        expect(shouldDismissSwipe(300, 800, TOWARD)).toBe(false)
+        expect(shouldDismissSwipe(20, 800, TOWARD)).toBe(false)
+    })
+})

--- a/core/ui/bottom-drawer/should-dismiss.ts
+++ b/core/ui/bottom-drawer/should-dismiss.ts
@@ -1,10 +1,10 @@
-// The drag-to-dismiss threshold for BottomDrawer, as a pure, unit-testable
-// function. The component's pan-gesture onEnd runs on the UI thread (a worklet)
-// and therefore can't call a non-worklet JS function, so it INLINES this same
-// comparison rather than importing this. Keep the two in sync — this version
-// exists so the unit test can pin the contract without an on-device gesture:
-// dragged past 100px, or flicked downward faster than 500px/s, dismisses; a
-// negative (upward) velocity never does.
+// Kept as a name only: the threshold now lives in ui/swipe-dismiss, which
+// generalises it over an axis sign so one function serves all four anchors.
+// This wrapper pins the bottom-sheet case (dir = +1) so the older spelling
+// keeps working while consumers migrate off `BottomDrawer` — see
+// docs/plans/overlay-engine.md.
+import { shouldDismissSwipe } from '@tinycld/core/ui/swipe-dismiss/should-dismiss'
+
 export function shouldDismissDrawer(translationY: number, velocityY: number): boolean {
-    return translationY > 100 || velocityY > 500
+    return shouldDismissSwipe(translationY, velocityY, 1)
 }

--- a/core/ui/drawer/index.tsx
+++ b/core/ui/drawer/index.tsx
@@ -4,8 +4,10 @@ import { ExitAnimationContext } from '@gluestack-ui/core/overlay/creator'
 import type { VariantProps } from '@gluestack-ui/utils/nativewind-utils'
 import { tva, useStyleContext, withStyleContext } from '@gluestack-ui/utils/nativewind-utils'
 import { useDeviceInsets } from '@tinycld/core/lib/use-safe-area'
+import { useSwipeToDismiss } from '@tinycld/core/ui/swipe-dismiss'
 import React from 'react'
 import { Platform, Pressable, ScrollView, View } from 'react-native'
+import { GestureDetector } from 'react-native-gesture-handler'
 import Animated, {
     Easing,
     FadeIn,
@@ -22,6 +24,18 @@ import Animated, {
 import { useCloseOnNavigate } from './use-close-on-navigate'
 
 const SCOPE = 'MODAL'
+
+// The swipe gesture lives on DrawerContent but the dismiss callback is given to
+// Drawer, so it reaches the content by context rather than by threading a prop
+// through every call site. Ours rather than gluestack's ModalContext: that one
+// is an implementation detail of the modal creator, and nothing guarantees it
+// keeps carrying handleClose across a version bump.
+const DrawerCloseContext = React.createContext<(() => void) | undefined>(undefined)
+
+// A Drawer is always given onClose in practice; the fallback only keeps the
+// gesture hook's contract total, since a drag that cannot dismiss still has to
+// spring back rather than throw.
+const NOOP = () => {}
 
 const RootComponent = withStyleContext(View, SCOPE)
 
@@ -251,13 +265,15 @@ const Drawer = React.forwardRef<React.ComponentRef<typeof UIDrawer>, IDrawerProp
     if (!props.isOpen) return null
 
     return (
-        <UIDrawer
-            ref={ref}
-            {...props}
-            pointerEvents="box-none"
-            className={drawerStyle({ size, anchor, class: className })}
-            context={{ size, anchor }}
-        />
+        <DrawerCloseContext.Provider value={props.onClose}>
+            <UIDrawer
+                ref={ref}
+                {...props}
+                pointerEvents="box-none"
+                className={drawerStyle({ size, anchor, class: className })}
+                context={{ size, anchor }}
+            />
+        </DrawerCloseContext.Provider>
     )
 })
 
@@ -284,6 +300,20 @@ const DrawerContent = React.forwardRef<
 >(function DrawerContent({ className, style, ...props }, ref) {
     const { size: parentSize, anchor: parentAnchor } = useStyleContext(SCOPE)
     const insets = useDeviceInsets()
+    const onClose = React.useContext(DrawerCloseContext)
+
+    // How far the panel must travel to clear the screen. Measured rather than
+    // constant: a side drawer's width is `w-[80%] max-w-[32rem]`, so it depends
+    // on the viewport and cannot be hard-coded. Seeded high so a dismissal in
+    // the first frame — before onLayout has run — still leaves the screen.
+    const [panelSize, setPanelSize] = React.useState(1000)
+    const isHorizontalAnchor = parentAnchor === 'left' || parentAnchor === 'right'
+
+    const { gesture, animatedStyle } = useSwipeToDismiss({
+        anchor: parentAnchor,
+        onClose: onClose ?? NOOP,
+        distance: panelSize,
+    })
 
     // 24px base padding (was `p-6`) plus the device safe-area inset on the edges
     // the drawer reaches, so its header/body clears the status bar / notch /
@@ -324,21 +354,33 @@ const DrawerContent = React.forwardRef<
                 : SlideOutDown.duration(200)
 
     return (
-        <UIDrawer.Content
-            ref={ref}
-            entering={enteringAnimation}
-            exiting={exitingAnimation}
-            {...props}
-            className={drawerContentStyle({
-                parentVariants: {
-                    size: parentSize,
-                    anchor: parentAnchor,
-                },
-                class: `${className || ''} ${customClass}`,
-            })}
-            style={[paddingStyle, style]}
-            pointerEvents="auto"
-        />
+        <GestureDetector gesture={gesture}>
+            <UIDrawer.Content
+                ref={ref}
+                entering={enteringAnimation}
+                exiting={exitingAnimation}
+                {...props}
+                // Composed, not replaced: this sits after {...props}, so
+                // assigning it plainly would silently swallow a caller's own
+                // onLayout.
+                onLayout={e => {
+                    const { width, height } = e.nativeEvent.layout
+                    setPanelSize(isHorizontalAnchor ? width : height)
+                    // Narrowed: RN's animated prop types widen onLayout to
+                    // include a SharedValue, which is not callable.
+                    if (typeof props.onLayout === 'function') props.onLayout(e)
+                }}
+                className={drawerContentStyle({
+                    parentVariants: {
+                        size: parentSize,
+                        anchor: parentAnchor,
+                    },
+                    class: `${className || ''} ${customClass}`,
+                })}
+                style={[paddingStyle, style, animatedStyle]}
+                pointerEvents="auto"
+            />
+        </GestureDetector>
     )
 })
 

--- a/core/ui/sheet/index.tsx
+++ b/core/ui/sheet/index.tsx
@@ -142,11 +142,11 @@ function SheetRoot({
             translateY.value = dir * Math.max(0, dir * e.translationY)
         })
         .onEnd(e => {
-            // Threshold inlined (kept in sync with shouldDismissDrawer, which the
-            // unit test pins): dragged past 100px or flicked away from the edge
-            // faster than 500px/s dismisses. This runs on the UI thread, so it
-            // must not call a non-worklet JS function — hence the literal
-            // comparison here.
+            // Threshold inlined (kept in sync with shouldDismissSwipe in
+            // ui/swipe-dismiss, which the unit test pins): dragged past 100px or
+            // flicked away from the edge faster than 500px/s dismisses. This
+            // runs on the UI thread, so it must not call a non-worklet JS
+            // function — hence the literal comparison here.
             if (dir * e.translationY > 100 || dir * e.velocityY > 500) {
                 translateY.value = withSpring(dir * sheetHeight.value, SPRING_CONFIG)
                 backdropOpacity.value = withTiming(0, { duration: 150 })

--- a/core/ui/swipe-dismiss/index.ts
+++ b/core/ui/swipe-dismiss/index.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect } from 'react'
+import type { ViewStyle } from 'react-native'
+import { Platform } from 'react-native'
+import { Gesture } from 'react-native-gesture-handler'
+import { runOnJS, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated'
+
+/** The edge a panel rests on, and therefore the direction it leaves in. */
+export type SwipeAnchor = 'left' | 'right' | 'top' | 'bottom'
+
+// Shared with Sheet (ui/sheet) so every edge surface settles identically.
+const SPRING_CONFIG = { damping: 28, stiffness: 220, mass: 0.8 }
+
+// A drag has to travel this far before it counts as a dismissal rather than a
+// scroll that wandered sideways. Mirrors shouldDismissSwipe, which the unit
+// test pins; the worklets below inline the comparison because they run on the
+// UI thread and cannot call a non-worklet JS function.
+const DISMISS_DISTANCE = 100
+const DISMISS_VELOCITY = 500
+
+/** +1 when the panel leaves rightward or downward, -1 when it leaves the other way. */
+const DIRECTION: Record<SwipeAnchor, number> = { right: 1, bottom: 1, left: -1, top: -1 }
+
+const IS_HORIZONTAL: Record<SwipeAnchor, boolean> = {
+    left: true,
+    right: true,
+    top: false,
+    bottom: false,
+}
+
+interface SwipeToDismissOptions {
+    /** The edge the panel rests on. Drags away from it dismiss. */
+    anchor: SwipeAnchor
+    /** Called once the panel has finished animating off-screen. */
+    onClose: () => void
+    /**
+     * How far the panel must travel to clear the screen. Pass a measured value
+     * where the size is not a constant — a Drawer's width is a percentage class,
+     * so it has to come from onLayout.
+     */
+    distance: number
+    /** Re-centres the panel when it reopens, so a reused node starts on-screen. */
+    isOpen?: boolean
+}
+
+/**
+ * Swipe an edge-anchored panel away to dismiss it.
+ *
+ * The panel tracks the finger 1:1, clamped so it can only move AWAY from the
+ * edge it rests on; released short of the threshold it springs back, and past
+ * it (or on a fast flick) it springs off-screen. Modelled on the two gestures
+ * core already had — Sheet's vertical drag and MobileDrawer's closeGesture —
+ * and generalised over an axis sign so one hook serves all four anchors.
+ *
+ * `onClose` fires from the spring's COMPLETION callback, not immediately. Both
+ * callers unmount the panel the instant their open flag flips, so closing first
+ * would make it vanish mid-drag instead of sliding off; waiting for the spring
+ * keeps it mounted for the ~200ms the animation needs.
+ *
+ * Native only. On web the gesture is disabled and the style is inert: a drawer
+ * there already has Escape, a backdrop click and a close button, and the boards
+ * peek deliberately leaves the surface behind it operable — a live gesture
+ * detector risks the "intercepts pointer events" regressions that surface has
+ * already paid for once.
+ */
+export function useSwipeToDismiss({
+    anchor,
+    onClose,
+    distance,
+    isOpen = true,
+}: SwipeToDismissOptions): {
+    gesture: ReturnType<typeof Gesture.Pan>
+    /**
+     * Typed as a plain ViewStyle rather than Reanimated's AnimatedStyle: the
+     * hook only ever produces a transform, and the wider union does not assign
+     * to the style prop of a gluestack-created Content.
+     */
+    animatedStyle: ViewStyle
+} {
+    const offset = useSharedValue(0)
+    const dir = DIRECTION[anchor]
+    const isHorizontal = IS_HORIZONTAL[anchor]
+    const isEnabled = Platform.OS !== 'web'
+
+    // A panel kept mounted across opens (Sheet does this) would otherwise
+    // reopen still translated from the drag that closed it.
+    useEffect(() => {
+        if (isOpen) offset.value = 0
+    }, [isOpen, offset])
+
+    const close = useCallback(() => onClose(), [onClose])
+
+    const basePan = Gesture.Pan().enabled(isEnabled)
+    // Only a deliberate drag along the panel's own axis starts this, so a
+    // scroll inside the panel is never stolen into a dismissal.
+    const gesture = (
+        isHorizontal ? basePan.activeOffsetX(dir * 10) : basePan.activeOffsetY(dir * 10)
+    )
+        .onUpdate(e => {
+            const travel = isHorizontal ? e.translationX : e.translationY
+            // Clamped to movement AWAY from the edge: dragging back the other
+            // way would lift the panel off the edge it rests on and open a gap.
+            offset.value = dir * Math.max(0, dir * travel)
+        })
+        .onEnd(e => {
+            const travel = isHorizontal ? e.translationX : e.translationY
+            const velocity = isHorizontal ? e.velocityX : e.velocityY
+            // Inlined rather than calling shouldDismissSwipe: this runs on the
+            // UI thread, which cannot call a non-worklet JS function.
+            if (dir * travel > DISMISS_DISTANCE || dir * velocity > DISMISS_VELOCITY) {
+                offset.value = withSpring(dir * distance, SPRING_CONFIG, finished => {
+                    if (finished) runOnJS(close)()
+                })
+            } else {
+                offset.value = withSpring(0, SPRING_CONFIG)
+            }
+        })
+
+    const animatedStyle = useAnimatedStyle(() =>
+        isHorizontal
+            ? { transform: [{ translateX: offset.value }] }
+            : { transform: [{ translateY: offset.value }] }
+    )
+
+    return { gesture, animatedStyle: animatedStyle as ViewStyle }
+}
+
+export { shouldDismissSwipe } from './should-dismiss'

--- a/core/ui/swipe-dismiss/should-dismiss.ts
+++ b/core/ui/swipe-dismiss/should-dismiss.ts
@@ -1,0 +1,16 @@
+// The drag-to-dismiss threshold for edge-anchored panels, as a pure,
+// unit-testable function. Every caller's pan-gesture onEnd runs on the UI
+// thread (a worklet) and therefore can't call a non-worklet JS function, so
+// each one INLINES this same comparison rather than importing this. Keep them
+// in sync — this version exists so the unit test can pin the contract without
+// an on-device gesture.
+//
+// `dir` is the sign of the off-screen direction, which is what generalises one
+// threshold over all four anchors: +1 for a panel that leaves rightward or
+// downward (anchor 'right' / 'bottom'), -1 for one that leaves leftward or
+// upward ('left' / 'top'). Multiplying both inputs by it reduces every anchor
+// to the same "away from the edge is positive" comparison, so a flick TOWARD
+// the edge can never dismiss.
+export function shouldDismissSwipe(translation: number, velocity: number, dir: number): boolean {
+    return dir * translation > 100 || dir * velocity > 500
+}


### PR DESCRIPTION
Recovered from a crashed session; reviewed and verified before opening.

**One threshold for every edge.** `BottomDrawer`'s dismiss rule was written for the bottom edge alone — a bare `translationY > 100 || velocityY > 500` — so anything anchored elsewhere needed its own copy with the comparisons flipped. It moves to `ui/swipe-dismiss` and takes the sign of the off-screen direction, which reduces all four anchors to the same "away from the edge is positive" comparison. A flick *toward* the edge can never dismiss.

`shouldDismissDrawer` stays as a delegating name so the older spelling keeps working while consumers migrate off `BottomDrawer`. `Sheet` inlines the comparison (it runs in a worklet and cannot call into JS) and gets its cross-reference updated.

**A Drawer can be swiped to dismiss.** `Drawer` predates the overlay engine and had no dismiss gesture, so a right-edge panel could only be closed by its button or the backdrop, while every other edge surface answered a swipe. It now uses the anchor-aware `useSwipeToDismiss`, so it gets the right gesture from the anchor it already declares. Thresholds and spring match `Sheet`'s.

## Testing

1738 unit tests pass; biome, tsc and core-isolation clean. The threshold's unit test asserts every case in both orientations — a helper shared by right/bottom panels and left/top ones is only correct if the sign genuinely mirrors it.

The gesture itself is native and not exercised here; worth a look on device.

## Related

tinycld/boards#88 puts the card peek on this hook and depends on it.