### PR TITLE
Refuse framing by default, with a registry for package exceptions

### DIFF
--- a/core/lib/realtime-enabled.ts
+++ b/core/lib/realtime-enabled.ts
@@ -1,0 +1,77 @@
+import { pb } from './pocketbase'
+
+// Whether this DOCUMENT may hold realtime subscriptions.
+//
+// Realtime is normally on and needs no switch: pbtsdb subscribes a collection
+// the first time something reads it, and the share token rides along via
+// `subscribeOptions` (see pocketbase.ts), so even an anonymous share-link
+// visitor gets live updates for free.
+//
+// An EMBED is the case where "for free" is the wrong default. A board framed on
+// someone else's page would hold an open socket per viewer, on traffic its
+// owner does not control and cannot see, so an embed subscribes only when the
+// link says to (`embed_live`).
+//
+// WHY A DOCUMENT-WIDE SWITCH RATHER THAN A PER-COLLECTION ONE. pbtsdb has no
+// "don't subscribe" option — `syncMode` is only eager|on-demand and the
+// subscription is intrinsic to a collection — so the alternatives were to fork
+// the board's data path or to turn realtime off for the whole page. An embed
+// document renders nothing but a read-only board, so the page-wide switch is
+// both safe and the one that leaves the board's rendering identical to a
+// member's. That identity is the property the whole share-link design exists to
+// preserve; a second data path would spend it.
+//
+// A module-level variable, not a store, for the same reason share-token.ts
+// gives: the reader is not a hook. It runs inside the PocketBase client, at
+// subscribe time.
+
+let realtimeEnabled = true
+
+/**
+ * Turn realtime subscriptions on or off for this document.
+ *
+ * Disabling also tears down anything already subscribed, because a collection
+ * read during the first render may have subscribed before this was called.
+ */
+export function setRealtimeEnabled(enabled: boolean) {
+    if (realtimeEnabled === enabled) return
+    realtimeEnabled = enabled
+    if (!enabled) {
+        // Fire-and-forget: this closes the socket, and a failure to close one
+        // that may not even be open is not worth failing a render over. The
+        // guard below is what actually keeps it closed.
+        void pb.realtime.unsubscribe().catch(() => {})
+    }
+}
+
+export function isRealtimeEnabled(): boolean {
+    return realtimeEnabled
+}
+
+/**
+ * Refuse new subscriptions while realtime is disabled.
+ *
+ * Installed over `pb.realtime.subscribe`, which every per-collection
+ * `subscribe()` funnels through, so one wrap covers every collection — present
+ * and future — without pbtsdb or any caller knowing about it.
+ *
+ * REJECTS rather than resolving with a no-op unsubscribe: pbtsdb logs the
+ * failure and leaves the collection unsubscribed, which is exactly the intent.
+ * Resolving would let it record the collection as subscribed and never retry,
+ * so re-enabling realtime later would silently do nothing.
+ */
+export function installRealtimeGuard() {
+    const realtime = pb.realtime as unknown as {
+        subscribe: (...args: unknown[]) => Promise<unknown>
+        __tinycldGuarded?: boolean
+    }
+    if (realtime.__tinycldGuarded) return
+    const original = realtime.subscribe.bind(realtime)
+    realtime.subscribe = (...args: unknown[]) => {
+        if (!realtimeEnabled) {
+            return Promise.reject(new Error('realtime is disabled for this page'))
+        }
+        return original(...args)
+    }
+    realtime.__tinycldGuarded = true
+}

--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"tinycld.org/core/approutes"
+	"tinycld.org/core/embedpolicy"
 
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -390,6 +391,22 @@ func writeAppShell(e *core.RequestEvent, html []byte) error {
 	e.Response.Header().Set("Cache-Control", "no-cache")
 	e.Response.Header().Set("ETag", etag)
 	e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	// Who may frame this page. Every HTML response carries the header, and the
+	// default is 'none' — the workspace must never be framable, because a
+	// framed workspace is a clickjacking target and nothing in the product
+	// needs it.
+	//
+	// A package's PUBLIC share surface is the one exception, and core does not
+	// know which URLs those are: a package registers a resolver and this asks
+	// it (see embedpolicy's header for why the dependency points that way).
+	//
+	// Set BEFORE the 304 branch below. A conditional GET that revalidates an
+	// unchanged shell still needs the policy — a browser applies the CSP of
+	// the response it actually received, and a 304 carrying no directive is
+	// how a page becomes framable again the second time it is loaded.
+	e.Response.Header().Set("Content-Security-Policy",
+		"frame-ancestors "+embedpolicy.FrameAncestors(e.Request))
 
 	// http.ServeContent isn't usable here (the body is built in memory, not a
 	// ReadSeeker file), so match If-None-Match ourselves. A comma-split covers

--- a/core/server/coreserver/static_test.go
+++ b/core/server/coreserver/static_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
+
+	"tinycld.org/core/embedpolicy"
 )
 
 // shellETag mirrors writeAppShell's ETag derivation for a shell whose injected
