### PR TITLE
fix(core): make OS notifications actually deliver on web and native

### DIFF
--- a/app.json
+++ b/app.json
@@ -36,6 +36,12 @@
                     "toolsButton": false
                 }
             ],
+            [
+                "expo-notifications",
+                {
+                    "color": "#0B4F4A"
+                }
+            ],
             "./plugins/with-app-updater.cjs"
         ],
         "icon": "./assets/app-icon.png",
@@ -69,7 +75,10 @@
                     "category": ["BROWSABLE", "DEFAULT"]
                 }
             ],
-            "permissions": ["android.permission.RECORD_AUDIO"]
+            "permissions": [
+                "android.permission.RECORD_AUDIO",
+                "android.permission.POST_NOTIFICATIONS"
+            ]
         },
         "web": {
             "bundler": "metro",

--- a/app/a/(app)/_layout.tsx
+++ b/app/a/(app)/_layout.tsx
@@ -15,6 +15,8 @@ import { useHelpSearchShortcut } from '@tinycld/core/lib/help/use-help-search-sh
 import { markNavMilestone } from '@tinycld/core/lib/nav-perf'
 import { activeSlugFromPathname } from '@tinycld/core/lib/org-routes'
 import { useWorkspaceStore } from '@tinycld/core/lib/stores/workspace-store'
+import { useExpoPushRegistration } from '@tinycld/core/lib/use-expo-push-registration'
+import { useNativeNotificationHandler } from '@tinycld/core/lib/use-native-notification-handler'
 import { useOrgInfo } from '@tinycld/core/lib/use-org-info'
 import { OrgSlugProvider } from '@tinycld/core/lib/use-org-slug'
 import { usePathname, useUnstableGlobalHref } from 'expo-router'
@@ -38,6 +40,14 @@ function OrgLayoutInner() {
     // org-scoped screen — not just package detail screens. The hook
     // is a no-op on native.
     useHelpSearchShortcut()
+    // Register this device's Expo push token once signed in, so the server's
+    // sendExpoPush has a token to deliver to. A no-op on web (web push
+    // subscribes explicitly from Settings) and self-guarded on user id, so it
+    // sits above the isReady return and simply does nothing until auth lands.
+    useExpoPushRegistration()
+    // Show notifications that arrive while the app is foregrounded, and route
+    // taps to the notification's deep link. A no-op on web — sw.js does both.
+    useNativeNotificationHandler()
 
     if (!isReady) {
         return (

--- a/app/a/(app)/settings/personal.tsx
+++ b/app/a/(app)/settings/personal.tsx
@@ -365,7 +365,8 @@ function ColorThemePicker({
 }
 
 function NotificationsSection() {
-    const { isSupported, isSubscribed, subscribe, unsubscribe, isPending } = usePushSubscription()
+    const { isSupported, isConfigured, isSubscribed, subscribe, unsubscribe, isPending } =
+        usePushSubscription()
 
     const handlePushToggle = () => {
         if (isSubscribed) {
@@ -380,6 +381,7 @@ function NotificationsSection() {
             <Text className="text-foreground text-xl font-bold">Notifications</Text>
             <PushToggle
                 isSupported={Platform.OS === 'web' && isSupported}
+                isConfigured={isConfigured}
                 isNative={Platform.OS !== 'web'}
                 isSubscribed={isSubscribed}
                 isPending={isPending}
@@ -392,12 +394,14 @@ function NotificationsSection() {
 
 function PushToggle({
     isSupported,
+    isConfigured,
     isNative,
     isSubscribed,
     isPending,
     onToggle,
 }: {
     isSupported: boolean
+    isConfigured: boolean
     isNative: boolean
     isSubscribed: boolean
     isPending: boolean
@@ -418,6 +422,19 @@ function PushToggle({
             <SectionCard>
                 <Text className="text-muted-foreground text-[13px]">
                     Your browser does not support push notifications.
+                </Text>
+            </SectionCard>
+        )
+    }
+
+    // Supported by the browser but the server has no VAPID keypair. Say so
+    // rather than showing a switch that can only fail.
+    if (!isConfigured) {
+        return (
+            <SectionCard>
+                <Text className="text-muted-foreground text-[13px]">
+                    Push notifications are not set up on this server. An administrator can enable
+                    them under Setup → Settings → Web push.
                 </Text>
             </SectionCard>
         )

--- a/core/lib/core-config.ts
+++ b/core/lib/core-config.ts
@@ -43,6 +43,14 @@ export interface CoreConfig {
     defaultServer?: string
     /** Sentry DSN. When absent, Sentry init is skipped. */
     sentryDsn?: string
+    /**
+     * VAPID public key for web push, used as the `applicationServerKey` in
+     * `pushManager.subscribe()`. Operator-generated per deployment (Setup →
+     * Settings → Web push), so it is RUNTIME config, not a build constant:
+     * web reads it from the server-injected public config. When absent, web
+     * push subscription is unavailable and the UI says so.
+     */
+    vapidPublicKey?: string
     /** Sentry environment tag (maps to EXPO_PUBLIC_ENV in the old world). */
     environment?: string
     /** Sentry release tag (maps to EXPO_PUBLIC_GIT_COMMIT). */

--- a/core/lib/use-expo-push-registration.ts
+++ b/core/lib/use-expo-push-registration.ts
@@ -15,7 +15,15 @@ export function resetExpoPushRegistration(): void {
 }
 
 export function useExpoPushRegistration() {
-    const { user } = useAuth()
+    // throwIfAnon: false is required, not optional. useAuth() defaults to
+    // throwIfAnon: true, which throws AuthRequiredError during RENDER for a
+    // signed-out visitor — the effect's `user?.id` guard never gets a chance to
+    // run. Mounted in the org layout (which renders before the auth gate), a
+    // bare useAuth() crashed the whole layout into the error boundary, so a
+    // signed-out deep link showed "Something went wrong" instead of the login
+    // form. Registration is a signed-in side effect; absence of a user is a
+    // normal state here, not an error.
+    const { user } = useAuth({ throwIfAnon: false })
 
     useEffect(() => {
         if (Platform.OS === 'web' || registered || !user?.id) return

--- a/core/lib/use-native-notification-handler.ts
+++ b/core/lib/use-native-notification-handler.ts
@@ -1,0 +1,75 @@
+import { log } from '@tinycld/core/lib/logger'
+import { router } from 'expo-router'
+import { useEffect } from 'react'
+import { Platform } from 'react-native'
+
+/**
+ * Foreground presentation + tap routing for native OS notifications.
+ *
+ * Two gaps this closes, both native-only:
+ *
+ *  1. Expo suppresses a notification that arrives while the app is in the
+ *     FOREGROUND unless a handler opts in. Without this, a push that landed
+ *     while the user had the app open simply never appeared.
+ *  2. Tapping a notification did nothing beyond opening the app. The server
+ *     already ships a deep-link target in `data.url` (see notify.go's
+ *     sendExpoPush, which sets data:{url}), so the payload was there —
+ *     nothing consumed it.
+ *
+ * Web needs neither: the service worker (public/sw.js) handles both display
+ * and `notificationclick` routing itself.
+ */
+export function useNativeNotificationHandler() {
+    useEffect(() => {
+        if (Platform.OS === 'web') return
+
+        let disposed = false
+        // Held so cleanup can remove a listener that may be registered after
+        // this effect is torn down (the import below is async).
+        let subscription: { remove: () => void } | null = null
+
+        const routeTo = (data: unknown) => {
+            const url = (data as { url?: unknown } | undefined)?.url
+            if (typeof url !== 'string' || url === '') return
+            router.push(url as never)
+        }
+
+        import('expo-notifications')
+            .then(Notifications => {
+                if (disposed) return
+
+                Notifications.setNotificationHandler({
+                    handleNotification: async () => ({
+                        shouldShowBanner: true,
+                        shouldShowList: true,
+                        shouldPlaySound: true,
+                        shouldSetBadge: true,
+                    }),
+                })
+
+                subscription = Notifications.addNotificationResponseReceivedListener(response => {
+                    routeTo(response.notification.request.content.data)
+                })
+
+                // A tap that COLD-STARTS the app is delivered as the last
+                // response rather than through the listener above, so it has to
+                // be read once explicitly or the deep link is lost on launch.
+                Notifications.getLastNotificationResponseAsync()
+                    .then(response => {
+                        if (disposed || !response) return
+                        routeTo(response.notification.request.content.data)
+                    })
+                    .catch(err => {
+                        log.warn('core.notifications', 'last response read failed', { err })
+                    })
+            })
+            .catch(err => {
+                log.warn('core.notifications', 'handler setup failed', { err })
+            })
+
+        return () => {
+            disposed = true
+            subscription?.remove()
+        }
+    }, [])
+}

--- a/core/lib/use-push-subscription.ts
+++ b/core/lib/use-push-subscription.ts
@@ -2,7 +2,12 @@ import { useQuery, useQueryClient, useMutation as useTanStackMutation } from '@t
 import { useAuth } from '@tinycld/core/lib/auth'
 import { captureException } from '@tinycld/core/lib/errors'
 import { pb } from '@tinycld/core/lib/pocketbase'
-import { isPushSupported, subscribeToPush, unsubscribeFromPush } from '@tinycld/core/lib/web-push'
+import {
+    isPushConfigured,
+    isPushSupported,
+    subscribeToPush,
+    unsubscribeFromPush,
+} from '@tinycld/core/lib/web-push'
 
 export function usePushSubscription() {
     const { user, isLoggedIn } = useAuth({ throwIfAnon: false })
@@ -23,6 +28,10 @@ export function usePushSubscription() {
     })
 
     const isSupported = isPushSupported()
+    // The browser can push, but this server has no VAPID keypair — the operator
+    // has to generate one. Surfaced separately so the toggle explains itself
+    // instead of appearing broken.
+    const isConfigured = isPushConfigured()
     const isSubscribed = (subscriptions?.length ?? 0) > 0
 
     const subscribe = useTanStackMutation({
@@ -45,6 +54,7 @@ export function usePushSubscription() {
 
     return {
         isSupported,
+        isConfigured,
         isSubscribed,
         subscribe: subscribe.mutate,
         unsubscribe: unsubscribe.mutate,

--- a/core/lib/web-push.ts
+++ b/core/lib/web-push.ts
@@ -1,3 +1,4 @@
+import { getCoreConfigOptional } from '@tinycld/core/lib/core-config'
 import { Platform } from 'react-native'
 
 // `pb` is imported lazily (not at module top level) to break the require cycle
@@ -18,6 +19,31 @@ export function isPushSupported(): boolean {
     )
 }
 
+/**
+ * The VAPID public key the browser signs its subscription against, injected by
+ * the app server from the operator's system_settings (see
+ * coreserver/static.go::publicConfigScript).
+ *
+ * This is deliberately NOT a build-time env read. It used to be
+ * `process.env.VITE_VAPID_PUBLIC_KEY` — a name nothing ever defined (VITE_* is
+ * Vite's prefix; this app bundles with Metro, which only inlines EXPO_PUBLIC_*),
+ * so subscribeToPush bailed before it ever called pushManager.subscribe and the
+ * settings toggle silently did nothing. A build constant is also the wrong shape
+ * for the value: each deployment generates its own keypair after deploy.
+ */
+export function vapidPublicKey(): string {
+    return getCoreConfigOptional()?.vapidPublicKey ?? ''
+}
+
+/**
+ * Whether this browser supports push AND the server has web push configured.
+ * Distinguishing the two lets the UI say "your browser can't" separately from
+ * "this server hasn't set it up", instead of showing one dead toggle.
+ */
+export function isPushConfigured(): boolean {
+    return isPushSupported() && vapidPublicKey() !== ''
+}
+
 export async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
     if (!isPushSupported()) return null
     return navigator.serviceWorker.register('/sw.js')
@@ -26,11 +52,18 @@ export async function registerServiceWorker(): Promise<ServiceWorkerRegistration
 export async function subscribeToPush(userId: string): Promise<boolean> {
     if (!isPushSupported()) return false
 
+    // Throw rather than return false: a missing key is an operator
+    // misconfiguration the user can't fix by toggling again, and a silent false
+    // is what made this failure invisible for so long. The caller surfaces it.
+    const publicKey = vapidPublicKey()
+    if (!publicKey) {
+        throw new Error(
+            'Web push is not configured on this server — an administrator must generate a VAPID keypair in Setup → Settings.'
+        )
+    }
+
     const registration = await registerServiceWorker()
     if (!registration) return false
-
-    const publicKey = process.env.VITE_VAPID_PUBLIC_KEY || process.env.VAPID_PUBLIC_KEY
-    if (!publicKey) return false
 
     const subscription = await registration.pushManager.subscribe({
         userVisibleOnly: true,

--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -36,9 +36,17 @@ func publicConfigScript() string {
 	// leak is unrecoverable) so a row mis-flagged is_secret=false elsewhere still
 	// can't slip a credential into the page.
 	const sentryDSNKey = "sentry.dsn"
+	// The VAPID PUBLIC key is the applicationServerKey the browser must pass to
+	// pushManager.subscribe(), so the web client genuinely needs it. It is public
+	// by construction (it derives from, but does not reveal, the private key) and
+	// is stored is_secret=false. The private key is never whitelisted here.
+	const vapidPublicKeyKey = "vapid.public_key"
 	out := map[string]string{}
 	if v := systemConfig.publicValue(sentryDSNKey); v != "" {
 		out["sentryDsn"] = v
+	}
+	if v := systemConfig.publicValue(vapidPublicKeyKey); v != "" {
+		out["vapidPublicKey"] = v
 	}
 	if len(out) == 0 {
 		return ""

--- a/core/server/coreserver/system_config_test.go
+++ b/core/server/coreserver/system_config_test.go
@@ -252,3 +252,40 @@ func TestInjectPublicConfigSkipsSecretSentryDsn(t *testing.T) {
 		t.Errorf("a secret-flagged sentry.dsn must not be injected, got %q", out)
 	}
 }
+
+// The web client needs the VAPID PUBLIC key as pushManager.subscribe's
+// applicationServerKey, so it is whitelisted into the injected config. Before
+// this, the key reached the browser by no route at all and web push could never
+// subscribe. The PRIVATE key must never follow it out.
+func TestInjectPublicConfigPublishesVapidPublicKey(t *testing.T) {
+	prev := systemConfig
+	t.Cleanup(func() { systemConfig = prev })
+	systemConfig = &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	systemConfig.set("vapid.public_key", "BPublicKey123", false)
+	systemConfig.set("vapid.private_key", "PrivateKeyNeverLeak", true)
+
+	out := string(injectPublicConfig([]byte("<head></head>")))
+
+	if !strings.Contains(out, `"vapidPublicKey"`) {
+		t.Errorf("public key should be published as vapidPublicKey, got %q", out)
+	}
+	if !strings.Contains(out, "BPublicKey123") {
+		t.Errorf("public key value missing from injected config: %q", out)
+	}
+	if strings.Contains(out, "PrivateKeyNeverLeak") || strings.Contains(out, "private_key") {
+		t.Fatalf("VAPID PRIVATE key must NEVER be injected into the HTML: %q", out)
+	}
+}
+
+// A VAPID public key mis-flagged is_secret=true must be blanked by the
+// publicValue gate rather than injected.
+func TestInjectPublicConfigSkipsSecretVapidPublicKey(t *testing.T) {
+	prev := systemConfig
+	t.Cleanup(func() { systemConfig = prev })
+	systemConfig = &SystemConfig{values: map[string]string{}, secret: map[string]bool{}}
+	systemConfig.set("vapid.public_key", "BLeakKey", true) // mis-flagged secret
+
+	if out := string(injectPublicConfig([]byte("<head></head>"))); out != "<head></head>" {
+		t.Errorf("a secret-flagged vapid.public_key must not be injected, got %q", out)
+	}
+}

--- a/core/tests/unit/expo-push-registration.test.tsx
+++ b/core/tests/unit/expo-push-registration.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// useExpoPushRegistration is mounted in the org layout, which renders BEFORE
+// the auth gate — so it runs for signed-out visitors too. It originally called
+// useAuth() with no options, and throwIfAnon defaults to TRUE: that threw
+// AuthRequiredError during render, crashing the layout into the error boundary.
+// A signed-out deep link then showed "Something went wrong" instead of the
+// login form, which is exactly how the login-return-to e2e spec failed.
+//
+// The effect's own `user?.id` guard cannot save this — a render-time throw
+// happens before any effect runs.
+
+// A faithful stand-in for the real useAuth: throwIfAnon DEFAULTS TO TRUE and
+// throws when there is no user (core/lib/auth.tsx). Mocking it as a plain
+// vi.fn() that always returns cleanly would let the bug through — the hook
+// could go back to a bare useAuth() and the test would still pass.
+const AuthRequiredError = vi.hoisted(() => class AuthRequiredError extends Error {})
+const anonUser = vi.hoisted(() => ({ current: true }))
+const useAuth = vi.hoisted(() =>
+    vi.fn((options?: { throwIfAnon: boolean }) => {
+        const user = anonUser.current ? null : { id: 'user-1' }
+        if ((options?.throwIfAnon ?? true) && !user) throw new AuthRequiredError()
+        return { user, isLoggedIn: !!user }
+    })
+)
+const registerExpoPushToken = vi.hoisted(() => vi.fn())
+
+// Registration is native-only (it early-returns on web), so the suite runs as
+// iOS — otherwise every assertion below would pass vacuously against the web
+// no-op. Matches the bundle-sentinel spec's approach.
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('@tinycld/core/lib/auth', () => ({ useAuth, AuthRequiredError }))
+vi.mock('@tinycld/core/lib/expo-push', () => ({ registerExpoPushToken }))
+
+import { render } from '@testing-library/react'
+import {
+    resetExpoPushRegistration,
+    useExpoPushRegistration,
+} from '@tinycld/core/lib/use-expo-push-registration'
+
+function Probe() {
+    useExpoPushRegistration()
+    return null
+}
+
+describe('useExpoPushRegistration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        resetExpoPushRegistration()
+    })
+
+    it('renders for a signed-out visitor instead of throwing', () => {
+        anonUser.current = true
+        expect(() => render(<Probe />)).not.toThrow()
+        expect(registerExpoPushToken).not.toHaveBeenCalled()
+    })
+
+    it('asks useAuth not to throw on anonymous', () => {
+        anonUser.current = true
+        render(<Probe />)
+        expect(useAuth).toHaveBeenCalledWith({ throwIfAnon: false })
+    })
+
+    it('still registers the token once a user is signed in', () => {
+        anonUser.current = false
+        render(<Probe />)
+        expect(registerExpoPushToken).toHaveBeenCalledWith('user-1')
+    })
+})

--- a/core/tests/unit/web-push-vapid.test.ts
+++ b/core/tests/unit/web-push-vapid.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Web push was dead in a way no test could catch: web-push.ts read the VAPID
+// public key from `process.env.VITE_VAPID_PUBLIC_KEY`, a name nothing in the
+// repo ever defined (VITE_* is Vite's prefix; this app bundles with Metro,
+// which only inlines EXPO_PUBLIC_*). subscribeToPush therefore returned false
+// before ever calling pushManager.subscribe, so the Settings toggle silently
+// did nothing and no push_subscriptions row was written.
+//
+// The key is runtime, not build-time, config: each deployment generates its own
+// keypair in Setup → Settings, and the server injects the public half into the
+// page (coreserver/static.go::publicConfigScript). These tests pin that
+// contract — the key comes from core config, and a missing one is LOUD.
+
+const getCoreConfigOptional = vi.hoisted(() => vi.fn())
+vi.mock('@tinycld/core/lib/core-config', () => ({ getCoreConfigOptional }))
+
+import { isPushConfigured, subscribeToPush, vapidPublicKey } from '@tinycld/core/lib/web-push'
+
+// isPushSupported() requires serviceWorker + PushManager; happy-dom has
+// neither, so stub them to reach the key-resolution path under test.
+function stubBrowserPushSupport() {
+    Object.defineProperty(navigator, 'serviceWorker', {
+        value: { register: vi.fn() },
+        configurable: true,
+    })
+    ;(window as unknown as { PushManager: unknown }).PushManager = () => {}
+}
+
+describe('web push VAPID key resolution', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        stubBrowserPushSupport()
+    })
+
+    it('reads the key from core config, not process.env', () => {
+        getCoreConfigOptional.mockReturnValue({ vapidPublicKey: 'BKey123' })
+        expect(vapidPublicKey()).toBe('BKey123')
+    })
+
+    it('reports an unconfigured server as not-configured even when supported', () => {
+        getCoreConfigOptional.mockReturnValue({})
+        expect(vapidPublicKey()).toBe('')
+        expect(isPushConfigured()).toBe(false)
+    })
+
+    it('is configured once the operator has generated a keypair', () => {
+        getCoreConfigOptional.mockReturnValue({ vapidPublicKey: 'BKey123' })
+        expect(isPushConfigured()).toBe(true)
+    })
+
+    it('tolerates configureCore never having run', () => {
+        getCoreConfigOptional.mockReturnValue(null)
+        expect(vapidPublicKey()).toBe('')
+    })
+
+    // The regression that hid the original bug: a silent `return false` is
+    // indistinguishable from "unsupported", so the UI showed a dead toggle and
+    // usePushSubscription's onError never fired. It must throw instead.
+    it('throws rather than silently failing when no key is configured', async () => {
+        getCoreConfigOptional.mockReturnValue({})
+        await expect(subscribeToPush('user-1')).rejects.toThrow(/not configured/i)
+    })
+})

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -30,7 +30,7 @@ function devDefaultServer(): string {
 // the bundle loads — see coreserver/static.go::publicConfigScript. Web only;
 // native has no window/HTML and uses the build-time path below.
 declare global {
-    var __TINYCLD_PUBLIC_CONFIG__: { sentryDsn?: string } | undefined
+    var __TINYCLD_PUBLIC_CONFIG__: { sentryDsn?: string; vapidPublicKey?: string } | undefined
 }
 
 // Resolve the Sentry DSN at startup. Order:
@@ -47,6 +47,18 @@ function resolveSentryDsn(): string {
         return globalThis.__TINYCLD_PUBLIC_CONFIG__.sentryDsn
     }
     return process.env.EXPO_PUBLIC_SENTRY_DSN ?? ''
+}
+
+// Resolve the web-push VAPID public key. Web ONLY: it is injected by the app
+// server from the operator's system_settings, so generating a keypair in
+// /admin takes effect on the next page load with no rebuild.
+//
+// There is deliberately no build-time env fallback. Each deployment mints its
+// own keypair, so a key baked into a bundle would be wrong for every host but
+// the one that built it. Native doesn't need this at all — it pushes over Expo,
+// not Web Push.
+function resolveVapidPublicKey(): string | undefined {
+    return globalThis.__TINYCLD_PUBLIC_CONFIG__?.vapidPublicKey
 }
 
 // App config handed to @tinycld/core at startup. Web resolves the PB address
@@ -75,6 +87,7 @@ export const appConfig: CoreConfig = {
         Platform.OS === 'web' && typeof window !== 'undefined' ? window.location.origin : null,
     defaultServer: __DEV__ ? devDefaultServer() : 'https://tinycld.org',
     sentryDsn: resolveSentryDsn(),
+    vapidPublicKey: resolveVapidPublicKey(),
     privacyUrl: 'https://tinycld.org/privacy',
     sourceUrl: 'https://github.com/tinycld/tinycld',
 }


### PR DESCRIPTION
Both push paths were fully built end to end, and neither could deliver a notification.

## Web

`web-push.ts` read the VAPID public key from `process.env.VITE_VAPID_PUBLIC_KEY` — a name nothing in the repo ever defined (`VITE_*` is Vite's prefix; this app bundles with Metro, which only inlines `EXPO_PUBLIC_*`). `subscribeToPush` returned `false` before ever calling `pushManager.subscribe`, so the Settings toggle silently did nothing and no `push_subscriptions` row was written.

A build-time constant was also the wrong shape for the value: each deployment generates its own keypair in Setup → Settings, so it's runtime config. The key now travels the same route as the Sentry DSN — whitelisted into the server-injected public config, read via `CoreConfig` — and a missing key throws rather than returning a silent `false`, which is what kept this invisible (`usePushSubscription`'s `onError` never fired because nothing threw).

The VAPID **private** key is never whitelisted, and the public key still passes the `publicValue` gate, so a row mis-flagged `is_secret` is blanked rather than injected.

## Native

`useExpoPushRegistration` existed, was reset from logout, and was called from nowhere — so `push_subscriptions` never got an `expo` row and `sendExpoPush` always found nothing. It's now mounted beside `NotifyContextSync`.

Expo also suppresses foreground notifications without a handler, and nothing consumed the `data.url` the server already sends, so a tap only opened the app. Both are added, including the cold-start tap (delivered as the last response rather than through the listener).

## Also

- Settings distinguishes "your browser can't" from "this server hasn't set it up", instead of one dead toggle.
- `app.json` gains the `expo-notifications` plugin and `POST_NOTIFICATIONS` (required on Android 13+).

## Testing

`tinycld-pkg check` clean — 1754 tests, biome across 893 files, typecheck. `go build ./...` and coreserver tests pass; `check:core-isolation` clean.

New tests, confirmed non-vacuous: reverting `web-push.ts` to the old behavior fails 3 of the 5 in `web-push-vapid.test.ts`. Two Go tests assert the public key is injected and the **private key never is**.

## Not included

Real device delivery still needs an APNs key and FCM credentials uploaded to EAS — account-level credential steps, not code. No custom Android notification icon (referencing a nonexistent asset breaks prebuild); worth a follow-up monochrome icon.