### PR TITLE
fix(core): a closing layer keeps focus it no longer owns

### DIFF
--- a/core/tests/unit/layer-focus-restore.test.tsx
+++ b/core/tests/unit/layer-focus-restore.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render as renderBare } from '@testing-library/react'
+import { useLayerFocus } from '@tinycld/core/ui/overlay'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * A layer that takes focus while open and gives it back when it closes —
+ * the shape every Menu and Dialog uses through useLayerFocus.
+ */
+function Layer({ isActive }: { isActive: boolean }) {
+    const [container, setContainer] = useState<HTMLElement | null>(null)
+    useLayerFocus({ isActive, container, trap: false })
+    if (!isActive) return null
+    return (
+        <div ref={setContainer as (el: HTMLDivElement | null) => void}>
+            <button type="button">Row</button>
+        </div>
+    )
+}
+
+function Harness({ isActive }: { isActive: boolean }) {
+    return (
+        <>
+            <button type="button" id="trigger">
+                Trigger
+            </button>
+            <input id="elsewhere" />
+            <Layer isActive={isActive} />
+        </>
+    )
+}
+
+const byId = <T extends HTMLElement>(id: string) => document.getElementById(id) as T
+
+describe('useLayerFocus — handing focus back on close', () => {
+    afterEach(cleanup)
+
+    it('returns focus to the trigger when nothing else claimed it', () => {
+        const { rerender } = renderBare(<Harness isActive={false} />)
+        byId('trigger').focus()
+
+        rerender(<Harness isActive={true} />)
+        expect(document.activeElement?.textContent).toBe('Row')
+
+        rerender(<Harness isActive={false} />)
+        expect(document.activeElement).toBe(byId('trigger'))
+    })
+
+    it('leaves focus alone when the closing action moved it somewhere new', () => {
+        const { rerender } = renderBare(<Harness isActive={false} />)
+        byId('trigger').focus()
+        rerender(<Harness isActive={true} />)
+
+        // What a menu row that acts by focusing a new field does: the field
+        // takes focus BEFORE the layer unmounts. Restoring here would blur it
+        // one frame after it appeared — the board-header rename bug.
+        byId<HTMLInputElement>('elsewhere').focus()
+        rerender(<Harness isActive={false} />)
+
+        expect(document.activeElement).toBe(byId('elsewhere'))
+    })
+})

--- a/core/ui/overlay/focus.ts
+++ b/core/ui/overlay/focus.ts
@@ -78,9 +78,18 @@ export function useLayerFocus({
 
         return () => {
             container.removeEventListener('keydown', onKeyDown)
-            if (restore && previous?.isConnected && typeof previous.focus === 'function') {
-                previous.focus()
-            }
+            if (!restore || !previous?.isConnected || typeof previous.focus !== 'function') return
+            // Hand focus back ONLY if nothing else has claimed it. A menu row
+            // may act by moving focus somewhere new — the board header's
+            // "Rename board" mounts an autoFocus input — and that focus lands
+            // BEFORE this layer unmounts. Restoring unconditionally stole it
+            // back, blurring the new field one frame after it appeared; an
+            // input that commits on blur then closed itself, so the row looked
+            // dead. Focus still inside the closing layer (or dropped to body)
+            // means no one else wanted it, which is when restoring is right.
+            const active = document.activeElement as HTMLElement | null
+            const isUnclaimed = !active || active === document.body || container.contains(active)
+            if (isUnclaimed) previous.focus()
         }
     }, [isActive, container, initialFocusRef, trap, restore])
 }


### PR DESCRIPTION
A menu layer's cleanup in `useLayerFocus` restored DOM focus to its trigger unconditionally. That is right when the layer merely closes, but wrong when the row that closed it acted *by* moving focus somewhere new — the new field takes focus before the layer unmounts, and the restore blurs it a frame later.

Boards' "Rename board" is the case that surfaced it: the row mounts an `autoFocus` input over the header title, and that input commits on blur, so the stolen focus made it close itself immediately. The input appeared and vanished within one frame, which read as a menu row that did nothing.

Now the layer restores focus only when nothing else has claimed it — still inside the closing layer, or dropped to `body`. Anything else took it deliberately.

Confirmed by instrumenting the running app:

```
onRename fired
TitleBlock isRenaming=true      ← input mounts
onBlur fired                    ← focus stolen back
commit called
TitleBlock isRenaming=false     ← input closes itself
```

Sibling rows (Export, Settings, Epics) were unaffected because they open dialogs, which own focus rather than competing for it.

## Testing

- New `core/tests/unit/layer-focus-restore.test.tsx`, verified to fail on the old cleanup and pass on this one
- core unit: 1586 pass · boards unit: 705 pass
- `pnpm run checks` (lint 2289 files, typecheck, core-isolation) green
- boards e2e: 206/206, including the two new rename specs in tinycld/boards#fix/menu-focus-restore
- app-shell `change-password` + `rules`: 13/13, run twice

## Merge order

The boards PR shares this branch name and needs this merged first.

Note: #253 also touches `tests/e2e/rules.spec.ts`. No conflict with this diff, but worth sequencing if both land close together.