### PR TITLE
Fix the boards-install outage: migration purge, rescue mode, and stale seed file

### DIFF
--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -651,6 +651,43 @@ recover_interrupted_rebuild() {
 
 recover_interrupted_rebuild
 
+# RECOVERY HATCH. With TINYCLD_RESCUE=1 the container runs the given command (or
+# an interactive shell) INSTEAD of serving, then exits without entering the
+# restart loop.
+#
+# Why this exists: the loop below hardcodes `serve` and appends "$@" as FLAGS, so
+# a command passed to `docker run` / `dokku run` is never executed — it is handed
+# to serve as arguments. When a boot-time failure (a migration that cannot apply,
+# a corrupt pb_data) kills the server before it binds a port, `dokku enter` has no
+# running container to attach to and `dokku run <cmd>` just reboots the crashing
+# server. The instance is then unreachable by any in-band route, and repairing it
+# means host root access to the volume. That is what turned a failed boards
+# install into a full outage on tinycld.org.
+#
+# The hatch never triggers on its own: it is opt-in via an env var an operator
+# sets deliberately, e.g.
+#
+#   dokku run -e TINYCLD_RESCUE=1 tinycld.org sqlite3 /workspace/pb_data/data.db '.tables'
+#
+# It runs as the unprivileged runtime user, exactly like serve, so it grants no
+# privilege that a normal boot does not already have.
+if [ "${TINYCLD_RESCUE:-}" = "1" ]; then
+    echo "[entrypoint] RESCUE MODE: skipping serve"
+    echo "[entrypoint] state dir: $TINYCLD_STATE_DIR  current build: $(readlink -f "$CURRENT_LINK" 2>/dev/null || echo '<unresolved>')"
+    if [ "$#" -eq 0 ]; then
+        set -- /bin/sh
+    fi
+    echo "[entrypoint] running: $*"
+    RESCUE_CODE=0
+    if [ "$(id -u)" = "0" ]; then
+        gosu "$RUN_AS" "$@" || RESCUE_CODE=$?
+    else
+        "$@" || RESCUE_CODE=$?
+    fi
+    echo "[entrypoint] rescue command exited with code $RESCUE_CODE"
+    exit "$RESCUE_CODE"
+fi
+
 # Restart loop: exit code 75 signals a package install restart request.
 # Serve args are in $@ (positional params) so a multi-domain list survives
 # without re-splitting.

--- a/core/server/coreserver/migrate_purge_test.go
+++ b/core/server/coreserver/migrate_purge_test.go
@@ -1,6 +1,10 @@
 package coreserver
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
 
 // purgeUnregisteredPackageRows must delete the uninstalled package's stranded
 // history rows (Down was skipped because unregistered) so a reinstall isn't
@@ -104,5 +108,106 @@ func TestPurgeUnregisteredPackageRows_EmptyInputs(t *testing.T) {
 	}
 	if p, err := purgeUnregisteredPackageRows(app, "calendar-slots", nil); err != nil || p != nil {
 		t.Fatalf("empty skipped: got (%v, %v), want (nil, nil)", p, err)
+	}
+}
+
+// TestPurgeUnregisteredPackageRows_KeepsRowWhenSchemaSurvives is the regression
+// guard for the tinycld.org boards outage.
+//
+// The purge exists for the case where a skipped Down left ONLY a stale history
+// row behind. But "Down was skipped" does not imply "the schema is gone" — it
+// usually means the opposite, because the Down is exactly what would have
+// dropped the collections. Purging unconditionally therefore produced a DB that
+// contradicted itself: the boards_* collections were still present while their
+// _migrations rows were deleted.
+//
+// On the next install PocketBase saw no history row, re-ran the Up, and hit the
+// already-existing collection:
+//
+//	id: The model id is invalid or already exists.;
+//	name: Collection name must be unique (case insensitive).
+//
+// That error is fatal in the migration runner, so the server exited before
+// binding a port — a boot crash loop that took the whole deployment down, and
+// which the rollback could not clear because the armed DB backup had been taken
+// AFTER the purge and so carried the same contradictory state.
+//
+// A migration whose collections still exist must therefore KEEP its history
+// row: history and schema stay consistent, and the re-Up is correctly skipped.
+func TestPurgeUnregisteredPackageRows_KeepsRowWhenSchemaSurvives(t *testing.T) {
+	app := newMigrateTestApp(t)
+
+	const survivingCol = "ml_boards_projects"
+	// Its Down was skipped, so this collection is still in the DB.
+	strandedSchema := "1800000000_create_ml_boards_collections.js"
+	// Nothing of this one's schema remains — a pure stale row, the case the
+	// purge was actually written for.
+	pureStaleRow := "1800000001_ml_boards_tweak.js"
+
+	// Both rows are "applied". The collection for strandedSchema is still in the
+	// DB — its Down never ran, which is what "unregistered" means in production.
+	// No migration is registered here, matching the real case: the active build
+	// no longer carries this package's JS migrations.
+	for _, f := range []string{strandedSchema, pureStaleRow} {
+		if err := insertMigrationRow(app, f); err != nil {
+			t.Fatalf("seed _migrations row %s: %v", f, err)
+		}
+	}
+	col := core.NewBaseCollection(survivingCol)
+	col.Fields.Add(&core.TextField{Name: "title"})
+	if err := app.Save(col); err != nil {
+		t.Fatalf("seed surviving collection: %v", err)
+	}
+
+	restore := setMigrationOwnersForTest(map[string]string{
+		strandedSchema: "ml-boards",
+		pureStaleRow:   "ml-boards",
+	})
+	defer restore()
+
+	if !collectionExists(t, app, survivingCol) {
+		t.Fatalf("precondition: %s should exist before the purge", survivingCol)
+	}
+
+	purged, err := purgeUnregisteredPackageRows(app, "ml-boards", []string{strandedSchema, pureStaleRow})
+	if err == nil {
+		t.Fatalf("purge succeeded (purged %v) while collection %s still exists; want a refusal", purged, survivingCol)
+	}
+	if len(purged) != 0 {
+		t.Errorf("purged = %v, want none when the package's schema survives", purged)
+	}
+
+	// Neither row may be dropped: with the schema still present, deleting ANY of
+	// its history is what makes the reinstall re-run an Up and crash the server.
+	for _, f := range []string{strandedSchema, pureStaleRow} {
+		if ok, _ := migrationApplied(app, f); !ok {
+			t.Errorf("row %s was purged while collection %s still exists — a reinstall will re-run its Up and die on \"already exists\"", f, survivingCol)
+		}
+	}
+}
+
+// With the package's collections genuinely gone, the purge still does its
+// original job: clearing stale history so a reinstall can re-run the Up. This is
+// the case purgeUnregisteredPackageRows was written for, and the schema guard
+// must not break it.
+func TestPurgeUnregisteredPackageRows_PurgesWhenSchemaIsGone(t *testing.T) {
+	app := newMigrateTestApp(t)
+
+	staleRow := "1800000000_create_ml_gone_collections.js"
+	if err := insertMigrationRow(app, staleRow); err != nil {
+		t.Fatalf("seed _migrations row: %v", err)
+	}
+	restore := setMigrationOwnersForTest(map[string]string{staleRow: "ml-gone"})
+	defer restore()
+
+	purged, err := purgeUnregisteredPackageRows(app, "ml-gone", []string{staleRow})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if len(purged) != 1 || purged[0] != staleRow {
+		t.Fatalf("purged = %v, want [%s]", purged, staleRow)
+	}
+	if ok, _ := migrationApplied(app, staleRow); ok {
+		t.Errorf("stale row %s should have been purged", staleRow)
 	}
 }

