### PR TITLE
Fix CLI login, and scope storage settings to the deployment that owns the disk

### DIFF
--- a/app/a/(app)/settings/index.tsx
+++ b/app/a/(app)/settings/index.tsx
@@ -1,9 +1,9 @@
 import { getIcon } from '@tinycld/core/components/workspace/package-icon-map'
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import { packageSettings } from '@tinycld/core/lib/packages/derive-components'
-import { isSavedServersSupported } from '@tinycld/core/lib/servers'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { useCurrentRole } from '@tinycld/core/lib/use-current-role'
+import { useSavedServers } from '@tinycld/core/lib/use-saved-servers'
 import { useRouter } from 'expo-router'
 import {
     ChevronRight,
@@ -54,14 +54,20 @@ export default function SettingsIndex() {
 }
 
 // Saved servers are device/connection scope — not a personal preference and not
-// org administration, so neither existing group fits. Native-only: web is
-// same-origin by design and has nothing to switch between.
+// org administration, so neither existing group fits.
+//
+// Gated on having something to switch BETWEEN, the same rule the user menu's
+// switcher uses. The list always contains at least the current origin (on web
+// it is seeded from it), so a lone entry is just a label for where you already
+// are — and it left this link opening a titled screen with a blank body, since
+// ServersSection renders nothing for an empty list.
 function DeviceSettings() {
     const foregroundColor = useThemeColor('foreground')
     const orgHref = useOrgHref()
     const router = useRouter()
+    const { servers } = useSavedServers()
 
-    if (!isSavedServersSupported()) return null
+    if (servers.length < 2) return null
 
     return (
         <SettingsGroup label="This device">

--- a/app/a/(app)/settings/servers.tsx
+++ b/app/a/(app)/settings/servers.tsx
@@ -3,6 +3,7 @@ import { ServersSection } from '@tinycld/core/components/settings/ServersSection
 import { useOrgHref } from '@tinycld/core/lib/org-routes'
 import { useThemeColor } from '@tinycld/core/lib/use-app-theme'
 import { useNavigateBack } from '@tinycld/core/lib/use-navigate-back'
+import { useSavedServers } from '@tinycld/core/lib/use-saved-servers'
 import { ArrowLeft, Server } from 'lucide-react-native'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 
@@ -18,6 +19,7 @@ export default function ServersSettings() {
     const orgHref = useOrgHref()
     const navigateBack = useNavigateBack(() => orgHref('settings'))
     const fgColor = useThemeColor('foreground')
+    const hasOtherServers = useSavedServers().servers.length > 1
 
     return (
         <View className="flex-1 bg-background">
@@ -31,9 +33,23 @@ export default function ServersSettings() {
             </View>
             <ScrollView className="flex-1" contentContainerStyle={{ padding: 16 }}>
                 <View className="max-w-[600px] w-full">
-                    <ServersSection />
+                    <NoOtherServers isVisible={!hasOtherServers} />
+                    <ServersSection isVisible={hasOtherServers} />
                 </View>
             </ScrollView>
         </View>
+    )
+}
+
+// ServersSection renders nothing when there is nothing to switch between, which
+// would leave this screen a bare header. The route stays reachable by URL even
+// though the nav link is gated, so say why it is empty.
+function NoOtherServers({ isVisible }: { isVisible: boolean }) {
+    if (!isVisible) return null
+
+    return (
+        <Text className="text-muted-foreground">
+            You have not saved another server yet. Add one to switch between them from this device.
+        </Text>
     )
 }

--- a/app/a/(app)/settings/storage.tsx
+++ b/app/a/(app)/settings/storage.tsx
@@ -14,17 +14,35 @@ import { Divider } from '@tinycld/core/ui/divider'
 import { FormErrorSummary, NumberInput, useForm, z, zodResolver } from '@tinycld/core/ui/form'
 import { ArrowLeft } from 'lucide-react-native'
 import { newRecordId } from 'pbtsdb/core'
-import { useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 
-// Storage usage + per-user limit for this deployment. Org branding (name /
-// slug / logo) is owned by the deployment (the hosting router) and is not
-// editable in-app, so storage is what this screen manages — the route, title,
-// and nav label all say so rather than promising organization management.
+// Who is using the disk, and the per-user cap. This deployment's operator owns
+// the hardware, so the only storage question the app can answer for them is
+// which user is filling it — there is no plan to report against and no bytes
+// total to bill for. Anything shaped like a ceiling sold to an organization
+// belongs to whoever sells the hosting, not here.
+//
+// Usage comes from core's /api/storage-usage, which sums every collection the
+// installed packages registered as a quota source. It names no package, so the
+// numbers stay right as packages are added or removed.
+
+const BYTES_PER_GB = 1024 * 1024 * 1024
 
 const storageLimitSchema = z.object({
     limitGb: z.number().min(0, 'Must be 0 or greater'),
 })
+
+interface UserBytes {
+    userId: string
+    name: string
+    email: string
+    bytes: number
+}
+
+interface StorageUsage {
+    users: UserBytes[]
+    limitPerUser: number
+}
 
 function formatStorageBytes(bytes: number): string {
     return bytes === 0 ? '0 B' : formatBytes(bytes)
@@ -66,21 +84,13 @@ export default function StorageSettings() {
     )
 }
 
-function StorageSection() {
+function usePerUserLimit() {
     const queryClient = useQueryClient()
     const [settingsCollection] = useStore('settings')
-    const [showBreakdown, setShowBreakdown] = useState(false)
 
-    const dangerColor = useThemeColor('danger')
-    const warningColor = useThemeColor('warning')
-    const successColor = useThemeColor('success')
-
-    const { data: storageInfo, isLoading } = useQuery({
+    const { data: usage, isLoading } = useQuery<StorageUsage>({
         queryKey: ['storage-usage'],
-        queryFn: () =>
-            pb.send('/api/drive/storage-usage', {
-                query: { breakdown: 'users' },
-            }),
+        queryFn: () => pb.send('/api/storage-usage', {}),
     })
 
     const { data: settings } = useOrgLiveQuery(query =>
@@ -90,28 +100,17 @@ function StorageSection() {
                 and(eq(settings.app, 'core'), eq(settings.key, 'storage_limit_bytes'))
             )
     )
-
     const existingSetting = settings?.[0]
 
-    const currentLimitGb = storageInfo?.has_limit
-        ? storageInfo.limit_bytes / (1024 * 1024 * 1024)
-        : 0
-
-    const {
-        control: limitControl,
-        handleSubmit: handleLimitSubmit,
-        setError: setLimitError,
-        getValues: getLimitValues,
-        formState: { errors: limitErrors, isSubmitted: isLimitSubmitted, isDirty: isLimitDirty },
-    } = useForm({
+    const form = useForm({
         mode: 'onChange',
         resolver: zodResolver(storageLimitSchema),
-        values: { limitGb: currentLimitGb },
+        values: { limitGb: (usage?.limitPerUser ?? 0) / BYTES_PER_GB },
     })
 
     const saveLimit = useMutation({
         mutationFn: mutation(function* (data: z.infer<typeof storageLimitSchema>) {
-            const valueBytes = Math.round(data.limitGb * 1024 * 1024 * 1024)
+            const valueBytes = Math.round(data.limitGb * BYTES_PER_GB)
             if (existingSetting) {
                 yield settingsCollection.update(existingSetting.id, draft => {
                     draft.value = valueBytes
@@ -129,115 +128,50 @@ function StorageSection() {
             queryClient.invalidateQueries({ queryKey: ['storage-usage'] })
         },
         onError: handleMutationErrorsWithForm({
-            setError: setLimitError,
-            getValues: getLimitValues,
+            setError: form.setError,
+            getValues: form.getValues,
         }),
     })
 
-    const onSaveLimit = handleLimitSubmit(data => saveLimit.mutate(data))
-    const canSaveLimit = !saveLimit.isPending && isLimitDirty
+    return { usage, isLoading, form, saveLimit }
+}
+
+function StorageSection() {
+    const { usage, isLoading, form, saveLimit } = usePerUserLimit()
 
     if (isLoading) {
         return (
-            <View className="gap-3">
-                <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
-                    Loading...
-                </Text>
-            </View>
+            <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
+                Loading...
+            </Text>
         )
     }
 
-    const userUsed = storageInfo?.user_used_bytes ?? 0
-    const limitBytes = storageInfo?.limit_bytes ?? 0
-    const hasLimit = storageInfo?.has_limit ?? false
-    const usagePercent =
-        hasLimit && limitBytes > 0 ? Math.min((userUsed / limitBytes) * 100, 100) : 0
-    const orgDriveBytes = storageInfo?.org_drive_bytes ?? 0
-    const orgMailBytes = storageInfo?.org_mail_bytes ?? 0
-    const users = storageInfo?.users as
-        | { user_name: string; user_email: string; drive_used: number }[]
-        | undefined
-
-    const barColor =
-        usagePercent > 90 ? dangerColor : usagePercent > 70 ? warningColor : successColor
+    const limitBytes = usage?.limitPerUser ?? 0
+    const onSaveLimit = form.handleSubmit(data => saveLimit.mutate(data))
+    const canSave = !saveLimit.isPending && form.formState.isDirty
 
     return (
         <View className="gap-4">
-            <View className="gap-2">
-                <Text className="text-primary" style={{ fontSize: 13 }}>
-                    Your Usage
-                </Text>
-                <View className="flex-row justify-between items-center">
-                    <Text className="text-foreground" style={{ fontSize: 15 }}>
-                        {formatStorageBytes(userUsed)}
-                        {hasLimit ? ` of ${formatStorageBytes(limitBytes)}` : ''}
-                    </Text>
-                    {hasLimit && (
-                        <Text
-                            className={usagePercent > 90 ? 'text-danger' : 'text-muted-foreground'}
-                            style={{ fontSize: 13 }}
-                        >
-                            {usagePercent.toFixed(1)}%
-                        </Text>
-                    )}
-                </View>
-                {hasLimit && (
-                    <View className="h-2 rounded overflow-hidden bg-surface-secondary">
-                        <View
-                            className="h-full rounded"
-                            style={{
-                                width: `${usagePercent}%`,
-                                backgroundColor: barColor,
-                            }}
-                        />
-                    </View>
-                )}
-            </View>
-
-            <View className="gap-2">
-                <Text className="text-primary" style={{ fontSize: 13 }}>
-                    Organization Total
-                </Text>
-                <View className="flex-row gap-4">
-                    <View>
-                        <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
-                            Drive
-                        </Text>
-                        <Text className="text-foreground" style={{ fontSize: 15 }}>
-                            {formatStorageBytes(orgDriveBytes)}
-                        </Text>
-                    </View>
-                    <View>
-                        <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
-                            Mail
-                        </Text>
-                        <Text className="text-foreground" style={{ fontSize: 15 }}>
-                            {formatStorageBytes(orgMailBytes)}
-                        </Text>
-                    </View>
-                </View>
-            </View>
-
-            <Divider />
-
             <View className="gap-3">
                 <Text className="text-foreground" style={{ fontSize: 15, fontWeight: '600' }}>
                     Per-User Storage Limit
                 </Text>
                 <Text className="text-muted-foreground" style={{ fontSize: 12 }}>
-                    Set to 0 for unlimited storage. Applies to drive uploads only.
+                    Set to 0 for unlimited storage. Applies to everything a user owns.
                 </Text>
-
-                <FormErrorSummary errors={limitErrors} isEnabled={isLimitSubmitted} />
-
+                <FormErrorSummary
+                    errors={form.formState.errors}
+                    isEnabled={form.formState.isSubmitted}
+                />
                 <View className="flex-row gap-3 items-end">
                     <View className="flex-1">
-                        <NumberInput control={limitControl} name="limitGb" label="Limit (GB)" />
+                        <NumberInput control={form.control} name="limitGb" label="Limit (GB)" />
                     </View>
                     <Pressable
                         onPress={onSaveLimit}
-                        disabled={!canSaveLimit}
-                        className={`px-4 py-2 rounded-lg self-start bg-primary ${canSaveLimit ? 'opacity-100' : 'opacity-50'}`}
+                        disabled={!canSave}
+                        className={`px-4 py-2 rounded-lg self-start bg-primary ${canSave ? 'opacity-100' : 'opacity-50'}`}
                     >
                         <Text className="text-primary-foreground" style={{ fontWeight: '600' }}>
                             {saveLimit.isPending ? 'Saving...' : 'Save Limit'}
@@ -246,70 +180,65 @@ function StorageSection() {
                 </View>
             </View>
 
-            {users && users.length > 0 && (
-                <>
-                    <Divider />
-                    <View className="gap-3">
-                        <Pressable onPress={() => setShowBreakdown(v => !v)}>
-                            <Text
-                                className="text-foreground"
-                                style={{ fontSize: 15, fontWeight: '600' }}
-                            >
-                                Per-User Breakdown {showBreakdown ? '▾' : '▸'}
-                            </Text>
-                        </Pressable>
-                        <UserBreakdownTable
-                            users={users}
-                            limitBytes={limitBytes}
-                            isVisible={showBreakdown}
-                        />
-                    </View>
-                </>
-            )}
+            <Divider />
+
+            <UsageByUser users={usage?.users ?? []} limitBytes={limitBytes} />
         </View>
     )
 }
 
-function UserBreakdownTable({
-    users,
-    limitBytes,
-    isVisible,
-}: {
-    users: { user_name: string; user_email: string; drive_used: number }[]
-    limitBytes: number
-    isVisible: boolean
-}) {
+// Largest consumer first, as the server sorts them.
+function UsageByUser({ users, limitBytes }: { users: UserBytes[]; limitBytes: number }) {
+    return (
+        <View className="gap-3">
+            <Text className="text-foreground" style={{ fontSize: 15, fontWeight: '600' }}>
+                Usage by User
+            </Text>
+            <EmptyUsers isVisible={users.length === 0} />
+            {users.map(user => (
+                <UserUsageRow key={user.userId} user={user} limitBytes={limitBytes} />
+            ))}
+        </View>
+    )
+}
+
+function EmptyUsers({ isVisible }: { isVisible: boolean }) {
     if (!isVisible) return null
 
     return (
-        <View className="gap-2">
-            {users.map(user => {
-                const percent =
-                    limitBytes > 0 ? Math.min((user.drive_used / limitBytes) * 100, 100) : 0
-                return (
-                    <View
-                        key={user.user_email}
-                        className="flex-row justify-between items-center py-1"
-                    >
-                        <View className="flex-1">
-                            <Text className="text-foreground" style={{ fontSize: 13 }}>
-                                {user.user_name || user.user_email}
-                            </Text>
-                            {user.user_name && (
-                                <Text className="text-muted-foreground" style={{ fontSize: 12 }}>
-                                    {user.user_email}
-                                </Text>
-                            )}
-                        </View>
-                        <Text
-                            className={percent > 90 ? 'text-danger' : 'text-muted-foreground'}
-                            style={{ fontSize: 13 }}
-                        >
-                            {formatStorageBytes(user.drive_used)}
-                        </Text>
-                    </View>
-                )
-            })}
+        <Text className="text-muted-foreground" style={{ fontSize: 13 }}>
+            No stored data yet.
+        </Text>
+    )
+}
+
+function UserUsageRow({ user, limitBytes }: { user: UserBytes; limitBytes: number }) {
+    const isOverLimit = limitBytes > 0 && user.bytes > limitBytes
+
+    return (
+        <View className="flex-row justify-between items-center py-1">
+            <View className="flex-1">
+                <Text className="text-foreground" style={{ fontSize: 13 }}>
+                    {user.name || user.email}
+                </Text>
+                <UserSubtitle name={user.name} email={user.email} />
+            </View>
+            <Text
+                className={isOverLimit ? 'text-danger' : 'text-muted-foreground'}
+                style={{ fontSize: 13 }}
+            >
+                {formatStorageBytes(user.bytes)}
+            </Text>
         </View>
+    )
+}
+
+function UserSubtitle({ name, email }: { name: string; email: string }) {
+    if (!name) return null
+
+    return (
+        <Text className="text-muted-foreground" style={{ fontSize: 12 }}>
+            {email}
+        </Text>
     )
 }

--- a/app/p/oauth/authorize.tsx
+++ b/app/p/oauth/authorize.tsx
@@ -186,6 +186,15 @@ function CodeInput({ code, onChangeCode }: { code: string; onChangeCode: (code: 
     )
 }
 
+// The server's message when it sent one, else a generic fallback covering the
+// three states a lookup failure can mean.
+const FALLBACK_CODE_ERROR = 'That code is not valid, has expired, or has already been used.'
+
+function authorizeErrorMessage(error: unknown): string {
+    const message = (error as { response?: { message?: string } })?.response?.message
+    return message && message.trim() !== '' ? message : FALLBACK_CODE_ERROR
+}
+
 function InfoStatus({ info }: { info: ReturnType<typeof useAuthorizeInfo> }) {
     if (info.isLoading) {
         return (
@@ -196,11 +205,10 @@ function InfoStatus({ info }: { info: ReturnType<typeof useAuthorizeInfo> }) {
     }
 
     if (info.isError) {
-        return (
-            <Text className="text-destructive">
-                That code is not valid, has expired, or has already been used.
-            </Text>
-        )
+        // Show what the server actually said. It distinguishes "already been
+        // used", "has expired" and "Sign in to approve this request"; a fixed
+        // catch-all made an auth or server failure read as a bad code.
+        return <Text className="text-destructive">{authorizeErrorMessage(info.error)}</Text>
     }
 
     return null

--- a/core/components/settings/ServersSection.tsx
+++ b/core/components/settings/ServersSection.tsx
@@ -12,12 +12,13 @@ import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 // target origin (localStorage is origin-partitioned, so a browser cannot hold
 // another origin's session). The copy below branches on canSwitchInPlace rather
 // than making one claim that is false on half the platforms.
-export function ServersSection() {
+export function ServersSection({ isVisible = true }: { isVisible?: boolean }) {
     const { servers, activeOrigin, busyOrigin, error, add, switchTo, remove } = useSavedServers()
     const fg = useThemeColor('foreground')
 
-    // The hook self-gates by platform, so an empty list is the only check needed.
-    if (servers.length === 0) return null
+    // The caller decides whether a list with nothing to switch between is worth
+    // showing; an empty list never is.
+    if (!isVisible || servers.length === 0) return null
 
     // No heading of its own: this is the entire body of the Servers settings
     // screen, which supplies the title.

--- a/core/server/coreserver/composition_parity_test.go
+++ b/core/server/coreserver/composition_parity_test.go
@@ -77,7 +77,7 @@ var hostHookCounts = map[string]int{
 	"OnRecordUpdateExecute":           4,
 	"OnRecordUpdateRequest":           9,
 	"OnRecordValidate":                6,
-	"OnServe":                         22,
+	"OnServe":                         23,
 	"OnSettingsReload":                1,
 	"OnTerminate":                     2,
 }

--- a/core/server/coreserver/server.go
+++ b/core/server/coreserver/server.go
@@ -340,6 +340,10 @@ func RegisterSharedCore(app *pocketbase.PocketBase) {
 	RegisterInviteEndpoint(app)
 	RegisterInviteLinkEndpoints(app)
 	RegisterOrgInfoEndpoint(app)
+	// Per-user storage breakdown. Shared: a hosting tenant's admin has the
+	// same "which of my users is filling the disk" question as a self-hoster,
+	// and it reports no ceiling the org could not already read.
+	RegisterStorageUsageEndpoint(app)
 	RegisterPasswordResetMailer(app)
 	RegisterAuditHooks(app)
 	RegisterAccountDelete(app)

--- a/core/server/coreserver/storage_usage.go
+++ b/core/server/coreserver/storage_usage.go
@@ -1,0 +1,55 @@
+package coreserver
+
+import (
+	"net/http"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+
+	"tinycld.org/core/quota"
+)
+
+// StorageUsageResponse is the per-user storage breakdown: who is using the
+// disk, and the per-user ceiling (0 = unlimited) their usage is measured
+// against.
+//
+// Deliberately NOT a deployment total against a plan ceiling. A single-tenant
+// deployment's operator owns the disk; the only question the app can answer
+// for them is which user is filling it. What an organization owes for the
+// space it occupies is a commercial question belonging to whoever sells the
+// hosting, and core knows nothing about plans, ceilings or billing.
+type StorageUsageResponse struct {
+	Users        []quota.UserBytes `json:"users"`
+	LimitPerUser int64             `json:"limitPerUser"`
+}
+
+// RegisterStorageUsageEndpoint serves GET /api/storage-usage.
+//
+// Package-agnostic by construction: it sums whatever collections the installed
+// packages registered as quota sources, so it counts drive, mail, boards and
+// anything added later without naming one.
+//
+// Sources and the per-user ceiling are read per request rather than captured,
+// because this registers from RegisterSharedCore — shared by the single-org
+// app and a hosting tenant, which bind quota with different limit resolvers
+// (a tenant's org ceiling comes from the router). Reading through the same
+// registry and resolver enforcement uses keeps the reported numbers and the
+// enforced ceiling describing one set of collections in both compositions.
+func RegisterStorageUsageEndpoint(app *pocketbase.PocketBase) {
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		e.Router.GET("/api/storage-usage", func(re *core.RequestEvent) error {
+			users, err := quota.UsageByUser(re.App, quota.RegisteredSources())
+			if err != nil {
+				return re.InternalServerError("Failed to compute storage usage", err)
+			}
+			perUser := quota.SettingsLimits(re.App).PerUser
+			return re.JSON(http.StatusOK, StorageUsageResponse{
+				Users:        users,
+				LimitPerUser: perUser,
+			})
+			// Admin-gated: a per-user breakdown names every member and what
+			// they store, which is not a member's business to read.
+		}).BindFunc(requireAdmin)
+		return e.Next()
+	})
+}

--- a/core/server/oauth/authorize.go
+++ b/core/server/oauth/authorize.go
@@ -8,6 +8,30 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
+// parseFormBody populates re.Request.Form from the request body, accepting
+// BOTH form encodings a browser can produce.
+//
+// http.Request.ParseForm alone parses only application/x-www-form-urlencoded;
+// against a multipart/form-data body it silently parses the URL query and
+// leaves the body's fields unreachable, so every FormValue reads "". That is
+// not a theoretical case: the consent screen posts a FormData, and the
+// PocketBase JS SDK deliberately omits Content-Type for a FormData body so
+// fetch sets multipart/form-data with its boundary. The result was a 404
+// "That code is not valid" for a code that was present, correct, and pending.
+func parseFormBody(re *core.RequestEvent) error {
+	if strings.HasPrefix(re.Request.Header.Get("Content-Type"), "multipart/form-data") {
+		// Populates Request.MultipartForm and merges its values into Form,
+		// which is what FormValue reads.
+		return re.Request.ParseMultipartForm(multipartMaxMemory)
+	}
+	return re.Request.ParseForm()
+}
+
+// multipartMaxMemory caps in-memory storage for a parsed multipart body;
+// anything larger spills to temp files. These endpoints carry only short text
+// fields, so this is generous.
+const multipartMaxMemory = 32 << 20
+
 // AuthorizeInfoResponse describes a pending device request so the consent
 // screen can name the client and list the scopes before the user approves.
 type AuthorizeInfoResponse struct {
@@ -66,8 +90,9 @@ func handleAuthorizeInfo(app core.App, re *core.RequestEvent) error {
 	})
 }
 
-// handleApproveDevice implements POST /oauth/authorize for the device flow:
-// the signed-in user binds themselves to a pending grant and activates it.
+// handleApproveDevice implements POST /oauth/authorize/approve for the device
+// flow: the signed-in user binds themselves to a pending grant and activates
+// it. (Bare POST /oauth/authorize is the authorization-code endpoint below.)
 func handleApproveDevice(app core.App, re *core.RequestEvent) error {
 	if re.Auth == nil {
 		return re.UnauthorizedError("Sign in to approve this request", nil)
@@ -75,7 +100,7 @@ func handleApproveDevice(app core.App, re *core.RequestEvent) error {
 	if err := rejectOAuthToken(re); err != nil {
 		return err
 	}
-	if err := re.Request.ParseForm(); err != nil {
+	if err := parseFormBody(re); err != nil {
 		return re.BadRequestError("Malformed form body", err)
 	}
 	userCode := strings.ToUpper(strings.TrimSpace(re.Request.FormValue("user_code")))
@@ -128,7 +153,7 @@ func handleDenyDevice(app core.App, re *core.RequestEvent) error {
 	if err := rejectOAuthToken(re); err != nil {
 		return err
 	}
-	if err := re.Request.ParseForm(); err != nil {
+	if err := parseFormBody(re); err != nil {
 		return re.BadRequestError("Malformed form body", err)
 	}
 	userCode := strings.ToUpper(strings.TrimSpace(re.Request.FormValue("user_code")))
@@ -164,7 +189,7 @@ func handleAuthorize(app core.App, re *core.RequestEvent) error {
 	if err := rejectOAuthToken(re); err != nil {
 		return err
 	}
-	if err := re.Request.ParseForm(); err != nil {
+	if err := parseFormBody(re); err != nil {
 		return re.BadRequestError("Malformed form body", err)
 	}
 	q := re.Request.Form

--- a/core/server/oauth/authorize_test.go
+++ b/core/server/oauth/authorize_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -888,5 +889,103 @@ func TestMetadataAdvertisesSupportedGrants(t *testing.T) {
 	}
 	if len(md.ScopesSupported) == 0 {
 		t.Error("metadata must advertise the scope catalog")
+	}
+}
+
+// The consent screen posts a FormData, and the PocketBase JS SDK deliberately
+// omits Content-Type for such a body, so the browser sends
+// multipart/form-data. http.Request.ParseForm does not read a multipart body:
+// before parseFormBody, user_code came back "" and a present, pending code was
+// rejected with 404 "That code is not valid". Every other test here sends
+// application/x-www-form-urlencoded, which is why this shipped.
+func multipartBody(t *testing.T, fields map[string]string) (string, string) {
+	t.Helper()
+	var buf strings.Builder
+	w := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		if err := w.WriteField(k, v); err != nil {
+			t.Fatalf("write field %q: %v", k, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return buf.String(), w.FormDataContentType()
+}
+
+func TestApproveDeviceAcceptsMultipartBody(t *testing.T) {
+	app := newSchemaApp(t)
+	userCode, userID := pendingUserCodeGrant(t, app)
+
+	body, contentType := multipartBody(t, map[string]string{
+		"user_code":    userCode,
+		"device_label": "Browser consent screen",
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize/approve", strings.NewReader(body))
+	req.Header.Set("Content-Type", contentType)
+
+	user, err := app.FindRecordById("users", userID)
+	if err != nil {
+		t.Fatalf("find user: %v", err)
+	}
+	re := &core.RequestEvent{App: app}
+	re.Request = req
+	re.Response = rec
+	re.Auth = user
+
+	if err := handleApproveDevice(app, re); err != nil {
+		t.Fatalf("handleApproveDevice: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	grant, err := FindGrantByUserCode(app, userCode)
+	if err != nil {
+		t.Fatalf("grant not found after approval: %v", err)
+	}
+	if grant.GetString("status") != "active" {
+		t.Fatalf("status = %q, want active", grant.GetString("status"))
+	}
+	if grant.GetString("user") != userID {
+		t.Fatalf("grant user = %q, want %q", grant.GetString("user"), userID)
+	}
+	if grant.GetString("device_label") != "Browser consent screen" {
+		t.Errorf("device_label = %q, want the multipart value",
+			grant.GetString("device_label"))
+	}
+}
+
+func TestDenyDeviceAcceptsMultipartBody(t *testing.T) {
+	app := newSchemaApp(t)
+	userCode, userID := pendingUserCodeGrant(t, app)
+
+	body, contentType := multipartBody(t, map[string]string{"user_code": userCode})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize/deny", strings.NewReader(body))
+	req.Header.Set("Content-Type", contentType)
+
+	user, err := app.FindRecordById("users", userID)
+	if err != nil {
+		t.Fatalf("find user: %v", err)
+	}
+	re := &core.RequestEvent{App: app}
+	re.Request = req
+	re.Response = rec
+	re.Auth = user
+
+	if err := handleDenyDevice(app, re); err != nil {
+		t.Fatalf("handleDenyDevice: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	// RevokeGrant clears the code, so the grant must no longer be findable by it.
+	if _, err := FindGrantByUserCode(app, userCode); err == nil {
+		t.Fatal("user_code still resolves after deny; revocation did not clear it")
 	}
 }

--- a/core/server/quota/quota_test.go
+++ b/core/server/quota/quota_test.go
@@ -398,3 +398,75 @@ func TestFixedLimitsStillReadsPerUserFromSettings(t *testing.T) {
 		t.Fatalf("PerUser = %d, want 4096 from settings", limits.PerUser)
 	}
 }
+
+func TestUsageByUserRanksOwnersAndExcludesSharedBytes(t *testing.T) {
+	app, _, alice, bob := setupQuotaApp(t)
+
+	if err := addOwned(t, app, alice, "a1", 300); err != nil {
+		t.Fatal(err)
+	}
+	if err := addOwned(t, app, bob, "b1", 1000); err != nil {
+		t.Fatal(err)
+	}
+	// Shared bytes belong to no one and must not be attributed to a user.
+	if err := addShared(t, app, "s1", 5000); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := UsageByUser(app, testSources())
+	if err != nil {
+		t.Fatalf("UsageByUser: %v", err)
+	}
+
+	byEmail := map[string]int64{}
+	for _, r := range rows {
+		byEmail[r.Email] = r.Bytes
+	}
+	if got := byEmail["alice@example.com"]; got != 300 {
+		t.Errorf("alice = %d, want 300", got)
+	}
+	if got := byEmail["bob@example.com"]; got != 1000 {
+		t.Errorf("bob = %d, want 1000", got)
+	}
+
+	// Biggest consumer first — the whole point of the abuse view.
+	if len(rows) < 2 {
+		t.Fatalf("got %d rows, want at least 2", len(rows))
+	}
+	if rows[0].Email != "bob@example.com" {
+		t.Errorf("first row = %q, want the largest consumer (bob)", rows[0].Email)
+	}
+
+	var total int64
+	for _, r := range rows {
+		total += r.Bytes
+	}
+	if total != 1300 {
+		t.Errorf("sum of per-user bytes = %d, want 1300 (shared bytes excluded)", total)
+	}
+}
+
+// A package can declare a quota source and be absent from an assembly. The
+// breakdown must report zeros rather than failing, or the lean shell breaks.
+func TestUsageByUserToleratesAMissingCollection(t *testing.T) {
+	app, _, alice, _ := setupQuotaApp(t)
+
+	if err := addOwned(t, app, alice, "a1", 42); err != nil {
+		t.Fatal(err)
+	}
+
+	sources := append(testSources(), Source{
+		Slug: "absent", Collection: "not_installed_items",
+		SizeField: "size", OwnerField: "created_by",
+	})
+
+	rows, err := UsageByUser(app, sources)
+	if err != nil {
+		t.Fatalf("UsageByUser with an uninstalled source: %v", err)
+	}
+	for _, r := range rows {
+		if r.Email == "alice@example.com" && r.Bytes != 42 {
+			t.Errorf("alice = %d, want 42", r.Bytes)
+		}
+	}
+}

--- a/core/server/quota/usage.go
+++ b/core/server/quota/usage.go
@@ -3,6 +3,7 @@ package quota
 import (
 	"fmt"
 	"regexp"
+	"sort"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
@@ -95,4 +96,61 @@ func sumCollection(app core.App, src Source, ownerID string) (int64, error) {
 func isMissingTable(app core.App, collection string) bool {
 	_, err := app.FindCollectionByNameOrId(collection)
 	return err != nil
+}
+
+// UserBytes is one user's owned bytes, for the per-user breakdown.
+type UserBytes struct {
+	UserID string `json:"userId"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`
+	Bytes  int64  `json:"bytes"`
+}
+
+// UsageByUser returns every user's owned bytes, largest first.
+//
+// This is the "who is filling the disk" view: it aggregates across every
+// registered source that declares an owner, so it counts each installed
+// package's bytes without naming any of them. Users owning nothing are
+// included (zero), so the list doubles as the member roster.
+//
+// Shared data — a source with no OwnerField — belongs to no one and is
+// deliberately absent: attributing it to a user would be a lie, and the
+// per-user ceiling does not consider it either (see UserUsage).
+func UsageByUser(app core.App, sources []Source) ([]UserBytes, error) {
+	owned := make([]Source, 0, len(sources))
+	for _, src := range sources {
+		if src.OwnerField != "" {
+			owned = append(owned, src)
+		}
+	}
+
+	var users []struct {
+		ID    string `db:"id"`
+		Name  string `db:"name"`
+		Email string `db:"email"`
+	}
+	if err := app.DB().NewQuery(`SELECT id, name, email FROM users`).All(&users); err != nil {
+		return nil, fmt.Errorf("quota: list users: %w", err)
+	}
+
+	out := make([]UserBytes, 0, len(users))
+	for _, u := range users {
+		var total int64
+		for _, src := range owned {
+			n, err := sumCollection(app, src, u.ID)
+			if err != nil {
+				return nil, err
+			}
+			total += n
+		}
+		out = append(out, UserBytes{UserID: u.ID, Name: u.Name, Email: u.Email, Bytes: total})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Bytes != out[j].Bytes {
+			return out[i].Bytes > out[j].Bytes
+		}
+		return out[i].Email < out[j].Email
+	})
+	return out, nil
 }

--- a/scripts/check-core-isolation.ts
+++ b/scripts/check-core-isolation.ts
@@ -107,10 +107,6 @@ const ALLOWLIST: { file: string; reason: string }[] = [
         file: 'core/server/blankfile/blankfile.go',
         reason: 'blank files attach to drive_items; same document-access registry as driveshare',
     },
-    {
-        file: 'app/a/(app)/settings/storage.tsx',
-        reason: 'storage settings call a drive route; quota sources should expose usage through core',
-    },
 ]
 
 const SCAN_ROOTS = ['core', 'cli', 'app', 'scripts', 'server']

--- a/scripts/paths.ts
+++ b/scripts/paths.ts
@@ -58,9 +58,38 @@ function buildMemberDirIndex(): Map<string, string> {
             index.set(name, dir)
         }
     }
+    // A member may also be nested one level down inside a dir that is not
+    // itself a member — hosting/ui, whose parent ships Go only and stays out of
+    // the workspace. Scanned after the top level so a top-level member always
+    // wins a name collision.
+    for (const entry of fs.readdirSync(WS_ROOT)) {
+        const parent = path.join(WS_ROOT, entry)
+        if (entry === 'node_modules' || entry.startsWith('.')) continue
+        let nestedEntries: string[]
+        try {
+            if (!fs.statSync(parent).isDirectory()) continue
+            nestedEntries = fs.readdirSync(parent)
+        } catch {
+            continue
+        }
+        for (const nested of nestedEntries) {
+            if (nested === 'node_modules' || nested.startsWith('.')) continue
+            const dir = path.join(parent, nested)
+            let name: unknown
+            try {
+                if (!fs.statSync(dir).isDirectory()) continue
+                name = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).name
+            } catch {
+                continue
+            }
+            if (typeof name === 'string' && name.length > 0 && !index.has(name)) {
+                index.set(name, dir)
+            }
+        }
+    }
     // @tinycld/core now lives nested inside the tinycld member (at <APP_DIR>/core/),
     // not as a top-level sibling. The top-level scan above won't find it, so look
-    // for it explicitly. (Only core is nested; feature siblings stay top-level.)
+    // for it explicitly.
     if (!index.has('@tinycld/core')) {
         const nestedCore = path.join(APP_DIR, 'core')
         const corePkg = path.join(nestedCore, 'package.json')

--- a/scripts/write-workspace-root.ts
+++ b/scripts/write-workspace-root.ts
@@ -119,8 +119,62 @@ function discoverPresentMembers(wsRoot: string): string[] {
     })
 }
 
+// Members nested one level down inside a dir that is not itself a member —
+// hosting/ui, whose parent ships Go only and is deliberately not in the
+// workspace. Returned as "parent/child" so pnpm's `packages:` entry points at
+// the real path. Mirrors the same one-level scan in tinycld.packages.ts.
+function discoverNestedMembers(wsRoot: string): string[] {
+    let entries: string[]
+    try {
+        entries = fs.readdirSync(wsRoot)
+    } catch {
+        return []
+    }
+    const out: string[] = []
+    for (const parentName of entries) {
+        if (parentName === 'node_modules' || parentName.startsWith('.')) continue
+        const parent = path.join(wsRoot, parentName)
+        let nested: string[]
+        try {
+            if (!fs.statSync(parent).isDirectory()) continue
+            // A dir that is itself a member is already covered by the flat scan.
+            if (
+                fs.existsSync(path.join(parent, 'manifest.ts')) ||
+                fs.existsSync(path.join(parent, 'manifest.js'))
+            ) {
+                continue
+            }
+            nested = fs.readdirSync(parent)
+        } catch {
+            continue
+        }
+        for (const childName of nested) {
+            if (childName === 'node_modules' || childName.startsWith('.')) continue
+            const dir = path.join(parent, childName)
+            try {
+                if (!fs.statSync(dir).isDirectory()) continue
+            } catch {
+                continue
+            }
+            const hasManifest =
+                fs.existsSync(path.join(dir, 'manifest.ts')) ||
+                fs.existsSync(path.join(dir, 'manifest.js'))
+            if (fs.existsSync(path.join(dir, 'package.json')) && hasManifest) {
+                out.push(`${parentName}/${childName}`)
+            }
+        }
+    }
+    return out
+}
+
 function memberUnion(wsRoot: string): string[] {
-    return [...new Set([...ALL_MEMBERS, ...discoverPresentMembers(wsRoot)])]
+    return [
+        ...new Set([
+            ...ALL_MEMBERS,
+            ...discoverPresentMembers(wsRoot),
+            ...discoverNestedMembers(wsRoot),
+        ]),
+    ]
 }
 
 function pnpmWorkspaceYaml(wsRoot: string, pins: Record<string, string>): string {


### PR DESCRIPTION
Three bugs found while using a downloaded CLI and reviewing settings.

### CLI login always failed

Approving a device login said **"That code is not valid"** for a code that was present, correct and pending. The code *is* in the query string and *does* prefill — the break was on submit.

The consent screen posts a `FormData`; the PocketBase SDK omits `Content-Type` for such a body, so the browser sends `multipart/form-data`. The handlers used `ParseForm`, which reads only urlencoded bodies — against multipart it parses the URL query, so `user_code` arrived empty.

Fixed in all three POST handlers (approve, deny, and the authorization-code endpoint, which had the same latent defect). No test caught it because every server test sets an explicit urlencoded header and the smoke script posts `URLSearchParams` — nothing took the path a browser takes. The new tests post real multipart bodies and fail with the reported error without the fix.

The screen also showed one fixed string for any error, so "already used", "expired" and a 401 all read as a bad code. It now shows what the server said.

### Storage settings

The screen asked two questions at once: who is filling the disk, and how the org stands against a ceiling it was sold. Only the first is this app's to answer — an operator owns their own hardware, and what an org owes is the hosting provider's concern. The plan half moves to hosting; this keeps the per-user view.

New `GET /api/storage-usage` aggregates over the registered quota sources, so it counts drive, mail, boards and anything added later without naming a package. It replaces a call into drive's route, which is why core-isolation carried an allowlist entry for this file — **that entry is now gone**, and the screen works in an assembly without drive.

### Servers settings

Offered on every deployment: the link was gated on a predicate that always returns true, the body on a non-empty list. The list always holds the current origin, so a single-server user got an entry leading to a blank screen. Now gated on having a second server, matching the user menu's existing rule.

### Also

The generator can now discover a member nested inside a non-member dir, so hosting's client surface lives at `hosting/ui` and stays in the hosting repo. Nesting isn't new — `tinycld/core` is already nested, just hardcoded.

### Verification

Verified against a live server in a real browser: the device flow completes ("Device connected") and the device code exchanges for a working token. Lint, typecheck, core-isolation, 1795 app tests and the full Go suite pass.

Companion PRs: tinycld/drive, tinycld/hosting, tinycld/bootstrap (same branch name).