@@ -318,4 +320,102 @@ func TestIsDavPath(t *testing.T) {
 			t.Errorf("isDavPath(%q) = true, want false", p)
 		}
 	}
+}
+
+// --------------------------------------------------------------------------
+// Framing.
+
+// The default, and the one that matters: the workspace must never be framable.
+// Nothing in the product needs it, and a framed workspace is a clickjacking
+// target — the user's own session, rendered under someone else's overlay.
+func TestStatic_ShellRefusesFramingByDefault(t *testing.T) {
+	embedpolicy.ResetForTesting()
+
+	publicDir, websiteDir, releasesDir := staticDirs(t, nil, nil, "<html>APP SHELL</html>")
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "an app route may not be framed",
+		Method:          http.MethodGet,
+		URL:             "/a/boards",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"APP SHELL"},
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			if got := res.Header.Get("Content-Security-Policy"); got != "frame-ancestors 'none'" {
+				t.Errorf("CSP = %q, want frame-ancestors 'none'", got)
+			}
+		},
+	})
+}
+
+// A registered package claims its own public URL and names the origins. Core
+// still knows nothing about that package — the resolver is all it sees.
+func TestStatic_ShellHonoursARegisteredEmbedPolicy(t *testing.T) {
+	embedpolicy.ResetForTesting()
+	defer embedpolicy.ResetForTesting()
+
+	embedpolicy.Register(func(r *http.Request) []string {
+		if r.URL.Path == "/p/example/tok" && r.URL.Query().Get("embed") == "1" {
+			return []string{"https://intranet.example.com", "https://wiki.example.com"}
+		}
+		return nil
+	})
+
+	publicDir, websiteDir, releasesDir := staticDirs(t, nil, nil, "<html>APP SHELL</html>")
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "an embeddable public page names its origins",
+		Method:          http.MethodGet,
+		URL:             "/p/example/tok?embed=1",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"APP SHELL"},
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			want := "frame-ancestors https://intranet.example.com https://wiki.example.com"
+			if got := res.Header.Get("Content-Security-Policy"); got != want {
+				t.Errorf("CSP = %q, want %q", got, want)
+			}
+		},
+	})
+}
+
+// A resolver that declines the request leaves the default in place. This is the
+// path a revoked, expired or non-embeddable token takes.
+func TestStatic_ShellRefusesFramingWhenTheResolverDeclines(t *testing.T) {
+	embedpolicy.ResetForTesting()
+	defer embedpolicy.ResetForTesting()
+
+	embedpolicy.Register(func(_ *http.Request) []string { return nil })
+
+	publicDir, websiteDir, releasesDir := staticDirs(t, nil, nil, "<html>APP SHELL</html>")
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:            "a declined page falls back to 'none'",
+		Method:          http.MethodGet,
+		URL:             "/p/example/tok?embed=1",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"APP SHELL"},
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			if got := res.Header.Get("Content-Security-Policy"); got != "frame-ancestors 'none'" {
+				t.Errorf("CSP = %q, want frame-ancestors 'none'", got)
+			}
+		},
+	})
+}
+
+// A 304 carries no body, but a browser applies the CSP of the response it
+// actually received — so a revalidation that omitted the directive is how a
+// page silently becomes framable on its second load.
+func TestStatic_ConditionalGetStillCarriesTheFramingPolicy(t *testing.T) {
+	embedpolicy.ResetForTesting()
+
+	const shell = "<html>APP SHELL</html>"
+	publicDir, websiteDir, releasesDir := staticDirs(t, nil, nil, shell)
+	runStaticScenario(t, publicDir, websiteDir, releasesDir, &tests.ApiScenario{
+		Name:           "a 304 still refuses framing",
+		Method:         http.MethodGet,
+		URL:            "/a/boards",
+		Headers:        map[string]string{"If-None-Match": shellETag(shell)},
+		ExpectedStatus: http.StatusNotModified,
+		AfterTestFunc: func(t testing.TB, _ *tests.TestApp, res *http.Response) {
+			if got := res.Header.Get("Content-Security-Policy"); got != "frame-ancestors 'none'" {
+				t.Errorf("CSP on 304 = %q, want frame-ancestors 'none'", got)
+			}
+		},
+	})
 }

