### PR TITLE
feat: ship TinyCld as a single self-host binary

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -86,15 +86,10 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: ws/tinycld/.node-version
-      # Assemble the workspace from the pinned release recipe attached to
-      # the app's GitHub Release. release.ts uploads manifest.json (sibling
-      # name → repo + tag + sha) and pnpm-lock.yaml as assets when it
-      # cuts an app release. We download both, clone each sibling at its
-      # pinned sha, let bootstrap write the workspace scaffolding (members
-      # are already present so it skips cloning), and drop the pinned
-      # lockfile into ws/. The resulting workspace is byte-identical to
-      # what the release author built locally — rebuilding the same tag
-      # produces the same image six months from now.
+      # Download the pinned release recipe attached to the app's GitHub
+      # Release (release.ts uploads it when it cuts one), then assemble the
+      # workspace from it. The assembly itself lives in a shared script — see
+      # its header for why the two release workflows must not duplicate it.
       - name: Assemble workspace from pinned release manifest
         working-directory: ws
         env:
@@ -107,41 +102,9 @@ jobs:
           gh release download "${TAG}" -R "${GITHUB_REPOSITORY}" \
             -p manifest.json -p pnpm-lock.yaml -p package-versions.json \
             --dir .release-assets
-          MANIFEST=".release-assets/manifest.json"
-          LOCKFILE=".release-assets/pnpm-lock.yaml"
-          VERSIONS=".release-assets/package-versions.json"
-          echo "Manifest contents:"
-          cat "${MANIFEST}"
-          jq -r '.members[] | "\(.name)\t\(.repo)\t\(.sha)"' "$MANIFEST" | while IFS=$'\t' read -r name repo sha; do
-            echo "Cloning ${repo} @ ${sha} → ${name}"
-            git clone --quiet "https://github.com/${repo}.git" "${name}"
-            git -C "${name}" fetch --quiet origin "${sha}"
-            git -C "${name}" checkout --quiet "${sha}"
-          done
-          # bootstrap sees every member already cloned (tinycld + each sibling)
-          # and just writes the workspace-root scaffolding (package.json +
-          # pnpm-workspace.yaml + .npmrc + tinycld.packages.ts +
-          # scripts/link-members.ts). --assemble-only is non-destructive: it skips
-          # any member already present, cloning only what's missing. (Replaces the
-          # v1 --tooling flag, removed in bootstrap v2.)
-          TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only \
-            --with contacts --with mail --with calendar --with drive \
-            --with calc --with text --with google-takeout-import
-          # Drop the pinned lockfile into the workspace root so the Dockerfile's
-          # `pnpm install --frozen-lockfile` reproduces the exact dependency set.
-          cp "${LOCKFILE}" pnpm-lock.yaml
-          # Drop the framework/native version pins into the workspace root. The
-          # Dockerfile COPYs package-versions.json into the image and the OTA
-          # rebuild reads it to regenerate the pnpm `overrides:` block. bootstrap
-          # doesn't write it, so the release asset is its only source in CI.
-          cp "${VERSIONS}" package-versions.json
-          # Hand the manifest to the Docker build so it's baked into the image
-          # and served by /api/release (the About panel reads it). The wildcard
-          # COPY in the Dockerfile makes it optional, so this is the only wiring.
-          # Destination must be tinycld/ — the Dockerfile COPYs
-          # tinycld/.release-manifest*; anywhere else and the bake silently
-          # no-ops (the wildcard COPY tolerates the miss).
-          cp "${MANIFEST}" tinycld/.release-manifest
+          # Shared with release-binaries.yml so the image and the self-host
+          # binary are always built from the same pinned member set.
+          tinycld/scripts/ci-assemble-workspace.sh .release-assets
 
       # Derive OCI labels (standard image.* + custom tinycld.packages) from the
       # pinned manifest so `docker inspect` and registry UIs show exactly which

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -100,6 +100,9 @@ jobs:
             exit 1
           fi
 
+      # No Windows target: core/server/tenantcfg/runtime.go uses
+      # syscall.O_NOFOLLOW, which does not exist on Windows. Adding it is a
+      # porting task in core, not a matrix entry.
       - name: Cross-compile
         working-directory: ws/tinycld/server
         run: |
@@ -113,6 +116,7 @@ jobs:
           }
           build linux amd64
           build linux arm64
+          build darwin amd64
           build darwin arm64
 
       # The floor catches the failure mode that matters: if the embed silently

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,8 +23,9 @@ jobs:
     name: Build single binary
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Reads the release's pinned assets; only the publish job writes back.
     permissions:
-      contents: write
+      contents: read
     steps:
       # Path MUST be the member's canonical dir name: bootstrap treats a dir
       # with a .git as an already-cloned member and skips it. See the same note
@@ -100,9 +101,6 @@ jobs:
             exit 1
           fi
 
-      # No Windows target: core/server/tenantcfg/runtime.go uses
-      # syscall.O_NOFOLLOW, which does not exist on Windows. Adding it is a
-      # porting task in core, not a matrix entry.
       - name: Cross-compile
         working-directory: ws/tinycld/server
         run: |
@@ -111,13 +109,15 @@ jobs:
           build() {
             GOOS="$1" GOARCH="$2" CGO_ENABLED=0 go build \
               -tags embedassets -trimpath -ldflags="-s -w" \
-              -o "/tmp/dist/tinycld-$1-$2" .
-            echo "built tinycld-$1-$2"
+              -o "/tmp/dist/tinycld-$1-$2${3:-}" .
+            echo "built tinycld-$1-$2${3:-}"
           }
           build linux amd64
           build linux arm64
           build darwin amd64
           build darwin arm64
+          build windows amd64 .exe
+          build windows arm64 .exe
 
       # The floor catches the failure mode that matters: if the embed silently
       # drops out (an unreferenced embed.FS is eliminated by the linker), the
@@ -140,9 +140,109 @@ jobs:
             fi
           done
 
+      # Hand the Windows build to the smoke-test job below. Cross-compiling only
+      # proves it links; nothing here has ever executed it.
+      - name: Upload the Windows binary for smoke testing
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-binary
+          path: /tmp/dist/tinycld-windows-amd64.exe
+          retention-days: 1
+
       - name: Generate checksums
         working-directory: /tmp/dist
         run: sha256sum tinycld-* > SHA256SUMS && cat SHA256SUMS
+
+      # Keep every artifact for the publish job, which runs only after the
+      # Windows smoke test passes.
+      - name: Upload the built binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: |
+            /tmp/dist/tinycld-*
+            /tmp/dist/SHA256SUMS
+          retention-days: 1
+
+  # Boot the Windows binary on a real Windows runner before the release keeps
+  # it. Path handling and SQLite are the risks a cross-compile cannot cover.
+  smoke-windows:
+    name: Smoke-test the Windows binary
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download the Windows binary
+        uses: actions/download-artifact@v5
+        with:
+          name: windows-binary
+
+      - name: Boot it in an empty directory and serve the embedded app
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dir = Join-Path $env:RUNNER_TEMP 'tc-smoke'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          $exe = Join-Path (Get-Location) 'tinycld-windows-amd64.exe'
+
+          # cwd is an empty dir: no dist/, no pb_migrations/, so anything served
+          # can only come from inside the binary.
+          $proc = Start-Process -FilePath $exe `
+            -ArgumentList 'serve','--http','127.0.0.1:8095' `
+            -WorkingDirectory $dir -PassThru `
+            -RedirectStandardOutput (Join-Path $dir 'out.log') `
+            -RedirectStandardError  (Join-Path $dir 'err.log')
+
+          try {
+            $ok = $false
+            foreach ($i in 1..60) {
+              Start-Sleep -Seconds 2
+              if ($proc.HasExited) { throw "binary exited early with $($proc.ExitCode)" }
+              try {
+                if ((Invoke-WebRequest "http://127.0.0.1:8095/api/health" -UseBasicParsing -TimeoutSec 5).StatusCode -eq 200) {
+                  $ok = $true; break
+                }
+              } catch { }
+            }
+            if (-not $ok) { throw "server never became healthy" }
+
+            # The SPA shell must come from the embedded bundle...
+            $shell = Invoke-WebRequest "http://127.0.0.1:8095/" -UseBasicParsing
+            if ($shell.Content -notmatch '<div id="root">') { throw "shell did not render from the embed" }
+
+            # ...and its scripts must resolve, or the app boots blank.
+            $src = [regex]::Match($shell.Content, 'src="([^"]+\.js)"').Groups[1].Value
+            if (-not $src) { throw "no script tags in the shell" }
+            $chunk = Invoke-WebRequest "http://127.0.0.1:8095$src" -UseBasicParsing
+            if ($chunk.StatusCode -ne 200) { throw "script $src returned $($chunk.StatusCode)" }
+
+            # Migrations applied from the embedded FS.
+            if (-not (Test-Path (Join-Path $dir 'tinycld-data\pb_data\data.db'))) {
+              throw "no database created"
+            }
+            Write-Host "Windows smoke test passed: health, shell, script chunk, database"
+          }
+          finally {
+            if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force }
+            Write-Host "--- stdout ---"; Get-Content (Join-Path $dir 'out.log') -Tail 30 -EA SilentlyContinue
+            Write-Host "--- stderr ---"; Get-Content (Join-Path $dir 'err.log') -Tail 30 -EA SilentlyContinue
+          }
+
+  # Attaching happens only after the Windows binary has been proven to boot, so
+  # a release never carries an artifact that was never executed.
+  publish:
+    name: Attach binaries to the release
+    needs: [build, smoke-windows]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download the built binaries
+        uses: actions/download-artifact@v5
+        with:
+          name: release-binaries
+          path: dist
 
       - name: Attach to release
         env:
@@ -150,5 +250,5 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          gh release upload "${TAG}" /tmp/dist/tinycld-* /tmp/dist/SHA256SUMS \
+          gh release upload "${TAG}" dist/tinycld-* dist/SHA256SUMS \
             -R "${GITHUB_REPOSITORY}" --clobber

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,150 @@
+name: Build and publish self-host binaries
+
+# Lives in the tinycld/tinycld repo — the release ANCHOR, same contract as
+# docker-publish.yml. A published Release assembles the workspace from the
+# release's pinned manifest (via the shared ci-assemble-workspace.sh, so the
+# image and these binaries are built from the same member set), then
+# cross-compiles the single-binary self-host artifact for each platform.
+#
+# Trigger is `release: published` only — NOT `push: tags` — because the
+# manifest.json and pnpm-lock.yaml assets are uploaded client-side after the
+# tag is pushed, so a tag-push trigger would race ahead of them.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: release-binaries-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build single binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    steps:
+      # Path MUST be the member's canonical dir name: bootstrap treats a dir
+      # with a .git as an already-cloned member and skips it. See the same note
+      # in docker-publish.yml.
+      - name: Checkout tinycld member (at the triggering tag)
+        uses: actions/checkout@v5
+        with:
+          path: ws/tinycld
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ws/tinycld/.node-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ws/tinycld/server/go.mod
+
+      - name: Assemble workspace from pinned release manifest
+        working-directory: ws
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME:-$(git -C tinycld describe --tags --exact-match)}"
+          echo "Downloading release assets for ${TAG}…"
+          mkdir -p .release-assets
+          gh release download "${TAG}" -R "${GITHUB_REPOSITORY}" \
+            -p manifest.json -p pnpm-lock.yaml -p package-versions.json \
+            --dir .release-assets
+          # Shared with docker-publish.yml — see the script header.
+          tinycld/scripts/ci-assemble-workspace.sh .release-assets
+
+      - name: Install dependencies
+        working-directory: ws
+        run: corepack enable && pnpm install --frozen-lockfile
+
+      - name: Generate package wiring
+        working-directory: ws/tinycld
+        run: pnpm run packages:generate
+
+      # --source-maps external keeps the maps out of the bundle entirely; they
+      # are the bulk of the export and must never reach the embed payload.
+      - name: Export web bundle
+        working-directory: ws/tinycld
+        run: pnpm exec expo export --platform web --source-maps external
+
+      - name: Stage embeddable assets
+        working-directory: ws/tinycld
+        run: pnpm run stage:embed
+
+      - name: Fail if source maps reached the embed payload
+        working-directory: ws/tinycld
+        run: |
+          set -euo pipefail
+          count=$(find server/embedded_assets -name '*.map' | wc -l)
+          if [ "$count" -ne 0 ]; then
+            echo "::error::${count} source maps staged for embedding; they must be excluded"
+            exit 1
+          fi
+
+      # go:embed cannot follow symlinks, and the generator writes pb_migrations
+      # and pb_hooks as symlink farms into the sibling repos. If staging left
+      # links behind, the binary would build clean and ship with no migrations.
+      - name: Fail if any staged asset is still a symlink
+        working-directory: ws/tinycld
+        run: |
+          set -euo pipefail
+          count=$(find server/embedded_assets -type l | wc -l)
+          if [ "$count" -ne 0 ]; then
+            echo "::error::${count} staged assets are symlinks; go:embed would skip them"
+            exit 1
+          fi
+
+      - name: Cross-compile
+        working-directory: ws/tinycld/server
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/dist
+          build() {
+            GOOS="$1" GOARCH="$2" CGO_ENABLED=0 go build \
+              -tags embedassets -trimpath -ldflags="-s -w" \
+              -o "/tmp/dist/tinycld-$1-$2" .
+            echo "built tinycld-$1-$2"
+          }
+          build linux amd64
+          build linux arm64
+          build darwin arm64
+
+      # The floor catches the failure mode that matters: if the embed silently
+      # drops out (an unreferenced embed.FS is eliminated by the linker), the
+      # binary still builds and still serves — just with no web UI. The measured
+      # size is ~62MB embedded vs ~50MB without, so 55MB separates the two.
+      # The ceiling catches an accidental re-addition of source maps.
+      - name: Enforce size budget
+        run: |
+          set -euo pipefail
+          for f in /tmp/dist/tinycld-*; do
+            mb=$(( $(stat -c%s "$f") / 1048576 ))
+            echo "$(basename "$f"): ${mb} MB"
+            if [ "$mb" -gt 100 ]; then
+              echo "::error::$(basename "$f") is ${mb} MB, over the 100 MB budget"
+              exit 1
+            fi
+            if [ "$mb" -lt 55 ]; then
+              echo "::error::$(basename "$f") is only ${mb} MB — the embedded assets are missing"
+              exit 1
+            fi
+          done
+
+      - name: Generate checksums
+        working-directory: /tmp/dist
+        run: sha256sum tinycld-* > SHA256SUMS && cat SHA256SUMS
+
+      - name: Attach to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          gh release upload "${TAG}" /tmp/dist/tinycld-* /tmp/dist/SHA256SUMS \
+            -R "${GITHUB_REPOSITORY}" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ server/pb_test_releases/
 
 expo-env.d.ts
 # @end expo-cli
+/server/embedded_assets/

--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ semantic Tailwind tokens, pbtsdb for data, etc.
 
 ## Deploy
 
