### PR TITLE
fix(core): a notify rule with no title fails at save, not after it runs

### DIFF
--- a/core/lib/automation/api.ts
+++ b/core/lib/automation/api.ts
@@ -21,6 +21,15 @@ export interface CatalogParam {
     label: string
     field: CatalogField
     template: boolean
+    /**
+     * The action cannot run without a value. True for every relation param,
+     * and for text params whose definition says so (core:notify's title,
+     * which becomes the required notifications.title).
+     *
+     * Optional in the type because a server older than this field omits it;
+     * absent reads as false, which is the pre-existing behavior.
+     */
+    required?: boolean
 }
 
 export interface CatalogTrigger {

--- a/core/lib/automation/core-defs.ts
+++ b/core/lib/automation/core-defs.ts
@@ -52,7 +52,12 @@ export const CORE_AUTOMATION: AutomationDefinitions = {
             label: 'Send me a notification',
             kind: 'native',
             params: [
-                { key: 'title', type: 'text' },
+                // Required: this becomes notifications.title, which the schema
+                // declares required. Left optional, a blank title saved and ran
+                // fine and then failed at the INSERT with "title: cannot be
+                // blank" — a notification the user never received, on a run
+                // recorded as matched.
+                { key: 'title', type: 'text', required: true },
                 { key: 'body', type: 'text' },
                 { key: 'url', type: 'text', label: 'Link (optional)' },
             ],

--- a/core/lib/automation/draft.ts
+++ b/core/lib/automation/draft.ts
@@ -218,10 +218,20 @@ function validateActionParams(
 ): string[] {
     const errors: string[] = []
     for (const param of action.params ?? []) {
-        // Text params and field-ref params may legitimately be empty strings
-        // (matches what the engine can execute), so only relation params are
-        // enforced non-empty here.
-        if (param.field.type !== 'relation') continue
+        // Most text and field-ref params may legitimately be empty strings, so
+        // only params the catalog marks required are enforced — every relation
+        // param, plus text params that back a required column.
+        //
+        // This used to test `type !== 'relation'` and skip everything else,
+        // which let core:notify save with a blank title. The rule then RAN,
+        // reported a matched run, and failed at the insert with "title: cannot
+        // be blank" — a notification nobody received, on a run that looked
+        // healthy.
+        // A relation param is required regardless of the flag: the engine
+        // refuses an empty one, and deriving it here means the client stays
+        // correct against a catalog (or a test fixture) that predates
+        // `required` rather than silently dropping the check.
+        if (!param.required && param.field.type !== 'relation') continue
         const value = draftAction.params[param.key]
         const provided = value !== undefined && value !== null
         if (!provided || (typeof value === 'string' && value.trim() === '')) {

--- a/core/lib/automation/types.ts
+++ b/core/lib/automation/types.ts
@@ -93,6 +93,18 @@ export interface TypedParamDef {
     label?: string
     options?: string[]
     /**
+     * The action cannot run without a non-empty value. Relation params are
+     * always enforced; a TEXT param is optional by default, because most of
+     * them legitimately accept an empty string.
+     *
+     * Some do not. `core:notify`'s title lands in `notifications.title`, which
+     * is `required: true` in the schema — so a blank one failed at the DB with
+     * "title: cannot be blank" AFTER the rule had saved and run, and the run
+     * was recorded as matched. Marking it required moves that to save time,
+     * where the builder can show it.
+     */
+    required?: boolean
+    /**
      * Required when `type` is 'relation' (validateDefinitions enforces both
      * directions): the target collection NAME the record picker lists. A
      * column-referencing param inherits its target from the column instead;

--- a/core/server/automation/catalog.go
+++ b/core/server/automation/catalog.go
@@ -39,6 +39,7 @@ type catalogParam struct {
 	Label    string       `json:"label"`
 	Field    catalogField `json:"field"`    // resolved type info (novel params synthesize from ParamDef.Type)
 	Template bool         `json:"template"` // true for text params when the trigger has fields (UI shows the placeholder menu)
+	Required bool         `json:"required"` // the action cannot run without a value (relation params, and text params that say so)
 }
 
 type catalogAction struct {
@@ -250,6 +251,9 @@ func resolveParam(app core.App, col *core.Collection, p ParamDef) catalogParam {
 		}
 	}
 	out.Template = out.Field.Type == "text"
+	// A relation param is required implicitly (the engine refuses an empty
+	// one); anything else says so in its definition.
+	out.Required = p.Required || out.Field.Type == "relation"
 	return out
 }
 

--- a/core/server/automation/defs.go
+++ b/core/server/automation/defs.go
@@ -82,6 +82,11 @@ type ParamDef struct {
 	// RelationTarget names the collection a typed relation param picks from.
 	// Column params leave it empty — their target resolves from the column.
 	RelationTarget string `json:"relationTarget"`
+	// Required means the action cannot run without a non-empty value. Relation
+	// params are always enforced; a text param is optional unless it says so,
+	// because most legitimately accept an empty string. core:notify's title
+	// does not — it becomes notifications.title, which the schema requires.
+	Required bool `json:"required"`
 }
 
 type ActionDef struct {

--- a/core/server/automation/register.go
+++ b/core/server/automation/register.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
+	"strings"
 
 	"tinycld.org/core/logging"
 	"tinycld.org/core/notify"
@@ -77,6 +78,15 @@ func registerCoreNativeActions() {
 	RegisterAction("core:notify", func(a core.App, req ActionRequest) error {
 		if !appIsLive(a) {
 			return fmt.Errorf("core:notify: server is shutting down")
+		}
+		// notifications.title is required in the schema, so a blank one fails
+		// at the INSERT with a raw "title: cannot be blank." Refuse it here
+		// instead: the run then records a comprehensible reason, and the rule
+		// counts toward auto-disable rather than silently never delivering.
+		// The builder blocks this at save time; this covers rules saved before
+		// that validation existed, and anything writing the record directly.
+		if strings.TrimSpace(req.Params["title"]) == "" {
+			return fmt.Errorf("core:notify: a title is required")
 		}
 		return deliverNotification(a, notify.NotifyParams{
 			UserID:  req.OwnerID,

--- a/core/tests/unit/rule-draft-validation.test.ts
+++ b/core/tests/unit/rule-draft-validation.test.ts
@@ -46,7 +46,16 @@ const CATALOG: CatalogResponse = {
             label: 'Send me a notification',
             kind: 'native',
             available: true,
-            params: [{ key: 'title', label: 'Title', template: true, field: { type: 'text' } }],
+            params: [
+                {
+                    key: 'title',
+                    label: 'Title',
+                    template: true,
+                    required: true,
+                    field: { type: 'text' },
+                },
+                { key: 'body', label: 'Body', template: true, field: { type: 'text' } },
+            ],
         },
     ],
 } as unknown as CatalogResponse
@@ -177,5 +186,51 @@ describe('draftToRecord', () => {
                 },
             ],
         })
+    })
+})
+
+// core:notify's title becomes notifications.title, which the schema declares
+// required. validateActionParams used to enforce ONLY relation params, so a
+// blank title saved happily, the rule ran, the run was recorded as matched, and
+// delivery then failed at the insert with "title: cannot be blank" — a
+// notification the user never got, on a rule that looked healthy.
+describe('required action params', () => {
+    it('rejects a blank required text param', () => {
+        const draft = {
+            ...savableDraft(),
+            actions: [{ uid: 'a1', ref: 'core:notify', params: { title: '' } }],
+        }
+        expect(validateDraft(draft, CATALOG)).toContain(
+            "Action 'Send me a notification' requires 'Title'"
+        )
+    })
+
+    it('rejects whitespace as a value', () => {
+        const draft = {
+            ...savableDraft(),
+            actions: [{ uid: 'a1', ref: 'core:notify', params: { title: '   ' } }],
+        }
+        expect(validateDraft(draft, CATALOG)).toContain(
+            "Action 'Send me a notification' requires 'Title'"
+        )
+    })
+
+    it('rejects the param being absent entirely', () => {
+        const draft = {
+            ...savableDraft(),
+            actions: [{ uid: 'a1', ref: 'core:notify', params: {} }],
+        }
+        expect(validateDraft(draft, CATALOG)).toContain(
+            "Action 'Send me a notification' requires 'Title'"
+        )
+    })
+
+    it('still allows an OPTIONAL text param to be empty', () => {
+        // The point of the `required` flag: body is text too, and blank is fine.
+        const draft = {
+            ...savableDraft(),
+            actions: [{ uid: 'a1', ref: 'core:notify', params: { title: 'hi', body: '' } }],
+        }
+        expect(validateDraft(draft, CATALOG)).toEqual([])
     })
 })

--- a/tests/e2e/rules.spec.ts
+++ b/tests/e2e/rules.spec.ts
@@ -123,6 +123,10 @@ test.describe('Rules', () => {
         )
         await page.getByText('add action', { exact: true }).click()
         await page.getByText('Send me a notification', { exact: true }).click()
+        // The title is required — it becomes the notification's own title,
+        // which the schema requires. Leaving it blank now fails validation at
+        // save (it used to save, run, and then fail at the insert).
+        await page.getByText('Title').locator('..').getByRole('textbox').first().fill('t')
         await page.getByText('Save', { exact: true }).click()
         await expect(page.getByText(ruleName, { exact: true })).toBeVisible()
 
@@ -159,6 +163,10 @@ test.describe('Rules', () => {
         )
         await page.getByText('add action', { exact: true }).click()
         await page.getByText('Send me a notification', { exact: true }).click()
+        // The title is required — it becomes the notification's own title,
+        // which the schema requires. Leaving it blank now fails validation at
+        // save (it used to save, run, and then fail at the insert).
+        await page.getByText('Title').locator('..').getByRole('textbox').first().fill('t')
         await page.getByText('Save', { exact: true }).click()
         await expect(page.getByText(ruleName, { exact: true })).toBeVisible()
 


### PR DESCRIPTION
## The bug

`core:notify`'s `title` becomes `notifications.title`, which the schema declares `required: true`. Nothing enforced that — `validateActionParams` checked **only relation params**, on the stated reasoning that empty text "matches what the engine can execute". For this action it doesn't.

So a rule with a blank title:

1. saved happily,
2. ran, and was recorded as a **matched** run,
3. then failed at the INSERT with `title: cannot be blank`.

A notification the user never received, on a rule that looked healthy in run history — and because the run recorded success, auto-disable could never see it failing. The rules e2e suite had been creating exactly this rule and logging the error on every CI run, which is how it surfaced.

## The fix

Params gain a `required` flag, threaded through the Go catalog (`defs.go` → `catalog.go`) to the client. `title` sets it.

Enforced in three places, because each covers a different caller:

- **Builder** (`draft.ts`) — blocks save and names the missing field.
- **Action** (`register.go`) — refuses a blank title, so the run records a comprehensible reason rather than a raw DB error. Covers rules saved before this validation existed, and anything writing the record directly.
- **Relation params** stay derived as required *independently* of the flag, so the client remains correct against a catalog that predates it. (My first attempt keyed solely on the flag and broke exactly this — caught by an existing test.)

Telling detail: `url` was already labelled "Link (optional)". The intent that the other two were required existed all along; only the enforcement was missing.

## Testing

`tinycld-pkg check` clean — **1761 unit tests**, biome, typecheck. Go build + `automation`/`notify` tests pass.

Rules e2e: **11/11 pass**, and `title: cannot be blank` no longer appears in the server log.

New validation tests are non-vacuous: reverting the `draft.ts` change fails 3 of them. Three e2e specs that relied on saving a titleless notify action now fill the title, since a blank one is correctly rejected.