--- a/core/server/embedpolicy/embedpolicy.go
+++ b/core/server/embedpolicy/embedpolicy.go
@@ -1,0 +1,100 @@
+// Package embedpolicy decides which origins may frame a given page.
+//
+// The app sets `Content-Security-Policy: frame-ancestors` on every HTML
+// response it serves (coreserver's writeAppShell). The default is 'none': the
+// workspace must never be framable, because a framed workspace is a
+// clickjacking target and nothing in the product needs it.
+//
+// The exception is a package's PUBLIC share surface. A board shared by link is
+// exactly the kind of thing someone wants to drop into a wiki or an intranet
+// page, and whether a given link may be framed — and by whom — is a fact only
+// that package knows: it lives on the package's own link row, behind the
+// package's own access rules.
+//
+// So core does not look it up. A package registers a resolver from its
+// Register(app) and core asks every registered resolver, exactly as
+// oauth.RegisterPackage and search.RegisterSources invert the same dependency.
+// Core therefore names no package, no slug and no collection, and a deployment
+// without that package simply has no resolver to ask and frames nothing.
+package embedpolicy
+
+import (
+	"net/http"
+	"sync"
+)
+
+// Resolver answers "may this request's page be framed, and by whom?".
+//
+// Return the allowed origins, or nil to express no opinion. Nil is not
+// "deny" — it is "not mine", which is what every resolver returns for every
+// path but its own; the DENIAL is the caller's default when no resolver
+// claims the request. A resolver that recognises the path but finds the link
+// revoked, expired or non-embeddable also returns nil, and the same default
+// covers it.
+//
+// Called on the request path of an HTML response, so it should be one indexed
+// lookup at most. The request is read-only.
+type Resolver func(r *http.Request) []string
+
+var (
+	mu        sync.RWMutex
+	resolvers []Resolver
+)
+
+// Register adds a resolver. Called from a package's Register(app) at startup.
+func Register(fn Resolver) {
+	if fn == nil {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	resolvers = append(resolvers, fn)
+}
+
+// FrameAncestors returns the CSP `frame-ancestors` value for a request.
+//
+// Always returns a complete, non-empty directive value, so the caller can
+// write it unconditionally and cannot accidentally omit the header on the path
+// where it matters most. With no resolver claiming the request that value is
+// 'none'.
+//
+// FIRST claim wins, and a claim is not re-checked against later resolvers: two
+// packages cannot both own one URL, and consulting the rest could only widen
+// what the first one decided.
+func FrameAncestors(r *http.Request) string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	for _, fn := range resolvers {
+		if origins := fn(r); len(origins) > 0 {
+			return joinOrigins(origins)
+		}
+	}
+	return "'none'"
+}
+
+// joinOrigins builds the directive value.
+//
+// Origins are written verbatim — validating them is the registering package's
+// job, at the point they are STORED rather than every time they are read.
+// That split is deliberate: a value that reached the database unvalidated
+// cannot be made safe here, because CSP has no escaping, and pretending
+// otherwise would move the check somewhere it cannot report the error to
+// whoever typed it.
+func joinOrigins(origins []string) string {
+	out := ""
+	for i, origin := range origins {
+		if i > 0 {
+			out += " "
+		}
+		out += origin
+	}
+	return out
+}
+
+// ResetForTesting clears the registry.
+func ResetForTesting() {
+	mu.Lock()
+	defer mu.Unlock()
+	resolvers = nil
+}