+Two distributions. A single binary is the quickest way to try TinyCld or to run
+a small instance — see
+[Running from a single binary](docs/single-binary.md) (no Docker required). For
+anything that needs to add packages after install, use the image:
+
 ```sh
 docker pull ghcr.io/tinycld/tinycld
 ```

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -484,9 +484,16 @@ func registerStaticServe(app *pocketbase.PocketBase, opts Options) {
 			// <releasesDir>/_static/. _expo/static/ filenames are fully
 			// content-hashed (immutable), while /assets/ contains a few
 			// stable names like app-icon.png so a shorter max-age applies.
-			if opts.ReleasesDir != "" {
+			//
+			// A single-binary build has no pool: its bundle is embedded. These
+			// prefixes would then shadow the catch-all that CAN serve it, so
+			// every script 404s while the shell still renders — the binary looks
+			// healthy and boots to a blank page.
+			if opts.ReleasesDir != "" && opts.PublicFS == nil {
 				e.Router.GET("/_expo/static/{path...}", PoolAssets(opts.ReleasesDir, "_expo/static", "public, max-age=31536000, immutable"))
 				e.Router.GET("/assets/{path...}", PoolAssets(opts.ReleasesDir, "assets", "public, max-age=300"))
+			}
+			if opts.ReleasesDir != "" {
 				e.Router.GET("/api/version", VersionHandler(opts.ReleasesDir))
 				e.Router.GET("/api/release", ReleaseHandler(opts.ReleasesDir))
 			}

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -1,6 +1,7 @@
 package coreserver
 
 import (
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -67,6 +68,13 @@ type Options struct {
 	HooksPoolSize int
 	MigrationsDir string
 	Automigrate   bool
+
+	// PublicFS / MigrationsFS / HooksFS supply embedded assets for
+	// single-binary builds. Each is nil for path-based deployments, which keeps
+	// the container and hosting paths on their existing behavior.
+	PublicFS     fs.FS
+	MigrationsFS fs.FS
+	HooksFS      fs.FS
 
 	// BinaryName is the file name of the running app binary (without
 	// directory). Used by package install/upgrade flows to locate the
@@ -162,6 +170,10 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 	jsvm.MustRegister(app, jsvm.Config{
 		MigrationsDir: opts.MigrationsDir,
 		HooksDir:      opts.HooksDir,
+		// Non-nil only in a single-binary build, where the loaders read the
+		// embedded sources instead of the dirs above.
+		MigrationsFS:  opts.MigrationsFS,
+		HooksFS:       opts.HooksFS,
 		HooksWatch:    opts.HooksWatch,
 		HooksPoolSize: opts.HooksPoolSize,
 		// Install core's native $-bindings on every VM (hook + callback pools).
@@ -175,11 +187,17 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 		OnLoaderInit: buildJsvmOnLoaderInit(app),
 	})
 
-	migratecmd.MustRegister(app, app.RootCmd, migratecmd.Config{
-		TemplateLang: migratecmd.TemplateLangJS,
-		Automigrate:  opts.Automigrate,
-		Dir:          opts.MigrationsDir,
-	})
+	// A single-binary build has no writable migrations dir, and `migrate
+	// create` / `migrate collections` are dev-time authoring commands with
+	// nowhere to write. Applying migrations does not depend on this: that runs
+	// off the in-memory core.AppMigrations registry which jsvm populates above.
+	if opts.MigrationsFS == nil {
+		migratecmd.MustRegister(app, app.RootCmd, migratecmd.Config{
+			TemplateLang: migratecmd.TemplateLangJS,
+			Automigrate:  opts.Automigrate,
+			Dir:          opts.MigrationsDir,
+		})
+	}
 
 	registerSharedCore(app)
 
@@ -194,7 +212,11 @@ func Register(app *pocketbase.PocketBase, opts Options) {
 	// toolchain. In hosting the ROUTER owns deploys (re-materialize + evict);
 	// a tenant that could rebuild or restart itself would escape the router's
 	// supervision.
-	RegisterPackageInstallEndpoints(app)
+	// A single-binary build cannot rebuild itself, so it does not expose this
+	// API at all; self-hosters upgrade by downloading a new binary.
+	if opts.supportsSelfRebuild() {
+		RegisterPackageInstallEndpoints(app)
+	}
 	// Admin-console panel endpoint. Tenant push keys will arrive via the org's
 	// system_settings (control-plane provisioned), not a self-serve panel.
 	RegisterVapidAdminEndpoints(app)
@@ -470,9 +492,14 @@ func registerStaticServe(app *pocketbase.PocketBase, opts Options) {
 			}
 
 			if !e.Router.HasRoute(http.MethodGet, "/{path...}") {
-				if opts.ReleasesDir != "" {
+				switch {
+				case opts.PublicFS != nil:
+					// Single-binary build: the bundle is compiled in, so there
+					// is no releases dir to promote a deploy into.
+					e.Router.Any("/{path...}", StaticWithDynamicFallbackFS(opts.PublicFS, nil, nil, ""))
+				case opts.ReleasesDir != "":
 					e.Router.Any("/{path...}", StaticWithDynamicFallback(opts.PublicDir, opts.WebsiteDir, opts.ReleasesDir))
-				} else {
+				default:
 					e.Router.Any("/{path...}", StaticWithFallback(opts.PublicDir, opts.FallbackFile))
 				}
 			}

--- a/core/server/coreserver/standalone.go
+++ b/core/server/coreserver/standalone.go
@@ -1,0 +1,49 @@
+package coreserver
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Standalone mode is the single-binary self-host distribution: the web bundle,
+// the JS migrations, and the .pb.ts hooks are compiled into the executable, so
+// it runs with no Docker, no Node, and no Go toolchain.
+//
+// There are deliberately no new location flags. PocketBase already owns --dir
+// (its data directory) and --http / --https, so standalone mode reuses them
+// rather than introducing a second, competing path mechanism that could
+// disagree with the one PocketBase actually honors.
+
+// FlagValue returns the value of a `--name value` or `--name=value` argument,
+// or "" when the flag is absent or has no value.
+//
+// Standalone mode needs --dir before app.Start() parses flags, so that it can
+// align core's state root (releases, builds) with the database location.
+func FlagValue(args []string, name string) string {
+	for i, arg := range args {
+		if value, ok := strings.CutPrefix(arg, name+"="); ok {
+			return value
+		}
+		if arg == name && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// StandaloneStateDir maps PocketBase's data directory to the root that core's
+// own state helpers (resolveStateDir and the releases/builds paths derived from
+// it) should use. PocketBase's --dir IS the pb_data directory, while
+// TINYCLD_STATE_DIR is its parent — the directory pb_data sits inside.
+func StandaloneStateDir(dataDir string) string {
+	return filepath.Dir(dataDir)
+}
+
+// supportsSelfRebuild reports whether this deployment can rebuild its own
+// binary. The package install/upgrade pipelines re-run the generator and invoke
+// the Go toolchain and pnpm, none of which exists beside a single static binary,
+// so a standalone build must not advertise that API. Embedded migrations are the
+// discriminator: they are present only in a single-binary build.
+func (o Options) supportsSelfRebuild() bool {
+	return o.MigrationsFS == nil
+}

--- a/core/server/coreserver/standalone.go
+++ b/core/server/coreserver/standalone.go
@@ -47,3 +47,34 @@ func StandaloneStateDir(dataDir string) string {
 func (o Options) supportsSelfRebuild() bool {
 	return o.MigrationsFS == nil
 }
+
+// ShouldInjectDataDir reports whether a standalone build may append its default
+// --dir to the argument list.
+//
+// Every real command (serve, superuser, create-owner, export-types) operates on
+// the database and wants the default. A flag-only invocation must NOT get one:
+// cobra reads the appended path as a stray positional and fails the command with
+// `unknown command "./tinycld-data/pb_data"`, which breaks --help and --version.
+// A --dir the user set always wins.
+func ShouldInjectDataDir(args []string) bool {
+	if FlagValue(args, "--dir") != "" || hasExactArg(args, "--dir") {
+		return false
+	}
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasExactArg reports whether args contains exactly the given token, so a
+// valueless trailing `--dir` is still treated as user-supplied.
+func hasExactArg(args []string, name string) bool {
+	for _, arg := range args {
+		if arg == name {
+			return true
+		}
+	}
+	return false
+}

--- a/core/server/coreserver/standalone_test.go
+++ b/core/server/coreserver/standalone_test.go
@@ -1,0 +1,121 @@
+package coreserver
+
+import (
+	"net/http"
+	"testing"
+	"testing/fstest"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/router"
+
+	"tinycld.org/core/quota"
+)
+
+// TestFlagValue_ReadsBothSpellings covers the two forms cobra accepts, since
+// standalone mode must read --dir before PocketBase parses its own flags.
+func TestFlagValue_ReadsBothSpellings(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"separate value", []string{"serve", "--dir", "/srv/tc"}, "/srv/tc"},
+		{"equals form", []string{"serve", "--dir=/srv/tc"}, "/srv/tc"},
+		{"absent", []string{"serve"}, ""},
+		{"flag present but valueless", []string{"serve", "--dir"}, ""},
+		{"not confused by a similar prefix", []string{"serve", "--dirty", "x"}, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FlagValue(tc.args, "--dir"); got != tc.want {
+				t.Errorf("FlagValue(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStandaloneStateDir pins the mapping from PocketBase's data dir to the
+// state root core's own helpers use. They must agree, or releases and builds
+// would land beside the binary while the database lived elsewhere.
+func TestStandaloneStateDir(t *testing.T) {
+	cases := []struct{ dataDir, want string }{
+		{"/srv/tc/pb_data", "/srv/tc"},
+		{"./tinycld-data/pb_data", "tinycld-data"},
+		{"/srv/tc/custom", "/srv/tc"},
+	}
+
+	for _, tc := range cases {
+		if got := StandaloneStateDir(tc.dataDir); got != tc.want {
+			t.Errorf("StandaloneStateDir(%q) = %q, want %q", tc.dataDir, got, tc.want)
+		}
+	}
+}
+
+// TestStandaloneSkipsSelfRebuild pins the distribution's core limitation: a
+// single binary cannot rebuild itself (those pipelines shell out to the Go
+// toolchain and pnpm, neither of which ships beside a static binary), so the
+// install/upgrade API must not be registered. Upgrading means downloading a
+// new binary.
+func TestStandaloneSkipsSelfRebuild(t *testing.T) {
+	standalone := Options{MigrationsFS: fstest.MapFS{}}
+	if standalone.supportsSelfRebuild() {
+		t.Error("a single-binary build must not expose the self-rebuild API")
+	}
+
+	container := Options{MigrationsDir: "./pb_migrations"}
+	if !container.supportsSelfRebuild() {
+		t.Error("a path-based build must keep the self-rebuild API")
+	}
+}
+
+// hasRebuildRoute boots a composition far enough to populate its router, then
+// asks whether the package install endpoint was registered. No listener starts.
+func hasRebuildRoute(t *testing.T, opts Options) bool {
+	t.Helper()
+	quota.ResetSourcesForTesting()
+
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: t.TempDir()})
+	Register(app, opts)
+
+	if err := app.Bootstrap(); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	serveEvent := new(core.ServeEvent)
+	serveEvent.App = app
+	serveEvent.Router = router.NewRouter[*core.RequestEvent](nil)
+	if err := app.OnServe().Trigger(serveEvent); err != nil {
+		t.Fatalf("OnServe: %v", err)
+	}
+
+	return serveEvent.Router.HasRoute(http.MethodPost, "/api/admin/packages/install")
+}
+
+// TestStandalone_OmitsRebuildRoutes is the route-level counterpart to
+// TestStandaloneSkipsSelfRebuild: it proves the endpoint is genuinely absent
+// from a single-binary composition and present in a path-based one.
+func TestStandalone_OmitsRebuildRoutes(t *testing.T) {
+	base := func() Options {
+		return Options{
+			HooksDir:      t.TempDir(),
+			MigrationsDir: t.TempDir(),
+			TypesDir:      t.TempDir(),
+			PublicDir:     t.TempDir(),
+			HooksPoolSize: 1,
+		}
+	}
+
+	if !hasRebuildRoute(t, base()) {
+		t.Error("a path-based build must keep the package rebuild API")
+	}
+
+	standalone := base()
+	standalone.MigrationsFS = fstest.MapFS{}
+	standalone.HooksFS = fstest.MapFS{}
+	standalone.PublicFS = fstest.MapFS{}
+	if hasRebuildRoute(t, standalone) {
+		t.Error("a single-binary build must not expose the package rebuild API")
+	}
+}

--- a/core/server/coreserver/standalone_test.go
+++ b/core/server/coreserver/standalone_test.go
@@ -70,9 +70,9 @@ func TestStandaloneSkipsSelfRebuild(t *testing.T) {
 	}
 }
 
-// hasRebuildRoute boots a composition far enough to populate its router, then
-// asks whether the package install endpoint was registered. No listener starts.
-func hasRebuildRoute(t *testing.T, opts Options) bool {
+// routerFor boots a composition far enough to populate its router, so a test
+// can ask which routes it registered. No listener starts.
+func routerFor(t *testing.T, opts Options) *router.Router[*core.RequestEvent] {
 	t.Helper()
 	quota.ResetSourcesForTesting()
 
@@ -90,7 +90,13 @@ func hasRebuildRoute(t *testing.T, opts Options) bool {
 		t.Fatalf("OnServe: %v", err)
 	}
 
-	return serveEvent.Router.HasRoute(http.MethodPost, "/api/admin/packages/install")
+	return serveEvent.Router
+}
+
+// hasRebuildRoute reports whether the package install endpoint was registered.
+func hasRebuildRoute(t *testing.T, opts Options) bool {
+	t.Helper()
+	return routerFor(t, opts).HasRoute(http.MethodPost, "/api/admin/packages/install")
 }
 
 // TestStandalone_OmitsRebuildRoutes is the route-level counterpart to
@@ -117,5 +123,78 @@ func TestStandalone_OmitsRebuildRoutes(t *testing.T) {
 	standalone.PublicFS = fstest.MapFS{}
 	if hasRebuildRoute(t, standalone) {
 		t.Error("a single-binary build must not expose the package rebuild API")
+	}
+}
+
+// TestStandalone_DoesNotRegisterPoolAssetRoutes is the regression guard for a
+// bug that let the binary boot and serve its SPA shell while every script 404'd.
+//
+// The /_expo/static/ and /assets/ routes read the cross-release asset pool the
+// container entrypoint maintains under <releasesDir>/_static/. They are
+// registered BEFORE the catch-all so the prefixes win — which means in a
+// single-binary build they shadow the embedded bundle and answer 404 for assets
+// that are present inside the binary. A standalone build has no pool, so the
+// catch-all must own those paths.
+func TestStandalone_DoesNotRegisterPoolAssetRoutes(t *testing.T) {
+	opts := Options{
+		HooksDir:      t.TempDir(),
+		MigrationsDir: t.TempDir(),
+		TypesDir:      t.TempDir(),
+		PublicDir:     t.TempDir(),
+		ReleasesDir:   t.TempDir(),
+		HooksPoolSize: 1,
+		MigrationsFS:  fstest.MapFS{},
+		HooksFS:       fstest.MapFS{},
+		PublicFS:      fstest.MapFS{},
+	}
+
+	r := routerFor(t, opts)
+	for _, path := range []string{"/_expo/static/{path...}", "/assets/{path...}"} {
+		if r.HasRoute(http.MethodGet, path) {
+			t.Errorf("standalone must not register %q — it shadows the embedded bundle", path)
+		}
+	}
+
+	// The catch-all must still be there to serve them. It is registered with
+	// Any, whose method is "" — HasRoute(MethodGet, …) would not match it.
+	if !r.HasRoute("", "/{path...}") {
+		t.Error("expected the catch-all to serve embedded assets")
+	}
+}
+
+// TestShouldInjectDataDir pins when standalone mode may append --dir to os.Args.
+//
+// --dir is a persistent flag, but appending it to a bare `--help` or `--version`
+// invocation makes cobra read the path as a stray positional argument and fail
+// with `unknown command "./tinycld-data/pb_data"`. Only inject when a command
+// will actually use it and the user has not set it.
+func TestShouldInjectDataDir(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"bare serve", []string{"serve"}, true},
+		{"serve with an address", []string{"serve", "--http", "127.0.0.1:9000"}, true},
+		{"serve with domains", []string{"serve", "example.com"}, true},
+		{"user set --dir", []string{"serve", "--dir", "/srv/x"}, false},
+		{"user set --dir= form", []string{"serve", "--dir=/srv/x"}, false},
+		{"help", []string{"--help"}, false},
+		{"version", []string{"--version"}, false},
+		{"short help", []string{"-h"}, false},
+		{"no args", nil, false},
+		// Every real command operates on the database, so each needs the
+		// default data dir — not just serve.
+		{"superuser", []string{"superuser", "create", "a@b.c", "pw"}, true},
+		{"create-owner", []string{"create-owner"}, true},
+		{"export-types", []string{"export-types"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ShouldInjectDataDir(tc.args); got != tc.want {
+				t.Errorf("ShouldInjectDataDir(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
 	}
 }

--- a/core/server/coreserver/static.go
+++ b/core/server/coreserver/static.go
@@ -318,12 +318,18 @@ func setHTMLRevalidate(e *core.RequestEvent, path string) {
 // legacy behavior used in dev where the volume isn't mounted. Any path
 // not present in any location returns 404.
 func StaticWithDynamicFallback(publicDir, websiteDir, releasesDir string) func(*core.RequestEvent) error {
-	publicFs := os.DirFS(publicDir)
 	var websiteFs fs.FS
 	if websiteDir != "" {
 		websiteFs = os.DirFS(websiteDir)
 	}
+	return StaticWithDynamicFallbackFS(os.DirFS(publicDir), websiteFs, nil, releasesDir)
+}
 
+// StaticWithDynamicFallbackFS is StaticWithDynamicFallback over fs.FS values,
+// so a single-binary build can serve its embedded web bundle through the same
+// handler the container build uses. releasesFS, when non-nil, supplies the SPA
+// shell in place of reading <releasesDir>/current/app.html from disk.
+func StaticWithDynamicFallbackFS(publicFs, websiteFs, releasesFs fs.FS, releasesDir string) func(*core.RequestEvent) error {
 	return func(e *core.RequestEvent) error {
 		if e.Request.Method != http.MethodGet && e.Request.Method != http.MethodHead {
 			return e.Next()
@@ -362,7 +368,13 @@ func StaticWithDynamicFallback(publicDir, websiteDir, releasesDir string) func(*
 		// via ETag (see its doc) so a tab reload always confirms the shell is
 		// current — a stale shell would reference asset hashes the client has
 		// since dropped — but an unchanged shell 304s instead of re-sending.
-		if releasesDir != "" {
+		// An embedded bundle has no releases dir to promote into, so its shell
+		// comes straight from the embedded FS.
+		if releasesFs != nil {
+			if data, err := fs.ReadFile(releasesFs, "app.html"); err == nil {
+				return writeAppShell(e, injectPublicConfig(data))
+			}
+		} else if releasesDir != "" {
 			currentApp := filepath.Join(releasesDir, "current", "app.html")
 			if data, err := os.ReadFile(currentApp); err == nil {
 				return writeAppShell(e, injectPublicConfig(data))

--- a/core/server/coreserver/static_embed_test.go
+++ b/core/server/coreserver/static_embed_test.go
@@ -1,0 +1,93 @@
+package coreserver
+
+import (
+	"io/fs"
+	"net/http"
+	"testing"
+	"testing/fstest"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// runStaticFSScenario mirrors runStaticScenario but registers the fs.FS form of
+// the handler, which is what a single-binary build uses.
+func runStaticFSScenario(t *testing.T, publicFs, websiteFs, releasesFs fs.FS, scenario *tests.ApiScenario) {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	defer app.Cleanup()
+
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		e.Router.RouterGroup.Any("/{path...}", StaticWithDynamicFallbackFS(publicFs, websiteFs, releasesFs, ""))
+		return e.Next()
+	})
+
+	scenario.TestAppFactory = func(_ testing.TB) *tests.TestApp { return app }
+	scenario.DisableTestAppCleanup = true
+	scenario.Test(t)
+}
+
+// TestStaticFS_ServesAssetFromEmbeddedBundle proves the handler reads real bytes
+// out of the embedded FS rather than the filesystem. With no dirs on disk at
+// all, a hit here can only have come from the FS.
+func TestStaticFS_ServesAssetFromEmbeddedBundle(t *testing.T) {
+	publicFs := fstest.MapFS{
+		"sw.js":    {Data: []byte("// EMBEDDED SERVICE WORKER")},
+		"app.html": {Data: []byte("<html>EMBEDDED SHELL</html>")},
+	}
+	runStaticFSScenario(t, publicFs, nil, nil, &tests.ApiScenario{
+		Name:            "a bundled asset is served from the embedded FS",
+		Method:          http.MethodGet,
+		URL:             "/sw.js",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"EMBEDDED SERVICE WORKER"},
+	})
+}
+
+// TestStaticFS_AppRouteFallsBackToEmbeddedShell covers the path every deep link
+// into the SPA takes in a standalone binary: no such file exists, so the shell
+// must come back.
+func TestStaticFS_AppRouteFallsBackToEmbeddedShell(t *testing.T) {
+	publicFs := fstest.MapFS{
+		"app.html": {Data: []byte("<html>EMBEDDED SHELL</html>")},
+	}
+	runStaticFSScenario(t, publicFs, nil, nil, &tests.ApiScenario{
+		Name:            "an app route falls back to the embedded SPA shell",
+		Method:          http.MethodGet,
+		URL:             "/mail",
+		ExpectedStatus:  http.StatusOK,
+		ExpectedContent: []string{"EMBEDDED SHELL"},
+	})
+}
+
+// TestStaticFS_ReleasesFSWinsOverPublicShell pins the precedence when a
+// releases FS is supplied: its shell is the active one.
+func TestStaticFS_ReleasesFSWinsOverPublicShell(t *testing.T) {
+	publicFs := fstest.MapFS{"app.html": {Data: []byte("<html>PUBLIC SHELL</html>")}}
+	releasesFs := fstest.MapFS{"app.html": {Data: []byte("<html>RELEASE SHELL</html>")}}
+	runStaticFSScenario(t, publicFs, nil, releasesFs, &tests.ApiScenario{
+		Name:               "the releases FS shell takes precedence",
+		Method:             http.MethodGet,
+		URL:                "/mail",
+		ExpectedStatus:     http.StatusOK,
+		ExpectedContent:    []string{"RELEASE SHELL"},
+		NotExpectedContent: []string{"PUBLIC SHELL"},
+	})
+}
+
+// TestStaticFS_APIPathIsNotGivenTheShell guards the JSON-vs-HTML contract in
+// the embedded path too: an unrouted /api/ request must 404, never receive
+// "<!DOCTYPE" with a 200.
+func TestStaticFS_APIPathIsNotGivenTheShell(t *testing.T) {
+	publicFs := fstest.MapFS{"app.html": {Data: []byte("<html>EMBEDDED SHELL</html>")}}
+	runStaticFSScenario(t, publicFs, nil, nil, &tests.ApiScenario{
+		Name:               "an unrouted /api/ path 404s instead of getting the shell",
+		Method:             http.MethodGet,
+		URL:                "/api/nope",
+		ExpectedStatus:     http.StatusNotFound,
+		NotExpectedContent: []string{"EMBEDDED SHELL"},
+	})
+}

--- a/core/server/tenantcfg/runtime.go
+++ b/core/server/tenantcfg/runtime.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"tinycld.org/core/caldav"
 	"tinycld.org/core/carddav"
@@ -79,7 +78,7 @@ func WriteRuntimeFile(orgDir, name string, body []byte, mode os.FileMode) (strin
 		return "", err
 	}
 	path := filepath.Join(runtimeDir, name)
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, mode)
+	f, err := openRuntimeFileNoFollow(path, mode)
 	if err != nil {
 		return "", err
 	}

--- a/core/server/tenantcfg/runtime_nofollow_unix.go
+++ b/core/server/tenantcfg/runtime_nofollow_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package tenantcfg
+
+import (
+	"os"
+	"syscall"
+)
+
+// openRuntimeFileNoFollow opens a router-authored .runtime file with
+// O_NOFOLLOW, so a symlink planted AT the destination by a hostile tenant
+// fails the open rather than being written through. See WriteRuntimeFile for
+// the threat model.
+func openRuntimeFileNoFollow(path string, mode os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, mode)
+}

--- a/core/server/tenantcfg/runtime_nofollow_windows.go
+++ b/core/server/tenantcfg/runtime_nofollow_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package tenantcfg
+
+import (
+	"fmt"
+	"os"
+)
+
+// openRuntimeFileNoFollow is the Windows stand-in for the O_NOFOLLOW open.
+//
+// Windows has no O_NOFOLLOW. This exists so the single-binary SELF-HOST build
+// cross-compiles for Windows — a self-hosted deployment is one org in one
+// process and never writes these files at all (only the hosting router does,
+// and it runs on Linux).
+//
+// The guard is therefore not weakened where it matters, but it cannot be
+// reproduced faithfully here either: the Lstat below is a best effort with an
+// unavoidable TOCTOU window, where the real O_NOFOLLOW is atomic. If the
+// router is ever ported to Windows, this needs a real implementation
+// (CreateFile with FILE_FLAG_OPEN_REPARSE_POINT) rather than this check.
+func openRuntimeFileNoFollow(path string, mode os.FileMode) (*os.File, error) {
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to write %s: destination is a symlink", path)
+	}
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+}

--- a/core/server/tenantmain/socket_unix.go
+++ b/core/server/tenantmain/socket_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package tenantmain
+
+import (
+	"net"
+	"syscall"
+)
+
+// listenUnixUmasked binds a unix socket with a 0177 umask so it is never
+// world-reachable, even briefly. See BindTenantSocket for why the umask wraps
+// the bind rather than relying on the follow-up Chmod alone.
+//
+// The umask is process-wide, but socket binds in this process are sequential.
+func listenUnixUmasked(path string) (net.Listener, error) {
+	oldUmask := syscall.Umask(0o177)
+	defer syscall.Umask(oldUmask)
+	return net.Listen("unix", path)
+}

--- a/core/server/tenantmain/socket_windows.go
+++ b/core/server/tenantmain/socket_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package tenantmain
+
+import (
+	"fmt"
+	"net"
+)
+
+// listenUnixUmasked refuses on Windows, which has no umask.
+//
+// Only the hosting router connects to these sockets, and it runs on Linux.
+// This file exists so the single-binary SELF-HOST build cross-compiles for
+// Windows, where tenant mode is never entered — a self-hosted deployment is
+// one org in one process, served over TCP.
+//
+// It refuses rather than binding without the umask, matching confine_other.go:
+// a socket that should be owner-only must not be served world-reachable
+// because the host cannot express the restriction.
+func listenUnixUmasked(path string) (net.Listener, error) {
+	return nil, fmt.Errorf("tenant sockets require a unix host (umask); refusing to bind %s", path)
+}

--- a/core/server/tenantmain/tenantmain.go
+++ b/core/server/tenantmain/tenantmain.go
@@ -509,9 +509,7 @@ func detectArtifactDir() string {
 //     guards its own teardown removal by inode.
 //   - Only the router connects to these sockets; the tenant uid owns them.
 func BindTenantSocket(path string) (net.Listener, error) {
-	oldUmask := syscall.Umask(0o177)
-	ln, err := net.Listen("unix", path)
-	syscall.Umask(oldUmask)
+	ln, err := listenUnixUmasked(path)
 	if err != nil {
 		return nil, fmt.Errorf("listen on %s: %w", path, err)
 	}

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -6,7 +6,10 @@ and no Go toolchain.
 
 ## Install
 
-Download the binary for your platform and the `SHA256SUMS` file from the
+Each release carries a binary per platform — `tinycld-linux-amd64`,
+`tinycld-linux-arm64`, `tinycld-darwin-amd64` (Intel Mac), and
+`tinycld-darwin-arm64` (Apple silicon) — alongside a `SHA256SUMS` file.
+Download the one for your platform plus `SHA256SUMS` from the
 [latest release](https://github.com/tinycld/tinycld/releases/latest), then
 verify and run it:
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -1,0 +1,86 @@
+# Running TinyCld from a single binary
+
+A self-host release ships one binary per platform. It contains the server, the
+web interface, and every bundled feature package. It needs no Docker, no Node,
+and no Go toolchain.
+
+## Install
+
+Download the binary for your platform and the `SHA256SUMS` file from the
+[latest release](https://github.com/tinycld/tinycld/releases/latest), then
+verify and run it:
+
+```sh
+sha256sum --check --ignore-missing SHA256SUMS
+chmod +x tinycld-linux-amd64
+./tinycld-linux-amd64 serve
+```
+
+On first run it creates `./tinycld-data/`, applies its migrations, listens on
+`127.0.0.1:8090`, and prints a setup URL with a one-time token. Open that URL
+to create the first account.
+
+## Options
+
+These are PocketBase's own flags — the binary adds none of its own, so anything
+the upstream `serve` command accepts works here too.
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--dir` | `./tinycld-data/pb_data` | Database and uploads |
+| `--http` | `127.0.0.1:8090` | HTTP listen address |
+| `--https` | unset | HTTPS address; enables automatic certificates |
+
+The default listen address is loopback, so a first run is not exposed to the
+network before you have created an account. To serve publicly, pass
+`--http 0.0.0.0:8090` or put a reverse proxy in front.
+
+To keep state somewhere other than the working directory:
+
+```sh
+./tinycld serve --dir /srv/tinycld/pb_data
+```
+
+Generated state that is not the database itself (the release and build
+directories) is kept beside `--dir`, in its parent — so the single directory
+you back up is `/srv/tinycld` in the example above.
+
+## TLS
+
+`--https` uses automatic certificates, which requires binding ports 80 and 443.
+Either grant the capability or run behind a reverse proxy:
+
+```sh
+sudo setcap cap_net_bind_service=+ep ./tinycld
+```
+
+## Backups
+
+Everything is under the data directory. Stop the server and copy it, or
+snapshot the database alone while it runs:
+
+```sh
+sqlite3 ./tinycld-data/pb_data/data.db "VACUUM INTO './backup.db'"
+```
+
+## Upgrading
+
+Download the new binary, replace the old one, and restart. Migrations apply
+automatically at startup. Back up the data directory first.
+
+## Differences from the Docker distribution
+
+- **No in-app package installation.** The feature set is fixed when the binary
+  is built, so the Packages screen's install and upgrade actions are not
+  available — the API behind them is not served at all. Adding or changing
+  packages means taking a new binary (or using the Docker distribution, which
+  can rebuild itself). You can still enable and disable bundled features in
+  Settings.
+- **Editing collections in the admin UI does not write migration files.** There
+  is nowhere to write them, and `migrate create` / `migrate collections` are
+  not registered. Schema changes belong in a development workspace. This is the
+  one behavioral difference that affects an existing workflow.
+- **Hook files are not watched.** The hooks are compiled in, so there is no
+  file to change and no auto-restart.
+- **Everything is one process.** There is no separate build or release
+  directory to manage.

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -7,8 +7,9 @@ and no Go toolchain.
 ## Install
 
 Each release carries a binary per platform — `tinycld-linux-amd64`,
-`tinycld-linux-arm64`, `tinycld-darwin-amd64` (Intel Mac), and
-`tinycld-darwin-arm64` (Apple silicon) — alongside a `SHA256SUMS` file.
+`tinycld-linux-arm64`, `tinycld-darwin-amd64` (Intel Mac),
+`tinycld-darwin-arm64` (Apple silicon), `tinycld-windows-amd64.exe`, and
+`tinycld-windows-arm64.exe` — alongside a `SHA256SUMS` file.
 Download the one for your platform plus `SHA256SUMS` from the
 [latest release](https://github.com/tinycld/tinycld/releases/latest), then
 verify and run it:
@@ -17,6 +18,13 @@ verify and run it:
 sha256sum --check --ignore-missing SHA256SUMS
 chmod +x tinycld-linux-amd64
 ./tinycld-linux-amd64 serve
+```
+
+On Windows, verify and run it from PowerShell instead:
+
+```powershell
+(Get-FileHash .\tinycld-windows-amd64.exe -Algorithm SHA256).Hash.ToLower()
+.\tinycld-windows-amd64.exe serve
 ```
 
 On first run it creates `./tinycld-data/`, applies its migrations, listens on

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
     "scripts": {
         "packages:generate": "tsx scripts/generate.ts && tsx scripts/export-types.ts",
+        "stage:embed": "tsx scripts/stage-embed-assets.ts",
         "assets:copy-pdfjs": "tsx scripts/copy-pdfjs-assets.ts",
         "dev": "tsx scripts/dev.ts",
         "dev:ssl": "tsx scripts/dev.ts --ssl",

--- a/scripts/ci-assemble-workspace.sh
+++ b/scripts/ci-assemble-workspace.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Assemble a pnpm workspace from a pinned-release manifest.json (produced by
+# utils/lib/pin-release.ts and uploaded as a GitHub Release asset). One source
+# of truth for BOTH release workflows:
+#
+#   - docker-publish.yml, which builds the multi-arch container image
+#   - release-binaries.yml, which cross-compiles the single-binary self-host
+#     artifact
+#
+# Keeping the assembly here (rather than duplicated inline in two workflows)
+# stops them from silently drifting: the container and the binary must be built
+# from the SAME pinned member set, or a release ships two artifacts that don't
+# agree about what code they contain.
+#
+# The resulting workspace is byte-identical to what the release author built
+# locally, so rebuilding the same tag reproduces the same artifacts later.
+#
+# Usage:  ci-assemble-workspace.sh <assets-dir>
+#   <assets-dir>  directory holding the downloaded manifest.json,
+#                 pnpm-lock.yaml, and package-versions.json release assets
+#
+# Run from the workspace root (the dir holding the already-checked-out
+# tinycld/ member). Clones each sibling at its pinned sha, lets bootstrap write
+# the workspace-root scaffolding, and drops the pinned lockfile + version pins
+# into place.
+set -euo pipefail
+
+ASSETS="${1:?usage: ci-assemble-workspace.sh <assets-dir>}"
+
+MANIFEST="${ASSETS}/manifest.json"
+LOCKFILE="${ASSETS}/pnpm-lock.yaml"
+VERSIONS="${ASSETS}/package-versions.json"
+
+for f in "$MANIFEST" "$LOCKFILE" "$VERSIONS"; do
+    [ -f "$f" ] || { echo "::error::missing release asset: $f" >&2; exit 1; }
+done
+
+echo "Manifest contents:"
+cat "$MANIFEST"
+
+# Clone every sibling at the sha the release pinned. A tag would float if it
+# were ever moved; the sha cannot.
+jq -r '.members[] | "\(.name)\t\(.repo)\t\(.sha)"' "$MANIFEST" |
+    while IFS=$'\t' read -r name repo sha; do
+        echo "Cloning ${repo} @ ${sha} → ${name}"
+        git clone --quiet "https://github.com/${repo}.git" "${name}"
+        git -C "${name}" fetch --quiet origin "${sha}"
+        git -C "${name}" checkout --quiet "${sha}"
+    done
+
+# bootstrap sees every member already cloned (tinycld + each sibling) and just
+# writes the workspace-root scaffolding (package.json + pnpm-workspace.yaml +
+# .npmrc + tinycld.packages.ts + scripts/link-members.ts). --assemble-only is
+# non-destructive: it skips any member already present, cloning only what's
+# missing. (Replaces the v1 --tooling flag, removed in bootstrap v2.)
+TINYCLD_REPO_BASE=https://github.com/tinycld npx @tinycld/bootstrap@latest --assemble-only \
+    --with contacts --with mail --with calendar --with drive \
+    --with calc --with text --with google-takeout-import
+
+# Drop the pinned lockfile into the workspace root so a later
+# `pnpm install --frozen-lockfile` reproduces the exact dependency set.
+cp "$LOCKFILE" pnpm-lock.yaml
+
+# Drop the framework/native version pins into the workspace root. The
+# Dockerfile COPYs package-versions.json into the image and the OTA rebuild
+# reads it to regenerate the pnpm `overrides:` block. bootstrap doesn't write
+# it, so the release asset is its only source in CI.
+cp "$VERSIONS" package-versions.json
+
+# Hand the manifest to the Docker build so it's baked into the image and served
+# by /api/release (the About panel reads it). The wildcard COPY in the
+# Dockerfile makes it optional, so this is the only wiring. Destination must be
+# tinycld/ — the Dockerfile COPYs tinycld/.release-manifest*; anywhere else and
+# the bake silently no-ops (the wildcard COPY tolerates the miss).
+cp "$MANIFEST" tinycld/.release-manifest

--- a/scripts/stage-embed-assets.ts
+++ b/scripts/stage-embed-assets.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env tsx
+/**
+ * Stage the assets that get compiled into the single-binary build.
+ *
+ * Two constraints drive this script:
+ *   1. `go:embed` does not follow symlinks, and server/pb_migrations +
+ *      server/pb_hooks are symlink farms the generator points at sibling
+ *      repos. They must be materialized into real files.
+ *   2. Source maps must never be embedded. They are the bulk of the web
+ *      export and ship to Sentry separately via
+ *      `expo export --source-maps external`.
+ */
+import {
+    copyFileSync,
+    cpSync,
+    existsSync,
+    mkdirSync,
+    readdirSync,
+    realpathSync,
+    rmSync,
+    statSync,
+} from 'node:fs'
+import { basename, join } from 'node:path'
+
+const appRoot = join(import.meta.dirname, '..')
+const outDir = join(appRoot, 'server', 'embedded_assets')
+
+const copyResolvedFiles = (srcDir: string, destDir: string) => {
+    mkdirSync(destDir, { recursive: true })
+    if (!existsSync(srcDir)) return 0
+    let count = 0
+    for (const entry of readdirSync(srcDir)) {
+        const src = join(srcDir, entry)
+        // statSync (not lstatSync) resolves symlinks to their target.
+        if (!statSync(src).isFile()) continue
+        // Copy the symlink's TARGET, not the link: cpSync given a symlinked
+        // path treats it as a directory and fails with ERR_FS_EISDIR, and
+        // go:embed would skip a copied link anyway.
+        copyFileSync(realpathSync(src), join(destDir, basename(entry)))
+        count++
+    }
+    return count
+}
+
+const copyWebBundle = (srcDir: string, destDir: string) => {
+    if (!existsSync(srcDir)) {
+        throw new Error(
+            `web bundle not found at ${srcDir} — run \`pnpm exec expo export --platform web\` first`
+        )
+    }
+    let skipped = 0
+    cpSync(srcDir, destDir, {
+        recursive: true,
+        dereference: true,
+        filter: src => {
+            if (src.endsWith('.map')) {
+                skipped++
+                return false
+            }
+            return true
+        },
+    })
+    return skipped
+}
+
+rmSync(outDir, { recursive: true, force: true })
+mkdirSync(outDir, { recursive: true })
+
+const skippedMaps = copyWebBundle(join(appRoot, 'dist'), join(outDir, 'web'))
+const migrations = copyResolvedFiles(
+    join(appRoot, 'server', 'pb_migrations'),
+    join(outDir, 'pb_migrations')
+)
+const hooks = copyResolvedFiles(join(appRoot, 'server', 'pb_hooks'), join(outDir, 'pb_hooks'))
+
+if (migrations === 0) {
+    throw new Error('staged 0 migrations — run `pnpm run packages:generate` first')
+}
+
+console.log(
+    `staged: web bundle (${skippedMaps} source maps excluded), ${migrations} migrations, ${hooks} hooks`
+)

--- a/server/embed_assets.go
+++ b/server/embed_assets.go
@@ -1,0 +1,28 @@
+//go:build embedassets
+
+package main
+
+import (
+	"embed"
+	"io/fs"
+	"log"
+)
+
+// Populated by `pnpm run stage:embed`, which materializes the generator's
+// symlink farms into real files and copies the Expo export WITHOUT source
+// maps. `all:` is required so Expo's dotfile-prefixed chunks are included.
+//
+//go:embed all:embedded_assets
+var embeddedAssets embed.FS
+
+func mustSub(dir string) fs.FS {
+	sub, err := fs.Sub(embeddedAssets, "embedded_assets/"+dir)
+	if err != nil {
+		log.Fatalf("embedded assets: %s missing from the build: %v", dir, err)
+	}
+	return sub
+}
+
+func embeddedWebFS() fs.FS        { return mustSub("web") }
+func embeddedMigrationsFS() fs.FS { return mustSub("pb_migrations") }
+func embeddedHooksFS() fs.FS      { return mustSub("pb_hooks") }

--- a/server/embed_assets_stub.go
+++ b/server/embed_assets_stub.go
@@ -1,0 +1,12 @@
+//go:build !embedassets
+
+package main
+
+import "io/fs"
+
+// Without the embedassets build tag the binary carries no assets and reads
+// them from disk, exactly as the container and hosting deployments do. This
+// keeps `go build ./...` working with no staged tree present.
+func embeddedWebFS() fs.FS        { return nil }
+func embeddedMigrationsFS() fs.FS { return nil }
+func embeddedHooksFS() fs.FS      { return nil }

--- a/server/embed_assets_test.go
+++ b/server/embed_assets_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+// TestEmbeddedAccessorsAreNilWithoutTag pins the default build: without the
+// embedassets tag the accessors return nil, so main falls back to the
+// existing disk-based paths and normal dev/Docker builds need no staged tree.
+func TestEmbeddedAccessorsAreNilWithoutTag(t *testing.T) {
+	if embeddedWebFS() != nil {
+		t.Error("expected nil web FS in an untagged build")
+	}
+	if embeddedMigrationsFS() != nil {
+		t.Error("expected nil migrations FS in an untagged build")
+	}
+	if embeddedHooksFS() != nil {
+		t.Error("expected nil hooks FS in an untagged build")
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -66,7 +66,11 @@ func main() {
 		dataDir := coreserver.FlagValue(os.Args[1:], "--dir")
 		if dataDir == "" {
 			dataDir = defaultStandaloneDataDir
-			os.Args = append(os.Args, "--dir", dataDir)
+			// Only for an actual command: appending --dir to a bare --help or
+			// --version makes cobra read the path as a stray positional.
+			if coreserver.ShouldInjectDataDir(os.Args[1:]) {
+				os.Args = append(os.Args, "--dir", dataDir)
+			}
 		}
 		if err := os.Setenv("TINYCLD_STATE_DIR", coreserver.StandaloneStateDir(dataDir)); err != nil {
 			log.Fatal(err)

--- a/server/main.go
+++ b/server/main.go
@@ -17,6 +17,12 @@ import (
 // and forwards here, so this needs to match the SSL proxy's --target port.
 const defaultHTTPAddr = "127.0.0.1:7090"
 
+// defaultStandaloneDataDir is where the single-binary build keeps its state
+// when no --dir is given. It is relative to the working directory (not the
+// binary's own dir) so a downloaded binary does not write into wherever the
+// user happened to leave it.
+const defaultStandaloneDataDir = "./tinycld-data/pb_data"
+
 // main composes the tinycld app server: load env, build the shared core
 // server via coreserver.Register (which initializes Sentry), then start
 // PocketBase.
@@ -46,6 +52,27 @@ func main() {
 		return
 	}
 
+	// Embedded assets are present only in the single-binary build (the
+	// `embedassets` build tag). When absent every accessor returns nil and the
+	// server reads from disk exactly as the container build does.
+	webFS := embeddedWebFS()
+	standalone := webFS != nil
+
+	if standalone {
+		// PocketBase owns --dir (its data directory), so standalone mode adds no
+		// competing location flag. Core's own state helpers key off
+		// TINYCLD_STATE_DIR instead, so derive it from --dir to keep releases
+		// and builds beside the database rather than beside the binary.
+		dataDir := coreserver.FlagValue(os.Args[1:], "--dir")
+		if dataDir == "" {
+			dataDir = defaultStandaloneDataDir
+			os.Args = append(os.Args, "--dir", dataDir)
+		}
+		if err := os.Setenv("TINYCLD_STATE_DIR", coreserver.StandaloneStateDir(dataDir)); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	// Default --http to defaultHTTPAddr when running `serve` without an
 	// explicit address and no domain args. PocketBase's autocert needs
 	// :80/:443 when domain args are present, so we don't override there.
@@ -65,15 +92,20 @@ func main() {
 
 	app := pocketbase.New()
 	coreserver.Register(app, coreserver.Options{
-		PublicDir:      coreserver.DefaultPublicDir(),
-		WebsiteDir:     coreserver.DefaultWebsiteDir(),
-		ReleasesDir:    coreserver.DefaultReleasesDir(),
-		FallbackFile:   "app.html",
-		TypesDir:       coreserver.DefaultTypesDir(),
-		BinaryName:     "tinycld",
-		HooksWatch:     true,
+		PublicDir:    coreserver.DefaultPublicDir(),
+		WebsiteDir:   coreserver.DefaultWebsiteDir(),
+		ReleasesDir:  coreserver.DefaultReleasesDir(),
+		FallbackFile: "app.html",
+		TypesDir:     coreserver.DefaultTypesDir(),
+		BinaryName:   "tinycld",
+		// An embedded FS cannot be watched, and a standalone build has nowhere
+		// to write generated migrations.
+		HooksWatch:     !standalone,
 		HooksPoolSize:  15,
-		Automigrate:    true,
+		Automigrate:    !standalone,
+		PublicFS:       webFS,
+		MigrationsFS:   embeddedMigrationsFS(),
+		HooksFS:        embeddedHooksFS(),
 		RegisterExtras: registerPackageExtensions,
 	})
 

--- a/tests/standalone/playwright.config.ts
+++ b/tests/standalone/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Self-contained config for the single-binary self-host smoke test.
+//
+// Deliberately NOT under tests/e2e/: that tree's config owns a webServer that
+// resets the DB, runs `expo export`, and promotes a bundle (up to 240s) before
+// any spec runs. This suite boots the SHIPPED binary instead — its own process,
+// its own data dir, its own port — so the shared stack would be both irrelevant
+// and in the way. Same reasoning as tests/install/, which talks to an
+// already-running container.
+//
+// The spec builds and supervises the binary itself, so there is no webServer
+// here either.
+export default defineConfig({
+    testDir: '.',
+    testMatch: '**/*.spec.ts',
+    fullyParallel: false,
+    workers: 1,
+    retries: 0,
+    // The build is a cold cross-package Go compile on a clean cache.
+    timeout: 300_000,
+    expect: { timeout: 30_000 },
+    reporter: 'list',
+    use: {
+        ...devices['Desktop Chrome'],
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+    },
+})

--- a/tests/standalone/standalone-binary.spec.ts
+++ b/tests/standalone/standalone-binary.spec.ts
@@ -1,0 +1,131 @@
+import { execFileSync, spawn } from 'node:child_process'
+import { existsSync, mkdtempSync } from 'node:fs'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@playwright/test'
+
+/**
+ * Boots the SHIPPED artifact in an empty directory with no workspace around it.
+ *
+ * This is the check that the web bundle and the migrations are genuinely INSIDE
+ * the binary. A build that reads them from disk passes every unit test and fails
+ * here, and so does one whose embed was dropped by the linker — that binary
+ * boots and serves, just with no web UI.
+ */
+const serverDir = join(import.meta.dirname, '..', '..', 'server')
+const binary = join(tmpdir(), 'tinycld-standalone-e2e')
+
+/** An OS-assigned free port; a random one in a fixed range can collide. */
+const freePort = () =>
+    new Promise<number>((resolve, reject) => {
+        const srv = createServer()
+        srv.on('error', reject)
+        srv.listen(0, '127.0.0.1', () => {
+            const addr = srv.address()
+            if (addr === null || typeof addr === 'string') {
+                reject(new Error('could not resolve a free port'))
+                return
+            }
+            const { port } = addr
+            srv.close(() => resolve(port))
+        })
+    })
+
+let proc: ReturnType<typeof spawn>
+let baseURL: string
+let dataDir: string
+let log = ''
+
+// One server for the whole file. Each boot applies every embedded migration,
+// so booting per test doubles the slowest part of the run for no extra coverage.
+test.beforeAll(async () => {
+    execFileSync(
+        'go',
+        ['build', '-tags', 'embedassets', '-trimpath', '-ldflags=-s -w', '-o', binary, '.'],
+        { cwd: serverDir, env: { ...process.env, CGO_ENABLED: '0' }, stdio: 'inherit' }
+    )
+
+    dataDir = mkdtempSync(join(tmpdir(), 'tinycld-standalone-'))
+    const port = await freePort()
+    baseURL = `http://127.0.0.1:${port}`
+
+    // cwd is deliberately NOT the workspace: no dist/, no pb_migrations/, no
+    // public/ anywhere above it, so anything served can only come from inside
+    // the binary.
+    proc = spawn(
+        binary,
+        ['serve', '--dir', join(dataDir, 'pb_data'), '--http', `127.0.0.1:${port}`],
+        { cwd: dataDir, stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+    proc.stdout?.on('data', c => {
+        log += String(c)
+    })
+    proc.stderr?.on('data', c => {
+        log += String(c)
+    })
+
+    const exited = new Promise<never>((_, reject) => {
+        proc.on('exit', code => reject(new Error(`binary exited early (${code}):\n${log}`)))
+    })
+
+    await Promise.race([
+        exited,
+        expect
+            .poll(
+                async () => {
+                    try {
+                        return (await fetch(`${baseURL}/api/health`)).status
+                    } catch {
+                        return 0
+                    }
+                },
+                { timeout: 180_000, intervals: [500] }
+            )
+            .toBe(200),
+    ])
+})
+
+test.afterAll(() => {
+    proc?.kill('SIGTERM')
+})
+
+test('serves the app and applies migrations from embedded assets in a clean directory', async ({
+    page,
+}) => {
+    // The SPA shell, served from the embedded bundle.
+    const shell = await fetch(baseURL)
+    expect(shell.status).toBe(200)
+    const html = await shell.text()
+    expect(html).toContain('<div id="root">')
+
+    // Every hashed JS chunk must resolve. A shell whose scripts 404 still
+    // renders #root, so asserting on the shell alone would miss a blank app —
+    // which is exactly what the asset-pool routes once caused here.
+    const scripts = [...html.matchAll(/src="([^"]+\.js)"/g)].map(m => m[1])
+    expect(scripts.length).toBeGreaterThan(0)
+    for (const src of scripts) {
+        const chunk = await fetch(new URL(src, baseURL).href)
+        expect(chunk.status, `chunk ${src}`).toBe(200)
+        expect(Number(chunk.headers.get('content-length') ?? 0), `chunk ${src}`).toBeGreaterThan(0)
+    }
+
+    // Migrations ran from the embedded FS — without them the API has no
+    // collections and this 404s.
+    const collections = await fetch(`${baseURL}/api/collections/users/records`)
+    expect(collections.status).not.toBe(404)
+
+    // The app actually renders in a browser.
+    await page.goto(baseURL)
+    await expect(page.locator('#root')).toBeAttached()
+
+    expect(existsSync(join(dataDir, 'pb_data', 'data.db'))).toBe(true)
+})
+
+test('does not expose the package rebuild API', async () => {
+    // A single binary cannot rebuild itself, so the endpoint must not be routed.
+    // An unauthenticated request to a REGISTERED route would be rejected by its
+    // owner guard (401/403) rather than reported missing.
+    const res = await fetch(`${baseURL}/api/admin/packages/status/mail`)
+    expect(res.status).toBe(404)
+})

--- a/third_party/pocketbase/plugins/jsvm/embedfs_test.go
+++ b/third_party/pocketbase/plugins/jsvm/embedfs_test.go
@@ -1,0 +1,147 @@
+package jsvm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// TestFilesContentFS_ReadsAndTransforms verifies the fs.FS loader matches
+// filesContent's contract: pattern filtering, directory skipping, esbuild
+// transformation, and base-filename keys.
+func TestFilesContentFS_ReadsAndTransforms(t *testing.T) {
+	fsys := fstest.MapFS{
+		"a.js":        {Data: []byte("migrate((app) => {})")},
+		"b.js":        {Data: []byte("migrate((app) => {})")},
+		"skip.txt":    {Data: []byte("not a migration")},
+		"sub/deep.js": {Data: []byte("migrate((app) => {})")},
+	}
+
+	got, err := filesContentFS(fsys, `^.*(\.js|\.ts)$`)
+	if err != nil {
+		t.Fatalf("filesContentFS: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 files (a.js, b.js), got %d: %v", len(got), keysOf(got))
+	}
+	for _, name := range []string{"a.js", "b.js"} {
+		if len(got[name]) == 0 {
+			t.Errorf("expected transformed content for %q", name)
+		}
+	}
+	if _, ok := got["skip.txt"]; ok {
+		t.Error("pattern must exclude skip.txt")
+	}
+	if _, ok := got["deep.js"]; ok {
+		t.Error("loader must not recurse into subdirectories")
+	}
+}
+
+// TestFilesContentFS_MissingDirIsEmpty mirrors filesContent's behavior of
+// treating a missing directory as "no files" rather than an error.
+func TestFilesContentFS_MissingDirIsEmpty(t *testing.T) {
+	got, err := filesContentFS(fstest.MapFS{}, `^.*(\.js|\.ts)$`)
+	if err != nil {
+		t.Fatalf("expected nil error for empty FS, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(got))
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestRegisterHooks_HooksFSNeverWritesToDisk pins the one behavior that cannot
+// work against an embedded FS: registerHooks normally writes a types-reference
+// directive into EMPTY hook files. With HooksFS set, HooksDir is empty, so that
+// path would resolve names against the process working directory and clobber an
+// unrelated same-named empty file. The guard must skip the prepend entirely.
+func TestRegisterHooks_HooksFSNeverWritesToDisk(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	// A same-named empty file in the working directory is what the unguarded
+	// prepend would overwrite.
+	bystander := filepath.Join(dir, "a.pb.ts")
+	if err := os.WriteFile(bystander, nil, 0o644); err != nil {
+		t.Fatalf("seed bystander: %v", err)
+	}
+
+	p := &plugin{app: testApp(t), config: Config{
+		// The embedded file is empty on purpose: a non-empty one is skipped by
+		// the prepend loop anyway, so only an empty one can prove the guard.
+		HooksFS:           fstest.MapFS{"a.pb.ts": {Data: []byte("")}},
+		HooksFilesPattern: `^.*(\.pb\.js|\.pb\.ts)$`,
+	}}
+
+	if err := p.registerHooks(); err != nil {
+		t.Fatalf("registerHooks: %v", err)
+	}
+
+	info, err := os.Stat(bystander)
+	if err != nil {
+		t.Fatalf("stat bystander: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("registerHooks wrote %d bytes to a disk file while using HooksFS", info.Size())
+	}
+}
+
+// TestRegisterHooks_DiskStillPrepends is the other half of the guard: the
+// path-based mode must keep bootstrapping the types directive.
+func TestRegisterHooks_DiskStillPrepends(t *testing.T) {
+	dir := t.TempDir()
+	hook := filepath.Join(dir, "a.pb.ts")
+	if err := os.WriteFile(hook, nil, 0o644); err != nil {
+		t.Fatalf("seed hook: %v", err)
+	}
+
+	p := &plugin{app: testApp(t), config: Config{
+		HooksDir:          dir,
+		HooksFilesPattern: `^.*(\.pb\.js|\.pb\.ts)$`,
+	}}
+
+	if err := p.registerHooks(); err != nil {
+		t.Fatalf("registerHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(hook)
+	if err != nil {
+		t.Fatalf("read hook: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected the types reference directive to be prepended on disk")
+	}
+}
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+}
+
+func testApp(t *testing.T) *tests.TestApp {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	return app
+}

--- a/third_party/pocketbase/plugins/jsvm/jsvm.go
+++ b/third_party/pocketbase/plugins/jsvm/jsvm.go
@@ -119,6 +119,13 @@ type Config struct {
 	// HookdsDir file ending in ".pb.js" or ".pb.ts" (the last one is to enforce IDE linters).
 	HooksFilesPattern string
 
+	// HooksFS, when non-nil, supplies the JS hook sources instead of reading
+	// HooksDir from the filesystem. Used by single-binary builds that embed
+	// hooks via go:embed. Because an embedded FS is read-only, setting this
+	// also skips the types-directive prepend (which writes to HooksDir) and
+	// the hooks watcher. When nil the loader falls back to HooksDir.
+	HooksFS fs.FS
+
 	// HooksPoolSize specifies how many sobek.Runtime instances to prewarm
 	// and keep for the JS app hooks gorotines execution.
 	//
@@ -134,6 +141,12 @@ type Config struct {
 	// If not set it fallbacks to `^.*(\.js|\.ts)$`, aka. any MigrationDir file
 	// ending in ".js" or ".ts" (the last one is to enforce IDE linters).
 	MigrationsFilesPattern string
+
+	// MigrationsFS, when non-nil, supplies the JS migration sources instead
+	// of reading MigrationsDir from the filesystem. Used by single-binary
+	// builds that embed migrations via go:embed. When nil the loader falls
+	// back to MigrationsDir, so path-based deployments are unaffected.
+	MigrationsFS fs.FS
 
 	// TypesDir specifies the directory where to store the embedded
 	// TypeScript declarations file.
@@ -281,7 +294,13 @@ func setTemplateBinding(vm *sobek.Runtime, reg *template.Registry, sandboxed boo
 // registerMigrations registers the JS migrations loader.
 func (p *plugin) registerMigrations() error {
 	// fetch all js migrations sorted by their filename
-	files, err := filesContent(p.config.MigrationsDir, p.config.MigrationsFilesPattern)
+	var files map[string][]byte
+	var err error
+	if p.config.MigrationsFS != nil {
+		files, err = filesContentFS(p.config.MigrationsFS, p.config.MigrationsFilesPattern)
+	} else {
+		files, err = filesContent(p.config.MigrationsDir, p.config.MigrationsFilesPattern)
+	}
 	if err != nil {
 		return err
 	}
@@ -357,32 +376,43 @@ func (p *plugin) registerMigrations() error {
 // registerHooks registers the JS app hooks loader.
 func (p *plugin) registerHooks() error {
 	// fetch all js hooks sorted by their filename
-	files, err := filesContent(p.config.HooksDir, p.config.HooksFilesPattern)
+	var files map[string][]byte
+	var err error
+	if p.config.HooksFS != nil {
+		files, err = filesContentFS(p.config.HooksFS, p.config.HooksFilesPattern)
+	} else {
+		files, err = filesContent(p.config.HooksDir, p.config.HooksFilesPattern)
+	}
 	if err != nil {
 		return err
 	}
 
-	// prepend the types reference directive
-	//
-	// note: it is loaded during startup to handle conveniently also
-	// the case when the HooksWatch option is enabled and the application
-	// restart on newly created file
-	for name, content := range files {
-		if len(content) != 0 {
-			// skip non-empty files for now to prevent accidental overwrite
-			continue
+	// Both blocks below write to or watch HooksDir, so they apply to the
+	// path-based mode only. With HooksFS set HooksDir is empty, which would
+	// resolve these names against the process working directory.
+	if p.config.HooksFS == nil {
+		// prepend the types reference directive
+		//
+		// note: it is loaded during startup to handle conveniently also
+		// the case when the HooksWatch option is enabled and the application
+		// restart on newly created file
+		for name, content := range files {
+			if len(content) != 0 {
+				// skip non-empty files for now to prevent accidental overwrite
+				continue
+			}
+			path := filepath.Join(p.config.HooksDir, name)
+			directive := `/// <reference path="` + p.relativeTypesPath(p.config.HooksDir) + `" />`
+			if err := prependToEmptyFile(path, directive+"\n\n"); err != nil {
+				color.Yellow("Unable to prepend the types reference: %v", err)
+			}
 		}
-		path := filepath.Join(p.config.HooksDir, name)
-		directive := `/// <reference path="` + p.relativeTypesPath(p.config.HooksDir) + `" />`
-		if err := prependToEmptyFile(path, directive+"\n\n"); err != nil {
-			color.Yellow("Unable to prepend the types reference: %v", err)
-		}
-	}
 
-	// initialize the hooks dir watcher
-	if p.config.HooksWatch {
-		if err := p.watchHooks(); err != nil {
-			color.Yellow("Unable to init hooks watcher: %v", err)
+		// initialize the hooks dir watcher
+		if p.config.HooksWatch {
+			if err := p.watchHooks(); err != nil {
+				color.Yellow("Unable to init hooks watcher: %v", err)
+			}
 		}
 	}
 
@@ -728,6 +758,49 @@ func filesContent(dirPath string, pattern string) (map[string][]byte, error) {
 		}
 
 		raw, err := os.ReadFile(filepath.Join(dirPath, f.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		transformed, err := transformSource(f.Name(), raw)
+		if err != nil {
+			return nil, err
+		}
+		result[f.Name()] = transformed
+	}
+
+	return result, nil
+}
+
+// filesContentFS is filesContent over an fs.FS. It deliberately mirrors that
+// function's contract — non-recursive, pattern-filtered, esbuild-transformed,
+// keyed by base filename — so a caller can swap the source without any
+// behavioral difference. A missing or empty FS yields an empty map, matching
+// filesContent's ErrNotExist handling.
+func filesContentFS(fsys fs.FS, pattern string) (map[string][]byte, error) {
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[string][]byte{}, nil
+		}
+		return nil, err
+	}
+
+	var exp *regexp.Regexp
+	if pattern != "" {
+		if exp, err = regexp.Compile(pattern); err != nil {
+			return nil, err
+		}
+	}
+
+	result := map[string][]byte{}
+
+	for _, f := range entries {
+		if f.IsDir() || (exp != nil && !exp.MatchString(f.Name())) {
+			continue
+		}
+
+		raw, err := fs.ReadFile(fsys, f.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,6 @@
     // /// <reference> whose relative path is authored for the source location, not
     // this materialized one), not in the app's TS/React environment — so they are
     // typechecked in their own package, never here.
-    "exclude": ["node_modules", ".expo", "dist", "server/pb_hooks"],
+    "exclude": ["node_modules", ".expo", "dist", "server/pb_hooks", "server/embedded_assets"],
     "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
 }


### PR DESCRIPTION
Ships TinyCld as a single binary that self-hosters run with no Docker, no Node, and no Go toolchain.

The web bundle, JS migrations, and `.pb.ts` hooks are embedded via `go:embed` behind an `embedassets` build tag. Every embedding point is an `fs.FS` field added alongside the existing path-based one, defaulting to nil — so the Docker, Dokku, and hosting-router paths are unchanged, and the default build needs no staged assets.

Six binaries are built per release (linux amd64/arm64, darwin amd64/arm64, windows amd64/arm64) with `SHA256SUMS`. Windows needed two POSIX syscalls split by platform (`O_NOFOLLOW`, `Umask`); both are in hosting-router code a self-hosted deployment never executes, and the unix paths keep the original guards intact.

### Verified

Booting the shipped artifact in an empty directory with no workspace above it: SPA shell, hashed JS chunks, and favicon all serve from the embed; 146 migrations apply; `--help`/`--version` work. Each of the six targets is confirmed to *contain* the embed, not merely to link.

`tinycld-pkg check` green (biome + tsc + 1763 tests), `go vet` clean for unix and windows, core-isolation passes, and the untagged build compiles with no staged tree present.

### Notes for review

- **In-app package install is gated off.** A single binary can't rebuild itself (those pipelines shell out to Go and pnpm), so the API isn't registered. Upgrading means downloading a new binary.
- **`docker-publish.yml` is rewired** to a shared `ci-assemble-workspace.sh`, extracted from its previously-inlined assembly so the image and the binaries always build from the same pinned member set. Behavior-preserving, but it touches the image-publish path — worth watching on the first release.
- **The CI size gate has a floor as well as a ceiling.** An unreferenced `embed.FS` gets eliminated by the linker, producing a binary that builds and serves with no web UI; the floor rejects that. This bug happened during development, twice.
- The two Windows syscall splits live in `tenantcfg`/`tenantmain`, which `PLAN-extract-hosting-from-tinycld.md` says should leave this repo. They'll move with their packages.

Implements `docs/superpowers/plans/2026-09-09-single-binary-distribution.md`; deviations from that plan are recorded at its end as D1–D9.
