### PR TITLE
fix(core): a hover tooltip must not swallow the press beneath it

### DIFF
--- a/core/tests/unit/popover-pointer-transparent.test.tsx
+++ b/core/tests/unit/popover-pointer-transparent.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render as renderBare } from '@testing-library/react'
+import { OverlayProvider } from '@tinycld/core/ui/overlay'
+import { Popover } from '@tinycld/core/ui/popover'
+import type { ReactElement } from 'react'
+import { Text } from 'react-native'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const render = (ui: ReactElement) => renderBare(<OverlayProvider>{ui}</OverlayProvider>)
+
+// The stub renders testID and pointerEvents as plain attributes.
+function surface(): Element {
+    const node = document.querySelector('[testid="surf"]')
+    if (!node) throw new Error('no popover surface rendered')
+    return node
+}
+
+/**
+ * A hover tooltip is placed against the very element the pointer is on, so an
+ * interactive surface lands between a press and its release and swallows the
+ * mouseup — the control under it silently never fires. Only such a surface
+ * opts out of pointer events; everything with its own controls needs them.
+ */
+describe('Popover pointerTransparent', () => {
+    afterEach(cleanup)
+
+    it('lets presses through when set', () => {
+        render(
+            <Popover anchor={{ x: 10, y: 10 }} isOpen testID="surf" pointerTransparent>
+                <Text>who reacted</Text>
+            </Popover>
+        )
+        expect(surface().getAttribute('pointerevents')).toBe('none')
+    })
+
+    it('captures presses by default, so a menu keeps its own', () => {
+        render(
+            <Popover anchor={{ x: 10, y: 10 }} isOpen testID="surf">
+                <Text>a menu item</Text>
+            </Popover>
+        )
+        expect(surface().getAttribute('pointerevents')).toBe('auto')
+    })
+})

--- a/core/ui/popover/index.tsx
+++ b/core/ui/popover/index.tsx
@@ -99,6 +99,20 @@ export interface PopoverProps {
     onKeyDown?: (event: KeyboardEvent) => void
     /** `trap` keeps Tab inside (a picker with fields); `none` for a Menu, whose focus roves. */
     focus?: 'trap' | 'none'
+    /**
+     * Let presses fall THROUGH the surface to whatever is beneath it.
+     *
+     * For a surface that is purely informational and follows the pointer — a
+     * hover tooltip. Such a surface is placed against the very element the
+     * pointer is on, so an interactive one lands between a press and its
+     * release: the element under it receives pointerdown, the surface appears,
+     * and mouseup is delivered to the surface instead. The press never
+     * completes and the control silently does nothing.
+     *
+     * Leave this alone for anything with its own controls; a menu, a picker
+     * and a form all need the presses this gives away.
+     */
+    pointerTransparent?: boolean
     children: ReactNode
 }
 
@@ -124,6 +138,7 @@ export function Popover({
     role,
     onKeyDown,
     focus = 'trap',
+    pointerTransparent = false,
     children,
 }: PopoverProps) {
     const [internalOpen, setInternalOpen] = useState(false)
@@ -179,6 +194,7 @@ export function Popover({
                 role={role}
                 onKeyDown={onKeyDown}
                 focus={focus}
+                pointerTransparent={pointerTransparent}
                 close={close}
             >
                 {children}
@@ -285,6 +301,7 @@ interface PopoverLayerProps {
     role?: PopoverProps['role']
     onKeyDown?: PopoverProps['onKeyDown']
     focus: 'trap' | 'none'
+    pointerTransparent?: boolean
     close: () => void
     children: ReactNode
 }
@@ -307,6 +324,7 @@ function OpenPopoverLayer({
     role,
     onKeyDown,
     focus,
+    pointerTransparent,
     close,
     children,
 }: PopoverLayerProps) {
@@ -450,7 +468,7 @@ function OpenPopoverLayer({
                 testID={testID}
                 role={role}
                 tabIndex={-1}
-                pointerEvents="auto"
+                pointerEvents={pointerTransparent ? 'none' : 'auto'}
                 className={`${SURFACE_CLASS} ${className ?? ''}`}
                 style={[SURFACE_SHADOW, surfaceStyle]}
             >

--- a/core/ui/reactions/ReactorTooltip.tsx
+++ b/core/ui/reactions/ReactorTooltip.tsx
@@ -114,6 +114,11 @@ function TooltipSurface({
             }}
             placement="top-start"
             focus="none"
+            // The surface is placed against the very chip the pointer is on,
+            // so an interactive one lands between a press and its release:
+            // the chip gets pointerdown, this appears, and mouseup goes here
+            // instead. The toggle silently never fired.
+            pointerTransparent
             title="Reactions"
         >
             <View className="px-2.5 py-1.5 max-w-[220px]">


### PR DESCRIPTION
Pressing a reaction chip did nothing — no toggle, no request, no error. The
chip could not be taken back, and a second person could not join an existing
reaction; only adding through the picker worked.

## Root cause

The chip button receives `pointerdown` and `mousedown` but never `mouseup` or
`click`. `ReactorTooltip`'s Popover is anchored to the pointer and placed
`top-start` against the very chip being pressed, and its surface carries
`pointerEvents="auto"`. Hovering opens it between the press and the release,
so the release lands on the tooltip instead of the chip and RNW's `Pressable`
never completes the press.

The node is not remounted and nothing throws, which is why this read as a dead
control rather than an error.

## Fix

`Popover` gains an opt-in `pointerTransparent`, and `ReactorTooltip` sets it: a
surface that is purely informational and follows the pointer must let presses
through to what it is describing. The default is unchanged, so every menu,
picker and form keeps the presses it needs.

## Verification

- New unit test pins both directions of the contract; it fails without the fix.
- Core: `tsc` clean, biome clean, 1749 unit tests pass.
- boards `card-reactions.spec.ts` (7) and `comment-reactions.spec.ts` (5) all
  pass locally — the 4 CI failures on tinycld/boards#85 and #86.