### PR TITLE
test: seed the lucide stub with the git icons

### DIFF
--- a/tests/lucide-react-native-stub.cjs
+++ b/tests/lucide-react-native-stub.cjs
@@ -78,6 +78,10 @@ const knownIcons = {
     // drive icons (if any are value-checked)
     FolderOpen: Icon,
     Folder: Icon,
+    // boards: pr-link-status.ts's state → icon table (tests/pr-link-chip.test.ts)
+    GitMerge: Icon,
+    GitPullRequest: Icon,
+    GitPullRequestClosed: Icon,
     // oauth: ConnectedAppsSection's revoke button
     Trash2: Icon,
     File: Icon,


### PR DESCRIPTION
boards' PR-link chip maps a pull request's state to `GitMerge`, `GitPullRequest` or `GitPullRequestClosed`.

The stub returns `undefined` for any icon absent from `knownIcons`, so a test importing one fails on a value check rather than on anything it means to assert. Four lines, following the file's existing per-package convention.

Needed by the boards GitHub-integration branch; harmless on its own.