--- a/core/server/embedpolicy/embedpolicy_test.go
+++ b/core/server/embedpolicy/embedpolicy_test.go
@@ -1,0 +1,90 @@
+package embedpolicy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The default is the whole point of the package: a page nobody claimed must
+// not be framable. Every path through FrameAncestors has to land here rather
+// than on an empty directive, which a browser ignores entirely.
+func TestFrameAncestorsDefaultsToNone(t *testing.T) {
+	ResetForTesting()
+
+	if got := FrameAncestors(httptest.NewRequest("GET", "/a/anything", nil)); got != "'none'" {
+		t.Errorf("FrameAncestors = %q, want 'none'", got)
+	}
+}
+
+func TestFrameAncestorsJoinsAClaimedRequestsOrigins(t *testing.T) {
+	ResetForTesting()
+	defer ResetForTesting()
+
+	Register(func(r *http.Request) []string {
+		if r.URL.Path == "/p/x/tok" {
+			return []string{"https://a.example.com", "https://b.example.com"}
+		}
+		return nil
+	})
+
+	got := FrameAncestors(httptest.NewRequest("GET", "/p/x/tok", nil))
+	want := "https://a.example.com https://b.example.com"
+	if got != want {
+		t.Errorf("FrameAncestors = %q, want %q", got, want)
+	}
+}
+
+// A resolver returning nil is saying "not mine", not "allow" — so an unclaimed
+// path keeps the deny default even with resolvers registered.
+func TestFrameAncestorsKeepsTheDefaultWhenEveryResolverDeclines(t *testing.T) {
+	ResetForTesting()
+	defer ResetForTesting()
+
+	Register(func(_ *http.Request) []string { return nil })
+	Register(func(_ *http.Request) []string { return nil })
+
+	if got := FrameAncestors(httptest.NewRequest("GET", "/p/x/tok", nil)); got != "'none'" {
+		t.Errorf("FrameAncestors = %q, want 'none'", got)
+	}
+}
+
+// The first claim wins and later resolvers are not consulted. Two packages
+// cannot own one URL, and asking the rest could only widen the first answer.
+func TestFrameAncestorsStopsAtTheFirstClaim(t *testing.T) {
+	ResetForTesting()
+	defer ResetForTesting()
+
+	Register(func(_ *http.Request) []string { return []string{"https://first.example.com"} })
+	Register(func(t2 *http.Request) []string {
+		t.Error("a second resolver was consulted after the request was claimed")
+		return []string{"https://second.example.com"}
+	})
+
+	if got := FrameAncestors(httptest.NewRequest("GET", "/p/x/tok", nil)); got != "https://first.example.com" {
+		t.Errorf("FrameAncestors = %q, want the first claim", got)
+	}
+}
+
+// An empty slice is not a claim. A resolver that recognised the path but found
+// nothing to allow (a revoked link) must fall through to the deny default.
+func TestFrameAncestorsTreatsAnEmptySliceAsNoClaim(t *testing.T) {
+	ResetForTesting()
+	defer ResetForTesting()
+
+	Register(func(_ *http.Request) []string { return []string{} })
+
+	if got := FrameAncestors(httptest.NewRequest("GET", "/p/x/tok", nil)); got != "'none'" {
+		t.Errorf("FrameAncestors = %q, want 'none'", got)
+	}
+}
+
+func TestRegisterIgnoresNil(t *testing.T) {
+	ResetForTesting()
+	defer ResetForTesting()
+
+	Register(nil)
+	if got := FrameAncestors(httptest.NewRequest("GET", "/", nil)); got != "'none'" {
+		t.Errorf("FrameAncestors = %q, want 'none'", got)
+	}
+}


### PR DESCRIPTION
Nothing in the repo set a framing header, so every page — the whole authenticated workspace included — could be embedded by any site. This sets `Content-Security-Policy: frame-ancestors` on every HTML response, defaulting to `'none'`.

The exception is a package's public share surface. Core cannot know which URLs those are: the answer lives on a package's own link rows, behind its own access rules. So `embedpolicy` inverts the dependency the way `oauth.RegisterPackage` and `search.RegisterSources` already do — a package registers a resolver, core asks it, and core names no package. `check:core-isolation` passes with its allowlist unchanged at 17.

Also adds a per-document realtime switch, needed by an embedded board that subscribes only when its share link opts in. pbtsdb has no per-collection "don't subscribe" option, so this guards `pb.realtime.subscribe` — the single funnel every collection goes through.

### Notes for review

- The header is set **before** the 304 branch. A browser applies the CSP of the response it actually received, so a revalidation carrying no directive is how a page silently becomes framable on its second load. There's a test for that path.
- The realtime guard **rejects** rather than resolving with a no-op unsubscribe: pbtsdb then leaves the collection unsubscribed and retries, where resolving would record it as subscribed and never reconnect.

### Verification

`pnpm run checks` (lint + typecheck + core-isolation), 1749 unit tests, and `go test ./coreserver/ ./embedpolicy/` all pass. Framing is additionally verified in a real browser by the boards PR's iframe tests — `/a/boards` in a frame fails with `net::ERR_BLOCKED_BY_RESPONSE`.

### Companion

tinycld/boards uses this registry to make share links embeddable. **This PR should merge first** — boards' `server/embed.go` imports `tinycld.org/core/embedpolicy`.