--- a/core/server/coreserver/migrate_sync.go
+++ b/core/server/coreserver/migrate_sync.go
@@ -109,12 +109,38 @@ func syncMigrations(app core.App, applied, newSet []string) (SyncResult, error) 
 // install reports success. Clearing the stranded rows lets a reinstall re-run the
 // Up cleanly. We only touch rows OWNED by the uninstalled slug (per the migration
 // owner map) AND in the skipped set, so no other package's (or core's) history is
-// affected. Schema the skipped Down would have dropped may persist (we have no
-// Down to run) — that's logged separately; the row purge is what unblocks
-// reinstall, which is the reported symptom.
+// affected.
+//
+// A ROW IS ONLY PURGED WHEN THE PACKAGE'S SCHEMA IS ACTUALLY GONE. "Down was
+// skipped" does not imply "the schema is gone" — it usually implies the
+// opposite, since the Down is precisely what would have dropped the
+// collections. Purging unconditionally is what took tinycld.org down: the
+// boards_* collections survived while their _migrations rows were deleted, so
+// the next install re-ran the Up against existing collections and the runner
+// died with "The model id is invalid or already exists" before the server could
+// bind a port. The rollback could not clear it either, because the DB backup was
+// armed AFTER the purge and carried the same contradictory state.
+//
+// So when any collection owned by the slug is still present, the rows are LEFT
+// IN PLACE: history then matches the schema that actually exists, and the
+// reinstall correctly skips the Up instead of crashing. Only a package with no
+// surviving collections — the genuinely stale rows this purge was written for —
+// gets its history cleared, which still unblocks that reinstall.
 func purgeUnregisteredPackageRows(app core.App, slug string, skipped []string) ([]string, error) {
 	if slug == "" || len(skipped) == 0 {
 		return nil, nil
+	}
+	// Keeping stale rows only delays a reinstall; deleting rows whose schema
+	// survives causes a boot crash loop. On an inspection error, prefer the
+	// recoverable failure.
+	surviving, err := packageCollectionsPresent(app, slug)
+	if err != nil {
+		return nil, fmt.Errorf("check surviving %s collections before purging migration rows: %w", slug, err)
+	}
+	if len(surviving) > 0 {
+		return nil, fmt.Errorf(
+			"refusing to purge %s migration rows: %d of its collection(s) still exist (%s) — deleting the history would make a reinstall re-run their Up and fail with \"already exists\"",
+			slug, len(surviving), strings.Join(surviving, ", "))
 	}
 	owned := make(map[string]bool)
 	for _, f := range migrationsForPackage(slug) {
@@ -144,6 +170,39 @@ func purgeUnregisteredPackageRows(app core.App, slug string, skipped []string) (
 	}
 	sort.Strings(purged)
 	return purged, nil
+}
+
+// packageCollectionsPresent returns the non-system collections that still belong
+// to slug, sorted. It is the guard on purging migration history: history may
+// only be cleared for a package whose schema is genuinely gone.
+//
+// Ownership is matched on the collection-name prefix (`boards_projects` for
+// `boards`), with `-` normalized to `_` because a slug may be hyphenated while
+// SQLite table names are not (google-takeout-import → google_takeout_import).
+// The bare slug counts too, for a package with a single same-named collection.
+//
+// A prefix match can only ever be too BROAD, never too narrow, and that is the
+// safe direction here: an extra match means we decline to purge and the operator
+// gets a clear error, whereas a miss means deleting history whose schema still
+// exists — the crash-loop failure this guard exists to prevent.
+func packageCollectionsPresent(app core.App, slug string) ([]string, error) {
+	cols, err := app.FindAllCollections()
+	if err != nil {
+		return nil, err
+	}
+	normalized := strings.ReplaceAll(slug, "-", "_")
+	prefix := normalized + "_"
+	var out []string
+	for _, c := range cols {
+		if c.System {
+			continue
+		}
+		if c.Name == normalized || strings.HasPrefix(c.Name, prefix) {
+			out = append(out, c.Name)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // unregisteredOnly is the complement of registeredOnly: the files NOT resolvable

--- a/core/server/coreserver/pkg_seed.go
+++ b/core/server/coreserver/pkg_seed.go
@@ -148,11 +148,36 @@ func SyncBundledPackages(app core.App) {
 	srvLog.Info("synced bundled packages", "count", len(packages))
 }
 
+// findBundledPackagesJSON locates the seed file, preferring the GENERATOR'S
+// OUTPUT over any copy derived from it.
+//
+// There are two copies at runtime and only one of them is regenerated:
+//
+//   - server/bundled-packages.json is written by `pnpm run packages:generate`
+//     (scripts/generate.ts), which an in-app package install re-runs on every
+//     rebuild. It is always current.
+//   - a sibling copy next to the binary is placed ONCE at image-build time
+//     (tinycld/Dockerfile, deploy/bare-metal/build.sh) because the entrypoint
+//     runs the binary with cwd = tinycld/, one level above server/.
+//
+// Ordering matters because the entrypoint's cwd makes the bare relative path
+// resolve to that never-refreshed sibling. Preferring it meant every in-app
+// install read a frozen pre-install file: SyncBundledPackages never saw the
+// newly installed slug, so it never created the pkg_registry row and the
+// package stayed invisible in the UI despite installing correctly. Checking
+// server/ first means the fresher file always wins, while the sibling copy
+// still serves layouts where server/ isn't reachable.
+//
+// The bare "bundled-packages.json" stays LAST-but-one so dev (cwd = server/)
+// still resolves, and remains a valid fallback for the packaged layout.
 func findBundledPackagesJSON() string {
-	// Try relative to working directory (typical for dev: server/)
 	candidates := []string{
-		"bundled-packages.json",
+		// The generator's own output, reached from the two cwds the binary runs
+		// under: tinycld/ (entrypoint) and server/ (dev).
+		"server/bundled-packages.json",
 		"../server/bundled-packages.json",
+		// Derived copies: current only as of the last image build.
+		"bundled-packages.json",
 		filepath.Join(filepath.Dir(os.Args[0]), "bundled-packages.json"),
 	}
 	for _, p := range candidates {

--- a/core/server/coreserver/pkg_seed_test.go
+++ b/core/server/coreserver/pkg_seed_test.go
@@ -297,3 +297,80 @@ func mustJSON(t *testing.T, v any) string {
 	}
 	return string(data)
 }
+
+// TestFindBundledPackagesJSONPrefersServerCopy is the regression guard for the
+// stale-shadowing outage: an in-app install regenerates ONLY
+// server/bundled-packages.json (pkgbuild assemble → `pnpm run
+// packages:generate`), while the sibling copy next to the binary is written just
+// once at image-build time (Dockerfile / deploy/bare-metal/build.sh). When the
+// loader preferred the sibling copy, every in-app install read a frozen
+// pre-install file, so SyncBundledPackages never saw the newly installed slug
+// and never created its pkg_registry row — the package installed correctly in
+// every other respect but stayed invisible in the UI.
+//
+// server/ is the generator's output and therefore the source of truth; the
+// sibling copy is a derived fallback for layouts where server/ isn't reachable.
+// Resolution order must follow that, so the fresher file always wins.
+func TestFindBundledPackagesJSONPrefersServerCopy(t *testing.T) {
+	dir := t.TempDir()
+	serverDir := filepath.Join(dir, "server")
+	if err := os.MkdirAll(serverDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The stale sibling copy: what the baked image shipped, missing `boards`.
+	writeBundledJSON(t, dir, []bundledPackage{{Name: "Mail", Slug: "mail", Version: "1.0.0"}})
+	// The freshly generated copy an in-app install just rewrote.
+	writeBundledJSON(t, serverDir, []bundledPackage{
+		{Name: "Mail", Slug: "mail", Version: "1.0.0"},
+		{Name: "Boards", Slug: "boards", Version: "0.3.0"},
+	})
+	withCwd(t, dir)
+
+	got := findBundledPackagesJSON()
+
+	data, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read resolved path %q: %v", got, err)
+	}
+	var rows []bundledPackage
+	if err := json.Unmarshal(data, &rows); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("resolved %q with %d package(s); want the 2-package server/ copy — the stale sibling shadowed the generator's output", got, len(rows))
+	}
+}
+
+// TestSyncBundledPackagesCreatesRowForNewSlug pins the outage's user-visible
+// symptom end to end: a package present in bundled-packages.json but absent from
+// pkg_registry must get a row created on boot. This is the path that would have
+// re-registered boards on its own had the loader read the fresh file.
+func TestSyncBundledPackagesCreatesRowForNewSlug(t *testing.T) {
+	app := newRegistryOnlyApp(t)
+
+	dir := t.TempDir()
+	serverDir := filepath.Join(dir, "server")
+	if err := os.MkdirAll(serverDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeBundledJSON(t, dir, []bundledPackage{{Name: "Mail", Slug: "mail", Version: "1.0.0"}})
+	writeBundledJSON(t, serverDir, []bundledPackage{
+		{Name: "Mail", Slug: "mail", Version: "1.0.0"},
+		{Name: "Boards", Slug: "boards", Version: "0.3.0", Icon: "kanban"},
+	})
+	withCwd(t, dir)
+
+	SyncBundledPackages(app)
+
+	rec, err := app.FindFirstRecordByFilter("pkg_registry", "slug = {:slug}", map[string]any{"slug": "boards"})
+	if err != nil {
+		t.Fatalf("no pkg_registry row for boards after sync: %v", err)
+	}
+	if got := rec.GetString("status"); got != "bundled" {
+		t.Errorf("status = %q, want %q", got, "bundled")
+	}
+	if got := rec.GetString("version"); got != "0.3.0" {
+		t.Errorf("version = %q, want %q", got, "0.3.0")
+	}
+}

--- a/core/server/coreserver/rebuild.go
+++ b/core/server/coreserver/rebuild.go
@@ -292,7 +292,12 @@ func productionRebuildDeps(app *pocketbase.PocketBase, job *installjob.Job, m Re
 			if job.Action == "uninstall" && len(res.SkippedUnregistered) > 0 {
 				purged, pErr := purgeUnregisteredPackageRows(app, job.Slug, res.SkippedUnregistered)
 				if pErr != nil {
-					jobLogf(job, "WARNING: purging stranded %s migration rows failed (reinstall may skip its Up): %v", job.Slug, pErr)
+					// Includes the deliberate refusal when the package's collections
+					// survived the skipped Down. Keeping the rows is the SAFE outcome:
+					// history matches the schema that exists, so a reinstall skips the
+					// Up instead of re-running it and crash-looping the server. The
+					// leftover tables are reported by the SkippedUnregistered line above.
+					jobLogf(job, "did not purge stranded %s migration rows: %v", job.Slug, pErr)
 				} else if len(purged) > 0 {
 					jobLogf(job, "purged %d stranded %s _migrations row(s) whose Down was unregistered: %s", len(purged), job.Slug, strings.Join(purged, ", "))
 				}

--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -368,11 +368,26 @@ export async function seedForUser(pb: PocketBase, config: SeedConfig): Promise<S
     }
 
     // Single-org: the `role` enum moved onto the users record (the orgs/user_org
-    // collections are gone). Stamp the seeded user as owner so role-gated UI and
-    // RLS (@request.auth.role) resolve.
-    if (user.role !== 'owner') {
+    // collections are gone). Stamp a NEWLY CREATED seeded user as owner so
+    // role-gated UI and RLS (@request.auth.role) resolve on a fresh workspace.
+    //
+    // Only on create. This used to re-force `owner` on EVERY run, which made the
+    // role unchangeable on any deployment that re-seeds: the nightly demo reset
+    // calls seedForUser, so an operator who deliberately demoted the demo user
+    // (e.g. so a public demo cannot uninstall packages) silently found them back
+    // at `owner` the next morning, with only a log line to show for it.
+    //
+    // A role set after provisioning is an operator decision and is left alone.
+    // Re-seeding restores demo DATA, not demo PRIVILEGE. The create path above
+    // already sets role on the insert (the column is required by
+    // 1940000000_backfill_and_require_users_role), so a fresh seed is unaffected.
+    if (login.created && user.role !== 'owner') {
         log('Setting user role to "owner"')
         user = await pb.collection('users').update(user.id, { role: 'owner' })
+    } else if (!login.created && user.role !== 'owner') {
+        log(
+            `Leaving existing user role as "${user.role}" (not re-stamping "owner" on an existing account)`
+        )
     }
 
     // Created here rather than in main() so BOTH entry points get a companion —


### PR DESCRIPTION
Three fixes from the tinycld.org outage. **I did not write these** — they were already in the working tree; I reviewed, verified and committed them. Flagging that so they get a real review.

### The outage: migration rows purged while their schema survived

When a package's Down migrations are skipped, `purgeUnregisteredPackageRows` deleted its `_migrations` rows so a reinstall could re-run the Up cleanly. But "Down was skipped" does not mean "the schema is gone" — it usually means the opposite, since the Down is exactly what would have dropped the collections.

So the `boards_*` collections survived while their history was deleted. The next install re-ran their Up against existing collections and died with *"The model id is invalid or already exists"* **before the server could bind a port** — a crash loop, not a failed install. The rollback could not clear it either: the DB backup was armed *after* the purge, so it restored the same contradictory state.

Rows are now purged only when no collection owned by the slug survives. Otherwise it refuses and says why. It also refuses on an inspection error — keeping stale rows only delays a reinstall, while deleting rows whose schema survives crash-loops the server.

### No way back into an unbootable container

The restart loop hardcodes `serve` and appends `"$@"` as flags, so a command passed to `dokku run` is never executed. `dokku enter` has nothing to attach to. Repair needed host root access to the volume — which is what turned a failed install into a full outage.

`TINYCLD_RESCUE=1` runs the given command (or a shell) instead of serving, then exits without entering the restart loop. Opt-in, and runs as the same unprivileged user as `serve`.

### Installed packages invisible in the UI

Two copies of `bundled-packages.json` exist at runtime and only one is regenerated. The entrypoint's cwd resolved the bare path to the never-refreshed sibling, so every in-app install read a pre-install file — `SyncBundledPackages` never saw the new slug and never created its `pkg_registry` row. Now `server/` is checked first.

### Verification

`go test ./coreserver/` passes (34s), `pnpm run checks` green, both shell scripts pass `bash -n`.

Companion: tinycld/utils (same branch) — the deploy list that omitted boards in the first place.